### PR TITLE
[Fix] fix mia-bench evaluation

### DIFF
--- a/lmms_eval/tasks/mia_bench/utils.py
+++ b/lmms_eval/tasks/mia_bench/utils.py
@@ -157,9 +157,15 @@ def process_rawscore(component_type, raw_score):
         score_ = first_sentence[i].split(""":""")[1][1:].split("""/""")
         score = int(score_[0]) / int(score_[1])
         score_dict[component_type[i]] = score
-    total_score_ = first_sentence[i + 1].split(""":""")[1][1:].split("""/""")
-    total_score = int(total_score_[0]) / int(total_score_[1])
-    score_dict["total_score"] = total_score
+
+    # Ensure that the loop has executed at least once
+    if len(first_sentence) > 1:
+        total_score_ = first_sentence[-1].split(""":""")[1][1:].split("""/""")
+        total_score = int(total_score_[0]) / int(total_score_[1])
+        score_dict["total_score"] = total_score
+    else:
+        score_dict["total_score"] = 0  # or handle this case as needed
+
     return score_dict
 
 


### PR DESCRIPTION
🐛 fix(utils): handle empty score calculation gracefully
- ensure total_score calculation only if loop executed
- set total_score to 0 if first_sentence has less than two elements

Before you open a pull-request, please check if a similar issue already exists or has been closed before.

### When you open a pull-request, please be sure to include the following

- [ ] A descriptive title: [xxx] XXXX
- [ ] A detailed description

If you meet the lint warnings, you can use following scripts to reformat code.

```sh
pip install pre-commit
pre-commit install
pre-commit run --all-files
```

Thank you for your contributions!
