### PR TITLE
[Dataset] Support VMCBench (CVPR 25)

### DIFF
--- a/lmms_eval/tasks/vmcbench/utils.py
+++ b/lmms_eval/tasks/vmcbench/utils.py
@@ -1,7 +1,7 @@
 import os
-import numpy as np
 import random
 
+import numpy as np
 
 dir_name = os.path.dirname(os.path.abspath(__file__))
 

--- a/lmms_eval/tasks/vmcbench/utils.py
+++ b/lmms_eval/tasks/vmcbench/utils.py
@@ -1,0 +1,146 @@
+import os
+import numpy as np
+import random
+
+
+dir_name = os.path.dirname(os.path.abspath(__file__))
+
+
+datasets_category_map = {
+    "SEEDBench": "general",
+    "MMStar": "general",
+    "A-OKVQA": "general",
+    "VizWiz": "general",
+    "MMVet": "general",
+    "VQAv2": "general",
+    "OKVQA": "general",
+    "MMMU": "reason",
+    "MathVista": "reason",
+    "ScienceQA": "reason",
+    "RealWorldQA": "reason",
+    "GQA": "reason",
+    "MathVision": "reason",
+    "TextVQA": "ocr",
+    "OCRVQA": "ocr",
+    "AI2D": "doc",
+    "ChartQA": "doc",
+    "DocVQA": "doc",
+    "InfoVQA": "doc",
+    "TableVQABench": "doc",
+}
+
+
+def vmcbench_doc_to_visual(doc):
+    return [doc["image"].convert("RGB")]
+
+
+def vmcbench_doc_to_text(doc, lmms_eval_specific_kwargs=None):
+    question = doc["question"]
+
+    options = {cand: doc[cand] for cand in "ABCD"}
+    options_prompt = "Options:\n"
+    for key, item in options.items():
+        options_prompt += f"{key}. {item}\n"
+
+    prompt = f"Question: {question}\n{options_prompt}"
+
+    if "pre_prompt" in lmms_eval_specific_kwargs and lmms_eval_specific_kwargs["pre_prompt"] != "":
+        prompt = f"{lmms_eval_specific_kwargs['pre_prompt']}{prompt}"
+    if "post_prompt" in lmms_eval_specific_kwargs and lmms_eval_specific_kwargs["post_prompt"] != "":
+        prompt = f"{prompt}{lmms_eval_specific_kwargs['post_prompt']}"
+
+    return prompt
+
+
+def parse_multi_choice_response(response, all_choices, index2ans):
+    """
+    Parse the prediction from the generated response.
+    Return the predicted index e.g., A, B, C, D.
+    """
+    response = str(response)
+    for char in [",", ".", "!", "?", ";", ":", "'"]:
+        response = response.strip(char)
+    response = " " + response + " "  # add space to avoid partial match
+
+    index_ans = True
+    ans_with_brack = False
+    candidates = []
+    for choice in all_choices:  # e.g., (A) (B) (C) (D)
+        if f"({choice})" in response or f"{choice}. " in response:
+            candidates.append(choice)
+            ans_with_brack = True
+
+    if len(candidates) == 0:
+        for choice in all_choices:  # e.g., A B C D
+            if f" {choice} " in response:
+                candidates.append(choice)
+
+    # if all above doesn't get candidates, check if the content is larger than 5 tokens and try to parse the example
+    if len(candidates) == 0 and len(response.split()) > 5:
+        for index, ans in index2ans.items():
+            if ans.lower() in response.lower():
+                candidates.append(index)
+                index_ans = False  # it's content ans.
+
+    if len(candidates) == 0:  # still not get answer, randomly choose one.
+        pred_index = random.choice(all_choices)
+    elif len(candidates) > 1:
+        start_indexes = []
+        if index_ans:
+            if ans_with_brack:
+                for can in candidates:
+                    index = response.rfind(f"({can})")
+                    start_indexes.append(index)  # -1 will be ignored anyway
+            else:
+                for can in candidates:
+                    index = response.rfind(f" {can} ")
+                    start_indexes.append(index)
+        else:
+            for can in candidates:
+                index = response.lower().rfind(index2ans[can].lower())
+                start_indexes.append(index)
+        # get the last one
+        pred_index = candidates[np.argmax(start_indexes)]
+    else:  # if only one candidate, use it.
+        pred_index = candidates[0]
+
+    return pred_index
+
+
+def vmcbench_process_results(doc, results):
+    """
+    Args:
+        doc: a instance of the eval dataset
+        results: [pred]
+    Returns:
+        a dictionary with key: metric name, value: metric value
+    """
+    response = results[0]
+
+    all_choices = []
+    for i in range(4):
+        all_choices.append(chr(65 + i))
+    index2ans = {index: doc[index] for index in all_choices}
+
+    pred_index = parse_multi_choice_response(response, all_choices, index2ans)
+    answer = doc["answer"]
+
+    score = int(pred_index == answer)
+
+    category = doc["category"]
+    main_category = datasets_category_map[category]
+    return {
+        main_category: {"question_id": doc["index"], "category": category, "score": score},
+        "average": {"question_id": doc["index"], "category": category, "score": score},
+    }
+
+
+def vmcbench_aggregate_results(results):
+    """
+    Args:
+        results: a list of values returned by process_results
+    Returns:
+        A score
+    """
+    scores = [result["score"] for result in results]
+    return sum(scores) / len(scores)

