### PR TITLE
update gpt-3.5-turbo version

### DIFF
--- a/lmms_eval/tasks/mmupd/mmupd.yaml
+++ b/lmms_eval/tasks/mmupd/mmupd.yaml
@@ -12,4 +12,4 @@ task:
 metadata:
   version: 0.0
   sys_prompt: ""
-  gpt_eval_model_name: "gpt-3.5-turbo-0613"
+  gpt_eval_model_name: "gpt-3.5-turbo-0125"

--- a/lmms_eval/tasks/mmupd/mmupd_base.yaml
+++ b/lmms_eval/tasks/mmupd/mmupd_base.yaml
@@ -6,5 +6,5 @@ task:
 metadata:
   version: 0.0
   sys_prompt: ""
-  gpt_eval_model_name: "gpt-3.5-turbo-0613"
+  gpt_eval_model_name: "gpt-3.5-turbo-0125"
   

--- a/lmms_eval/tasks/mmupd/mmupd_instruction.yaml
+++ b/lmms_eval/tasks/mmupd/mmupd_instruction.yaml
@@ -6,4 +6,4 @@ task:
 metadata:
   version: 0.0
   sys_prompt: ""
-  gpt_eval_model_name: "gpt-3.5-turbo-0613"
+  gpt_eval_model_name: "gpt-3.5-turbo-0125"

--- a/lmms_eval/tasks/mmupd/mmupd_option.yaml
+++ b/lmms_eval/tasks/mmupd/mmupd_option.yaml
@@ -6,4 +6,4 @@ task:
 metadata:
   version: 0.0
   sys_prompt: ""
-  gpt_eval_model_name: "gpt-3.5-turbo-0613"
+  gpt_eval_model_name: "gpt-3.5-turbo-0125"


### PR DESCRIPTION
Hi! 

I have updated gpt-3.5-turbo version from `gpt-3.5-turbo-0613` to `gpt-3.5-turbo-0125` since `gpt-3.5-turbo-0613` will be deprecated.   

I confirmed that the results do not change by testing with the original UPD codebase.

So could you please merge this?

Thank you.