### PR TITLE
[FIX] Minor errors in `gemini_api.py` and `internvl2.py`.

### DIFF
--- a/lmms_eval/models/gemini_api.py
+++ b/lmms_eval/models/gemini_api.py
@@ -52,6 +52,7 @@ class GeminiAPI(lmms):
         self.timeout = timeout
         self.model = genai.GenerativeModel(model_version)
         self.continual_mode = continual_mode
+        self.response_persistent_file = ""
         self.interleave = interleave
         # if self.continual_mode and response_persistent_folder is None:
         #     raise ValueError("Continual mode requires a persistent path for the response. We will cache the Gemini API response in this path and use it for future requests. Please provide a valid path.")

--- a/lmms_eval/models/internvl2.py
+++ b/lmms_eval/models/internvl2.py
@@ -312,7 +312,7 @@ class InternVL2(lmms):
                     contexts = image_tokens + "\n" + contexts
                 else:
                     pixel_values = None
-                    num_patch_list = None
+                    num_patches_list = None
                 response, history = self.model.chat(self.tokenizer, pixel_values, contexts, gen_kwargs, num_patches_list=num_patches_list, history=None, return_history=True)
             elif self.modality == "video":
                 assert len(visuals) == 1, f"Only one video is supported, but got {len(visuals)} videos."


### PR DESCRIPTION
This PR fixes two minor errors in models.
## Initialize `self.response_persistent_file` in `gemini_api.py`
- When we use `GeminiAPI` with `continual_mode=False`, It causes ValueError since `self.response_persistent_file` is not declared.
https://github.com/EvolvingLMMs-Lab/lmms-eval/blob/8821357aa338a17b94102118cbb5c8b94f594ae0/lmms_eval/models/gemini_api.py#L58-L64
- So I initialized `self.response_persistent_file` with an empty string (`""`) to prevent error.

### Wrong variable name in `internvl2.py`
- In `internvl2.py`, `self.model.chat()` in line 316 requires `num_patches_list` variable.
- But in line 315, we declare `num_patch_list` instead of `num_patches_list`.
https://github.com/EvolvingLMMs-Lab/lmms-eval/blob/8821357aa338a17b94102118cbb5c8b94f594ae0/lmms_eval/models/internvl2.py#L313-L316
- This seems a typo error, so I fixed it.


BTW, Happy New Year!