### PR TITLE
[Fix] Fix the error when running models caused by `generate_until_multi_round`

### DIFF
--- a/lmms_eval/api/samplers.py
+++ b/lmms_eval/api/samplers.py
@@ -37,9 +37,7 @@ class ContextSampler:
                     + (
                         str(self.doc_to_target(doc)[0])
                         if type(self.doc_to_target(doc)) is list
-                        else self.doc_to_target(doc)
-                        if (self.config.doc_to_choice is None or type(self.doc_to_target(doc)) is str)
-                        else str(self.doc_to_choice(doc)[self.doc_to_target(doc)])
+                        else self.doc_to_target(doc) if (self.config.doc_to_choice is None or type(self.doc_to_target(doc)) is str) else str(self.doc_to_choice(doc)[self.doc_to_target(doc)])
                     )
                     for doc in selected_docs
                 ]

--- a/lmms_eval/api/samplers.py
+++ b/lmms_eval/api/samplers.py
@@ -37,7 +37,9 @@ class ContextSampler:
                     + (
                         str(self.doc_to_target(doc)[0])
                         if type(self.doc_to_target(doc)) is list
-                        else self.doc_to_target(doc) if (self.config.doc_to_choice is None or type(self.doc_to_target(doc)) is str) else str(self.doc_to_choice(doc)[self.doc_to_target(doc)])
+                        else self.doc_to_target(doc)
+                        if (self.config.doc_to_choice is None or type(self.doc_to_target(doc)) is str)
+                        else str(self.doc_to_choice(doc)[self.doc_to_target(doc)])
                     )
                     for doc in selected_docs
                 ]

--- a/lmms_eval/models/batch_gpt4.py
+++ b/lmms_eval/models/batch_gpt4.py
@@ -202,3 +202,6 @@ class BatchGPT4(lmms):
 
     def list_batches(self, limit=10):
         return self.client.batches.list(limit=limit)
+
+    def generate_until_multi_round(self, requests) -> List[str]:
+        raise NotImplementedError("TODO: Implement multi-round generation for BatchGPT4")

--- a/lmms_eval/models/cambrian.py
+++ b/lmms_eval/models/cambrian.py
@@ -308,3 +308,6 @@ class Cambrian(lmms):
         res = re_ords.get_original(res)
         pbar.close()
         return res
+
+    def generate_until_multi_round(self, requests) -> List[str]:
+        raise NotImplementedError("TODO: Implement multi-round generation for Cambrian")

--- a/lmms_eval/models/claude.py
+++ b/lmms_eval/models/claude.py
@@ -267,3 +267,6 @@ class Claude(lmms):
 
     def loglikelihood(self, requests: List[Instance]) -> List[Tuple[float, bool]]:
         assert False, "Not supported for claude"
+
+    def generate_until_multi_round(self, requests) -> List[str]:
+        raise NotImplementedError("TODO: Implement multi-round generation for Claude")

--- a/lmms_eval/models/cogvlm2.py
+++ b/lmms_eval/models/cogvlm2.py
@@ -224,3 +224,6 @@ class CogVLM2(lmms):
 
         pbar.close()
         return res
+
+    def generate_until_multi_round(self, requests) -> List[str]:
+        raise NotImplementedError("TODO: Implement multi-round generation for CogVLM2")

--- a/lmms_eval/models/from_log.py
+++ b/lmms_eval/models/from_log.py
@@ -114,3 +114,6 @@ class FromLog(lmms):
     def loglikelihood(self, requests: List[Instance]) -> List[Tuple[float, bool]]:
         # TODO
         assert False, "not support"
+
+    def generate_until_multi_round(self, requests) -> List[str]:
+        return generate_until(self, requests)

--- a/lmms_eval/models/fuyu.py
+++ b/lmms_eval/models/fuyu.py
@@ -264,3 +264,6 @@ class Fuyu(lmms):
 
     def tok_decode(self, tokens):
         return self.tokenizer.decode(tokens)
