### PR TITLE
Fix typo in Qwen-VL that was causing "reference before assignment"

### DIFF
--- a/lmms_eval/models/qwen_vl.py
+++ b/lmms_eval/models/qwen_vl.py
@@ -239,13 +239,14 @@ class Qwen_VL(lmms):
             # Similar to llava, is visual paths has len 0
             # Then nothing will be executed
             query = []
-            for visual_path, context in zip(visual_paths, contexts):
-                query.append({"image": visual_path})
-                query.append({"text": context})
-
             if len(visual_paths) == 0:
                 for context in contexts:
                     query.append({"text": context})
+            else: 
+                for visual_path, context in zip(visual_paths, contexts):
+                    query.append({"image": visual_path})
+                    query.append({"text": context})
+
 
             questions = self.tokenizer.from_list_format(query)
             input_ids = self.tokenizer(questions, return_tensors="pt", padding="longest")

--- a/lmms_eval/models/qwen_vl.py
+++ b/lmms_eval/models/qwen_vl.py
@@ -228,10 +228,13 @@ class Qwen_VL(lmms):
                     until = [until]
                 elif not isinstance(until, list):
                     raise ValueError(f"Expected `gen_kwargs['until']` to be of type Union[str,list] but got {type(until)}")
+
+            if isinstance(contexts, tuple):
+                contexts = list(contexts)
+
             for i in range(len(contexts)):
                 if "<image>" in contexts[i]:
                     contexts[i] = contexts[i].replace("<image>", "")
-            questions = [self.prompt.format(visual_path, context) for visual_path, context in zip(visual_paths, contexts)]
 
             # Similar to llava, is visual paths has len 0
             # Then nothing will be executed

--- a/lmms_eval/models/qwen_vl.py
+++ b/lmms_eval/models/qwen_vl.py
@@ -230,7 +230,7 @@ class Qwen_VL(lmms):
                     raise ValueError(f"Expected `gen_kwargs['until']` to be of type Union[str,list] but got {type(until)}")
             for i in range(len(contexts)):
                 if "<image>" in contexts[i]:
-                    context[i] = contexts[i].replace("<image>", "")
+                    contexts[i] = contexts[i].replace("<image>", "")
             questions = [self.prompt.format(visual_path, context) for visual_path, context in zip(visual_paths, contexts)]
 
             # Similar to llava, is visual paths has len 0


### PR DESCRIPTION
Hi! This PR fixes an issue in the Qwen-VL `generate_until` method that was caused by a typo (`contexts[i]` was being referenced as `context[i]`; singular). I also added an `if` statement that converts `contexts` to a list so we can use _item assignment_ with the indexing operator. Finally, made a minor refactor to make the construction of the `query` more readable. 

