### PR TITLE
Fix NoneType Error in `flatten` Function for Text-Only Tasks in LLAVA Models

### DIFF
--- a/lmms_eval/models/llava.py
+++ b/lmms_eval/models/llava.py
@@ -278,15 +278,14 @@ class Llava(lmms):
         return res
 
     def flatten(self, input):
-        if not input or any(i is None for i in input):  
-            return []  
+        if not input or any(i is None for i in input):
+            return []
         new_list = []
         for i in input:
-            if i:  
+            if i:
                 for j in i:
                     new_list.append(j)
         return new_list
-
 
     def generate_until(self, requests: List[Instance]) -> List[str]:
         res = []

--- a/lmms_eval/models/llava.py
+++ b/lmms_eval/models/llava.py
@@ -278,11 +278,15 @@ class Llava(lmms):
         return res
 
     def flatten(self, input):
+        if not input or any(i is None for i in input):  
+            return []  
         new_list = []
         for i in input:
-            for j in i:
-                new_list.append(j)
+            if i:  
+                for j in i:
+                    new_list.append(j)
         return new_list
+
 
     def generate_until(self, requests: List[Instance]) -> List[str]:
         res = []

--- a/lmms_eval/models/llava_onevision.py
+++ b/lmms_eval/models/llava_onevision.py
@@ -361,13 +361,12 @@ class Llava_OneVision(lmms):
         pbar.close()
         return res
 
-
     def flatten(self, input):
-        if not input or any(i is None for i in input):  
-            return []  
+        if not input or any(i is None for i in input):
+            return []
         new_list = []
         for i in input:
-            if i:  
+            if i:
                 for j in i:
                     new_list.append(j)
         return new_list

--- a/lmms_eval/models/llava_onevision.py
+++ b/lmms_eval/models/llava_onevision.py
@@ -361,11 +361,15 @@ class Llava_OneVision(lmms):
         pbar.close()
         return res
 
+
     def flatten(self, input):
+        if not input or any(i is None for i in input):  
+            return []  
         new_list = []
         for i in input:
-            for j in i:
-                new_list.append(j)
+            if i:  
+                for j in i:
+                    new_list.append(j)
         return new_list
 
     def load_video(self, video_path, max_frames_num):

--- a/lmms_eval/models/tinyllava.py
+++ b/lmms_eval/models/tinyllava.py
@@ -185,13 +185,17 @@ class TinyLlava(lmms):
         except:
             return self.tokenizer.decode([tokens])
 
+
     def flatten(self, input):
+        if not input or any(i is None for i in input):  
+            return []  
         new_list = []
         for i in input:
-            for j in i:
-                new_list.append(j)
+            if i:  
+                for j in i:
+                    new_list.append(j)
         return new_list
-
+        
     def loglikelihood(self, requests: List[Instance]) -> List[Tuple[float, bool]]:
         # TODO
         res = []


### PR DESCRIPTION

### PR Description
This PR resolves a `NoneType` iteration error in the `flatten` function when handling text-only tasks (e.g., MMLU or HellaSwag) in LLAVA family models.

#### Problem
The `flatten` function processes batched visual tokens but receives `None` or empty inputs in text-only tasks. This leads to a `NoneType` iteration error in the original implementation.

#### Solution
1. Added input validation to `flatten`:
   - Checks if the input is `None` or empty.
   - Returns an empty list if validation fails.
2. Ensures sub-elements are validated before iteration.

This update ensures compatibility with text-only tasks while maintaining functionality for visual tasks.
