### PR TITLE
Delete model and cache before multigpu data gathering

### DIFF
--- a/lmms_eval/evaluator.py
+++ b/lmms_eval/evaluator.py
@@ -256,10 +256,6 @@ def simple_evaluate(
         cli_args=cli_args,
     )
 
-    if hasattr(lm, "_model"):
-        del lm._model
-        torch.cuda.empty_cache()
-
     if lm.rank == 0:
         if isinstance(model, str):
             model_name = model
@@ -538,6 +534,10 @@ def evaluate(
                 pbar.update(1)
 
             pbar.close()
+
+    if hasattr(lm, "_model"):
+        del lm._model
+        torch.cuda.empty_cache()
 
     if WORLD_SIZE > 1:
         # if multigpu, then gather data across all ranks to rank 0


### PR DESCRIPTION
This PR solves an OOM issue when evaluating large models (e.g., 34B or 72B) on multiple GPUs.

- The model inference and result postprocessing can successfully complete, but multigpu data gathering to rank 0 (or any other any) cause the OOM issue.

This PR moves the model and cache deletion before the multrgpu data gathering to save the GPU memory.