### PR TITLE
Fix `videomme` evaluation

### DIFF
--- a/lmms_eval/api/task.py
+++ b/lmms_eval/api/task.py
@@ -780,6 +780,7 @@ class ConfigurableTask(Task):
 
             if "video" in dataset_kwargs and dataset_kwargs["video"]:
                 hf_home = os.getenv("HF_HOME", "~/.cache/huggingface/")
+                hf_home = os.path.expanduser(hf_home)
                 cache_dir = dataset_kwargs["cache_dir"]
                 cache_dir = os.path.join(hf_home, cache_dir)
                 accelerator = Accelerator()

--- a/lmms_eval/tasks/videomme/utils.py
+++ b/lmms_eval/tasks/videomme/utils.py
@@ -177,7 +177,7 @@ def extract_subtitles(video_path, subtitle_path):
 def videomme_doc_to_visual(doc):
     cache_dir = os.path.join(base_cache_dir, cache_name)
     video_path = doc["videoID"] + ".mp4"
-    video_path = os.path.join(cache_dir, video_path)
+    video_path = os.path.join(cache_dir, "data", video_path)
     if os.path.exists(video_path):
         video_path = video_path
     elif os.path.exists(video_path.replace("mp4", "MP4")):


### PR DESCRIPTION
This minor fix for `videomme` evaluation makes sure that videos are downloaded to and loaded from the correct folder.