### PR TITLE
[Evaluation] Improve string processing order for better whitespace handling

### DIFF
--- a/lmms_eval/tasks/mmstar/utils.py
+++ b/lmms_eval/tasks/mmstar/utils.py
@@ -39,8 +39,8 @@ def mmstar_doc_to_text(doc, lmms_eval_specific_kwargs=None):
 
 def exact_match(pred, gt):
     """Brought from MMStar"""
-    answer = gt.lower().strip().replace("\n", " ")
-    predict = pred.lower().strip().replace("\n", " ")
+    answer = gt.lower().replace("\n", " ").strip()
+    predict = pred.lower().replace("\n", " ").strip()
     try:
         if answer == predict[0]:
             return 1.0


### PR DESCRIPTION
Before you open a pull-request, please check if a similar issue already exists or has been closed before.

### When you open a pull-request, please be sure to include the following

- [X] A descriptive title: [xxx] XXXX
- [X] A detailed description

## Changes
Changed the string processing order from `lower().strip().replace('\n', ' ')` to `lower().replace('\n', ' ').strip()`.

## Rationale
1. In the current order, after `strip()` followed by newline-to-space conversion, newlines at the beginning or end of the string are converted to spaces but remain in the string.
2. The modified order first converts newlines to spaces, then removes all leading and trailing whitespace at once, resulting in cleaner output.
3. This ensures more consistent output especially when processing multi-line inputs.
