### PR TITLE
[Feat] add @maj and @pass to support sampling multiples times during evaluation

### DIFF
--- a/lmms_eval/api/metrics.py
+++ b/lmms_eval/api/metrics.py
@@ -1,5 +1,4 @@
 # the code is adapted from https://github.com/EleutherAI/lm-evaluation-harness
-import logging
 import math
 import random
 import re
@@ -9,10 +8,9 @@ from typing import List
 
 import numpy as np
 import sacrebleu
+from loguru import logger as eval_logger
 
 from lmms_eval.api.registry import register_aggregation, register_metric
-
-eval_logger = logging.getLogger("lm-eval")
 
 
 # Register Aggregations First
@@ -301,17 +299,19 @@ def anls(
     references,
     predictions,
     thresh_hold=0.5,
-):  # This is a passthrough function
+):
     """https://github.com/QwenLM/Qwen-VL/blob/master/eval_mm/infographicsvqa_eval.py"""
     values = []
+    # Unwrap predictions if it's a nested list
+    pred = predictions[0] if isinstance(predictions[0], str) else predictions[0][0]
+
     for answer in references:
         # preprocess both the answers - gt and prediction
         gt_answer = " ".join(answer.strip().lower().split())
-        det_answer = " ".join(predictions[0].strip().lower().split())
+        det_answer = " ".join(pred.strip().lower().split())
 
-        # dist = levenshtein_distance(answer.lower(), detObject['answer'].lower())
         dist = levenshtein_distance(gt_answer, det_answer)
-        length = max(len(answer.upper()), len(predictions[0].upper()))
+        length = max(len(answer.upper()), len(pred.upper()))
         values.append(0.0 if length == 0 else float(dist) / float(length))
 
     question_result = 1 - min(values)

--- a/lmms_eval/api/task.py
+++ b/lmms_eval/api/task.py
@@ -1432,7 +1432,10 @@ class ConfigurableTask(Task):
     @retry(stop=(stop_after_attempt(5) | stop_after_delay(1200)), wait=wait_fixed(2))
     def process_results(self, doc, results, full_docs=None):
         if self.OUTPUT_TYPE == "generate_until":
-            results[0] = results[0].strip()
+            if isinstance(results, list) and isinstance(results[0], list):
+                results = [res.strip() for res in results[0]]
+            else:
+                results = [res.strip() for res in results]
 
         kwargs = {}
         if full_docs is not None:
@@ -1518,7 +1521,7 @@ class ConfigurableTask(Task):
 
         elif "generate_until" in self.OUTPUT_TYPE:
             gold = self.doc_to_target(doc)
-            result = results[0]
+            result = [res.strip() for res in results]
             if self.config.doc_to_choice is not None:
                 # If you set doc_to_choice,
                 # it assumes that doc_to_target returns a number.

