### PR TITLE
[fix] Refactor GeminiAPI class to add video pooling and freeing

### DIFF
--- a/lmms_eval/models/gemini_api.py
+++ b/lmms_eval/models/gemini_api.py
@@ -75,6 +75,13 @@ class GeminiAPI(lmms):
 
         self.modality = modality
 
+        self.video_pool = []
+
+    def free_video(self):
+        for video in self.video_pool:
+            video.delete()
+        self.video_pool = []
+
     def flatten(self, input):
         new_list = []
         for i in input:
@@ -97,6 +104,7 @@ class GeminiAPI(lmms):
     def encode_video(self, video_path):
         uploaded_obj = genai.upload_file(path=video_path)
         time.sleep(5)
+        self.video_pool.append(uploaded_obj)
         return uploaded_obj
 
     def convert_video(self, images):
@@ -116,7 +124,7 @@ class GeminiAPI(lmms):
             return f"{task}___{split}___{doc_id}"
 
         for contexts, gen_kwargs, doc_to_visual, doc_id, task, split in [reg.args for reg in requests]:
-            if self.continual_mode is True and self.cache_mode == "resume":
+            if self.continual_mode and self.cache_mode == "resume":
                 doc_uuid = get_uuid(task, split, doc_id)
                 if doc_uuid in self.response_cache:
                     content = self.response_cache[doc_uuid]
@@ -171,6 +179,8 @@ class GeminiAPI(lmms):
                         content = ""
             res.append(content)
             pbar.update(1)
+
+            self.free_video()
 
             if self.continual_mode is True:  # Cache the response
                 doc_uuid = get_uuid(task, split, doc_id)


### PR DESCRIPTION
When evaluating large video datasets, sometimes the total size of the videos exceeds the 20 GB limit. Therefore, during evaluation, it's necessary to delete unnecessary videos while running the process.