### PR TITLE
[WIP] feat: add multimdoal fewshot evaluation

### DIFF
--- a/lmms_eval/api/samplers.py
+++ b/lmms_eval/api/samplers.py
@@ -12,10 +12,57 @@ class ContextSampler:
         self.doc_to_text = self.task.doc_to_text
         self.doc_to_target = self.task.doc_to_target
         self.doc_to_choice = self.task.doc_to_choice
+        self.doc_to_visual = self.task.doc_to_visual
 
         self.docs = docs  # HF dataset split, provided by task._fewshot_docs()
         if fewshot_indices:  # subset few-shot docs from
             self.docs = self.docs.select(fewshot_indices)
+
+    def get_multimodal_context(self, doc, num_fewshot):
+        n_samples = num_fewshot + 1 if self.config.fewshot_split == self.config.test_split else num_fewshot
+        # draw `n_samples` docs from fewshot_docs
+        fewshotex = self.sample(n_samples)
+        # get rid of the doc that's the one we're evaluating, if it's in the fewshot
+        # TODO: should we just stop people from using fewshot from same split as evaluating?
+        selected_docs = [x for x in fewshotex if x != doc][:num_fewshot]
+
+        labeled_examples = self.fewshot_delimiter.join([self._format_single_example(doc) for doc in selected_docs]) + self.fewshot_delimiter
+
+        # str, list of PIL Images
+        return labeled_examples, self._collect_images(selected_docs)
+
+    def _format_single_example(self, doc):
+        # Replace actual image content with placeholder
+        image_placeholder = f"<image>"
+
+        # Get text content (question/prompt)
+        text_content = self.doc_to_text(doc) if (self.config.doc_to_choice is None or isinstance(self.doc_to_text(doc), str)) else self.doc_to_choice(doc)[self.doc_to_text(doc)]
+
+        # Get target/label
+        target = self._format_target(doc)
+
+        # Combine with image placeholder
+        return f"{image_placeholder}\n{text_content}{self.target_delimiter}{target}"
+
+    def _collect_images(self, docs):
+        # Create a dictionary mapping image placeholders to actual PIL Images
+        image_list = []
+        for doc in docs:
+            image = self.doc_to_visual(doc)  # Assuming this is the PIL Image
+            image_list.append(image)
+        # flatten list of lists
+        image_list = [item for sublist in image_list for item in sublist]
+        return image_list
+
+    def _format_target(self, doc):
+        target = self.doc_to_target(doc)
+
+        if isinstance(target, list):
+            return str(target[0])
+        elif self.config.doc_to_choice is None or isinstance(target, str):
+            return target
+        else:
+            return str(self.doc_to_choice(doc)[target])
 
     def get_context(self, doc, num_fewshot):
         # draw an extra fewshot sample if using same split as evaluating on


### PR DESCRIPTION
**May still need improvement to satify all situations and make sure backward compatible.**

This pull request introduces support for multimodal contexts in the `lmms_eval` module, enhancing the ability to handle both text and visual data. The most important changes include adding methods to manage multimodal data in `samplers.py` and updating the `fewshot_context` function in `task.py` to accommodate these changes.

Enhancements for multimodal support:

* [`lmms_eval/api/samplers.py`]: Added methods `get_multimodal_context`, `_format_single_example`, `_collect_images`, and `_format_target` to handle multimodal data, including text and visual content.
* [`lmms_eval/api/task.py`]: Updated the `fewshot_context` function to include an `is_multimodal` parameter and logic to handle multimodal examples, including raising a `NotImplementedError` for multimodal chat templates.

Code improvements:

* [`lmms_eval/api/task.py`]: Replaced `deepcopy` with `copy.deepcopy` for clarity and consistency. (`[lmms_eval/api/task.pyL1181-R1186]
* [`lmms_eval/api/task.py`]: Simplified dataset loading by removing redundant checks for the `load_from_disk` key. (`[lmms_eval/api/task.pyL1037-R1037]

Fewshot Demo Yaml (textvqa)

```yaml
task: textvqa_val_fewshot
test_split: validation
training_split: train
validation_split: validation
fewshot_split: train
fewshot_config:
  sampler: first_n
  
metric_list:
  - metric: exact_match
    aggregation: mean
    higher_is_better: true
    ignore_case: true
    ignore_punctuation: true

lmms_eval_specific_kwargs:
  default:
    pre_prompt: "Question: "
    post_prompt: " Short answer in one phrase or single word:"
    ocr: false
  qwen_vl:
    pre_prompt: ""
    post_prompt: " Answer:"
    
include: _default_template_textvqa_yaml
```

If you meet the lint warnings, you can use following scripts to reformat code.

```sh
pip install pre-commit
pre-commit install
pre-commit run --all-files
```

Thank you for your contributions!