--- a/lmms_eval/tasks/vmcbench/vmcbench.yaml
+++ b/lmms_eval/tasks/vmcbench/vmcbench.yaml
@@ -1,0 +1,34 @@
+dataset_path: suyc21/VMCBench
+dataset_kwargs:
+  token: True
+task: "vmcbench"
+test_split: dev
+output_type: generate_until
+doc_to_visual: !function utils.vmcbench_doc_to_visual
+doc_to_text: !function utils.vmcbench_doc_to_text
+doc_to_target: "answer"
+# The return value of process_results will be used by metrics
+process_results: !function utils.vmcbench_process_results
+# Note that the metric name can be either a registed metric function (such as the case for GQA) or a key name returned by process_results
+metric_list:
+  - metric: general
+    aggregation: !function utils.vmcbench_aggregate_results
+    higher_is_better: true
+  - metric: reason
+    aggregation: !function utils.vmcbench_aggregate_results
+    higher_is_better: true
+  - metric: doc
+    aggregation: !function utils.vmcbench_aggregate_results
+    higher_is_better: true
+  - metric: ocr
+    aggregation: !function utils.vmcbench_aggregate_results
+    higher_is_better: true
+  - metric: average
+    aggregation: !function utils.vmcbench_aggregate_results
+    higher_is_better: true
+lmms_eval_specific_kwargs:
+  default:
+    pre_prompt: ""
+    post_prompt: "Answer with the option's letter from the given choices directly.\n"
+metadata:
+  - version: 0.0


### PR DESCRIPTION
Thanks for the great repo! This pull request provides minimal code implementation to support the VMCBench dataset. 

VMCBench is from "Automated Generation of Challenging Multiple-Choice Questions for Vision Language Model Evaluation" (CVPR 2025) [https://yuhui-zh15.github.io/AutoConverter-Website/](https://github.com/open-compass/VLMEvalKit/pull/url). 

VMCBench is created by transforming 20 existing VQA datasets into a unified multiple-choice format, totaling 9,018 questions. Using VLMEvalKit, we comprehensively evaluate 28 state-of-the-art VLMs on VMCBench, setting a new standard for scalable, consistent, and reproducible VLM evaluation.

We have carefully tested this pull request and performed code linting.

------
Running command:
```markdown
python -m accelerate.commands.launch \
    --num_processes=1 \
    -m lmms_eval \
    --model llava \
    --model_args pretrained="liuhaotian/llava-v1.5-7b" \
    --tasks vmcbench \
    --batch_size 1 \
    --log_samples \
    --log_samples_suffix llava_v1.5_vmcbench \
    --output_path ./logs/
```

Results:
```markdown
| Tasks  |Version|Filter|n-shot|Metric |   |Value |   |Stderr|
|--------|-------|------|-----:|-------|---|-----:|---|------|
|vmcbench|Yaml   |none  |     0|average|↑  |0.5250|±  |   N/A|
|vmcbench|Yaml   |none  |     0|doc    |↑  |0.3360|±  |   N/A|
|vmcbench|Yaml   |none  |     0|general|↑  |0.6657|±  |   N/A|
|vmcbench|Yaml   |none  |     0|ocr    |↑  |0.7700|±  |   N/A|
|vmcbench|Yaml   |none  |     0|reason |↑  |0.4367|±  |   N/A|
```