### PR TITLE
Fix the potential risk by PR #117

### DIFF
--- a/lmms_eval/api/task.py
+++ b/lmms_eval/api/task.py
@@ -776,8 +776,10 @@ class ConfigurableTask(Task):
                 if accelerator.is_main_process:
                     force_download = dataset_kwargs.get("force_download", False)
                     force_unzip = dataset_kwargs.get("force_unzip", False)
+                    print(force_download)
                     cache_path = snapshot_download(repo_id=self.DATASET_PATH, repo_type="dataset", force_download=force_download, etag_timeout=60)
                     zip_files = glob(os.path.join(cache_path, "**/*.zip"), recursive=True)
+                    tar_files = glob(os.path.join(cache_path, "**/*.tar*"), recursive=True)
 
                     def unzip_video_data(zip_file):
                         import zipfile
@@ -786,9 +788,56 @@ class ConfigurableTask(Task):
                             zip_ref.extractall(cache_dir)
                             eval_logger.info(f"Extracted all files from {zip_file} to {cache_dir}")
 
+                    def untar_video_data(tar_file):
+                        import tarfile
+                        with tarfile.open(tar_file, "r") as tar_ref:
+                            tar_ref.extractall(cache_dir)
+                            eval_logger.info(f"Extracted all files from {tar_file} to {cache_dir}")
+
+
+    
+                    def concat_tar_parts(tar_parts, output_tar):
+                        print("This is the output file:", output_tar, "from:", tar_parts)
+                        try:
+                            with open(output_tar, 'wb') as out_tar:
+                                from tqdm import tqdm
+                                for part in tqdm(sorted(tar_parts)):
+                                    with open(part, 'rb') as part_file:
+                                        out_tar.write(part_file.read())
+                        except Exception as ex:
+                            print("Error!!!", ex)
+                        eval_logger.info(f"Concatenated parts {tar_parts} into {output_tar}")
+
+                    # Unzip zip files if needed
                     if force_unzip or (not os.path.exists(cache_dir) and len(zip_files) > 0):
                         for zip_file in zip_files:
                             unzip_video_data(zip_file)
+
+                    # Concatenate and extract tar files if needed
+                    if force_unzip or (not os.path.exists(cache_dir) and len(tar_files) > 0):
+                        tar_parts_dict = {}
+                        
+                        # Group tar parts together
+                        for tar_file in tar_files:
+                            base_name = tar_file.split('.tar')[0]
+                            if base_name not in tar_parts_dict:
+                                tar_parts_dict[base_name] = []
+                            tar_parts_dict[base_name].append(tar_file)
+
+                        print(tar_parts_dict)
+                        
+                        # Concatenate and untar split parts
+                        for base_name, parts in tar_parts_dict.items():
+                            eval_logger.info(f"Extracting following tar files: {parts}")
+                            output_tar = base_name + ".tar"
+                            if not os.path.exists(output_tar):
+                                eval_logger.info(f"Start concatenating tar files")
+
+                                concat_tar_parts(parts, output_tar)
+                                eval_logger.info(f"Finish concatenating tar files")
+
+                            if not os.path.exists(os.path.join(cache_dir, os.path.basename(base_name))):
+                                untar_video_data(output_tar)
 
                 accelerator.wait_for_everyone()
                 dataset_kwargs.pop("cache_dir")

--- a/lmms_eval/api/task.py
+++ b/lmms_eval/api/task.py
@@ -776,7 +776,6 @@ class ConfigurableTask(Task):
                 if accelerator.is_main_process:
                     force_download = dataset_kwargs.get("force_download", False)
                     force_unzip = dataset_kwargs.get("force_unzip", False)
-                    print(force_download)
                     cache_path = snapshot_download(repo_id=self.DATASET_PATH, repo_type="dataset", force_download=force_download, etag_timeout=60)
                     zip_files = glob(os.path.join(cache_path, "**/*.zip"), recursive=True)
                     tar_files = glob(os.path.join(cache_path, "**/*.tar*"), recursive=True)
@@ -797,15 +796,11 @@ class ConfigurableTask(Task):
 
     
                     def concat_tar_parts(tar_parts, output_tar):
-                        print("This is the output file:", output_tar, "from:", tar_parts)
-                        try:
-                            with open(output_tar, 'wb') as out_tar:
-                                from tqdm import tqdm
-                                for part in tqdm(sorted(tar_parts)):
-                                    with open(part, 'rb') as part_file:
-                                        out_tar.write(part_file.read())
-                        except Exception as ex:
-                            print("Error!!!", ex)
+                        with open(output_tar, 'wb') as out_tar:
+                            from tqdm import tqdm
+                            for part in tqdm(sorted(tar_parts)):
+                                with open(part, 'rb') as part_file:
+                                    out_tar.write(part_file.read())
                         eval_logger.info(f"Concatenated parts {tar_parts} into {output_tar}")
 
                     # Unzip zip files if needed
@@ -824,7 +819,6 @@ class ConfigurableTask(Task):
                                 tar_parts_dict[base_name] = []
                             tar_parts_dict[base_name].append(tar_file)
 
-                        print(tar_parts_dict)
                         
                         # Concatenate and untar split parts
                         for base_name, parts in tar_parts_dict.items():

--- a/lmms_eval/models/llava_vid.py
+++ b/lmms_eval/models/llava_vid.py
@@ -405,7 +405,7 @@ class LlavaVid(lmms):
                     attention_mask=attention_masks,
                     modalities="video",
                     use_cache=self.use_cache,
-                    #stopping_criteria=[stopping_criteria],
+                    stopping_criteria=[stopping_criteria],
                     do_sample=True if gen_kwargs["temperature"] > 0 else False,
                     temperature=gen_kwargs["temperature"],
                     top_p=gen_kwargs["top_p"],


### PR DESCRIPTION
In the previous commit, I have commented the L408 (stopping_criteria for generation) in https://github.com/EvolvingLMMs-Lab/lmms-eval/blob/main/lmms_eval/models/llava_vid.py#L408C22-L408C39 to fit this model with transformers >4.40.2.  (The `stopping_criteria` still works with transformers==4.40.0)

Though this does not affect MCQ accuracy, no stopping criteria may potentially lead to risk on open-ended answers. Henceforth, a more responsible way is to remove this comment here.

I also include the lmms_eval/api/task.py to allow extracting videos from tars (which will make automatic evaluation of LongVideoBench really works from a brand new machine).

