### PR TITLE
[Fix] batch_gpt4.py parsing issue with openai's HttpxBinaryResponseContent

### DIFF
--- a/lmms_eval/models/batch_gpt4.py
+++ b/lmms_eval/models/batch_gpt4.py
@@ -159,7 +159,8 @@ class BatchGPT4(lmms):
             if batch_status.status == "completed":
                 eval_logger.info("Batch processing completed.")
                 batch_results = self.retrieve_batch_results(batch_status.output_file_id)
-                res = [result["response"]["choices"][0]["message"]["content"] for result in json.loads(batch_results)]
+                batch_results = batch_results.text.split("\n")
+                res = [json.loads(r)["response"]["body"]["choices"][0]["message"]["content"] for r in batch_results]
                 return res
             elif batch_status.status == "failed":
                 eval_logger.info("Batch processing failed.")


### PR DESCRIPTION
In the existing code, batch_results is being processed with json.loads().   
However, batch_results is of type HttpxBinaryResponseContent from openai, and cannot be directly converted.   
We should use either batch_results.content or batch_results.text.   
But they are batched, so they are in jsonl format.   
Using json.loads() directly on them results in the error "json.decoder.JSONDecodeError: Extra data: line 2 column 1."    
Therefore, it is preferable to split the content by \n and then process each line.   
This commit addresses this issue.   
If there are better implementations, please let me know.

Before you open a pull-request, please check if a similar issue already exists or has been closed before.

### When you open a pull-request, please be sure to include the following

- [x] A descriptive title: [xxx] XXXX
- [x] A detailed description

Thank you for your contributions!
