### PR TITLE
Update MLVU answer parsing

### DIFF
--- a/lmms_eval/tasks/mlvu/utils.py
+++ b/lmms_eval/tasks/mlvu/utils.py
@@ -51,12 +51,24 @@ def mlvu_doc_to_text(doc, lmms_eval_specific_kwargs=None):
 
 def extract_characters_regex(s):
     s = s.strip()
-    if ")" in s:
-        index = s.index(")")
-        pred = s[index - 1 : index]
-        return pred
-    else:
-        return s
+    answer_prefixes = [
+        "The best answer is",
+        "The correct answer is",
+        "The answer is",
+        "The answer",
+        "The best option is" "The correct option is",
+        "Best answer:" "Best option:",
+    ]
+    for answer_prefix in answer_prefixes:
+        s = s.replace(answer_prefix, "")
+
+    if len(s.split()) > 10 and not re.search("[ABCD]", s):
+        return ""
+
+    matches = re.search(r"[ABCD]", s)
+    if matches is None:
+        return ""
+    return matches[0]
 
 
 def mlvu_process_results(doc, results):


### PR DESCRIPTION
This PR updates the `extract_characters_regex` function in MLVU to improve parsing robustness. Previously, formats like ‘A.’ were incorrectly parsed as wrong answers when the ground truth was ‘A’. The function now follows the VideoMME style for improved handling.