### PR TITLE
[fix] Invalid group in mmsearch.yaml

### DIFF
--- a/lmms_eval/tasks/mmsearch/mmsearch.yaml
+++ b/lmms_eval/tasks/mmsearch/mmsearch.yaml
@@ -1,6 +1,6 @@
 # the final score is computed using the script lmms_eval/tasks/mmsearch/get_final_scores.py
 # the score file in the submission folder of the three task (end2end, rerank, summarization) should be input as args
-group: mathverse
+group: mmsearch
 task:
   - mmsearch_end2end
   - mmsearch_rerank


### PR DESCRIPTION
- Group in `mmsearch.yaml` is invalid (`mathverse`), so it cause an error when you trying to evaluate mathverse.
