### PR TITLE
[Docs] Fix broken hyperlink in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ Please check [supported models](lmms_eval/models/__init__.py) for more details.
 
 ### Supported tasks
 
-Please check [supported tasks](lmms_eval/docs/current_tasks.md) for more details.
+Please check [supported tasks](docs/current_tasks.md) for more details.
 
 ## Add Customized Model and Dataset
 


### PR DESCRIPTION
This pull request fixes a broken hyperlink in the README.md file.   
The original hyperlink was pointing to a file that no longer exists.   
The updated link now correctly points to the task documentation.   

Before you open a pull-request, please check if a similar issue already exists or has been closed before.

### When you open a pull-request, please be sure to include the following

- [ ] A descriptive title: [xxx] XXXX
- [ ] A detailed description

Thank you for your contributions!