+
+    def generate_until_multi_round(self, requests) -> List[str]:
+        raise NotImplementedError("TODO: Implement multi-round generation for Fuyu")

--- a/lmms_eval/models/gemini_api.py
+++ b/lmms_eval/models/gemini_api.py
@@ -181,6 +181,9 @@ class GeminiAPI(lmms):
         pbar.close()
         return res
 
+    def generate_until_multi_round(self, requests) -> List[str]:
+        raise NotImplementedError("TODO: Implement multi-round generation for Gemini API")
+
     def loglikelihood(self, requests: List[Instance]) -> List[Tuple[float, bool]]:
         # TODO
         assert False, "Gemini API not support"

--- a/lmms_eval/models/gpt4v.py
+++ b/lmms_eval/models/gpt4v.py
@@ -230,6 +230,9 @@ class GPT4V(lmms):
         pbar.close()
         return res
 
+    def generate_until_multi_round(self, requests) -> List[str]:
+        raise NotImplementedError("TODO: Implement multi-round generation for GPT4V")
+
     def loglikelihood(self, requests: List[Instance]) -> List[Tuple[float, bool]]:
         # TODO
         assert False, "GPT4V not support"

--- a/lmms_eval/models/idefics2.py
+++ b/lmms_eval/models/idefics2.py
@@ -229,3 +229,6 @@ class Idefics2(lmms):
 
         pbar.close()
         return res
+
+    def generate_until_multi_round(self, requests) -> List[str]:
+        raise NotImplementedError("TODO: Implement multi-round generation for Idefics2")

--- a/lmms_eval/models/instructblip.py
+++ b/lmms_eval/models/instructblip.py
@@ -225,3 +225,6 @@ class InstructBLIP(lmms):
 
         pbar.close()
         return res
+
+    def generate_until_multi_round(self, requests) -> List[str]:
+        raise NotImplementedError("TODO: Implement multi-round generation for InstructBlip")

--- a/lmms_eval/models/internvl.py
+++ b/lmms_eval/models/internvl.py
@@ -491,3 +491,6 @@ class InternVLChat(lmms):
 
     def loglikelihood(self, requests: List[Instance]) -> List[Tuple[float, bool]]:
         pass
+
+    def generate_until_multi_round(self, requests) -> List[str]:
+        raise NotImplementedError("TODO: Implement multi-round generation for InternVL")

--- a/lmms_eval/models/internvl2.py
+++ b/lmms_eval/models/internvl2.py
@@ -281,3 +281,6 @@ class InternVL2(lmms):
 
     def loglikelihood(self, requests: List[Instance]) -> List[Tuple[float, bool]]:
         assert False, "Not implemented yet."
+
+    def generate_until_multi_round(self, requests) -> List[str]:
+        raise NotImplementedError("TODO: Implement multi-round generation for InternVL2")

--- a/lmms_eval/models/llama_vid.py
+++ b/lmms_eval/models/llama_vid.py
@@ -277,3 +277,6 @@ class LLaMAVid(lmms):
     @property
     def world_size(self):
         return self._world_size
+
+    def generate_until_multi_round(self, requests) -> List[str]:
+        raise NotImplementedError("TODO: Implement multi-round generation for LLaMAVid")

--- a/lmms_eval/models/llava.py
+++ b/lmms_eval/models/llava.py
@@ -425,3 +425,6 @@ class Llava(lmms):
 
         pbar.close()
         return res
+
+    def generate_until_multi_round(self, requests) -> List[str]:
+        raise NotImplementedError("TODO: Implement multi-round generation for LLaVA")

--- a/lmms_eval/models/llava_hf.py
+++ b/lmms_eval/models/llava_hf.py
@@ -387,3 +387,6 @@ class LlavaHf(lmms):
 
         pbar.close()
         return res
+
+    def generate_until_multi_round(self, requests) -> List[str]:
+        raise NotImplementedError("TODO: Implement multi-round generation for LLaVAHF")

