### PR TITLE
Fix types to allow nullables in `llava_hf.py`

### DIFF
--- a/lmms_eval/models/llava_hf.py
+++ b/lmms_eval/models/llava_hf.py
@@ -280,7 +280,7 @@ class LlavaHf(lmms):
                 self.tokenizer.chat_template = VICUNA_CHAT_TEMPLATE
                 text = self.tokenizer.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
 
-            if self.accelerator.is_main_process and doc_id[0] % 1 == 0:
+            if self.accelerator.is_main_process and doc_id[0] % 100 == 0:
                 eval_logger.info(f"Prompt for doc ID {doc_id[0]}:\n\n{text}\n")
 
             inputs = self._image_processor(images=visuals, text=text, return_tensors="pt").to(self._device, self.model.dtype)

--- a/lmms_eval/models/llava_hf.py
+++ b/lmms_eval/models/llava_hf.py
@@ -46,9 +46,9 @@ class LlavaHf(lmms):
         revision: str = "main",
         device: str = "cuda",
         dtype: Optional[Union[str, torch.dtype]] = "auto",
-        batch_size: Union[int, str] = 1,
+        batch_size: int = 1,
         trust_remote_code: Optional[bool] = False,
-        attn_implementation: Optional[str] = "flash_attention_2",
+        attn_implementation: Optional[str] = None,
         device_map: str = "",
         chat_template: Optional[str] = None,
         use_cache: bool = True,
@@ -280,7 +280,7 @@ class LlavaHf(lmms):
                 self.tokenizer.chat_template = VICUNA_CHAT_TEMPLATE
                 text = self.tokenizer.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
 
-            if self.accelerator.is_main_process and doc_id[0] % 100 == 0:
+            if self.accelerator.is_main_process and doc_id[0] % 1 == 0:
                 eval_logger.info(f"Prompt for doc ID {doc_id[0]}:\n\n{text}\n")
 
             inputs = self._image_processor(images=visuals, text=text, return_tensors="pt").to(self._device, self.model.dtype)


### PR DESCRIPTION
A small fix to allow users to disable options like FA2 in the command line (previously `None` was cast to `str`)