--- a/lmms_eval/evaluator_utils.py
+++ b/lmms_eval/evaluator_utils.py
@@ -418,7 +418,9 @@ def consolidate_group_results(
 
                 for metric_config in agg_metric_list:
                     for filter_name in metric_config["filter_list"]:
-                        if metric != ",".join([metric_config["metric"], filter_name]):
+                        # if metric != ",".join([metric_config["metric"], filter_name]):
+                        #     continue
+                        if metric_config["metric"] not in metric:
                             continue
 
                         # compute group's pooled metric and stderr

--- a/lmms_eval/models/qwen2_vl.py
+++ b/lmms_eval/models/qwen2_vl.py
@@ -170,7 +170,10 @@ class Qwen2_VL(lmms):
             task = task[0]
             split = split[0]
             visuals = [doc_to_visual[0](self.task_dict[task][split][ids]) for ids in doc_id]
-            visuals = self.flatten(visuals)
+            if None in visuals:
+                visuals = []
+            else:
+                visuals = self.flatten(visuals)
 
             gen_kwargs = all_gen_kwargs[0]
 

--- a/lmms_eval/tasks/mmlu/flan_n_shot/generative/_mmlu.yaml
+++ b/lmms_eval/tasks/mmlu/flan_n_shot/generative/_mmlu.yaml
@@ -5,28 +5,28 @@ task:
     task:
       - mmlu_flan_n_shot_generative_stem
     aggregate_metric_list:
-      - metric: acc
+      - metric: exact_match
         weight_by_size: True
   - group: other
     task:
       - mmlu_flan_n_shot_generative_other
     aggregate_metric_list:
-      - metric: acc
+      - metric: exact_match
         weight_by_size: True
   - group: social sciences
     task:
       - mmlu_flan_n_shot_generative_social_sciences
     aggregate_metric_list:
-      - metric: acc
+      - metric: exact_match
         weight_by_size: True
   - group: humanities
     task:
       - mmlu_flan_n_shot_generative_humanities
     aggregate_metric_list:
-      - metric: acc
+      - metric: exact_match
         weight_by_size: True
 aggregate_metric_list:
-  - metric: acc
+  - metric: exact_match
     weight_by_size: True
 metadata:
   version: 2

--- a/lmms_eval/tasks/mmmu/mmmu_val_pass64.yaml
+++ b/lmms_eval/tasks/mmmu/mmmu_val_pass64.yaml
@@ -1,0 +1,52 @@
+dataset_path: lmms-lab/MMMU
+task: "mmmu_val_pass64"
+test_split: validation
+output_type: generate_until
+doc_to_visual: !function utils.mmmu_doc_to_visual
+doc_to_text: !function utils.mmmu_doc_to_text
+doc_to_target: "answer"
+
+generation_kwargs:
+  until:
+    - "Q:"
+    - "\n\n"
+  do_sample: true
+  temperature: 0.2
+repeats: 64
+
+filter_list:
+  - name: "maj@64"
+    filter:
+      - function: "take_first_k"
+        k: 64
+      - function: "majority_vote"
+      - function: "take_first"
+  - name: "maj@8"
+    filter:
+      - function: "take_first_k"
+        k: 8
+      - function: "majority_vote"
+      - function: "take_first"
+  - name: "pass@64"
+    filter:
+      - function: "take_first_k"
+        k: 64
+  - name: "pass@8"
+    filter:
+      - function: "take_first_k"
+        k: 8
+
+# The return value of process_results will be used by metrics
+process_results: !function utils.mmmu_process_results
+metric_list:
+  - metric: mmmu_acc
+    aggregation: !function utils.mmmu_aggregate_results
+    higher_is_better: true
+
+lmms_eval_specific_kwargs:
+  default:
+    prompt_type: "format"
+    multiple_choice_prompt: "Answer with the option's letter from the given choices directly."
+    open_ended_prompt: "Answer the question using a single word or phrase."
+
+include: _default_template_yaml

--- a/lmms_eval/tasks/mmmu/mmmu_val_reasoning.yaml
+++ b/lmms_eval/tasks/mmmu/mmmu_val_reasoning.yaml
@@ -1,0 +1,31 @@
+dataset_path: lmms-lab/MMMU
+task: "mmmu_val_reasoning"
+test_split: validation
+output_type: generate_until
+doc_to_visual: !function utils.mmmu_doc_to_visual
+doc_to_text: !function utils.mmmu_doc_to_text
+doc_to_target: "answer"
+# The return value of process_results will be used by metrics
+process_results: !function utils.mmmu_reasoning_process_results
+
+metric_list:
+  - metric: mmmu_judge_acc
+    aggregation: !function utils.mmmu_aggregate_judge_results
+    higher_is_better: true
+
+lmms_eval_specific_kwargs:
+  default:
+    prompt_type: "reasoning"
+    multiple_choice_prompt: "Please show step-by-step reasoning, and answer the question with option letter from given choices."
+    open_ended_prompt: "Please show step-by-step reasoning, and answer the question using a single word or phrase."
+
+generation_kwargs:
+  max_new_tokens: 256
+  until:
+    - "</s>"
+    - "Q:"
+    - "<|im_end|>"
+
+metadata:
+  version: 0.0
+  interleaved_format: false

--- a/lmms_eval/tasks/mmmu/utils.py
+++ b/lmms_eval/tasks/mmmu/utils.py
@@ -9,11 +9,9 @@ from pathlib import Path
 import numpy as np
 import yaml
 from loguru import logger as eval_logger
+from openai import AzureOpenAI, OpenAI
 
 from lmms_eval.tasks._task_utils.file_utils import generate_submission_file
-
-MULTI_CHOICE_PROMPT = "Answer with the option's letter from the given choices directly."
-OPEN_ENDED_PROMPT = "Answer the question using a single word or phrase."
 
 with open(Path(__file__).parent / "_default_template_yaml", "r") as f:
     raw_data = f.readlines()
@@ -24,6 +22,96 @@ with open(Path(__file__).parent / "_default_template_yaml", "r") as f:
             safe_data.append(line)
 
     config = yaml.safe_load("".join(safe_data))
+
+
+with open(Path(__file__).parent / "mmmu_val_reasoning.yaml", "r") as f:
+    raw_data = f.readlines()
+    safe_data = []
+    for i, line in enumerate(raw_data):
+        # remove function definition since yaml load cannot handle it
+        if "!function" not in line:
+            safe_data.append(line)
+
+    reasoning_config = yaml.safe_load("".join(safe_data))
+    MC_PROMPT = reasoning_config["lmms_eval_specific_kwargs"]["default"]["multiple_choice_prompt"]
+    OPEN_ENDED_PROMPT = reasoning_config["lmms_eval_specific_kwargs"]["default"]["open_ended_prompt"]
+
+
+NUM_SECONDS_TO_SLEEP = 5
+API_TYPE = os.getenv("API_TYPE", "openai")
+MODEL_VERSION = os.getenv("MODEL_VERSION", "gpt-4o-2024-08-06")
+
+JUDGE_RULES = """You are a strict evaluator assessing answer correctness. You must output 1 for fully correct answers and 0 for any other case.
+# Input
+Question:
+```
+{question}
+```
+Ground Truth Answer:
+```
+{answer}
+```
+Model Prediction:
+```
+{pred}
+```
+
+# Evaluation Rules
+- The model prediction contains the reasoning process, you should spot the final answer from the it.
+- For multiple-choice questions: Score 1 if the predicted answer matches the correct answer.
+- For open-ended questions:
+  * Score 1 if the prediction matches the answer semantically and contains all key elements
+  * Score 0 for partially correct answers or answers with extra incorrect information, even if the reasoning process is correct.
+- Ignore minor differences in formatting, capitalization, or spacing since the model may explain in a different way.
+- Treat numerical answers as correct if they match within reasonable precision
+- For questions requiring units, both value and unit must be correct
+
+# Strict Output format
+[0/1]"""
+
+if API_TYPE == "openai":
+    API_URL = os.getenv("OPENAI_API_URL", "https://api.openai.com/v1/chat/completions")
+    API_KEY = os.getenv("OPENAI_API_KEY", "YOUR_API_KEY")
+    client = OpenAI(api_key=API_KEY)
+elif API_TYPE == "azure":
+    API_URL = os.getenv("AZURE_ENDPOINT", "https://api.cognitive.microsoft.com/sts/v1.0/issueToken")
+    API_KEY = os.getenv("AZURE_API_KEY", "YOUR_API_KEY")
+    client = AzureOpenAI(azure_endpoint=API_URL, api_version="2023-07-01-preview", api_key=API_KEY)
+
+
+def get_chat_response(content: str, max_tokens: int, retries: int = 5):
+    global MODEL_VERSION
+    global client
+
+    messages = [
+        {
+            "role": "system",
+            "content": "You are a helpful and precise assistant for checking the correctness of the answer.",
+        },
+        {"role": "user", "content": content},
+    ]
+
+    payload = {
+        "model": MODEL_VERSION,
+        "messages": messages,
+        "temperature": 0.2,
+        "max_tokens": max_tokens,
+    }
+
+    for attempt in range(retries):
+        try:
+            response = client.chat.completions.create(**payload)
+            content = response.choices[0].message.content.strip()
+            return content
+        except requests.exceptions.RequestException as e:
+            eval_logger.warning(f"Request failed on attempt {attempt+1}: {e}")
+            time.sleep(NUM_SECONDS_TO_SLEEP)
+            if attempt == retries - 1:
+                eval_logger.error(f"Failed to get response after {retries} attempts")
+                return ""
+        except Exception as e:
+            eval_logger.error(f"Error on attempt {attempt+1}: {e}")
+            return ""
 
 
 def replace_images_tokens(input_string):
@@ -41,20 +129,20 @@ def parse_options(options):
     return choices_str
 
 
-def construct_prompt(doc):
+def construct_prompt(doc, mc_prompt="", open_ended_prompt=""):
     question = doc["question"]
     if doc["question_type"] == "multiple-choice":
         # Weirdly, data["options"] is a string in MMMU Huggingface dataset
         parsed_options = parse_options(ast.literal_eval(doc["options"]))
         # parsed_options already prepends a newline so no need to add space here
-        question = f"{question}\n{parsed_options}\n\n{MULTI_CHOICE_PROMPT}"
+        question = f"{question}\n{parsed_options}\n\n{mc_prompt}"
     else:
-        question = f"{question}\n\n{OPEN_ENDED_PROMPT}"
+        question = f"{question}\n\n{open_ended_prompt}"
     return question
 
 
-def mmmu_doc_to_text(doc):
-    question = construct_prompt(doc)
+def mmmu_doc_to_text(doc, lmms_eval_specific_kwargs=None):
+    question = construct_prompt(doc, lmms_eval_specific_kwargs["multiple_choice_prompt"], lmms_eval_specific_kwargs["open_ended_prompt"])
     if config["metadata"]["interleaved_format"]:
         question = replace_images_tokens(question)
     return question
@@ -70,20 +158,27 @@ def mmmu_doc_to_visual(doc):
 
 
 def mmmu_process_results(doc, results):
+    parsed_preds = []
+    for pred in results:
+        if doc["question_type"] == "multiple-choice":
+            index2ans, all_choices = get_multi_choice_info(ast.literal_eval(doc["options"]))
+            parsed_pred = parse_multi_choice_response(pred, all_choices, index2ans)
+        else:
+            parsed_pred = parse_open_response(pred)
+
+        parsed_preds.append(parsed_pred)
+
+    mmmu_exact_acc = {"id": doc["id"], "subdomain": extract_subset_name(doc["id"]), "question_type": doc["question_type"], "answer": doc["answer"], "parsed_pred": parsed_preds}
+    return {"mmmu_acc": mmmu_exact_acc, "mmmu_acc_pass_at_k": mmmu_exact_acc}
+
+
+def mmmu_reasoning_process_results(doc, results):
     pred = results[0]
-    if doc["question_type"] == "multiple-choice":
-        index2ans, all_choices = get_multi_choice_info(ast.literal_eval(doc["options"]))
-        parsed_pred = parse_multi_choice_response(pred, all_choices, index2ans)
-    else:
-        parsed_pred = parse_open_response(pred)
-    id = doc["id"]
-    mmmu_acc = {"id": id, "subdomain": extract_subset_name(doc["id"]), "question_type": doc["question_type"], "answer": doc["answer"], "parsed_pred": parsed_pred}
-    return {
-        "mmmu_acc": mmmu_acc,
-        "submission": {
-            id: pred,
-        },
-    }
+    formatted_question = construct_prompt(doc, MC_PROMPT, OPEN_ENDED_PROMPT)
+    llm_judge_prompt = JUDGE_RULES.format(question=formatted_question, answer=doc["answer"], pred=pred)
+    llm_judge_score = get_chat_response(llm_judge_prompt, max_tokens=20, retries=3)
+    mmmu_judge_acc = {"id": doc["id"], "subdomain": extract_subset_name(doc["id"]), "question_type": doc["question_type"], "answer": doc["answer"], "pred": pred, "score": llm_judge_score}
+    return {"mmmu_judge_acc": mmmu_judge_acc}
 
 
 def extract_subset_name(input_string):
@@ -141,6 +236,17 @@ def mmmu_aggregate_results(results):
     }
     print(printable_results)
     return printable_results["Overall"]["acc"]
