### PR TITLE
Add default prompt for seedbench_2.yaml

### DIFF
--- a/lmms_eval/tasks/seedbench_2/seedbench_2.yaml
+++ b/lmms_eval/tasks/seedbench_2/seedbench_2.yaml
@@ -41,6 +41,9 @@ metadata:
   - version: 0.0
 
 model_specific_prompt_kwargs:
+  default :
+    img_token : <image>
+    post_prompt : "Answer with the option's letter from the given choices directly."
   llava :
     img_token : <image>
     post_prompt : "Answer with the option's letter from the given choices directly."


### PR DESCRIPTION
Since there're only `model_specific_prompt_kwargs` for `llava` and `gpt4v` in `seedbench2.yaml`, attempting to evaluate other models resulted in a `TypeError: 'NoneType' object is not subscriptable` error due to the absence of this argument.

So I simply added default prompts in `seedbench2.yaml`.