--- a/lmms_eval/models/llava_sglang.py
+++ b/lmms_eval/models/llava_sglang.py
@@ -160,3 +160,6 @@ class LlavaSglang(lmms):
         pbar.close()
         runtime.shutdown()
         return res
+
+    def generate_until_multi_round(self, requests) -> List[str]:
+        raise NotImplementedError("TODO: Implement multi-round generation for LLaVA-SGLang")

--- a/lmms_eval/models/llava_vid.py
+++ b/lmms_eval/models/llava_vid.py
@@ -433,3 +433,6 @@ class LlavaVid(lmms):
             res.append(outputs)
             pbar.update(1)
         return res
+
+    def generate_until_multi_round(self, requests) -> List[str]:
+        raise NotImplementedError("TODO: Implement multi-round generation for LLaVAVid")

--- a/lmms_eval/models/longva.py
+++ b/lmms_eval/models/longva.py
@@ -471,3 +471,6 @@ class LongVA(lmms):
 
         pbar.close()
         return res
+
+    def generate_until_multi_round(self, requests) -> List[str]:
+        raise NotImplementedError("TODO: Implement multi-round generation for LongVA")

--- a/lmms_eval/models/mantis.py
+++ b/lmms_eval/models/mantis.py
@@ -307,3 +307,6 @@ class Mantis(lmms):
 
         pbar.close()
         return res
+
+    def generate_until_multi_round(self, requests) -> List[str]:
+        raise NotImplementedError("TODO: Implement multi-round generation for Mantis")

--- a/lmms_eval/models/minicpm_v.py
+++ b/lmms_eval/models/minicpm_v.py
@@ -219,3 +219,6 @@ class MiniCPM_V(lmms):
 
         pbar.close()
         return res
+
+    def generate_until_multi_round(self, requests) -> List[str]:
+        raise NotImplementedError("TODO: Implement multi-round generation")

--- a/lmms_eval/models/minimonkey.py
+++ b/lmms_eval/models/minimonkey.py
@@ -215,6 +215,9 @@ class MiniMonkey(lmms):
         pbar.close()
         return res
 
+    def generate_until_multi_round(self, requests) -> List[str]:
+        raise NotImplementedError("TODO: Implement multi-round generation")
+
 
 import numpy as np
 import torchvision.transforms as T

--- a/lmms_eval/models/mplug_owl_video.py
+++ b/lmms_eval/models/mplug_owl_video.py
@@ -194,3 +194,6 @@ class mplug_Owl(lmms):
 
     def loglikelihood(self, requests: List[Instance]) -> List[Tuple[float, bool]]:
         return super().loglikelihood(requests)
+
+    def generate_until_multi_round(self, requests) -> List[str]:
+        raise NotImplementedError("TODO: Implement multi-round generation")

--- a/lmms_eval/models/phi3v.py
+++ b/lmms_eval/models/phi3v.py
@@ -215,3 +215,6 @@ class Phi3v(lmms):
         res = re_ords.get_original(res)
         pbar.close()
         return res
+
+    def generate_until_multi_round(self, requests) -> List[str]:
+        raise NotImplementedError("TODO: Implement multi-round generation")

--- a/lmms_eval/models/qwen2_vl.py
+++ b/lmms_eval/models/qwen2_vl.py
@@ -273,3 +273,6 @@ class Qwen2_VL(lmms):
 
         pbar.close()
         return res
+
+    def generate_until_multi_round(self, requests) -> List[str]:
+        raise NotImplementedError("TODO: Implement multi-round generation")

--- a/lmms_eval/models/qwen_vl.py
+++ b/lmms_eval/models/qwen_vl.py
@@ -307,3 +307,6 @@ class Qwen_VL(lmms):
 
         pbar.close()
         return res
+
+    def generate_until_multi_round(self, requests) -> List[str]:
+        raise NotImplementedError("TODO: Implement multi-round generation")

