### PR TITLE
Fix: None value handler for seedbench-2 evaluation code

### DIFF
--- a/lmms_eval/tasks/seedbench_2/utils.py
+++ b/lmms_eval/tasks/seedbench_2/utils.py
@@ -13,6 +13,8 @@ def parse_choice_img(choice: str, img_token: str):
 
 def seed_doc_to_text(doc, model_specific_kwargs=None):
     question = doc["question"]
+    if model_specific_kwargs is None:
+        return question
     question.replace("<img>", model_specific_kwargs["img_token"])
     question += "\n" + f"A. {parse_choice_img(doc['choice_a'], model_specific_kwargs['img_token'])}\n"
     question += f"B. {parse_choice_img(doc['choice_b'], model_specific_kwargs['img_token'])}\n"


### PR DESCRIPTION
Since there're only `model_specific_prompt_kwargs` for `llava` and `gpt4v` in `seedbench2.yaml`, attempting to evaluate other models resulted in a `TypeError: 'NoneType' object is not subscriptable` error due to the absence of this argument.

So I simply added lines of code to handle None value in `seed_doc_to_text()`.