### PR TITLE
[Add Dataset] SEEDBench 2 Plus

### DIFF
--- a/docs/current_tasks.md
+++ b/docs/current_tasks.md
@@ -105,6 +105,7 @@
   - ScreenSpot REG / Instruction Generation (screenspot_reg)
 - SeedBench (seedbench)
 - SeedBench 2 (seedbench_2)
+- SeedBench 2 Plus (seedbench_2_plus)
 - ST-VQA (stvqa)
 - TextCaps (textcaps)
   - TextCaps Validation (textcaps_val)

--- a/lmms_eval/tasks/seedbench_2_plus/seedbench_2_plus.yaml
+++ b/lmms_eval/tasks/seedbench_2_plus/seedbench_2_plus.yaml
@@ -1,7 +1,7 @@
-dataset_path: lmms-lab/SEED-Bench-2
+dataset_path: doolayer/SEED-Bench-2-Plus
 dataset_kwargs:
   token: True
-task: "seedbench_2"
+task: "seedbench_2_plus"
 test_split: test
 output_type: generate_until
 doc_to_visual: !function utils.seed_doc_to_visual
@@ -16,37 +16,28 @@ generation_kwargs:
 process_results: !function utils.seed_process_result
 # Note that the metric name can be either a registed metric function (such as the case for GQA) or a key name returned by process_results
 metric_list:
-  - metric: seed_Video
+  - metric: seedbench_2_plus_Chart
     aggregation: !function utils.seed_aggregation_result
     higher_is_better: true
-  - metric: seed_Multiple_Images
+  - metric: seedbench_2_plus_Map
     aggregation: !function utils.seed_aggregation_result
     higher_is_better: true
-  - metric: seed_Image_&_Text_Generation
+  - metric: seedbench_2_plus_Web
     aggregation: !function utils.seed_aggregation_result
     higher_is_better: true
-  - metric: seed_Single_Image
-    aggregation: !function utils.seed_aggregation_result
-    higher_is_better: true
-  - metric: seed_Image_Generation
-    aggregation: !function utils.seed_aggregation_result
-    higher_is_better: true
-  - metric: seed_Interleaved_Image
-    aggregation: !function utils.seed_aggregation_result
-    higher_is_better: true
-  - metric: seed_all
+  - metric: seedbench_2_plus_all
     aggregation: !function utils.seed_aggregation_result
     higher_is_better: true
 metadata:
   - version: 0.0
 
 model_specific_prompt_kwargs:
-  default :
-    img_token : <image>
-    post_prompt : "Answer with the option's letter from the given choices directly."
   llava :
     img_token : <image>
     post_prompt : "Answer with the option's letter from the given choices directly."
   gpt4V :
+    img_token : <image>
+    post_prompt : "Answer with the option's letter from the given choices directly."
+  default :
     img_token : <image>
     post_prompt : "Answer with the option's letter from the given choices directly."

--- a/lmms_eval/tasks/seedbench_2_plus/utils.py
+++ b/lmms_eval/tasks/seedbench_2_plus/utils.py
@@ -1,0 +1,52 @@
+import json
+
+def seed_doc_to_visual(doc):
+    return [doc["image"].convert("RGB")]
+
+def parse_choice_img(choice: str, img_token: str):
+    if "jpg" in choice or "png" in choice:
+        return img_token
+    return choice
+
+
+def seed_doc_to_text(doc, model_specific_kwargs=None):
+    question = doc["question"]
+    question.replace("<img>", model_specific_kwargs["img_token"])
+    question += "\n" + f"A. {parse_choice_img(doc['choice_A'], model_specific_kwargs['img_token'])}\n"
+    question += f"B. {parse_choice_img(doc['choice_B'], model_specific_kwargs['img_token'])}\n"
+    question += f"C. {parse_choice_img(doc['choice_C'], model_specific_kwargs['img_token'])}\n"
+    question += f"D. {parse_choice_img(doc['choice_D'], model_specific_kwargs['img_token'])}"
+    
+    return f"{question}\n{model_specific_kwargs['post_prompt']}"
+
+
+def seed_process_result(doc, result):
+    pred = result[0].strip()
+    if len(pred) > 1:
+        pred = pred[0]
+    answer = doc["answer"]
+    data_type = doc["question_image_type"].capitalize()
+
+    return {f"seedbench_2_plus_{data_type}": {"pred": pred, "answer": answer, "question_id": doc["question_id"]}, f"seedbench_2_plus_all": {"pred": pred, "answer": answer, "question_id": doc["question_id"]}}
+
+
+def seed_aggregation_result(results):
+    total_count = 0
+    total_correct = 0
+    for result in results:
+        if result["pred"].lower().strip() == result["answer"].lower().strip():
+            total_correct += 1
+        total_count += 1
+    return total_correct / total_count if total_count != 0 else 0
+
+
+def seed_aggregation_result_all(results):
+    score = seed_aggregation_result(results)
+    stored_results = []
+    for result in results:
+        stored_results.append({"question_id": result["question_id"], "prediction": result["pred"]})
+    with open("./seed_submission.json", "w") as f:
+        json.dump(stored_results, f, indent=4)
+    print("Storing files for seed_submission ...")
+
+    return score


### PR DESCRIPTION
## Add the SEEDBench 2 Plus dataset and minor change in dataset docs.

#### Key Changes:

1. Add SEEDBench 2 Plus Dataset:
Added the SEEDBench 2 Plus dataset proposed in the [paper](https://arxiv.org/abs/2404.16790), which already implemented in VLMEvalKit.

2. Rename Existing SEEDBench 2 Task Names:
Changed the task names in the existing SEEDBench 2 dataset from hyphens (-) to underscores (_) to maintain consistency with other datasets. (seedbench-2 -> seenbench_2)

3. Add Descriptions for seedbench 2 plus:
Added descriptions for seedbench 2 plus

I have completed tests for SEEDBench 2 Plus benchmark  on several models with this code change, but please leave a comment if further review is needed.

The data uploaded to the [datasets repository](https://huggingface.co/datasets/doolayer/SEED-Bench-2-Plus) was created with the following code:
```
data_json_fname = "SEED-Bench-2-plus-text-rich.json"
data = json.load(open(data_json_fname))

for i, d in enumerate(tqdm(data)):
    img = d["data_id"]
    img = Image.open(img)
    data[i]["image"] = img

data_in_list_dict = {k: [d[k] for d in data] for k in data[0]}

ds = Dataset.from_dict(data_in_list_dict)
ds.push_to_hub("doolayer/my-image-dataset")
```
If the datasets repository should be managed by lmms-lab, I would appreciate comments on the necessary steps to handle that aspect.

Thank you.

---

Before you open a pull-request, please check if a similar issue already exists or has been closed before.

### When you open a pull-request, please be sure to include the following

- [x] A descriptive title: [xxx] XXXX
- [x] A detailed description

Thank you for your contributions!