--- a/lmms_eval/models/qwen_vl_api.py
+++ b/lmms_eval/models/qwen_vl_api.py
@@ -121,3 +121,6 @@ class Qwen_VL_API(lmms):
             for j in i:
                 new_list.append(j)
         return new_list
+
+    def generate_until_multi_round(self, requests) -> List[str]:
+        raise NotImplementedError("TODO: Implement multi-round generation")

--- a/lmms_eval/models/reka.py
+++ b/lmms_eval/models/reka.py
@@ -193,3 +193,6 @@ class Reka(lmms):
     def loglikelihood(self, requests: List[Instance]) -> List[Tuple[float, bool]]:
         # TODO
         assert False, "Reka not support loglikelihood"
+
+    def generate_until_multi_round(self, requests) -> List[str]:
+        raise NotImplementedError("TODO: Implement multi-round generation")

--- a/lmms_eval/models/srt_api.py
+++ b/lmms_eval/models/srt_api.py
@@ -293,3 +293,6 @@ class SRT_API(lmms):
     def loglikelihood(self, requests: List[Instance]) -> List[Tuple[float, bool]]:
         # TODO
         assert False, "GPT4V not support"
+
+    def generate_until_multi_round(self, requests) -> List[str]:
+        raise NotImplementedError("TODO: Implement multi-round generation")

--- a/lmms_eval/models/tinyllava.py
+++ b/lmms_eval/models/tinyllava.py
@@ -408,3 +408,6 @@ class TinyLlava(lmms):
 
         pbar.close()
         return res
+
+    def generate_until_multi_round(self, requests) -> List[str]:
+        raise NotImplementedError("TODO: Implement multi-round generation")

--- a/lmms_eval/models/video_chatgpt.py
+++ b/lmms_eval/models/video_chatgpt.py
@@ -203,3 +203,6 @@ class VideoChatGPT(lmms):
     @property
     def world_size(self):
         return self._world_size
+
+    def generate_until_multi_round(self, requests) -> List[str]:
+        raise NotImplementedError("TODO: Implement multi-round generation")

--- a/lmms_eval/models/video_llava.py
+++ b/lmms_eval/models/video_llava.py
@@ -209,3 +209,6 @@ class VideoLLaVA(lmms):
             res.append(outputs)
             pbar.update(1)
         return res
+
+    def generate_until_multi_round(self, requests) -> List[str]:
+        raise NotImplementedError("TODO: Implement multi-round generation")

--- a/lmms_eval/models/vila.py
+++ b/lmms_eval/models/vila.py
@@ -366,3 +366,6 @@ class VILA(lmms):
             res.append(outputs)
             pbar.update(1)
         return res
+
+    def generate_until_multi_round(self, requests) -> List[str]:
+        raise NotImplementedError("TODO: Implement multi-round generation")

--- a/lmms_eval/models/xcomposer2_4KHD.py
+++ b/lmms_eval/models/xcomposer2_4KHD.py
@@ -229,6 +229,9 @@ class XComposer2_4KHD(lmms):
     def loglikelihood(self, requests: List[Instance]) -> List[Tuple[float, bool]]:
         return super().loglikelihood(requests)
 
+    def generate_until_multi_round(self, requests) -> List[str]:
+        raise NotImplementedError("TODO: Implement multi-round generation")
+
 
 def padding_336(b):
     width, height = b.size

--- a/lmms_eval/models/xcomposer2d5.py
+++ b/lmms_eval/models/xcomposer2d5.py
@@ -182,3 +182,6 @@ class XComposer2D5(lmms):
 
     def loglikelihood(self, requests: List[Instance]) -> List[Tuple[float, bool]]:
         assert False, "Not implemented yet."
+
+    def generate_until_multi_round(self, requests) -> List[str]:
+        raise NotImplementedError("TODO: Implement multi-round generation")


### PR DESCRIPTION
`generate_until_multi_round` is an abstract method, so every model should have this method.

Due to time constraints, I currently only add an empty method that throws an exception to each model.