### PR TITLE
[Fix] repr llava doc

### DIFF
--- a/miscs/repr_scripts.sh
+++ b/miscs/repr_scripts.sh
@@ -11,4 +11,4 @@ pip install -r llava_repr_requirements.txt
 
 # Run and exactly reproduce llava_v1.5 results!
 # mme as an example
-accelerate launch --num_processes=1 -m lmms_eval --model llava   --model_args pretrained="liuhaotian/llava-v1.5-7b,use_flash_attention_2=False"   --tasks mme  --batch_size 1 --log_samples --log_samples_sufix reproduce --output_path ./logs/
+accelerate launch --num_processes=1 -m lmms_eval --model llava   --model_args pretrained="liuhaotian/llava-v1.5-7b,use_flash_attention_2=False,device_map=auto"   --tasks mme  --batch_size 1 --log_samples --log_samples_suffix reproduce --output_path ./logs/


### PR DESCRIPTION
When reproduce the llava model evaluation, some errors may occur like this issue:
+ https://github.com/EvolvingLMMs-Lab/lmms-eval/issues/33

This is because we don't pass the `device_map` according to the repr script here:
https://github.com/EvolvingLMMs-Lab/lmms-eval/blob/9dfb53afb49adb6d20607bc3ca989591969f5432/miscs/repr_scripts.sh#L14

which leads to the error in llava model code:
https://github.com/EvolvingLMMs-Lab/lmms-eval/blob/9dfb53afb49adb6d20607bc3ca989591969f5432/lmms_eval/models/llava.py#L68-L73

It seems that when `num_processes` is >1, it run into the `if` branch to select a specific cuda device, `cuda:0` for example.
and if the `num_processes` is 1 (that's how we do according to the reproduce script), it need user to define a device_map strategy, `auto` for example. And if we don't pass the `device_map`, it's default value is ""(empty).

So, the logic is really weird, actually when we try to use multi-gpu, we need to set a device_map, and if we only use one gpu(num_processes=1), it should be located on a specific cuda device.


BTW, there's also a typo: `--log_samples_sufix` and `--log_samples_suffix` in the script doc.