+
+
+def mmmu_aggregate_judge_results(results):
+    total_score = 0
+    for result in results:
+        try:
+            total_score += int(result["score"])
+        except:
+            eval_logger.warning(f"Failed to convert score to int for {result['id']}: {result['score']}")
+            total_score += 0
+    return total_score / len(results)
 
 
 ##################
@@ -253,16 +359,20 @@ def evaluate_mmmu(samples):
     judge_dict = dict()
     for sample in samples:
         gold_i = sample["answer"]
-        pred_i = sample["parsed_pred"]
-        if sample["question_type"] == "multiple-choice":
-            correct = eval_multi_choice(gold_i, pred_i)
-        else:  # open question
-            correct = eval_open(gold_i, pred_i)
+        pred_list = sample["parsed_pred"]
+        correct = False
+        for pred_i in pred_list:
+            if sample["question_type"] == "multiple-choice":
+                correct = eval_multi_choice(gold_i, pred_i)
+            else:  # open question
+                correct = eval_open(gold_i, pred_i)
 
-        if correct:
-            judge_dict[sample["id"]] = "Correct"
-            pred_correct += 1
-        else:
+            if correct:
+                judge_dict[sample["id"]] = "Correct"
+                pred_correct += 1
+                break
+
+        if not correct:
             judge_dict[sample["id"]] = "Wrong"
 
     if len(samples) == 0:

