### PR TITLE
Update llava_onevision.py to avoid erros on evaluation benchmarks with both single- and multi-image samples.

### DIFF
--- a/lmms_eval/models/llava_onevision.py
+++ b/lmms_eval/models/llava_onevision.py
@@ -418,7 +418,6 @@ class Llava_OneVision(lmms):
             question_input = []
             # import ipdb; ipdb.set_trace()
             for visual, context in zip(batched_visuals, batched_contexts):
-
                 if origin_image_aspect_ratio is not None and self._config.image_aspect_ratio != origin_image_aspect_ratio:
                     self._config.image_aspect_ratio = origin_image_aspect_ratio
                     eval_logger.info(f"Resetting image aspect ratio to {origin_image_aspect_ratio}")
@@ -630,7 +629,6 @@ class Llava_OneVision(lmms):
                         break
 
                 for visual, context in zip(batched_visuals, batched_contexts):
-
                     if origin_image_aspect_ratio is not None and self._config.image_aspect_ratio != origin_image_aspect_ratio:
                         self._config.image_aspect_ratio = origin_image_aspect_ratio
                         eval_logger.info(f"Resetting image aspect ratio to {origin_image_aspect_ratio}")


### PR DESCRIPTION
- Configuration rollback has been added to avoid errors on evaluation benchmarks with a mix of single and multiple images such as MMMU, SEEDBench, etc.
    - Original code will override the original `image_aspect_ratio` by [this line](https://github.com/LooperXX/lmms-eval/blob/2378120f3e054415cc5f9f2741e1030405a722de/lmms_eval/models/llava_onevision.py#L433). This behaviour appears in `loglikelihood`, `generate_until` and `generate_until_multi_round` functions. 
    - Such overriding behaviour will result in the `image_aspect_ratio` of all single-image samples encountered after multiple-image samples being overridden by e.g. `pad` on benchmarks with both single-image and multiple-image samples.