### PR TITLE
[Fix] of "Model llavavid not found in available models."

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ python3 -m accelerate.commands.launch --num_processes=8 -m lmms_eval --config ./
 **Evaluation of video model (llava-next-video-32B)**
 ```bash
 accelerate launch --num_processes 8 --main_process_port 12345 -m lmms_eval \
-    --model llavavid \
+    --model llava_vid \
     --model_args pretrained=lmms-lab/LLaVA-NeXT-Video-32B-Qwen,conv_template=qwen_1_5,video_decode_backend=decord,max_frames_num=32，mm_spatial_pool_mode=average,mm_newline_position=grid,mm_resampler_location=after \
     --tasks videomme \
     --batch_size 1 \

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ python3 -m accelerate.commands.launch --num_processes=8 -m lmms_eval --config ./
 ```bash
 accelerate launch --num_processes 8 --main_process_port 12345 -m lmms_eval \
     --model llava_vid \
-    --model_args pretrained=lmms-lab/LLaVA-NeXT-Video-32B-Qwen,conv_template=qwen_1_5,video_decode_backend=decord,max_frames_num=32，mm_spatial_pool_mode=average,mm_newline_position=grid,mm_resampler_location=after \
+    --model_args pretrained=lmms-lab/LLaVA-NeXT-Video-32B-Qwen,conv_template=qwen_1_5,video_decode_backend=decord,max_frames_num=32,mm_spatial_pool_mode=average,mm_newline_position=grid,mm_resampler_location=after \
     --tasks videomme \
     --batch_size 1 \
     --log_samples \


### PR DESCRIPTION
This PR fixes the bug of evaluation of llava_vid in the README.
The possible reason is that the model names do not match. [llavavid](https://github.com/EvolvingLMMs-Lab/lmms-eval/blob/main/README.md?plain=1#L197) in the README, but [llava_vid](https://github.com/EvolvingLMMs-Lab/lmms-eval/blob/main/lmms_eval/models/__init__.py#L32) in lmms_eval/models /__init__.py.

```
```
Before you open a pull-request, please check if a similar issue already exists or has been closed before.

### When you open a pull-request, please be sure to include the following

- [ ] A descriptive title: [xxx] XXXX
- [ ] A detailed description

If you meet the lint warnings, you can use following scripts to reformat code.

```sh
pip install pre-commit
pre-commit install
pre-commit run --all-files
```

Thank you for your contributions!
