### PR TITLE
Replaced incorrect variable name self._word_size to self._world_size

### DIFF
--- a/lmms_eval/models/aria.py
+++ b/lmms_eval/models/aria.py
@@ -106,12 +106,12 @@ class Aria(lmms):
         elif accelerator.num_processes == 1 and device_map == "auto":
             eval_logger.info(f"Using {accelerator.num_processes} devices with pipeline parallelism")
             self._rank = 0
-            self._word_size = 1
+            self._world_size = 1
         else:
             eval_logger.info(f"Using single device: {self._device}")
             self.model.to(self._device)
             self._rank = 0
-            self._word_size = 1
+            self._world_size = 1
         self.accelerator = accelerator
 
     @property
@@ -303,7 +303,7 @@ class Aria(lmms):
                     """
                     keywords = [
                         "Answer:",
-                        "answer is:", "choice is:", "option is:", 
+                        "answer is:", "choice is:", "option is:",
                         "Answer is:", "Choice is:", "Option is:",
                         "answer is", "choice is", "option is",
                         "Answer is", "Choice is", "Option is"

--- a/lmms_eval/models/auroracap.py
+++ b/lmms_eval/models/auroracap.py
@@ -159,7 +159,7 @@ class AuroraCap(lmms):
         else:
             self.model.to(self._device)
             self._rank = 0
-            self._word_size = 1
+            self._world_size = 1
 
         # For Video Caption
         self.video_decode_backend = video_decode_backend

--- a/lmms_eval/models/cogvlm2.py
+++ b/lmms_eval/models/cogvlm2.py
@@ -71,7 +71,7 @@ class CogVLM2(lmms):
             self._world_size = self.accelerator.num_processes
         else:
             self._rank = 0
-            self._word_size = 1
+            self._world_size = 1
 
     @property
     def config(self):

--- a/lmms_eval/models/fuyu.py
+++ b/lmms_eval/models/fuyu.py
@@ -83,7 +83,7 @@ class Fuyu(lmms):
         else:
             self.model.to(self._device)
             self._rank = 0
-            self._word_size = 1
+            self._world_size = 1
 
         """if accelerator.num_processes > 1:
             assert accelerator.distributed_type in [

--- a/lmms_eval/models/idefics2.py
+++ b/lmms_eval/models/idefics2.py
@@ -103,12 +103,12 @@ class Idefics2(lmms):
         elif accelerator.num_processes == 1 and device_map == "auto":
             eval_logger.info(f"Using {accelerator.num_processes} devices with pipeline parallelism")
             self._rank = 0
-            self._word_size = 1
+            self._world_size = 1
         else:
             eval_logger.info(f"Using single device: {self._device}")
             self.model.to(self._device)
             self._rank = 0
-            self._word_size = 1
+            self._world_size = 1
 
     @property
     def config(self):

--- a/lmms_eval/models/instructblip.py
+++ b/lmms_eval/models/instructblip.py
@@ -75,7 +75,7 @@ class InstructBLIP(lmms):
         else:
             self.model.to(self._device)
             self._rank = 0
-            self._word_size = 1
+            self._world_size = 1
 
     @property
     def config(self):

--- a/lmms_eval/models/internvideo2.py
+++ b/lmms_eval/models/internvideo2.py
@@ -255,7 +255,7 @@ class InternVideo2(lmms):
         elif accelerator.num_processes == 1 and device_map == "auto":
             eval_logger.info(f"Using {accelerator.num_processes} devices with tensor parallelism")
             self._rank = 0
-            self._word_size = 1
+            self._world_size = 1
         else:
             eval_logger.info(f"Using single device: {self._device}")
             self.model.to(self._device)

--- a/lmms_eval/models/internvl.py
+++ b/lmms_eval/models/internvl.py
@@ -206,7 +206,7 @@ class InternVLChat(lmms):
         elif accelerator.num_processes == 1 and device_map == "auto":
             eval_logger.info(f"Using {accelerator.num_processes} devices with tensor parallelism")
             self._rank = 0
-            self._word_size = 1
+            self._world_size = 1
         else:
             eval_logger.info(f"Using single device: {self._device}")
             self.model.to(self._device)

--- a/lmms_eval/models/internvl2.py
+++ b/lmms_eval/models/internvl2.py
@@ -232,7 +232,7 @@ class InternVL2(lmms):
         elif accelerator.num_processes == 1 and device_map == "auto":
             eval_logger.info(f"Using {accelerator.num_processes} devices with tensor parallelism")
             self._rank = 0
-            self._word_size = 1
+            self._world_size = 1
         else:
             eval_logger.info(f"Using single device: {self._device}")
             self.model.to(self._device)

--- a/lmms_eval/models/llama_vid.py
+++ b/lmms_eval/models/llama_vid.py
@@ -126,7 +126,7 @@ class LLaMAVid(lmms):
         elif accelerator.num_processes == 1 and device_map == "auto":
             eval_logger.info(f"Using {accelerator.num_processes} devices with tensor parallelism")
             self._rank = 0
-            self._word_size = 1
+            self._world_size = 1
         else:
             eval_logger.info(f"Using single device: {self._device}")
             self.model.to(self._device)

--- a/lmms_eval/models/llama_vision.py
+++ b/lmms_eval/models/llama_vision.py
@@ -80,12 +80,12 @@ class LlamaVision(lmms):
         elif accelerator.num_processes == 1 and device_map == "auto":
             eval_logger.info(f"Using {accelerator.num_processes} devices with pipeline parallelism")
             self._rank = 0
-            self._word_size = 1
+            self._world_size = 1
         else:
             eval_logger.info(f"Using single device: {self._device}")
             self.model.to(self._device)
             self._rank = 0
-            self._word_size = 1
+            self._world_size = 1
         self.accelerator = accelerator
 
     @property

--- a/lmms_eval/models/llava.py
+++ b/lmms_eval/models/llava.py
@@ -137,7 +137,7 @@ class Llava(lmms):
         elif accelerator.num_processes == 1 and device_map == "auto":
             eval_logger.info(f"Using {accelerator.num_processes} devices with tensor parallelism")
             self._rank = 0
-            self._word_size = 1
+            self._world_size = 1
         else:
             eval_logger.info(f"Using single device: {self._device}")
             self.model.to(self._device)

--- a/lmms_eval/models/llava_hf.py
+++ b/lmms_eval/models/llava_hf.py
@@ -129,12 +129,12 @@ class LlavaHf(lmms):
         elif accelerator.num_processes == 1 and device_map == "auto":
             eval_logger.info(f"Using {accelerator.num_processes} devices with pipeline parallelism")
             self._rank = 0
-            self._word_size = 1
+            self._world_size = 1
         else:
             eval_logger.info(f"Using single device: {self._device}")
             self.model.to(self._device)
             self._rank = 0
-            self._word_size = 1
+            self._world_size = 1
         self.accelerator = accelerator
 
     @property

--- a/lmms_eval/models/llava_vid.py
+++ b/lmms_eval/models/llava_vid.py
@@ -217,7 +217,7 @@ class LlavaVid(lmms):
         elif accelerator.num_processes == 1 and device_map == "auto":
             eval_logger.info(f"Using {accelerator.num_processes} devices with tensor parallelism")
             self._rank = 0
-            self._word_size = 1
+            self._world_size = 1
         else:
             eval_logger.info(f"Using single device: {self._device}")
             self.model.to(self._device)

--- a/lmms_eval/models/longva.py
+++ b/lmms_eval/models/longva.py
@@ -166,7 +166,7 @@ class LongVA(lmms):
         elif accelerator.num_processes == 1 and device_map == "auto":
             eval_logger.info(f"Using {accelerator.num_processes} devices with tensor parallelism")
             self._rank = 0
-            self._word_size = 1
+            self._world_size = 1
 
         else:
             eval_logger.info(f"Using single device: {self._device}")

--- a/lmms_eval/models/mantis.py
+++ b/lmms_eval/models/mantis.py
@@ -139,7 +139,7 @@ class Mantis(lmms):
         elif accelerator.num_processes == 1 and device_map == "auto":
             eval_logger.info(f"Using {accelerator.num_processes} devices with tensor parallelism")
             self._rank = 0
-            self._word_size = 1
+            self._world_size = 1
         else:
             eval_logger.info(f"Using single device: {self._device}")
             self.model.to(self._device)

--- a/lmms_eval/models/minicpm_v.py
+++ b/lmms_eval/models/minicpm_v.py
@@ -71,7 +71,7 @@ class MiniCPM_V(lmms):
         else:
             self.model.to(self._device)
             self._rank = 0
-            self._word_size = 1
+            self._world_size = 1
 
     @property
     def config(self):

--- a/lmms_eval/models/minimonkey.py
+++ b/lmms_eval/models/minimonkey.py
@@ -72,7 +72,7 @@ class MiniMonkey(lmms):
         else:
             # self.model.to(self._device)
             self._rank = 0
-            self._word_size = 1
+            self._world_size = 1
 
     @property
     def config(self):

--- a/lmms_eval/models/oryx.py
+++ b/lmms_eval/models/oryx.py
@@ -142,7 +142,7 @@ class Oryx(lmms):
         elif accelerator.num_processes == 1 and device_map == "auto":
             eval_logger.info(f"Using {accelerator.num_processes} devices with tensor parallelism")
             self._rank = 0
-            self._word_size = 1
+            self._world_size = 1
         else:
             eval_logger.info(f"Using single device: {self._device}")
             self.model.to(self._device)

--- a/lmms_eval/models/phi3v.py
+++ b/lmms_eval/models/phi3v.py
@@ -73,7 +73,7 @@ class Phi3v(lmms):
             eval_logger.info(f"Using single device: {self._device}")
             self.model.to(self._device)
             self._rank = 0
-            self._word_size = 1
+            self._world_size = 1
 
     @property
     def config(self):

--- a/lmms_eval/models/qwen2_5_vl.py
+++ b/lmms_eval/models/qwen2_5_vl.py
@@ -109,7 +109,7 @@ class Qwen2_5_VL(lmms):
             self._world_size = self.accelerator.num_processes
         else:
             self._rank = 0
-            self._word_size = 1
+            self._world_size = 1
 
     @property
     def config(self):

--- a/lmms_eval/models/qwen2_5_vl_interleave.py
+++ b/lmms_eval/models/qwen2_5_vl_interleave.py
@@ -111,7 +111,7 @@ class Qwen2_5_VL_Interleave(lmms):
             self._world_size = self.accelerator.num_processes
         else:
             self._rank = 0
-            self._word_size = 1
+            self._world_size = 1
 
         # self.continual_mode = continual_mode
         # if self.continual_mode and response_persistent_folder is None:

--- a/lmms_eval/models/qwen2_audio.py
+++ b/lmms_eval/models/qwen2_audio.py
@@ -111,7 +111,7 @@ class Qwen2_Audio(lmms):
         else:
             self.model.to(self._device)
             self._rank = 0
-            self._word_size = 1
+            self._world_size = 1
 
     @property
     def config(self):

--- a/lmms_eval/models/qwen2_vl.py
+++ b/lmms_eval/models/qwen2_vl.py
@@ -93,7 +93,7 @@ class Qwen2_VL(lmms):
             self._world_size = self.accelerator.num_processes
         else:
             self._rank = 0
-            self._word_size = 1
+            self._world_size = 1
 
     @property
     def config(self):

--- a/lmms_eval/models/qwen_vl.py
+++ b/lmms_eval/models/qwen_vl.py
@@ -71,7 +71,7 @@ class Qwen_VL(lmms):
         else:
             self.model.to(self._device)
             self._rank = 0
-            self._word_size = 1
+            self._world_size = 1
 
     @property
     def config(self):

--- a/lmms_eval/models/ross.py
+++ b/lmms_eval/models/ross.py
@@ -137,7 +137,7 @@ class Ross(lmms):
         elif accelerator.num_processes == 1 and device_map == "auto":
             eval_logger.info(f"Using {accelerator.num_processes} devices with tensor parallelism")
             self._rank = 0
-            self._word_size = 1
+            self._world_size = 1
         else:
             eval_logger.info(f"Using single device: {self._device}")
             self.model.to(self._device)

--- a/lmms_eval/models/slime.py
+++ b/lmms_eval/models/slime.py
@@ -137,7 +137,7 @@ class Slime(lmms):
         elif accelerator.num_processes == 1 and device_map == "auto":
             eval_logger.info(f"Using {accelerator.num_processes} devices with tensor parallelism")
             self._rank = 0
-            self._word_size = 1
+            self._world_size = 1
         else:
             eval_logger.info(f"Using single device: {self._device}")
             self.model.to(self._device)

--- a/lmms_eval/models/tinyllava.py
+++ b/lmms_eval/models/tinyllava.py
@@ -113,7 +113,7 @@ class TinyLlava(lmms):
         elif accelerator.num_processes == 1 and device_map == "auto":
             eval_logger.info(f"Using {accelerator.num_processes} devices with tensor parallelism")
             self._rank = 0
-            self._word_size = 1
+            self._world_size = 1
         else:
             eval_logger.info(f"Using single device: {self._device}")
             self.model.to(self._device)

--- a/lmms_eval/models/video_chatgpt.py
+++ b/lmms_eval/models/video_chatgpt.py
@@ -89,7 +89,7 @@ class VideoChatGPT(lmms):
         elif accelerator.num_processes == 1 and device_map == "auto":
             eval_logger.info(f"Using {accelerator.num_processes} devices with tensor parallelism")
             self._rank = 0
-            self._word_size = 1
+            self._world_size = 1
         else:
             eval_logger.info(f"Using single device: {self._device}")
             self.model.to(self._device)

--- a/lmms_eval/models/video_llava.py
+++ b/lmms_eval/models/video_llava.py
@@ -99,7 +99,7 @@ class VideoLLaVA(lmms):
         elif accelerator.num_processes == 1 and device_map == "auto":
             eval_logger.info(f"Using {accelerator.num_processes} devices with tensor parallelism")
             self._rank = 0
-            self._word_size = 1
+            self._world_size = 1
         else:
             eval_logger.info(f"Using single device: {self._device}")
             self.model.to(self._device)

--- a/lmms_eval/models/videochat2.py
+++ b/lmms_eval/models/videochat2.py
@@ -263,7 +263,7 @@ class VideoChat2(lmms):
         elif accelerator.num_processes == 1 and device_map == "auto":
             eval_logger.info(f"Using {accelerator.num_processes} devices with tensor parallelism")
             self._rank = 0
-            self._word_size = 1
+            self._world_size = 1
         else:
             eval_logger.info(f"Using single device: {self._device}")
             self.model.to(self._device)

--- a/lmms_eval/models/vila.py
+++ b/lmms_eval/models/vila.py
@@ -130,7 +130,7 @@ class VILA(lmms):
         elif accelerator.num_processes == 1 and device_map == "auto":
             eval_logger.info(f"Using {accelerator.num_processes} devices with tensor parallelism")
             self._rank = 0
-            self._word_size = 1
+            self._world_size = 1
         else:
             eval_logger.info(f"Using single device: {self._device}")
             self.model.to(self._device)

--- a/lmms_eval/models/vita.py
+++ b/lmms_eval/models/vita.py
@@ -139,7 +139,7 @@ class VITA(lmms):
         elif accelerator.num_processes == 1 and device_map == "auto":
             eval_logger.info(f"Using {accelerator.num_processes} devices with tensor parallelism")
             self._rank = 0
-            self._word_size = 1
+            self._world_size = 1
         else:
             eval_logger.info(f"Using single device: {self._device}")
             self.model.to(self._device)

--- a/lmms_eval/models/xcomposer2_4KHD.py
+++ b/lmms_eval/models/xcomposer2_4KHD.py
@@ -90,7 +90,7 @@ class XComposer2_4KHD(lmms):
         elif accelerator.num_processes == 1 and device_map == "auto":
             eval_logger.info(f"Using {accelerator.num_processes} devices with tensor parallelism")
             self._rank = 0
-            self._word_size = 1
+            self._world_size = 1
         else:
             eval_logger.info(f"Using single device: {self._device}")
             self.model.to(self._device)

--- a/lmms_eval/models/xcomposer2d5.py
+++ b/lmms_eval/models/xcomposer2d5.py
@@ -90,7 +90,7 @@ class XComposer2D5(lmms):
         elif accelerator.num_processes == 1 and device_map == "auto":
             eval_logger.info(f"Using {accelerator.num_processes} devices with tensor parallelism")
             self._rank = 0
-            self._word_size = 1
+            self._world_size = 1
         else:
             eval_logger.info(f"Using single device: {self._device}")
             self.model.to(self._device)


### PR DESCRIPTION
# Description

I found a typo (`self._word_size`, not `self._world_size`), when creating a custom model wrapper based on instructblip.py.
The typo exists in 35 files, probably because many people used instructblip.py as a template for their model wrapper implementation.

This PR simply replaces the incorrect variable name with the correct one :-)
