### PR TITLE
[feat] Add check for existence of accelerator before waiting

### DIFF
--- a/lmms_eval/evaluator.py
+++ b/lmms_eval/evaluator.py
@@ -607,7 +607,8 @@ def evaluate(
     else:
         results_dict = None
 
-    lm.accelerator.wait_for_everyone()
+    if hasattr(lm, "accelerator"):
+        lm.accelerator.wait_for_everyone()
     return results_dict
 
 


### PR DESCRIPTION
This pull request adds a check for the existence of the accelerator before waiting. Previously, the code would attempt to wait for the accelerator without checking if it exists, which could lead to errors. With this change, the code will only wait for the accelerator if it is present, ensuring smoother execution.