### PR TITLE
Update evaluator.py to load datasets first before loading models

### DIFF
--- a/lmms_eval/evaluator.py
+++ b/lmms_eval/evaluator.py
@@ -169,7 +169,7 @@ def simple_evaluate(
         task_manager = TaskManager(verbosity, model_name=model)
 
     task_dict = get_task_dict(tasks, task_manager)
-    
+
     ModelClass = get_model(model)
     lm = ModelClass.create_from_arg_string(
         model_args,

--- a/lmms_eval/evaluator.py
+++ b/lmms_eval/evaluator.py
@@ -165,6 +165,11 @@ def simple_evaluate(
     if model_args is None:
         model_args = ""
 
+    if task_manager is None:
+        task_manager = TaskManager(verbosity, model_name=model)
+
+    task_dict = get_task_dict(tasks, task_manager)
+    
     ModelClass = get_model(model)
     lm = ModelClass.create_from_arg_string(
         model_args,
@@ -173,11 +178,6 @@ def simple_evaluate(
             "device": device,
         },
     )
-
-    if task_manager is None:
-        task_manager = TaskManager(verbosity, model_name=model)
-
-    task_dict = get_task_dict(tasks, task_manager)
 
     # helper function to recursively apply config overrides to leaf subtasks, skipping their constituent groups.
     # (setting of num_fewshot ; bypassing metric calculation ; setting fewshot seed)


### PR DESCRIPTION
Downloading datasets before loading models will help prioritise data preparation without using GPUs.
- just adjusted the order of the code in evaluator.py
- it has been tested for most of the datasets for single-image and text-only scenarios and no anomalies were found