--- a/miscs/cicd_qwen2vl.sh
+++ b/miscs/cicd_qwen2vl.sh
@@ -1,0 +1,8 @@
+# Run and exactly reproduce qwen2vl results!
+# mme as an example
+pip3 install qwen_vl_utils
+accelerate launch --num_processes=8 --main_process_port=12345 -m lmms_eval \
+    --model qwen2_vl \
+    --model_args=pretrained=Qwen/Qwen2-VL-7B-Instruct,max_pixels=2359296 \
+    --tasks mme,gsm8k_cot_self_consistency,mmmu_val_reasoning,mmmu_val_pass64 \
+    --batch_size 1 --log_samples --log_samples_suffix reproduce --output_path ./logs/


### PR DESCRIPTION
With this PR, we fixed two problems:

1. Display the group results for `mmlu_flan_n_shot_generative` by changing the `acc` to `exact_match` since `acc` will result the group display not matched in evaluation metrics.

![image](https://github.com/user-attachments/assets/4ad9d23b-b542-4b3c-91fc-f14875d13fcd)

2. Introduce the @maj and @pass mechanisms to enable majority voting and multi-pass evaluation. In this mode, the model generates multiple response samples for a given question. The final correctness is determined either through majority voting (@maj), where the most frequently occurring answer is selected as the final output, or through multi-pass evaluation (@pass), where the presence of at least one correct response across the generated samples is sufficient to deem the final output correct.

![image](https://github.com/user-attachments/assets/e1c92795-a127-4120-b856-3101271e1d1a)

