### PR TITLE
Add support for specifying local dataset

### DIFF
--- a/lmms_eval/tasks/activitynetqa/_default_template_yaml
+++ b/lmms_eval/tasks/activitynetqa/_default_template_yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/ActivityNetQA
+local_dataset_path:
 dataset_kwargs:
   token: True
   video: True
@@ -9,6 +10,7 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: " Answer the question using a single word or phrase."
+  local_infer_dataset_path:
 
 metadata:
   version: 0.0

--- a/lmms_eval/tasks/ai2d/ai2d.yaml
+++ b/lmms_eval/tasks/ai2d/ai2d.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/ai2d
+local_dataset_path:
 task: "ai2d"
 dataset_kwargs:
   token: True
@@ -25,6 +26,7 @@ lmms_eval_specific_kwargs:
     prompt_format: mcq_xcomposer
     pre_prompt: "[UNUSED_TOKEN_146]user\nQuestion: "
     post_prompt: "[UNUSED_TOKEN_145]\n[UNUSED_TOKEN_146]assistant\nThe answer is"
+  local_infer_dataset_path:
 
 model_specific_target_kwargs:
   default: "mcq"

--- a/lmms_eval/tasks/ai2d/ai2d_lite.yaml
+++ b/lmms_eval/tasks/ai2d/ai2d_lite.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/LMMs-Eval-Lite
+local_dataset_path:
 task: "ai2d_lite"
 dataset_kwargs:
   token: True
@@ -26,6 +27,7 @@ lmms_eval_specific_kwargs:
     prompt_format: mcq_xcomposer
     pre_prompt: "[UNUSED_TOKEN_146]user\nQuestion: "
     post_prompt: "[UNUSED_TOKEN_145]\n[UNUSED_TOKEN_146]assistant\nThe answer is"
+  local_infer_dataset_path:
 
 model_specific_target_kwargs:
   default: "mcq"

--- a/lmms_eval/tasks/ai2d/ai2d_no_mask.yaml
+++ b/lmms_eval/tasks/ai2d/ai2d_no_mask.yaml
@@ -1,4 +1,5 @@
 dataset_path: Efficient-Large-Model/ai2d-no-mask
+local_dataset_path:
 task: "ai2d_no_mask"
 dataset_kwargs:
   token: True
@@ -25,6 +26,7 @@ lmms_eval_specific_kwargs:
     prompt_format: mcq_xcomposer
     pre_prompt: "[UNUSED_TOKEN_146]user\nQuestion: "
     post_prompt: "[UNUSED_TOKEN_145]\n[UNUSED_TOKEN_146]assistant\nThe answer is"
+  local_infer_dataset_path:
 
 model_specific_target_kwargs:
   default: "mcq"

--- a/lmms_eval/tasks/air_bench/_default_template_yaml
+++ b/lmms_eval/tasks/air_bench/_default_template_yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/AIR_Bench
+local_dataset_path:
 dataset_kwargs:
   token: True
 

--- a/lmms_eval/tasks/air_bench/air_bench_chat_mixed.yaml
+++ b/lmms_eval/tasks/air_bench/air_bench_chat_mixed.yaml
@@ -15,6 +15,7 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: "Give a detail answer to the question in English."
+  local_infer_dataset_path:
 metric_list:
   - metric: gpt_eval
     aggregation: !function utils.air_bench_aggregate_results_chat

--- a/lmms_eval/tasks/air_bench/air_bench_chat_music.yaml
+++ b/lmms_eval/tasks/air_bench/air_bench_chat_music.yaml
@@ -15,6 +15,7 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: "Give a detail answer to the question in English."
+  local_infer_dataset_path:
 metric_list:
   - metric: gpt_eval
     aggregation: !function utils.air_bench_aggregate_results_chat

--- a/lmms_eval/tasks/air_bench/air_bench_chat_sound.yaml
+++ b/lmms_eval/tasks/air_bench/air_bench_chat_sound.yaml
@@ -15,6 +15,7 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: "Give a detail answer to the question in English."
+  local_infer_dataset_path:
 metric_list:
   - metric: gpt_eval
     aggregation: !function utils.air_bench_aggregate_results_chat

--- a/lmms_eval/tasks/air_bench/air_bench_chat_speech.yaml
+++ b/lmms_eval/tasks/air_bench/air_bench_chat_speech.yaml
@@ -15,6 +15,7 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: "Give a detail answer to the question in English."
+  local_infer_dataset_path:
 metric_list:
   - metric: gpt_eval
     aggregation: !function utils.air_bench_aggregate_results_chat

--- a/lmms_eval/tasks/air_bench/air_bench_foundation_music.yaml
+++ b/lmms_eval/tasks/air_bench/air_bench_foundation_music.yaml
@@ -13,6 +13,7 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: "\nAnswer with the option's letter from the given choices directly."
+  local_infer_dataset_path:
 metric_list:
   - metric: accuracy
     aggregation: !function utils.air_bench_aggregate_results_foundation

--- a/lmms_eval/tasks/air_bench/air_bench_foundation_sound.yaml
+++ b/lmms_eval/tasks/air_bench/air_bench_foundation_sound.yaml
@@ -13,6 +13,7 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: "\nAnswer with the option's letter from the given choices directly."
+  local_infer_dataset_path:
 metric_list:
   - metric: accuracy
     aggregation: !function utils.air_bench_aggregate_results_foundation

--- a/lmms_eval/tasks/air_bench/air_bench_foundation_speech.yaml
+++ b/lmms_eval/tasks/air_bench/air_bench_foundation_speech.yaml
@@ -13,6 +13,7 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: "\nAnswer with the option's letter from the given choices directly."
+  local_infer_dataset_path:
 metric_list:
   - metric: accuracy
     aggregation: !function utils.air_bench_aggregate_results_foundation

--- a/lmms_eval/tasks/alpaca_audio/alpaca_audio.yaml
+++ b/lmms_eval/tasks/alpaca_audio/alpaca_audio.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/alpaca_audio
+local_dataset_path:
 dataset_kwargs:
   token: True
 
@@ -18,6 +19,7 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: "\nPlease give a detail answer to the question in the audio."
+  local_infer_dataset_path:
 metric_list:
   - metric: gpt_eval
     aggregation: !function utils.alpaca_audio_aggregate_results

--- a/lmms_eval/tasks/arc/arc_easy.yaml
+++ b/lmms_eval/tasks/arc/arc_easy.yaml
@@ -2,6 +2,7 @@ tag:
   - ai2_arc
 task: arc_easy
 dataset_path: allenai/ai2_arc
+local_dataset_path:
 dataset_name: ARC-Easy
 output_type: multiple_choice
 training_split: train

--- a/lmms_eval/tasks/av_odyssey/av_odyssey.yaml
+++ b/lmms_eval/tasks/av_odyssey/av_odyssey.yaml
@@ -1,4 +1,5 @@
 dataset_path: AV-Odyssey/AV_Odyssey_Bench_LMMs_Eval
+local_dataset_path:
 dataset_kwargs:
   token: True
   cache_dir: AV_Odyssey

--- a/lmms_eval/tasks/charades_sta/charades.yaml
+++ b/lmms_eval/tasks/charades_sta/charades.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/charades_sta
+local_dataset_path:
 dataset_kwargs:
   token: True
   cache_dir: charades_sta
@@ -28,3 +29,4 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: "Please find the visual event described by a sentence in the video, determining its starting and ending times. The format should be: 'The event happens in the start time - end time'. For example, The event 'person turn a light on' happens in the 24.3 - 30.4 seonds. Now I will give you the textual sentence: "
     post_prompt: "Please return its start time and end time."
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/chartqa/chartqa.yaml
+++ b/lmms_eval/tasks/chartqa/chartqa.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/ChartQA
+local_dataset_path:
 dataset_kwargs:
   token: True
 task: "chartqa"
@@ -31,4 +32,5 @@ lmms_eval_specific_kwargs:
   qwen_vl:
     pre_prompt: ""
     post_prompt: " Answer:"
+  local_infer_dataset_path:
 

--- a/lmms_eval/tasks/chartqa/chartqa_lite.yaml
+++ b/lmms_eval/tasks/chartqa/chartqa_lite.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/LMMs-Eval-Lite
+local_dataset_path:
 dataset_kwargs:
   token: True
 task: "chartqa_lite"
@@ -32,4 +33,5 @@ lmms_eval_specific_kwargs:
   qwen_vl:
     pre_prompt: ""
     post_prompt: " Answer:"
+  local_infer_dataset_path:
 

--- a/lmms_eval/tasks/cinepile/cinepile.yaml
+++ b/lmms_eval/tasks/cinepile/cinepile.yaml
@@ -1,4 +1,5 @@
 dataset_path: tomg-group-umd/cinepile
+local_dataset_path:
 dataset_kwargs:
   cache_dir: cinepile_cache
   From_YouTube: True
@@ -21,6 +22,7 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: "You will be provided with subtitles from a specific scene of a movie and all the video frames from that scene. After going through the movie scene and seeing the frames, please answer the question that follows. The question will have five possible answers labeled A, B, C, D, and E, please try to provide the most probable answer in your opinion. Your output should be just one of A,B,C,D,E and nothing else.\n**Output Format:**\n\t**Answer:** <Option_key>"
     post_prompt: "Note: Follow the output format strictly. Only answer with the option key (A, B, C, D, E) and nothing else."
+  local_infer_dataset_path:
 metric_list: ##
   - metric: cinepile_accuracy
     aggregation: !function utils.cinepile_aggregate_results

--- a/lmms_eval/tasks/clotho_aqa/_default_template_yaml
+++ b/lmms_eval/tasks/clotho_aqa/_default_template_yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/ClothoAQA
+local_dataset_path:
 dataset_kwargs:
   token: True
 doc_to_target: "answer"

--- a/lmms_eval/tasks/clotho_aqa/clotho_aqa_test.yaml
+++ b/lmms_eval/tasks/clotho_aqa/clotho_aqa_test.yaml
@@ -9,6 +9,7 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: "\nAnswer the question using a single word only. "
+  local_infer_dataset_path:
 metric_list:
   - metric: exact_match
     aggregation: mean

--- a/lmms_eval/tasks/clotho_aqa/clotho_aqa_val.yaml
+++ b/lmms_eval/tasks/clotho_aqa/clotho_aqa_val.yaml
@@ -9,6 +9,7 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: "\nAnswer the question using a single word only. "
+  local_infer_dataset_path:
 metric_list:
   - metric: exact_match
     aggregation: mean

--- a/lmms_eval/tasks/clotho_aqa/clotho_asqa_test_v2.yaml
+++ b/lmms_eval/tasks/clotho_aqa/clotho_asqa_test_v2.yaml
@@ -9,6 +9,7 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: ""
+  local_infer_dataset_path:
 metric_list:
   - metric: gpt_eval
     aggregation: !function utils.clotho_aqa_v2_aggregate_results

--- a/lmms_eval/tasks/cmmmu/_default_template_cmmmu_yaml
+++ b/lmms_eval/tasks/cmmmu/_default_template_cmmmu_yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/CMMMU
+local_dataset_path:
 output_type: generate_until
 doc_to_visual: !function utils.cmmmu_doc_to_visual
 doc_to_text: !function utils.cmmmu_doc_to_text

--- a/lmms_eval/tasks/coco_cap/coco2014_cap_test.yaml
+++ b/lmms_eval/tasks/coco_cap/coco2014_cap_test.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/COCO-Caption
+local_dataset_path:
 dataset_kwargs:
   token: True
 task : "coco2014_cap_test"

--- a/lmms_eval/tasks/coco_cap/coco2014_cap_val.yaml
+++ b/lmms_eval/tasks/coco_cap/coco2014_cap_val.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/COCO-Caption
+local_dataset_path:
 dataset_kwargs:
   token: True
 task: "coco2014_cap_val"

--- a/lmms_eval/tasks/coco_cap/coco2017_cap_test.yaml
+++ b/lmms_eval/tasks/coco_cap/coco2017_cap_test.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/COCO-Caption2017
+local_dataset_path:
 dataset_kwargs:
   token: True
 task : "coco2017_cap_test"

--- a/lmms_eval/tasks/coco_cap/coco2017_cap_val.yaml
+++ b/lmms_eval/tasks/coco_cap/coco2017_cap_val.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/COCO-Caption2017
+local_dataset_path:
 dataset_kwargs:
   token: True
 task: "coco2017_cap_val"

--- a/lmms_eval/tasks/coco_cap/coco2017_cap_val_lite.yaml
+++ b/lmms_eval/tasks/coco_cap/coco2017_cap_val_lite.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/LMMs-Eval-Lite
+local_dataset_path:
 dataset_kwargs:
   token: True
 task: "coco2017_cap_val_lite"

--- a/lmms_eval/tasks/common_voice_15/_default_template_yaml
+++ b/lmms_eval/tasks/common_voice_15/_default_template_yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/common_voice_15
+local_dataset_path:
 dataset_kwargs:
   token: True
 test_split: test

--- a/lmms_eval/tasks/common_voice_15/common_voice_15_en.yaml
+++ b/lmms_eval/tasks/common_voice_15/common_voice_15_en.yaml
@@ -7,4 +7,5 @@ lmms_eval_specific_kwargs:
   qwen2_audio:
     pre_prompt: ""
     post_prompt: " <|en|>"
+  local_infer_dataset_path:
 include : _default_template_yaml

--- a/lmms_eval/tasks/common_voice_15/common_voice_15_fr.yaml
+++ b/lmms_eval/tasks/common_voice_15/common_voice_15_fr.yaml
@@ -7,4 +7,5 @@ lmms_eval_specific_kwargs:
   qwen2_audio:
     pre_prompt: ""
     post_prompt: " <|fr|>"
+  local_infer_dataset_path:
 include : _default_template_yaml

--- a/lmms_eval/tasks/common_voice_15/common_voice_15_zh-CN.yaml
+++ b/lmms_eval/tasks/common_voice_15/common_voice_15_zh-CN.yaml
@@ -7,4 +7,5 @@ lmms_eval_specific_kwargs:
   qwen2_audio:
     pre_prompt: ""
     post_prompt: " <|zh|>"
+  local_infer_dataset_path:
 include : _default_template_yaml

--- a/lmms_eval/tasks/conbench/conbench.yaml
+++ b/lmms_eval/tasks/conbench/conbench.yaml
@@ -1,4 +1,5 @@
 dataset_path: ConBench/ConBench_D
+local_dataset_path:
 dataset_kwargs:
   token: True
 task: "ConBench"

--- a/lmms_eval/tasks/covost2/_default_template_en_zh_yaml
+++ b/lmms_eval/tasks/covost2/_default_template_en_zh_yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/covost2_en-zh
+local_dataset_path:
 dataset_name: en_zh
 dataset_kwargs:
   token: True
@@ -26,3 +27,4 @@ lmms_eval_specific_kwargs:
   qwen2_audio:
     pre_prompt: "Translate the speech into Chinese and only output the translation: <|en|>"
     post_prompt: ""
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/covost2/_default_template_zh_en_yaml
+++ b/lmms_eval/tasks/covost2/_default_template_zh_en_yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/covost2
+local_dataset_path:
 dataset_name: zh_en
 dataset_kwargs:
   token: True
@@ -26,3 +27,4 @@ lmms_eval_specific_kwargs:
   qwen2_audio:
     pre_prompt: "Translate the speech into English and only output the translation: <|zh|>"
     post_prompt: ""
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/covost2/covost2_en_zh_dev.yaml
+++ b/lmms_eval/tasks/covost2/covost2_en_zh_dev.yaml
@@ -1,6 +1,7 @@
 task: "covost2_en_zh_dev"
 include: _default_template_en_zh_yaml
 dataset_path: lmms-lab/covost2_en-zh
+local_dataset_path:
 dataset_name: en_zh
 test_split: dev
 lmms_eval_specific_kwargs:
@@ -10,3 +11,4 @@ lmms_eval_specific_kwargs:
   qwen2_audio:
     pre_prompt: "Translate the speech into Chinese and only output the translation: <|en|>"
     post_prompt: ""
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/covost2/covost2_en_zh_test.yaml
+++ b/lmms_eval/tasks/covost2/covost2_en_zh_test.yaml
@@ -1,6 +1,7 @@
 task: "covost2_en_zh_test"
 include: _default_template_en_zh_yaml
 dataset_path: lmms-lab/covost2_en-zh
+local_dataset_path:
 dataset_name: en_zh
 test_split: test
 lmms_eval_specific_kwargs:
@@ -10,3 +11,4 @@ lmms_eval_specific_kwargs:
   qwen2_audio:
     pre_prompt: "Translate the speech into Chinese and only output the translation: <|en|>"
     post_prompt: ""
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/cuva/_default_template_yaml
+++ b/lmms_eval/tasks/cuva/_default_template_yaml
@@ -1,4 +1,5 @@
 dataset_path: fesvhtr/CUVA_LMMs
+local_dataset_path:
 dataset_kwargs:
   token: True
   video: True

--- a/lmms_eval/tasks/cuva/cuva_test.yaml
+++ b/lmms_eval/tasks/cuva/cuva_test.yaml
@@ -19,4 +19,5 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: ""
+  local_infer_dataset_path:
 include: _default_template_yaml

--- a/lmms_eval/tasks/cvrr/_default_template_yaml
+++ b/lmms_eval/tasks/cvrr/_default_template_yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/CVRR-ES
+local_dataset_path:
 dataset_kwargs:
   token: True
   video: True
@@ -7,6 +8,7 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: ""
+  local_infer_dataset_path:
 
 metadata:
   version: 0.0

--- a/lmms_eval/tasks/detailcaps/_default_template_detailcaps_yaml
+++ b/lmms_eval/tasks/detailcaps/_default_template_detailcaps_yaml
@@ -1,3 +1,4 @@
 lmms_eval_specific_kwargs:
   default:
     prompt: "Describe this image in detail."
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/detailcaps/detailcaps.yaml
+++ b/lmms_eval/tasks/detailcaps/detailcaps.yaml
@@ -1,4 +1,5 @@
 dataset_path: foundation-multimodal-models/DetailCaps-4870
+local_dataset_path:
 dataset_kwargs:
   token: True
 task: "detailcaps"

--- a/lmms_eval/tasks/docvqa/_default_template_docvqa_yaml
+++ b/lmms_eval/tasks/docvqa/_default_template_docvqa_yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/DocVQA
+local_dataset_path:
 dataset_name: DocVQA
 dataset_kwargs:
   token: True
@@ -17,3 +18,4 @@ lmms_eval_specific_kwargs:
   qwen_vl:
     pre_prompt: ""
     post_prompt: " Answer:"
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/docvqa/docvqa_val_lite.yaml
+++ b/lmms_eval/tasks/docvqa/docvqa_val_lite.yaml
@@ -5,6 +5,7 @@ metric_list:
     aggregation: mean
     higher_is_better: true
 dataset_path: lmms-lab/LMMs-Eval-Lite
+local_dataset_path:
 dataset_name: docvqa_val
 dataset_kwargs:
   token: True
@@ -23,4 +24,5 @@ lmms_eval_specific_kwargs:
   qwen_vl:
     pre_prompt: ""
     post_prompt: " Answer:"
+  local_infer_dataset_path:
 

--- a/lmms_eval/tasks/dtcbench/dtcbench.yaml
+++ b/lmms_eval/tasks/dtcbench/dtcbench.yaml
@@ -1,4 +1,5 @@
 dataset_path: NCSOFT/K-DTCBench
+local_dataset_path:
 dataset_kwargs:
   token: True
 task: "dtcbench"

--- a/lmms_eval/tasks/egoplan/egoplan.yaml
+++ b/lmms_eval/tasks/egoplan/egoplan.yaml
@@ -1,4 +1,5 @@
 dataset_path: EgoLife-v1/EgoPlan
+local_dataset_path:
 dataset_kwargs:
   token: True
   cache_dir: egoplan
@@ -39,5 +40,6 @@ lmms_eval_specific_kwargs:
   xcomposer2_4khd:
     pre_prompt: "[UNUSED_TOKEN_146]user\n"
     post_prompt: " Answer this question with A, B, C, or D.[UNUSED_TOKEN_145]\n[UNUSED_TOKEN_146]assistant\n"
+  local_infer_dataset_path:
 metadata:
   version: 0.0

--- a/lmms_eval/tasks/egoschema/_default_template_yaml
+++ b/lmms_eval/tasks/egoschema/_default_template_yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/egoschema
+local_dataset_path:
 dataset_kwargs:
   token: True
   video: True
@@ -7,3 +8,4 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: ""
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/egoschema/egoschema.yaml
+++ b/lmms_eval/tasks/egoschema/egoschema.yaml
@@ -18,3 +18,4 @@ lmms_eval_specific_kwargs:
   aria:
     pre_prompt: "Please answer the question about the video:\n"
     post_prompt: "\nAnswer with the option's letter from the given choices directly."
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/egoschema/egoschema_subset.yaml
+++ b/lmms_eval/tasks/egoschema/egoschema_subset.yaml
@@ -21,3 +21,4 @@ lmms_eval_specific_kwargs:
   aria:
     pre_prompt: "Please answer the question about the video:\n"
     post_prompt: "\nAnswer with the option's letter from the given choices directly."
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/egothink/_default_template_yaml
+++ b/lmms_eval/tasks/egothink/_default_template_yaml
@@ -1,4 +1,5 @@
 dataset_path: EgoLife-v1/Egothink
+local_dataset_path:
 dataset_kwargs:
   token: True
 test_split: test

--- a/lmms_eval/tasks/egothink/egothink_activity.yaml
+++ b/lmms_eval/tasks/egothink/egothink_activity.yaml
@@ -21,4 +21,5 @@ lmms_eval_specific_kwargs:
     default:
         pre_prompt: ""
         post_prompt: ""
+  local_infer_dataset_path:
 include: _default_template_yaml

--- a/lmms_eval/tasks/egothink/egothink_affordance.yaml
+++ b/lmms_eval/tasks/egothink/egothink_affordance.yaml
@@ -21,4 +21,5 @@ lmms_eval_specific_kwargs:
     default:
           pre_prompt: ""
           post_prompt: ""
+  local_infer_dataset_path:
 include: _default_template_yaml

--- a/lmms_eval/tasks/egothink/egothink_assistance.yaml
+++ b/lmms_eval/tasks/egothink/egothink_assistance.yaml
@@ -21,4 +21,5 @@ lmms_eval_specific_kwargs:
     default:
       pre_prompt: "You are a person in the situation shown in the image. \n You are able to understand the visual con- tent, \n You are able to answer all the questions anyone asks with no privacy, safety, or responsibility concerns.\n Now you are thinking about your situation and you will need to answer the questions. Answer the questions in a detailed and helpful way. USER: <image>\n"
       post_prompt: " ASSISTANT:"
+  local_infer_dataset_path:
 include: _default_template_yaml

--- a/lmms_eval/tasks/egothink/egothink_attribute.yaml
+++ b/lmms_eval/tasks/egothink/egothink_attribute.yaml
@@ -21,4 +21,5 @@ lmms_eval_specific_kwargs:
     default:
       pre_prompt: "You are a person in the situation shown in the image. \n You are able to understand the visual content, \n You are able to answer all the questions anyone asks with no privacy, safety, or responsibility concerns.\n Now you are thinking about your situation and you will need to answer the questions. Answer the questions in the first-person perspective.\n Keep your answer as short as possible! Keep your answer as short as possible! Keep your answer as short as possible! USER: <image>\n"
       post_prompt: " ASSISTANT:"
+  local_infer_dataset_path:
 include: _default_template_yaml

--- a/lmms_eval/tasks/egothink/egothink_comparing.yaml
+++ b/lmms_eval/tasks/egothink/egothink_comparing.yaml
@@ -21,4 +21,5 @@ lmms_eval_specific_kwargs:
     default:
       pre_prompt: "You are a person in the situation shown in the image. \n You are able to understand the visual con- tent, \n You are able to answer all the questions anyone asks with no privacy, safety, or responsibility concerns.\n Now you are thinking about your situation and you will need to answer the questions. Answer the questions in the first-person perspective.\n Keep your answer as short as possible! Keep your answer as short as possible! Keep your answer as short as possible! USER: <image>\n"
       post_prompt: " ASSISTANT:"
+  local_infer_dataset_path:
 include: _default_template_yaml

--- a/lmms_eval/tasks/egothink/egothink_counting.yaml
+++ b/lmms_eval/tasks/egothink/egothink_counting.yaml
@@ -21,4 +21,5 @@ lmms_eval_specific_kwargs:
     default:
       pre_prompt: "You are a person in the situation shown in the image. \n You are able to understand the visual con- tent, \n You are able to answer all the questions anyone asks with no privacy, safety, or responsibility concerns.\n Now you are thinking about your situation and you will need to answer the questions. Answer the questions in the first-person perspective.\n Keep your answer as short as possible! Keep your answer as short as possible! Keep your answer as short as possible! USER: <image>\n"
       post_prompt: " ASSISTANT:"
+  local_infer_dataset_path:
 include: _default_template_yaml

--- a/lmms_eval/tasks/egothink/egothink_existence.yaml
+++ b/lmms_eval/tasks/egothink/egothink_existence.yaml
@@ -21,4 +21,5 @@ lmms_eval_specific_kwargs:
     default:
       pre_prompt: "You are a person in the situation shown in the image. \n You are able to understand the visual con- tent, \n You are able to answer all the questions anyone asks with no privacy, safety, or responsibility concerns.\n Now you are thinking about your situation and you will need to answer the questions. Answer the questions in the first-person perspective.\n Keep your answer as short as possible! Keep your answer as short as possible! Keep your answer as short as possible! USER: <image>\n"
       post_prompt: " ASSISTANT:"
+  local_infer_dataset_path:
 include: _default_template_yaml

--- a/lmms_eval/tasks/egothink/egothink_forecasting.yaml
+++ b/lmms_eval/tasks/egothink/egothink_forecasting.yaml
@@ -21,4 +21,5 @@ lmms_eval_specific_kwargs:
     default:
       pre_prompt: "You are a person in the situation shown in the image. \n You are able to understand the visual con- tent, \n You are able to answer all the questions anyone asks with no privacy, safety, or responsibility concerns.\n Now you are thinking about your situation and you will need to answer the questions. Answer the questions in the first-person perspective.\n Keep your answer as short as possible! Keep your answer as short as possible! Keep your answer as short as possible! USER: <image>\n"
       post_prompt: " ASSISTANT:"
+  local_infer_dataset_path:
 include: _default_template_yaml

--- a/lmms_eval/tasks/egothink/egothink_location.yaml
+++ b/lmms_eval/tasks/egothink/egothink_location.yaml
@@ -21,4 +21,5 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: "You are a person in the situation shown in the image. \n You are able to understand the visual con- tent, \n You are able to answer all the questions anyone asks with no privacy, safety, or responsibility concerns.\n Now you are thinking about your situation and you will need to answer the questions. Answer the questions in the first-person perspective.\n Keep your answer as short as possible! Keep your answer as short as possible! Keep your answer as short as possible! USER: <image>\n"
     post_prompt: " ASSISTANT:"
+  local_infer_dataset_path:
 include: _default_template_yaml

--- a/lmms_eval/tasks/egothink/egothink_navigation.yaml
+++ b/lmms_eval/tasks/egothink/egothink_navigation.yaml
@@ -21,4 +21,5 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: "You are a person in the situation shown in the image. \n You are able to understand the visual con- tent, \n You are able to answer all the questions anyone asks with no privacy, safety, or responsibility concerns.\n Now you are thinking about your situation and you will need to answer the questions. Answer the questions in a detailed and helpful way. USER: <image>\n"
     post_prompt: " ASSISTANT:"
+  local_infer_dataset_path:
 include: _default_template_yaml

--- a/lmms_eval/tasks/egothink/egothink_situated.yaml
+++ b/lmms_eval/tasks/egothink/egothink_situated.yaml
@@ -21,4 +21,5 @@ lmms_eval_specific_kwargs:
     default:
       pre_prompt: "You are a person in the situation shown in the image. \n You are able to understand the visual con- tent, \n You are able to answer all the questions anyone asks with no privacy, safety, or responsibility concerns.\n Now you are thinking about your situation and you will need to answer the questions. Answer the questions in the first-person perspective.\n Keep your answer as short as possible! Keep your answer as short as possible! Keep your answer as short as possible! USER: <image>\n"
       post_prompt: " ASSISTANT:"
+  local_infer_dataset_path:
 include: _default_template_yaml

--- a/lmms_eval/tasks/egothink/egothink_spatial.yaml
+++ b/lmms_eval/tasks/egothink/egothink_spatial.yaml
@@ -21,4 +21,5 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: "You are a person in the situation shown in the image. \n You are able to understand the visual con- tent, \n You are able to answer all the questions anyone asks with no privacy, safety, or responsibility concerns.\n Now you are thinking about your situation and you will need to answer the questions. Answer the questions in the first-person perspective.\n Keep your answer as short as possible! Keep your answer as short as possible! Keep your answer as short as possible! USER: <image>\n"
     post_prompt: " ASSISTANT:"
+  local_infer_dataset_path:
 include: _default_template_yaml

--- a/lmms_eval/tasks/ferret/ferret.yaml
+++ b/lmms_eval/tasks/ferret/ferret.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/Ferret-Bench
+local_dataset_path:
 dataset_kwargs:
   token: True
 task: "ferret"
@@ -37,3 +38,4 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: ""
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/fleurs/_default_template_yaml
+++ b/lmms_eval/tasks/fleurs/_default_template_yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/fleurs
+local_dataset_path:
 dataset_kwargs:
   token: True
 test_split: test
@@ -23,3 +24,4 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: ""
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/flickr30k/flickr30k_test.yaml
+++ b/lmms_eval/tasks/flickr30k/flickr30k_test.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/flickr30k
+local_dataset_path:
 dataset_kwargs:
   token: True
 task : "flickr30k_test"

--- a/lmms_eval/tasks/flickr30k/flickr30k_test_lite.yaml
+++ b/lmms_eval/tasks/flickr30k/flickr30k_test_lite.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/LMMs-Eval-Lite
+local_dataset_path:
 dataset_kwargs:
   token: True
 task : "flickr30k_test_lite"

--- a/lmms_eval/tasks/funqa/_default_template_yaml
+++ b/lmms_eval/tasks/funqa/_default_template_yaml
@@ -1,4 +1,5 @@
 dataset_path: fesvhtr/FunQA_LMMs
+local_dataset_path:
 dataset_kwargs:
   token: True
   video: True

--- a/lmms_eval/tasks/funqa/funqa_test.yaml
+++ b/lmms_eval/tasks/funqa/funqa_test.yaml
@@ -25,4 +25,5 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: ""
+  local_infer_dataset_path:
 include: _default_template_yaml

--- a/lmms_eval/tasks/gigaspeech/gigaspeech_dev.yaml
+++ b/lmms_eval/tasks/gigaspeech/gigaspeech_dev.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/gigaspeech
+local_dataset_path:
 dataset_name: dev
 dataset_kwargs:
   token: True
@@ -28,3 +29,4 @@ lmms_eval_specific_kwargs:
   qwen2_audio:
     pre_prompt: ""
     post_prompt: " <|en|>"
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/gigaspeech/gigaspeech_l_dev.yaml
+++ b/lmms_eval/tasks/gigaspeech/gigaspeech_l_dev.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/gigaspeech
+local_dataset_path:
 dataset_name: l
 dataset_kwargs:
   token: True
@@ -28,3 +29,4 @@ lmms_eval_specific_kwargs:
   qwen2_audio:
     pre_prompt: ""
     post_prompt: " <|en|>"
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/gigaspeech/gigaspeech_l_test.yaml
+++ b/lmms_eval/tasks/gigaspeech/gigaspeech_l_test.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/gigaspeech
+local_dataset_path:
 dataset_name: l
 dataset_kwargs:
   token: True
@@ -28,3 +29,4 @@ lmms_eval_specific_kwargs:
   qwen2_audio:
     pre_prompt: ""
     post_prompt: " <|en|>"
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/gigaspeech/gigaspeech_m_dev.yaml
+++ b/lmms_eval/tasks/gigaspeech/gigaspeech_m_dev.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/gigaspeech
+local_dataset_path:
 dataset_name: m
 dataset_kwargs:
   token: True
@@ -28,3 +29,4 @@ lmms_eval_specific_kwargs:
   qwen2_audio:
     pre_prompt: ""
     post_prompt: " <|en|>"
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/gigaspeech/gigaspeech_m_test.yaml
+++ b/lmms_eval/tasks/gigaspeech/gigaspeech_m_test.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/gigaspeech
+local_dataset_path:
 dataset_name: m
 dataset_kwargs:
   token: True
@@ -28,3 +29,4 @@ lmms_eval_specific_kwargs:
   qwen2_audio:
     pre_prompt: ""
     post_prompt: " <|en|>"
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/gigaspeech/gigaspeech_s_dev.yaml
+++ b/lmms_eval/tasks/gigaspeech/gigaspeech_s_dev.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/gigaspeech
+local_dataset_path:
 dataset_name: s
 dataset_kwargs:
   token: True
@@ -28,3 +29,4 @@ lmms_eval_specific_kwargs:
   qwen2_audio:
     pre_prompt: ""
     post_prompt: " <|en|>"
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/gigaspeech/gigaspeech_s_test.yaml
+++ b/lmms_eval/tasks/gigaspeech/gigaspeech_s_test.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/gigaspeech
+local_dataset_path:
 dataset_name: s
 dataset_kwargs:
   token: True
@@ -28,3 +29,4 @@ lmms_eval_specific_kwargs:
   qwen2_audio:
     pre_prompt: ""
     post_prompt: " <|en|>"
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/gigaspeech/gigaspeech_test.yaml
+++ b/lmms_eval/tasks/gigaspeech/gigaspeech_test.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/gigaspeech
+local_dataset_path:
 dataset_name: test
 dataset_kwargs:
   token: True
@@ -28,3 +29,4 @@ lmms_eval_specific_kwargs:
   qwen2_audio:
     pre_prompt: ""
     post_prompt: " <|en|>"
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/gigaspeech/gigaspeech_xl_dev.yaml
+++ b/lmms_eval/tasks/gigaspeech/gigaspeech_xl_dev.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/gigaspeech
+local_dataset_path:
 dataset_name: xl
 dataset_kwargs:
   token: True
@@ -28,3 +29,4 @@ lmms_eval_specific_kwargs:
   qwen2_audio:
     pre_prompt: ""
     post_prompt: " <|en|>"
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/gigaspeech/gigaspeech_xl_test.yaml
+++ b/lmms_eval/tasks/gigaspeech/gigaspeech_xl_test.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/gigaspeech
+local_dataset_path:
 dataset_name: xl
 dataset_kwargs:
   token: True
@@ -28,3 +29,4 @@ lmms_eval_specific_kwargs:
   qwen2_audio:
     pre_prompt: ""
     post_prompt: " <|en|>"
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/gigaspeech/gigaspeech_xs_dev.yaml
+++ b/lmms_eval/tasks/gigaspeech/gigaspeech_xs_dev.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/gigaspeech
+local_dataset_path:
 dataset_name: xs
 dataset_kwargs:
   token: True
@@ -28,3 +29,4 @@ lmms_eval_specific_kwargs:
   qwen2_audio:
     pre_prompt: ""
     post_prompt: " <|en|>"
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/gigaspeech/gigaspeech_xs_test.yaml
+++ b/lmms_eval/tasks/gigaspeech/gigaspeech_xs_test.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/gigaspeech
+local_dataset_path:
 dataset_name: xs
 dataset_kwargs:
   token: True
@@ -28,3 +29,4 @@ lmms_eval_specific_kwargs:
   qwen2_audio:
     pre_prompt: ""
     post_prompt: " <|en|>"
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/gpqa/cot_n_shot/_gpqa_cot_n_shot_yaml
+++ b/lmms_eval/tasks/gpqa/cot_n_shot/_gpqa_cot_n_shot_yaml
@@ -1,4 +1,5 @@
 dataset_path: Idavidrein/gpqa
+local_dataset_path:
 tag: gpqa
 output_type: generate_until
 process_docs: !function utils.process_docs

--- a/lmms_eval/tasks/gpqa/cot_zeroshot/_gpqa_cot_zeroshot_yaml
+++ b/lmms_eval/tasks/gpqa/cot_zeroshot/_gpqa_cot_zeroshot_yaml
@@ -1,4 +1,5 @@
 dataset_path: Idavidrein/gpqa
+local_dataset_path:
 tag: gpqa
 output_type: generate_until
 process_docs: !function utils.process_docs

--- a/lmms_eval/tasks/gpqa/generative/_gpqa_generative_n_shot_yaml
+++ b/lmms_eval/tasks/gpqa/generative/_gpqa_generative_n_shot_yaml
@@ -1,4 +1,5 @@
 dataset_path: Idavidrein/gpqa
+local_dataset_path:
 tag: gpqa
 output_type: generate_until
 process_docs: !function utils.process_docs

--- a/lmms_eval/tasks/gpqa/n_shot/_gpqa_n_shot_yaml
+++ b/lmms_eval/tasks/gpqa/n_shot/_gpqa_n_shot_yaml
@@ -1,4 +1,5 @@
 dataset_path: Idavidrein/gpqa
+local_dataset_path:
 tag: gpqa
 output_type: multiple_choice
 process_docs: !function utils.process_docs

--- a/lmms_eval/tasks/gpqa/zeroshot/_gpqa_zeroshot_yaml
+++ b/lmms_eval/tasks/gpqa/zeroshot/_gpqa_zeroshot_yaml
@@ -1,4 +1,5 @@
 dataset_path: Idavidrein/gpqa
+local_dataset_path:
 tag: gpqa
 output_type: multiple_choice
 process_docs: !function utils.process_docs

--- a/lmms_eval/tasks/gqa/gqa.yaml
+++ b/lmms_eval/tasks/gqa/gqa.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/GQA
+local_dataset_path:
 dataset_name: testdev_balanced_instructions
 dataset_kwargs:
   token: True
@@ -30,3 +31,4 @@ lmms_eval_specific_kwargs:
   qwen_vl:
     pre_prompt: ""
     post_prompt: " Answer:"
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/gqa/gqa_lite.yaml
+++ b/lmms_eval/tasks/gqa/gqa_lite.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/LMMs-Eval-Lite
+local_dataset_path:
 dataset_name: gqa
 dataset_kwargs:
   token: True
@@ -30,3 +31,4 @@ lmms_eval_specific_kwargs:
   qwen_vl:
     pre_prompt: ""
     post_prompt: " Answer:"
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/gqa/utils.py
+++ b/lmms_eval/tasks/gqa/utils.py
@@ -1,17 +1,32 @@
 from datasets import load_dataset
+import os
 
 GQA_RAW_IMAGE_DATASET = None
 GQA_ID2IMAGE = None
 
 
-def gqa_doc_to_visual(doc):
+def gqa_doc_to_visual(doc, lmms_eval_specific_kwargs=None):
     global GQA_RAW_IMAGE_DATASET
     global GQA_ID2IMAGE
+    
     if GQA_RAW_IMAGE_DATASET is None:
-        GQA_RAW_IMAGE_DATASET = load_dataset("lmms-lab/GQA", "testdev_balanced_images", split="testdev", token=True)
+        local_infer_dataset_path = (
+            lmms_eval_specific_kwargs.get("local_infer_dataset_path") 
+            if lmms_eval_specific_kwargs and lmms_eval_specific_kwargs.get("local_infer_dataset_path") is not None 
+            else None
+        )
+        dataset_path = os.path.join(local_infer_dataset_path, "lmms-lab/GQA") if local_infer_dataset_path else "lmms-lab/GQA"
+        
+        GQA_RAW_IMAGE_DATASET = load_dataset(
+            path=dataset_path,
+            name="testdev_balanced_images", 
+            split="testdev", 
+            token=True
+        )
         GQA_ID2IMAGE = {}
         for row in GQA_RAW_IMAGE_DATASET:
             GQA_ID2IMAGE[row["id"]] = row["image"].convert("RGB")
+    
     image = GQA_ID2IMAGE[doc["imageId"]]
     return [image]
 

--- a/lmms_eval/tasks/gqa_ru/gqa_ru.yaml
+++ b/lmms_eval/tasks/gqa_ru/gqa_ru.yaml
@@ -1,4 +1,5 @@
 dataset_path: deepvk/GQA-ru
+local_dataset_path:
 dataset_name: testdev_balanced_instructions
 dataset_kwargs:
   token: True
@@ -27,3 +28,4 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: "\nОтветь одним словом."
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/gqa_ru/utils.py
+++ b/lmms_eval/tasks/gqa_ru/utils.py
@@ -1,14 +1,28 @@
 from datasets import load_dataset
+import os
 
 GQA_RAW_IMAGE_DATASET = None
 GQA_ID2IMAGE = None
 
 
-def gqa_doc_to_visual(doc):
+def gqa_doc_to_visual(doc, lmms_eval_specific_kwargs=None):
     global GQA_RAW_IMAGE_DATASET
     global GQA_ID2IMAGE
     if GQA_RAW_IMAGE_DATASET is None:
-        GQA_RAW_IMAGE_DATASET = load_dataset("deepvk/GQA-ru", "testdev_balanced_images", split="testdev", token=True)
+
+        local_infer_dataset_path = (
+            lmms_eval_specific_kwargs.get("local_infer_dataset_path") 
+            if lmms_eval_specific_kwargs and lmms_eval_specific_kwargs.get("local_infer_dataset_path") is not None 
+            else None
+        )
+        dataset_path = os.path.join(local_infer_dataset_path, "deepvk/GQA-ru") if local_infer_dataset_path else "deepvk/GQA-ru"
+        
+        GQA_RAW_IMAGE_DATASET = load_dataset(
+            dataset_path,
+            "testdev_balanced_images",
+            split="testdev",
+            token=True
+        )
         GQA_ID2IMAGE = {}
         for row in GQA_RAW_IMAGE_DATASET:
             GQA_ID2IMAGE[row["id"]] = row["image"].convert("RGB")

--- a/lmms_eval/tasks/gsm8k/gsm8k-cot-llama.yaml
+++ b/lmms_eval/tasks/gsm8k/gsm8k-cot-llama.yaml
@@ -1,5 +1,6 @@
 dataset_name: main
 dataset_path: gsm8k
+local_dataset_path:
 doc_to_target: '{{answer.split(''####'')[-1].strip() if answer is defined else target}}'
 doc_to_text: "Given the following problem, reason and give a final answer to the problem.\nProblem: {{question}}\nYour response should end with \"The final answer is [answer]\" where [answer] is the response to the problem.\n"
 fewshot_config:

--- a/lmms_eval/tasks/gsm8k/gsm8k-cot-zeroshot.yaml
+++ b/lmms_eval/tasks/gsm8k/gsm8k-cot-zeroshot.yaml
@@ -2,6 +2,7 @@ tag:
   - math_word_problems
 task: gsm8k_cot_zeroshot
 dataset_path: gsm8k
+local_dataset_path:
 dataset_name: main
 output_type: generate_until
 training_split: train

--- a/lmms_eval/tasks/gsm8k/gsm8k-cot.yaml
+++ b/lmms_eval/tasks/gsm8k/gsm8k-cot.yaml
@@ -1,5 +1,6 @@
 dataset_name: main
 dataset_path: gsm8k
+local_dataset_path:
 doc_to_target: '{{answer.split(''####'')[-1].strip() if answer is defined else target}}'
 doc_to_text: 'Q: {{question}}
 

--- a/lmms_eval/tasks/gsm8k/gsm8k.yaml
+++ b/lmms_eval/tasks/gsm8k/gsm8k.yaml
@@ -2,6 +2,7 @@ tag:
   - math_word_problems
 task: gsm8k
 dataset_path: gsm8k
+local_dataset_path:
 dataset_name: main
 output_type: generate_until
 training_split: train

--- a/lmms_eval/tasks/hallusion_bench/hallusion_bench_image.yaml
+++ b/lmms_eval/tasks/hallusion_bench/hallusion_bench_image.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/HallusionBench
+local_dataset_path:
 dataset_kwargs:
   token: True
 task: "hallusion_bench_image"
@@ -12,6 +13,7 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: ""
+  local_infer_dataset_path:
 generation_kwargs:
   max_new_tokens: 128
   temperature: 0

--- a/lmms_eval/tasks/hellaswag/hellaswag.yaml
+++ b/lmms_eval/tasks/hellaswag/hellaswag.yaml
@@ -2,6 +2,7 @@ tag:
   - multiple_choice
 task: hellaswag
 dataset_path: hellaswag
+local_dataset_path:
 dataset_name: null
 output_type: multiple_choice
 training_split: train

--- a/lmms_eval/tasks/hrbench/hrbench4k.yaml
+++ b/lmms_eval/tasks/hrbench/hrbench4k.yaml
@@ -1,4 +1,5 @@
 dataset_path: DreamMr/HR-Bench
+local_dataset_path:
 dataset_name: hrbench_version_split
 dataset_kwargs:
   token: True

--- a/lmms_eval/tasks/hrbench/hrbench8k.yaml
+++ b/lmms_eval/tasks/hrbench/hrbench8k.yaml
@@ -1,4 +1,5 @@
 dataset_path: DreamMr/HR-Bench
+local_dataset_path:
 dataset_name: hrbench_version_split
 dataset_kwargs:
   token: True

--- a/lmms_eval/tasks/iconqa/_default_template_docvqa_yaml
+++ b/lmms_eval/tasks/iconqa/_default_template_docvqa_yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/ICON-QA
+local_dataset_path:
 dataset_kwargs:
   token: True
 output_type: generate_until
@@ -16,6 +17,7 @@ lmms_eval_specific_kwargs:
     statement: "Given a set of images and a question, please provide the answer to the question.\n"
     options_statement: "Question: {question}.\nOptions:\n{options}\nPlease answer with the option letter from the given choices directly."
     freeform_statement: "Question: {question}.\nPlease answer the question using a single word or phrase."
+  local_infer_dataset_path:
 metric_list:
   - metric: anls
     aggregation: mean

--- a/lmms_eval/tasks/ifeval/ifeval.yaml
+++ b/lmms_eval/tasks/ifeval/ifeval.yaml
@@ -1,5 +1,6 @@
 task: ifeval
 dataset_path: wis-k/instruction-following-eval
+local_dataset_path:
 dataset_name: null
 output_type: generate_until
 test_split: train

--- a/lmms_eval/tasks/ii_bench/ii_bench.yaml
+++ b/lmms_eval/tasks/ii_bench/ii_bench.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/II-Bench
+local_dataset_path:
 task: "ii-bench"
 test_split: test
 output_type: generate_until
@@ -17,4 +18,5 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: "Instruction: Please try to answer the single-answer multiple choice question below based on the picture provided.\n"
     post_prompt: "\nAnswer:"
+  local_infer_dataset_path:
   

--- a/lmms_eval/tasks/illusionvqa/illusionvqa.yaml
+++ b/lmms_eval/tasks/illusionvqa/illusionvqa.yaml
@@ -19,6 +19,7 @@ lmms_eval_specific_kwargs:
     prompt_format: mcq
     pre_prompt: "You'll be given an image, an instruction and some options. You have to select the correct one. Do not explain your reasoning. Answer with only the letter which corresponds to the correct option. Do not repeat the entire answer."
     post_prompt: ""
+  local_infer_dataset_path:
 
 
 generation_kwargs:

--- a/lmms_eval/tasks/illusionvqa/illusionvqa_comprehension.yaml
+++ b/lmms_eval/tasks/illusionvqa/illusionvqa_comprehension.yaml
@@ -1,3 +1,4 @@
 include: illusionvqa.yaml
 task: illusionvqa_comprehension
 dataset_path: csebuetnlp/illusionVQA-Comprehension
+local_dataset_path:

--- a/lmms_eval/tasks/illusionvqa/illusionvqa_soft_localization.yaml
+++ b/lmms_eval/tasks/illusionvqa/illusionvqa_soft_localization.yaml
@@ -1,3 +1,4 @@
 include: illusionvqa.yaml
 task: illusionvqa_soft_localization
 dataset_path: csebuetnlp/illusionVQA-Soft-Localization
+local_dataset_path:

--- a/lmms_eval/tasks/infovqa/_default_template_infovqa_yaml
+++ b/lmms_eval/tasks/infovqa/_default_template_infovqa_yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/DocVQA
+local_dataset_path:
 dataset_name: InfographicVQA
 dataset_kwargs:
   token: True
@@ -13,3 +14,4 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: "\nAnswer the question using a single word or phrase."
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/infovqa/infovqa_val_lite.yaml
+++ b/lmms_eval/tasks/infovqa/infovqa_val_lite.yaml
@@ -6,6 +6,7 @@ metric_list:
     aggregation: mean
     higher_is_better: true
 dataset_path: lmms-lab/LMMs-Eval-Lite
+local_dataset_path:
 dataset_name: infovqa_val 
 dataset_kwargs:
   token: True
@@ -20,3 +21,4 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: "\nAnswer the question using a single word or phrase."
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/internal_eval/_default_template_internal_eval_yaml
+++ b/lmms_eval/tasks/internal_eval/_default_template_internal_eval_yaml
@@ -2,4 +2,5 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: ""
+  local_infer_dataset_path:
 process_results_use_image: true

--- a/lmms_eval/tasks/internal_eval/d170_cn.yaml
+++ b/lmms_eval/tasks/internal_eval/d170_cn.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/D170_v4.1_CN
+local_dataset_path:
 dataset_kwargs:
   token: True
 task: "d170_cn"

--- a/lmms_eval/tasks/internal_eval/d170_en.yaml
+++ b/lmms_eval/tasks/internal_eval/d170_en.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/D170_v4.1_EN
+local_dataset_path:
 dataset_kwargs:
   token: True
 task: "d170_en"

--- a/lmms_eval/tasks/internal_eval/dc100_en.yaml
+++ b/lmms_eval/tasks/internal_eval/dc100_en.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/DC100_EN
+local_dataset_path:
 dataset_kwargs:
   token: True
 task: "dc100_en"

--- a/lmms_eval/tasks/internal_eval/dc200_cn.yaml
+++ b/lmms_eval/tasks/internal_eval/dc200_cn.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/DC200_CN
+local_dataset_path:
 dataset_kwargs:
   token: True
 task: "dc200_cn"

--- a/lmms_eval/tasks/jmmmu/_default_template_yaml
+++ b/lmms_eval/tasks/jmmmu/_default_template_yaml
@@ -1,4 +1,5 @@
 dataset_path: JMMMU/JMMMU
+local_dataset_path:
 test_split: test
 output_type: generate_until
 doc_to_visual: !function utils.jmmmu_doc_to_visual

--- a/lmms_eval/tasks/librispeech/librispeech_dev_clean.yaml
+++ b/lmms_eval/tasks/librispeech/librispeech_dev_clean.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/librispeech
+local_dataset_path:
 dataset_kwargs:
   token: True
 task : "librispeech_dev_clean"
@@ -28,3 +29,4 @@ lmms_eval_specific_kwargs:
   qwen2_audio:
     pre_prompt: ""
     post_prompt: " <|en|>"
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/librispeech/librispeech_dev_other.yaml
+++ b/lmms_eval/tasks/librispeech/librispeech_dev_other.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/librispeech
+local_dataset_path:
 dataset_kwargs:
   token: True
 task : "librispeech_dev_other"
@@ -28,3 +29,4 @@ lmms_eval_specific_kwargs:
   qwen2_audio:
     pre_prompt: ""
     post_prompt: " <|en|>"
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/librispeech/librispeech_test_clean.yaml
+++ b/lmms_eval/tasks/librispeech/librispeech_test_clean.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/librispeech
+local_dataset_path:
 dataset_kwargs:
   token: True
 task : "librispeech_test_clean"
@@ -28,3 +29,4 @@ lmms_eval_specific_kwargs:
   qwen2_audio:
     pre_prompt: ""
     post_prompt: " <|en|>"
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/librispeech/librispeech_test_other.yaml
+++ b/lmms_eval/tasks/librispeech/librispeech_test_other.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/librispeech
+local_dataset_path:
 dataset_kwargs:
   token: True
 task : "librispeech_test_other"
@@ -28,3 +29,4 @@ lmms_eval_specific_kwargs:
   qwen2_audio:
     pre_prompt: ""
     post_prompt: " <|en|>"
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/live_bench/live_bench_template_yaml
+++ b/lmms_eval/tasks/live_bench/live_bench_template_yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/LiveBench
+local_dataset_path:
 dataset_kwargs:
   token: True
 test_split: test
@@ -27,3 +28,4 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: ""
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/livexiv_tqa/livexiv_tqa_template_yaml
+++ b/lmms_eval/tasks/livexiv_tqa/livexiv_tqa_template_yaml
@@ -1,4 +1,5 @@
 dataset_path: LiveXiv/LiveXiv
+local_dataset_path:
 dataset_kwargs:
   token: True
 test_split: test
@@ -24,3 +25,4 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: ""
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/livexiv_vqa/livexiv_vqa_template_yaml
+++ b/lmms_eval/tasks/livexiv_vqa/livexiv_vqa_template_yaml
@@ -1,4 +1,5 @@
 dataset_path: LiveXiv/LiveXiv
+local_dataset_path:
 dataset_kwargs:
   token: True
 test_split: test
@@ -24,3 +25,4 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: ""
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/llava-bench-coco/llava-bench-coco.yaml
+++ b/lmms_eval/tasks/llava-bench-coco/llava-bench-coco.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/llava-bench-coco
+local_dataset_path:
 dataset_kwargs:
   token: True
 task: "llava_bench_coco"
@@ -36,3 +37,4 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: ""
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/llava-in-the-wild/llava-in-the-wild.yaml
+++ b/lmms_eval/tasks/llava-in-the-wild/llava-in-the-wild.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/llava-bench-in-the-wild
+local_dataset_path:
 dataset_kwargs:
   token: True
 task: "llava_in_the_wild"
@@ -37,3 +38,4 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: ""
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/llava-in-the-wild/llava-in-the-wild_ko.yaml
+++ b/lmms_eval/tasks/llava-in-the-wild/llava-in-the-wild_ko.yaml
@@ -1,4 +1,5 @@
 dataset_path: NCSOFT/K-LLaVA-W
+local_dataset_path:
 dataset_kwargs:
   token: True
 task: "llava_in_the_wild_ko"
@@ -37,3 +38,4 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: ""
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/llava_interleave_bench/in_domain.yaml
+++ b/lmms_eval/tasks/llava_interleave_bench/in_domain.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/LLaVA-NeXT-Interleave-Bench
+local_dataset_path:
 dataset_name: in_domain
 dataset_kwargs:
   token: True
@@ -24,3 +25,4 @@ lmms_eval_specific_kwargs:
   default:
     oe_post_prompt: ""
     mcq_post_prompt: ""
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/llava_interleave_bench/multi_view_in_domain.yaml
+++ b/lmms_eval/tasks/llava_interleave_bench/multi_view_in_domain.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/LLaVA-NeXT-Interleave-Bench
+local_dataset_path:
 dataset_name: multi_view_in_domain
 dataset_kwargs:
   token: True
@@ -24,3 +25,4 @@ lmms_eval_specific_kwargs:
   default:
     oe_post_prompt: ""
     mcq_post_prompt: ""
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/llava_interleave_bench/out_of_domain.yaml
+++ b/lmms_eval/tasks/llava_interleave_bench/out_of_domain.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/LLaVA-NeXT-Interleave-Bench
+local_dataset_path:
 dataset_name: out_of_domain
 dataset_kwargs:
   token: True
@@ -24,3 +25,4 @@ lmms_eval_specific_kwargs:
   default:
     oe_post_prompt: ""
     mcq_post_prompt: ""
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/llava_wilder/llava_wilder_small.yaml
+++ b/lmms_eval/tasks/llava_wilder/llava_wilder_small.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/LLaVA-Bench-Wilder
+local_dataset_path:
 dataset_kwargs:
   token: True
 task: "llava_wilder_small"
@@ -10,4 +11,5 @@ lmms_eval_specific_kwargs:
   xcomposer2_4khd:
     pre_prompt: "[UNUSED_TOKEN_146]user\nQuestion: "
     post_prompt: "[UNUSED_TOKEN_145]\n[UNUSED_TOKEN_146]assistant\n"
+  local_infer_dataset_path:
 include: _default_template_wilder_yaml

--- a/lmms_eval/tasks/longvideobench/longvideobench_test_i.yaml
+++ b/lmms_eval/tasks/longvideobench/longvideobench_test_i.yaml
@@ -1,4 +1,5 @@
 dataset_path: longvideobench/LongVideoBench
+local_dataset_path:
 dataset_kwargs:
   token: True
   cache_dir: longvideobench
@@ -26,4 +27,5 @@ lmms_eval_specific_kwargs:
     pre_prompt: ""
     post_prompt: "Answer with the option's letter from the given choices directly.\n"
     insert_interleave_subtitles: True
+  local_infer_dataset_path:
     

--- a/lmms_eval/tasks/longvideobench/longvideobench_test_v.yaml
+++ b/lmms_eval/tasks/longvideobench/longvideobench_test_v.yaml
@@ -1,4 +1,5 @@
 dataset_path: longvideobench/LongVideoBench
+local_dataset_path:
 dataset_kwargs:
   token: True
   cache_dir: longvideobench
@@ -25,4 +26,5 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: "Answer with the option's letter from the given choices directly.\n"
+  local_infer_dataset_path:
   

--- a/lmms_eval/tasks/longvideobench/longvideobench_val_i.yaml
+++ b/lmms_eval/tasks/longvideobench/longvideobench_val_i.yaml
@@ -1,4 +1,5 @@
 dataset_path: longvideobench/LongVideoBench
+local_dataset_path:
 dataset_kwargs:
   token: True
   cache_dir: longvideobench
@@ -26,4 +27,5 @@ lmms_eval_specific_kwargs:
     pre_prompt: ""
     post_prompt: "Answer with the option's letter from the given choices directly.\n"
     insert_interleave_subtitles: True
+  local_infer_dataset_path:
     

--- a/lmms_eval/tasks/longvideobench/longvideobench_val_v.yaml
+++ b/lmms_eval/tasks/longvideobench/longvideobench_val_v.yaml
@@ -1,4 +1,5 @@
 dataset_path: longvideobench/LongVideoBench
+local_dataset_path:
 dataset_kwargs:
   token: True
   cache_dir: longvideobench
@@ -25,4 +26,5 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: "Answer with the option's letter from the given choices directly.\n"
+  local_infer_dataset_path:
   

--- a/lmms_eval/tasks/mathverse/mathverse_testmini.yaml
+++ b/lmms_eval/tasks/mathverse/mathverse_testmini.yaml
@@ -1,4 +1,5 @@
 dataset_path: CaraJ/MathVerse-lmmseval
+local_dataset_path:
 dataset_name: testmini
 dataset_kwargs:
   token: False
@@ -29,6 +30,7 @@ lmms_eval_specific_kwargs:
   default:
     shot_type: "format-prompt" # can also be "custom-prompt"
     query_type: "query_wo" # now only support query_wo
+  local_infer_dataset_path:
 model_specific_generation_kwargs:
   llava:
     image_aspect_ratio: original

--- a/lmms_eval/tasks/mathverse/mathverse_testmini_text_dominant.yaml
+++ b/lmms_eval/tasks/mathverse/mathverse_testmini_text_dominant.yaml
@@ -1,4 +1,5 @@
 dataset_path: CaraJ/MathVerse-lmmseval
+local_dataset_path:
 dataset_name: testmini_version_split
 dataset_kwargs:
   token: False
@@ -29,6 +30,7 @@ lmms_eval_specific_kwargs:
   default:
     shot_type: "format-prompt" # can also be "custom-prompt"
     query_type: "query_wo" # now only support query_wo
+  local_infer_dataset_path:
 model_specific_generation_kwargs:
   llava:
     image_aspect_ratio: original

--- a/lmms_eval/tasks/mathverse/mathverse_testmini_text_lite.yaml
+++ b/lmms_eval/tasks/mathverse/mathverse_testmini_text_lite.yaml
@@ -1,4 +1,5 @@
 dataset_path: CaraJ/MathVerse-lmmseval
+local_dataset_path:
 dataset_name: testmini_version_split
 dataset_kwargs:
   token: False
@@ -29,6 +30,7 @@ lmms_eval_specific_kwargs:
   default:
     shot_type: "format-prompt" # can also be "custom-prompt"
     query_type: "query_wo" # now only support query_wo
+  local_infer_dataset_path:
 model_specific_generation_kwargs:
   llava:
     image_aspect_ratio: original

--- a/lmms_eval/tasks/mathverse/mathverse_testmini_text_only.yaml
+++ b/lmms_eval/tasks/mathverse/mathverse_testmini_text_only.yaml
@@ -1,4 +1,5 @@
 dataset_path: CaraJ/MathVerse-lmmseval
+local_dataset_path:
 dataset_name: testmini_text_only
 dataset_kwargs:
   token: False
@@ -29,6 +30,7 @@ lmms_eval_specific_kwargs:
   default:
     shot_type: "format-prompt" # can also be "custom-prompt"
     query_type: "query_wo" # now only support query_wo
+  local_infer_dataset_path:
 model_specific_generation_kwargs:
   llava:
     image_aspect_ratio: original

--- a/lmms_eval/tasks/mathverse/mathverse_testmini_vision_dominant.yaml
+++ b/lmms_eval/tasks/mathverse/mathverse_testmini_vision_dominant.yaml
@@ -1,4 +1,5 @@
 dataset_path: CaraJ/MathVerse-lmmseval
+local_dataset_path:
 dataset_name: testmini_version_split
 dataset_kwargs:
   token: False
@@ -29,6 +30,7 @@ lmms_eval_specific_kwargs:
   default:
     shot_type: "format-prompt" # can also be "custom-prompt"
     query_type: "query_wo" # now only support query_wo
+  local_infer_dataset_path:
 model_specific_generation_kwargs:
   llava:
     image_aspect_ratio: original

--- a/lmms_eval/tasks/mathverse/mathverse_testmini_vision_intensive.yaml
+++ b/lmms_eval/tasks/mathverse/mathverse_testmini_vision_intensive.yaml
@@ -1,4 +1,5 @@
 dataset_path: CaraJ/MathVerse-lmmseval
+local_dataset_path:
 dataset_name: testmini_version_split
 dataset_kwargs:
   token: False
@@ -29,6 +30,7 @@ lmms_eval_specific_kwargs:
   default:
     shot_type: "format-prompt" # can also be "custom-prompt"
     query_type: "query_wo" # now only support query_wo
+  local_infer_dataset_path:
 model_specific_generation_kwargs:
   llava:
     image_aspect_ratio: original

--- a/lmms_eval/tasks/mathverse/mathverse_testmini_vision_only.yaml
+++ b/lmms_eval/tasks/mathverse/mathverse_testmini_vision_only.yaml
@@ -1,4 +1,5 @@
 dataset_path: CaraJ/MathVerse-lmmseval
+local_dataset_path:
 dataset_name: testmini_version_split
 dataset_kwargs:
   token: False
@@ -29,6 +30,7 @@ lmms_eval_specific_kwargs:
   default:
     shot_type: "format-prompt" # can also be "custom-prompt"
     query_type: "query_wo" # now only support query_wo
+  local_infer_dataset_path:
 model_specific_generation_kwargs:
   llava:
     image_aspect_ratio: original

--- a/lmms_eval/tasks/mathvision/mathvision_reason_test.yaml
+++ b/lmms_eval/tasks/mathvision/mathvision_reason_test.yaml
@@ -1,4 +1,5 @@
 dataset_path: MathLLMs/MathVision
+local_dataset_path:
 dataset_kwargs:
   token: True
 task: "mathvision_reason_test"
@@ -24,3 +25,4 @@ lmms_eval_specific_kwargs:
     prompt_format: solution
     mc_prompt: "Answer the question with the option's letter from the given choices directly."
     short_answer_prompt: "Answer the question with a number directly."
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/mathvision/mathvision_reason_testmini.yaml
+++ b/lmms_eval/tasks/mathvision/mathvision_reason_testmini.yaml
@@ -1,4 +1,5 @@
 dataset_path: MathLLMs/MathVision
+local_dataset_path:
 dataset_kwargs:
   token: True
 task: "mathvision_reason_testmini"
@@ -24,3 +25,4 @@ lmms_eval_specific_kwargs:
     prompt_format: solution
     mc_prompt: "Answer the question with the option's letter from the given choices directly."
     short_answer_prompt: "Answer the question with a number directly."
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/mathvision/mathvision_test.yaml
+++ b/lmms_eval/tasks/mathvision/mathvision_test.yaml
@@ -1,4 +1,5 @@
 dataset_path: MathLLMs/MathVision
+local_dataset_path:
 dataset_kwargs:
   token: True
 task: "mathvision_test"
@@ -24,3 +25,4 @@ lmms_eval_specific_kwargs:
     prompt_format: solution
     mc_prompt: "Answer the question with the option's letter from the given choices directly."
     short_answer_prompt: "Answer the question with a number directly."
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/mathvision/mathvision_testmini.yaml
+++ b/lmms_eval/tasks/mathvision/mathvision_testmini.yaml
@@ -1,4 +1,5 @@
 dataset_path: MathLLMs/MathVision
+local_dataset_path:
 dataset_kwargs:
   token: True
 task: "mathvision_testmini"
@@ -24,3 +25,4 @@ lmms_eval_specific_kwargs:
     prompt_format: solution
     mc_prompt: "Answer the question with the option's letter from the given choices directly."
     short_answer_prompt: "Answer the question with a number directly."
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/mathvista/mathvista_test.yaml
+++ b/lmms_eval/tasks/mathvista/mathvista_test.yaml
@@ -1,4 +1,5 @@
 dataset_path: AI4Math/MathVista
+local_dataset_path:
 dataset_kwargs:
   token: True
 task: "mathvista_test"
@@ -22,3 +23,4 @@ metric_list:
 lmms_eval_specific_kwargs:
   default:
     shot_type: "reason-first" # can be "reason-first", "solution", "step-by-step"
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/mathvista/mathvista_testmini_cot.yaml
+++ b/lmms_eval/tasks/mathvista/mathvista_testmini_cot.yaml
@@ -1,4 +1,5 @@
 dataset_path: AI4Math/MathVista
+local_dataset_path:
 dataset_kwargs:
   token: True
 task: "mathvista_testmini_cot"
@@ -27,3 +28,4 @@ lmms_eval_specific_kwargs:
     use_ocr: False
   phi3v:
     shot_type: "solution"
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/mathvista/mathvista_testmini_format.yaml
+++ b/lmms_eval/tasks/mathvista/mathvista_testmini_format.yaml
@@ -1,4 +1,5 @@
 dataset_path: AI4Math/MathVista
+local_dataset_path:
 dataset_kwargs:
   token: True
 task: "mathvista_testmini_format"
@@ -27,3 +28,4 @@ lmms_eval_specific_kwargs:
     use_ocr: False
   phi3v:
     shot_type: "solution"
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/mathvista/mathvista_testmini_solution.yaml
+++ b/lmms_eval/tasks/mathvista/mathvista_testmini_solution.yaml
@@ -1,4 +1,5 @@
 dataset_path: AI4Math/MathVista
+local_dataset_path:
 dataset_kwargs:
   token: True
 task: "mathvista_testmini_solution"
@@ -27,3 +28,4 @@ lmms_eval_specific_kwargs:
     use_ocr: False
   phi3v:
     shot_type: "solution"
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/megabench/_default_template_yaml
+++ b/lmms_eval/tasks/megabench/_default_template_yaml
@@ -1,4 +1,5 @@
 dataset_path: TIGER-Lab/MEGA-Bench
+local_dataset_path:
 test_split: test
 dataset_kwargs:
   token: True
@@ -26,6 +27,7 @@ metric_list:
 lmms_eval_specific_kwargs:
   default:
     max_video_subsample_frame: 64
+  local_infer_dataset_path:
   
 metadata:
   - version: 0.0

--- a/lmms_eval/tasks/mia_bench/mia_bench.yaml
+++ b/lmms_eval/tasks/mia_bench/mia_bench.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/MIA-Bench
+local_dataset_path:
 dataset_kwargs:
   token: True
 task: "mia_bench"
@@ -16,6 +17,7 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: ""
+  local_infer_dataset_path:
 generation_kwargs:
   max_new_tokens: 512
 metadata:

--- a/lmms_eval/tasks/mirb/mirb.yaml
+++ b/lmms_eval/tasks/mirb/mirb.yaml
@@ -1,5 +1,6 @@
 
 dataset_path: VLLMs/MIRB-hf
+local_dataset_path:
 task: mirb
 dataset_kwargs:
   token: True
@@ -14,6 +15,7 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: ""
+  local_infer_dataset_path:
 
 
 generation_kwargs:

--- a/lmms_eval/tasks/mix_evals/audio2text/_default_template_yaml
+++ b/lmms_eval/tasks/mix_evals/audio2text/_default_template_yaml
@@ -1,10 +1,12 @@
 dataset_kwargs:
   token: true
 dataset_path: lmms-lab/MixEval-X-audio2text
+local_dataset_path:
 lmms_eval_specific_kwargs:
   default:
     post_prompt: ""
     pre_prompt: ""
+  local_infer_dataset_path:
 metadata:
   gpt_eval_model_name: gpt-4o-mini
   version: 0

--- a/lmms_eval/tasks/mix_evals/audio2text/mix_evals_audio2_text_freeform.yaml
+++ b/lmms_eval/tasks/mix_evals/audio2text/mix_evals_audio2_text_freeform.yaml
@@ -22,3 +22,4 @@ lmms_eval_specific_kwargs:
   gpt4v:
     pre_prompt: "These are frames from a video. Please answer the following questions about the video with a short phrase."
     post_prompt: ""
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/mix_evals/audio2text/mix_evals_audio2_text_freeform_hard.yaml
+++ b/lmms_eval/tasks/mix_evals/audio2text/mix_evals_audio2_text_freeform_hard.yaml
@@ -22,3 +22,4 @@ lmms_eval_specific_kwargs:
   gpt4v:
     pre_prompt: "These are frames from a video. Please answer the following questions about the video with a short phrase."
     post_prompt: ""
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/mix_evals/image2text/_default_template_yaml
+++ b/lmms_eval/tasks/mix_evals/image2text/_default_template_yaml
@@ -1,4 +1,5 @@
 dataset_path: MixEval/MixEval-X
+local_dataset_path:
 dataset_kwargs:
   video: true # a bit confusing, but this is because the official uses path to store image data, so we need to load it as a video dataset
   cache_dir: mix_evals_image2text
@@ -9,5 +10,6 @@ lmms_eval_specific_kwargs:
   gpt4v:
     post_prompt: ""
     pre_prompt: ""
+  local_infer_dataset_path:
 metadata:
   version: 0

--- a/lmms_eval/tasks/mix_evals/image2text/mix_evals_image2text_freeform_hard.yaml
+++ b/lmms_eval/tasks/mix_evals/image2text/mix_evals_image2text_freeform_hard.yaml
@@ -23,3 +23,4 @@ lmms_eval_specific_kwargs:
   gpt4v:
     pre_prompt: "Please answer the following questions about the image."
     post_prompt: ""
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/mix_evals/video2text/_default_template_yaml
+++ b/lmms_eval/tasks/mix_evals/video2text/_default_template_yaml
@@ -3,6 +3,7 @@ dataset_kwargs:
   token: true
   video: true
 dataset_path: MixEval/MixEval-X
+local_dataset_path:
 lmms_eval_specific_kwargs:
   default:
     post_prompt: ""
@@ -10,6 +11,7 @@ lmms_eval_specific_kwargs:
   gpt4v:
     post_prompt: ""
     pre_prompt: These are frames from a video. Please answer the following questions about the video.
+  local_infer_dataset_path:
 metadata:
   gpt_eval_model_name: gpt-4o-mini
   version: 0

--- a/lmms_eval/tasks/mix_evals/video2text/mix_evals_video2text_freeform.yaml
+++ b/lmms_eval/tasks/mix_evals/video2text/mix_evals_video2text_freeform.yaml
@@ -23,3 +23,4 @@ lmms_eval_specific_kwargs:
   gpt4v:
     pre_prompt: "These are frames from a video. Please answer the following questions about the video."
     post_prompt: ""
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/mix_evals/video2text/mix_evals_video2text_freeform_hard.yaml
+++ b/lmms_eval/tasks/mix_evals/video2text/mix_evals_video2text_freeform_hard.yaml
@@ -23,3 +23,4 @@ lmms_eval_specific_kwargs:
   gpt4v:
     pre_prompt: "These are frames from a video. Please answer the following questions about the video with a short phrase."
     post_prompt: ""
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/mix_evals/video2text/mix_evals_video2text_mc.yaml
+++ b/lmms_eval/tasks/mix_evals/video2text/mix_evals_video2text_mc.yaml
@@ -29,3 +29,4 @@ lmms_eval_specific_kwargs:
   gpt4v:
     pre_prompt: "These are frames from a video. Please answer the following questions about the video."
     post_prompt: "Answer with the option's letter from the given choices directly."
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/mix_evals/video2text/mix_evals_video2text_mc_hard.yaml
+++ b/lmms_eval/tasks/mix_evals/video2text/mix_evals_video2text_mc_hard.yaml
@@ -29,3 +29,4 @@ lmms_eval_specific_kwargs:
   gpt4v:
     pre_prompt: "These are frames from a video. Please answer the following questions about the video."
     post_prompt: "Answer with the option's letter from the given choices directly."
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/mix_evals/video2text/mix_evals_video2text_openended.yaml
+++ b/lmms_eval/tasks/mix_evals/video2text/mix_evals_video2text_openended.yaml
@@ -20,3 +20,4 @@ lmms_eval_specific_kwargs:
   gpt4v:
     pre_prompt: "These are frames from a video. Please answer the following questions about the video."
     post_prompt: ""
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/mlvu/mlvu_dev.yaml
+++ b/lmms_eval/tasks/mlvu/mlvu_dev.yaml
@@ -1,4 +1,5 @@
 dataset_path: sy1998/MLVU_dev
+local_dataset_path:
 dataset_kwargs:
   token: True
   cache_dir: mlvu

--- a/lmms_eval/tasks/mlvu/mlvu_test.yaml
+++ b/lmms_eval/tasks/mlvu/mlvu_test.yaml
@@ -1,4 +1,5 @@
 dataset_path: sy1998/MLVU_Test
+local_dataset_path:
 dataset_kwargs:
   token: True
   cache_dir: mlvu_test

--- a/lmms_eval/tasks/mmbench/_default_template_mmbench_cn_yaml
+++ b/lmms_eval/tasks/mmbench/_default_template_mmbench_cn_yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/MMBench
+local_dataset_path:
 dataset_kwargs:
   token: True
 doc_to_target: "answer"
@@ -17,6 +18,7 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: "\n请直接使用所提供的选项字母作为答案回答。"
+  local_infer_dataset_path:
 model_specific_generation_kwargs:
   llava:
     image_aspect_ratio: original

--- a/lmms_eval/tasks/mmbench/_default_template_mmbench_en_yaml
+++ b/lmms_eval/tasks/mmbench/_default_template_mmbench_en_yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/MMBench
+local_dataset_path:
 dataset_kwargs:
   token: True
 doc_to_target: "answer"
@@ -6,6 +7,7 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: "\nAnswer with the option's letter from the given choices directly."
+  local_infer_dataset_path:
 doc_to_visual: !function en_utils.mmbench_doc_to_visual
 doc_to_text: !function en_utils.mmbench_doc_to_text
 doc_to_target: "answer"

--- a/lmms_eval/tasks/mmbench/_default_template_mmbench_ko_yaml
+++ b/lmms_eval/tasks/mmbench/_default_template_mmbench_ko_yaml
@@ -1,4 +1,5 @@
 dataset_path: NCSOFT/K-MMBench
+local_dataset_path:
 dataset_kwargs:
   token: True
 doc_to_target: "answer"
@@ -6,6 +7,7 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: "\n주어진 선택지 중 해당 옵션의 문자로 직접 답하세요."
+  local_infer_dataset_path:
 doc_to_visual: !function ko_utils.mmbench_doc_to_visual
 doc_to_text: !function ko_utils.mmbench_doc_to_text
 doc_to_target: "answer"

--- a/lmms_eval/tasks/mmbench/_default_template_mmbench_ru_yaml
+++ b/lmms_eval/tasks/mmbench/_default_template_mmbench_ru_yaml
@@ -1,4 +1,5 @@
 dataset_path: deepvk/MMBench-ru
+local_dataset_path:
 dataset_kwargs:
   token: True
 doc_to_target: "answer"
@@ -6,6 +7,7 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: "\nВыбери правильный вариант ответа буквой."
+  local_infer_dataset_path:
 doc_to_visual: !function ru_utils.mmbench_doc_to_visual
 doc_to_text: !function ru_utils.mmbench_doc_to_text
 doc_to_target: "answer"

--- a/lmms_eval/tasks/mmbench/mmbench_cc.yaml
+++ b/lmms_eval/tasks/mmbench/mmbench_cc.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/MMBench
+local_dataset_path:
 dataset_name: cc
 dataset_kwargs:
   token: True
@@ -29,6 +30,7 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: "\n请直接使用所提供的选项字母作为答案回答。"
+  local_infer_dataset_path:
 model_specific_generation_kwargs:
   llava:
     image_aspect_ratio: original

--- a/lmms_eval/tasks/mmbench/mmbench_cn_dev_lite.yaml
+++ b/lmms_eval/tasks/mmbench/mmbench_cn_dev_lite.yaml
@@ -8,6 +8,7 @@ metric_list:
     higher_is_better: true
     aggregation: !function cn_utils.mmbench_aggregate_dev_results
 dataset_path: lmms-lab/LMMs-Eval-Lite
+local_dataset_path:
 dataset_name: mmbench_cn_dev
 dataset_kwargs:
   token: True
@@ -26,6 +27,7 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: "\n请直接使用所提供的选项字母作为答案回答。"
+  local_infer_dataset_path:
 model_specific_generation_kwargs:
   llava:
     image_aspect_ratio: original

--- a/lmms_eval/tasks/mmbench/mmbench_en_dev_lite.yaml
+++ b/lmms_eval/tasks/mmbench/mmbench_en_dev_lite.yaml
@@ -1,6 +1,7 @@
 task: "mmbench_en_dev_lite"
 test_split: lite 
 dataset_path: lmms-lab/LMMs-Eval-Lite
+local_dataset_path:
 dataset_name: mmbench_en_dev
 dataset_kwargs:
   token: True
@@ -9,6 +10,7 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: "\nAnswer with the option's letter from the given choices directly."
+  local_infer_dataset_path:
 doc_to_visual: !function en_utils.mmbench_doc_to_visual
 doc_to_text: !function en_utils.mmbench_doc_to_text
 doc_to_target: "answer"

--- a/lmms_eval/tasks/mme/mme.yaml
+++ b/lmms_eval/tasks/mme/mme.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/MME
+local_dataset_path:
 dataset_kwargs:
   token: True
 task: "mme"
@@ -39,5 +40,6 @@ lmms_eval_specific_kwargs:
   xcomposer2_4khd:
     pre_prompt: "[UNUSED_TOKEN_146]user\n"
     post_prompt: " Answer this question briefly[UNUSED_TOKEN_145]\n[UNUSED_TOKEN_146]assistant\n"
+  local_infer_dataset_path:
 metadata:
   - version: 0.0

--- a/lmms_eval/tasks/mme_realworld/mme_realworld.yaml
+++ b/lmms_eval/tasks/mme_realworld/mme_realworld.yaml
@@ -1,4 +1,5 @@
 dataset_path: yifanzhang114/MME-RealWorld-Lmms-eval
+local_dataset_path:
 dataset_kwargs:
   token: True
   # From_YouTube: True
@@ -31,5 +32,6 @@ lmms_eval_specific_kwargs:
   xcomposer2_4khd:
     pre_prompt: "[UNUSED_TOKEN_146]user\n"
     post_prompt: " Answer this question with A, B, C, or D.[UNUSED_TOKEN_145]\n[UNUSED_TOKEN_146]assistant\n"
+  local_infer_dataset_path:
 metadata:
   - version: 0.0

--- a/lmms_eval/tasks/mme_realworld/mme_realworld_cn.yaml
+++ b/lmms_eval/tasks/mme_realworld/mme_realworld_cn.yaml
@@ -1,4 +1,5 @@
 dataset_path: yifanzhang114/MME-RealWorld-CN-Lmms-eval
+local_dataset_path:
 dataset_kwargs:
   token: True
   # From_YouTube: True
@@ -31,5 +32,6 @@ lmms_eval_specific_kwargs:
   xcomposer2_4khd:
     pre_prompt: "[UNUSED_TOKEN_146]user\n"
     post_prompt: " 根据图像选择上述多项选择题的最佳答案。只需回答正确选项的字母（A, B, C, D 或 E）。[UNUSED_TOKEN_145]\n[UNUSED_TOKEN_146]assistant\n"
+  local_infer_dataset_path:
 metadata:
   - version: 0.0

--- a/lmms_eval/tasks/mme_realworld/mme_realworld_lite.yaml
+++ b/lmms_eval/tasks/mme_realworld/mme_realworld_lite.yaml
@@ -1,4 +1,5 @@
 dataset_path: yifanzhang114/MME-RealWorld-lite-lmms-eval
+local_dataset_path:
 dataset_kwargs:
   token: True
   # From_YouTube: True
@@ -31,5 +32,6 @@ lmms_eval_specific_kwargs:
   xcomposer2_4khd:
     pre_prompt: "[UNUSED_TOKEN_146]user\n"
     post_prompt: " Answer this question with A, B, C, or D.[UNUSED_TOKEN_145]\n[UNUSED_TOKEN_146]assistant\n"
+  local_infer_dataset_path:
 metadata:
   - version: 0.0

--- a/lmms_eval/tasks/mmlu/continuation/_continuation_template_yaml
+++ b/lmms_eval/tasks/mmlu/continuation/_continuation_template_yaml
@@ -1,4 +1,5 @@
 dataset_path: hails/mmlu_no_train # a copy of `cais/mmlu` with no auxiliary_train split
+local_dataset_path:
 output_type: multiple_choice
 test_split: test
 fewshot_split: dev

--- a/lmms_eval/tasks/mmlu/default/_default_template_yaml
+++ b/lmms_eval/tasks/mmlu/default/_default_template_yaml
@@ -1,4 +1,5 @@
 dataset_path: hails/mmlu_no_train # a copy of `cais/mmlu` with no auxiliary_train split
+local_dataset_path:
 test_split: test
 fewshot_split: dev
 fewshot_config:

--- a/lmms_eval/tasks/mmlu/flan_cot_fewshot/_mmlu_flan_cot_fewshot_template_yaml
+++ b/lmms_eval/tasks/mmlu/flan_cot_fewshot/_mmlu_flan_cot_fewshot_template_yaml
@@ -1,4 +1,5 @@
 dataset_path: hails/mmlu_no_train # a copy of `cais/mmlu` with no auxiliary_train split
+local_dataset_path:
 validation_split: validation
 test_split: test
 fewshot_split: dev

--- a/lmms_eval/tasks/mmlu/flan_cot_zeroshot/_mmlu_flan_cot_zeroshot_template_yaml
+++ b/lmms_eval/tasks/mmlu/flan_cot_zeroshot/_mmlu_flan_cot_zeroshot_template_yaml
@@ -1,4 +1,5 @@
 dataset_path: hails/mmlu_no_train # a copy of `cais/mmlu` with no auxiliary_train split
+local_dataset_path:
 validation_split: validation
 fewshot_split: dev
 output_type: generate_until

--- a/lmms_eval/tasks/mmlu/flan_n_shot/generative/_mmlu_flan_generative_template_yaml
+++ b/lmms_eval/tasks/mmlu/flan_n_shot/generative/_mmlu_flan_generative_template_yaml
@@ -1,4 +1,5 @@
 dataset_path: hails/mmlu_no_train # a copy of `cais/mmlu` with no auxiliary_train split
+local_dataset_path:
 test_split: test
 fewshot_split: dev
 fewshot_config:

--- a/lmms_eval/tasks/mmlu/flan_n_shot/loglikelihood/_mmlu_flan_loglikelihood_template_yaml
+++ b/lmms_eval/tasks/mmlu/flan_n_shot/loglikelihood/_mmlu_flan_loglikelihood_template_yaml
@@ -1,4 +1,5 @@
 dataset_path: hails/mmlu_no_train # a copy of `cais/mmlu` with no auxiliary_train split
+local_dataset_path:
 test_split: test
 fewshot_split: dev
 fewshot_config:

--- a/lmms_eval/tasks/mmlu/generative/_default_template_yaml
+++ b/lmms_eval/tasks/mmlu/generative/_default_template_yaml
@@ -1,4 +1,5 @@
 dataset_path: hails/mmlu_no_train # a copy of `cais/mmlu` with no auxiliary_train split
+local_dataset_path:
 test_split: test
 fewshot_split: dev
 fewshot_config:

--- a/lmms_eval/tasks/mmlu_pro/_default_template_yaml
+++ b/lmms_eval/tasks/mmlu_pro/_default_template_yaml
@@ -1,4 +1,5 @@
 dataset_path: TIGER-Lab/MMLU-Pro
+local_dataset_path:
 test_split: test
 fewshot_split: validation
 fewshot_config:

--- a/lmms_eval/tasks/mmmu/mmmu_group_img_test.yaml
+++ b/lmms_eval/tasks/mmmu/mmmu_group_img_test.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/MMMU
+local_dataset_path:
 task: "mmmu_test_group_img"
 test_split: test
 output_type: generate_until

--- a/lmms_eval/tasks/mmmu/mmmu_group_img_val.yaml
+++ b/lmms_eval/tasks/mmmu/mmmu_group_img_val.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/MMMU
+local_dataset_path:
 task: "mmmu_val_group_img"
 test_split: validation
 output_type: generate_until

--- a/lmms_eval/tasks/mmmu/mmmu_test.yaml
+++ b/lmms_eval/tasks/mmmu/mmmu_test.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/MMMU
+local_dataset_path:
 task: "mmmu_test"
 test_split: test
 output_type: generate_until

--- a/lmms_eval/tasks/mmmu/mmmu_val.yaml
+++ b/lmms_eval/tasks/mmmu/mmmu_val.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/MMMU
+local_dataset_path:
 task: "mmmu_val"
 test_split: validation
 output_type: generate_until
@@ -18,5 +19,6 @@ lmms_eval_specific_kwargs:
     prompt_type: "format"
     multiple_choice_prompt: "Answer with the option's letter from the given choices directly."
     open_ended_prompt: "Answer the question using a single word or phrase."
+  local_infer_dataset_path:
 
 include: _default_template_yaml

--- a/lmms_eval/tasks/mmmu/mmmu_val_pass64.yaml
+++ b/lmms_eval/tasks/mmmu/mmmu_val_pass64.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/MMMU
+local_dataset_path:
 task: "mmmu_val_pass64"
 test_split: validation
 output_type: generate_until
@@ -48,5 +49,6 @@ lmms_eval_specific_kwargs:
     prompt_type: "format"
     multiple_choice_prompt: "Answer with the option's letter from the given choices directly."
     open_ended_prompt: "Answer the question using a single word or phrase."
+  local_infer_dataset_path:
 
 include: _default_template_yaml

--- a/lmms_eval/tasks/mmmu/mmmu_val_reasoning.yaml
+++ b/lmms_eval/tasks/mmmu/mmmu_val_reasoning.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/MMMU
+local_dataset_path:
 task: "mmmu_val_reasoning"
 test_split: validation
 output_type: generate_until
@@ -28,6 +29,7 @@ lmms_eval_specific_kwargs:
     prompt_type: "reasoning"
     multiple_choice_prompt: "Please reason step by step, and answer the question with option letter from given choices in the format of Answer: <option letter>."
     open_ended_prompt: "Please reason step by step, and answer the question using a single word or phrase in the format of Answer: <answer>."
+  local_infer_dataset_path:
 
 generation_kwargs:
   max_new_tokens: 16384

--- a/lmms_eval/tasks/mmmu_pro/mmmu_pro_composite.yaml
+++ b/lmms_eval/tasks/mmmu_pro/mmmu_pro_composite.yaml
@@ -1,5 +1,6 @@
 task: "mmmu_pro_composite"
 dataset_path: MMMU/MMMU_Pro
+local_dataset_path:
 dataset_name: composite
 test_split: test
 output_type: generate_until

--- a/lmms_eval/tasks/mmmu_pro/mmmu_pro_composite_cot.yaml
+++ b/lmms_eval/tasks/mmmu_pro/mmmu_pro_composite_cot.yaml
@@ -1,5 +1,6 @@
 task: "mmmu_pro_composite_cot"
 dataset_path: MMMU/MMMU_Pro
+local_dataset_path:
 dataset_name: composite
 test_split: test
 output_type: generate_until

--- a/lmms_eval/tasks/mmmu_pro/mmmu_pro_standard.yaml
+++ b/lmms_eval/tasks/mmmu_pro/mmmu_pro_standard.yaml
@@ -1,5 +1,6 @@
 task: "mmmu_pro_standard"
 dataset_path: MMMU/MMMU_Pro
+local_dataset_path:
 dataset_name: "standard (10 options)"
 test_split: test
 output_type: generate_until
@@ -20,3 +21,4 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: "Answer with the option letter from the given choices directly."
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/mmmu_pro/mmmu_pro_standard_cot.yaml
+++ b/lmms_eval/tasks/mmmu_pro/mmmu_pro_standard_cot.yaml
@@ -1,5 +1,6 @@
 task: "mmmu_pro_standard_cot"
 dataset_path: MMMU/MMMU_Pro
+local_dataset_path:
 dataset_name: standard
 test_split: test
 output_type: generate_until
@@ -20,3 +21,4 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: "Answer the following multiple choice question. The last line of your response should be of the following format: 'Answer: $LETTER' (without quotes) where LETTER is one of options. Think step by step before answering."
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/mmmu_pro/mmmu_pro_vision.yaml
+++ b/lmms_eval/tasks/mmmu_pro/mmmu_pro_vision.yaml
@@ -1,5 +1,6 @@
 task: "mmmu_pro_vision"
 dataset_path: MMMU/MMMU_Pro
+local_dataset_path:
 dataset_name: vision
 test_split: test
 output_type: generate_until

--- a/lmms_eval/tasks/mmmu_pro/mmmu_pro_vision_cot.yaml
+++ b/lmms_eval/tasks/mmmu_pro/mmmu_pro_vision_cot.yaml
@@ -1,5 +1,6 @@
 task: "mmmu_pro_vision_cot"
 dataset_path: MMMU/MMMU_Pro
+local_dataset_path:
 dataset_name: vision
 test_split: test
 output_type: generate_until

--- a/lmms_eval/tasks/mmsearch/mmsearch_end2end.yaml
+++ b/lmms_eval/tasks/mmsearch/mmsearch_end2end.yaml
@@ -1,6 +1,7 @@
 # the final score is computed using the script lmms_eval/tasks/mmsearch/get_final_scores.py
 # the score file in the submission folder of the three task (end2end, rerank, summarization) should be input as args
 dataset_path: CaraJ/MMSearch
+local_dataset_path:
 dataset_name: end2end
 dataset_kwargs:
   token: False
@@ -29,3 +30,4 @@ metric_list:
 lmms_eval_specific_kwargs: # whenever a sample is infered, save it
   middle_resules_dir: /data1/zrr/jdz/mmsearch/mmsearch_middile_results
   result_cache_dir: /data1/zrr/jdz/mmsearch/mmsearch_result_cache_dir
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/mmsearch/mmsearch_rerank.yaml
+++ b/lmms_eval/tasks/mmsearch/mmsearch_rerank.yaml
@@ -1,6 +1,7 @@
 # the final score is computed using the script lmms_eval/tasks/mmsearch/get_final_scores.py
 # the score file in the submission folder of the three task (end2end, rerank, summarization) should be input as args
 dataset_path: CaraJ/MMSearch
+local_dataset_path:
 dataset_name: rerank
 dataset_kwargs:
   token: False
@@ -28,6 +29,7 @@ lmms_eval_specific_kwargs:
   default:
     shot_type: "format-prompt" # can also be "custom-prompt"
     query_type: "query_wo" # now only support query_wo
+  local_infer_dataset_path:
 model_specific_generation_kwargs:
   llava:
     image_aspect_ratio: original

--- a/lmms_eval/tasks/mmsearch/mmsearch_summarization.yaml
+++ b/lmms_eval/tasks/mmsearch/mmsearch_summarization.yaml
@@ -1,6 +1,7 @@
 # the final score is computed using the script lmms_eval/tasks/mmsearch/get_final_scores.py
 # the score file in the submission folder of the three task (end2end, rerank, summarization) should be input as args
 dataset_path: CaraJ/MMSearch
+local_dataset_path:
 dataset_name: summarization
 dataset_kwargs:
   token: False
@@ -28,6 +29,7 @@ lmms_eval_specific_kwargs:
   default:
     shot_type: "format-prompt" # can also be "custom-prompt"
     query_type: "query_wo" # now only support query_wo
+  local_infer_dataset_path:
 model_specific_generation_kwargs:
   llava:
     image_aspect_ratio: original

--- a/lmms_eval/tasks/mmstar/mmstar.yaml
+++ b/lmms_eval/tasks/mmstar/mmstar.yaml
@@ -1,4 +1,5 @@
 dataset_path: Lin-Chen/MMStar
+local_dataset_path:
 dataset_kwargs:
   token: True
 task: "mmstar"
@@ -36,5 +37,6 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: "\nAnswer with the option's letter from the given choices directly"
+  local_infer_dataset_path:
 metadata:
   - version: 0.0

--- a/lmms_eval/tasks/mmstar/mmstar_ko.yaml
+++ b/lmms_eval/tasks/mmstar/mmstar_ko.yaml
@@ -1,4 +1,5 @@
 dataset_path: NCSOFT/K-MMStar
+local_dataset_path:
 dataset_kwargs:
   token: True
 task: "mmstar_ko"
@@ -36,5 +37,6 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: ""
+  local_infer_dataset_path:
 metadata:
   - version: 0.0

--- a/lmms_eval/tasks/mmt/_default_template_yaml
+++ b/lmms_eval/tasks/mmt/_default_template_yaml
@@ -2,6 +2,7 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: "\nAnswer the question using a single character from the given options."
+  local_infer_dataset_path:
 generation_kwargs:
   max_new_tokens: 8
 metadata:

--- a/lmms_eval/tasks/mmt/mmt_mi_test.yaml
+++ b/lmms_eval/tasks/mmt/mmt_mi_test.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/MMT_MI-Benchmark
+local_dataset_path:
 dataset_kwargs:
   token: True
 task: "mmt_mi_test"

--- a/lmms_eval/tasks/mmt/mmt_mi_val.yaml
+++ b/lmms_eval/tasks/mmt/mmt_mi_val.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/MMT_MI-Benchmark
+local_dataset_path:
 dataset_kwargs:
   token: True
 task: "mmt_mi_val"

--- a/lmms_eval/tasks/mmt/mmt_test.yaml
+++ b/lmms_eval/tasks/mmt/mmt_test.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/MMT-Benchmark
+local_dataset_path:
 dataset_kwargs:
   token: True
 task: "mmt_test"

--- a/lmms_eval/tasks/mmt/mmt_val.yaml
+++ b/lmms_eval/tasks/mmt/mmt_val.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/MMT-Benchmark
+local_dataset_path:
 dataset_kwargs:
   token: True
 task: "mmt_val"

--- a/lmms_eval/tasks/mmupd/_default_template_mmupd_yaml
+++ b/lmms_eval/tasks/mmupd/_default_template_mmupd_yaml
@@ -1,4 +1,5 @@
 dataset_path: MM-UPD/MM-UPD
+local_dataset_path:
 doc_to_target: "answer"
 doc_to_visual: !function utils.mmupd_doc_to_visual
 doc_to_text: !function utils.mmupd_doc_to_text

--- a/lmms_eval/tasks/mmupd/mmaad_base.yaml
+++ b/lmms_eval/tasks/mmupd/mmaad_base.yaml
@@ -5,6 +5,7 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: "\n"
+  local_infer_dataset_path:
 include: _default_template_mmupd_yaml
 metric_list:
   - metric: gpt_eval_score

--- a/lmms_eval/tasks/mmupd/mmaad_instruction.yaml
+++ b/lmms_eval/tasks/mmupd/mmaad_instruction.yaml
@@ -5,6 +5,7 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: "\nIf all the options are incorrect, answer \"F. None of the above\"."
+  local_infer_dataset_path:
 include: _default_template_mmupd_yaml
 metric_list:
   - metric: gpt_eval_score

--- a/lmms_eval/tasks/mmupd/mmaad_option.yaml
+++ b/lmms_eval/tasks/mmupd/mmaad_option.yaml
@@ -5,6 +5,7 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: "\nAnswer with the option's letter from the given choices directly."
+  local_infer_dataset_path:
 include: _default_template_mmupd_yaml
 metric_list:
   - metric: gpt_eval_score

--- a/lmms_eval/tasks/mmupd/mmiasd_base.yaml
+++ b/lmms_eval/tasks/mmupd/mmiasd_base.yaml
@@ -5,6 +5,7 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: "\n"
+  local_infer_dataset_path:
 include: _default_template_mmupd_yaml
 metric_list:
   - metric: gpt_eval_score

--- a/lmms_eval/tasks/mmupd/mmiasd_instruction.yaml
+++ b/lmms_eval/tasks/mmupd/mmiasd_instruction.yaml
@@ -5,6 +5,7 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: "\nIf all the options are incorrect, answer \"F. None of the above\"."
+  local_infer_dataset_path:
 include: _default_template_mmupd_yaml
 metric_list:
   - metric: gpt_eval_score

--- a/lmms_eval/tasks/mmupd/mmiasd_option.yaml
+++ b/lmms_eval/tasks/mmupd/mmiasd_option.yaml
@@ -5,6 +5,7 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: "\nAnswer with the option's letter from the given choices directly."
+  local_infer_dataset_path:
 include: _default_template_mmupd_yaml
 metric_list:
   - metric: gpt_eval_score

--- a/lmms_eval/tasks/mmupd/mmivqd_base.yaml
+++ b/lmms_eval/tasks/mmupd/mmivqd_base.yaml
@@ -5,6 +5,7 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: "\n"
+  local_infer_dataset_path:
 include: _default_template_mmupd_yaml
 metric_list:
   - metric: gpt_eval_score

--- a/lmms_eval/tasks/mmupd/mmivqd_instruction.yaml
+++ b/lmms_eval/tasks/mmupd/mmivqd_instruction.yaml
@@ -5,6 +5,7 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: "\nIf the given image is irrelevant to the question, answer \"F. The image and question are irrelevant.\"."
+  local_infer_dataset_path:
 include: _default_template_mmupd_yaml
 metric_list:
   - metric: gpt_eval_score

--- a/lmms_eval/tasks/mmupd/mmivqd_option.yaml
+++ b/lmms_eval/tasks/mmupd/mmivqd_option.yaml
@@ -5,6 +5,7 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: "\nAnswer with the option's letter from the given choices directly."
+  local_infer_dataset_path:
 include: _default_template_mmupd_yaml
 metric_list:
   - metric: gpt_eval_score

--- a/lmms_eval/tasks/mmvet/mmvet.yaml
+++ b/lmms_eval/tasks/mmvet/mmvet.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/MMVet
+local_dataset_path:
 dataset_kwargs:
   token: True
 task: "mmvet"
@@ -25,3 +26,4 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: "First please perform reasoning, and think step by step to provide best answer to the following question: \n\n"
     post_prompt: ""
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/mmvetv2/mmvetv2.yaml
+++ b/lmms_eval/tasks/mmvetv2/mmvetv2.yaml
@@ -1,4 +1,5 @@
 dataset_path: whyu/mm-vet-v2
+local_dataset_path:
 dataset_kwargs:
   token: True
 task: "mmvetv2"
@@ -26,3 +27,4 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: "First please perform reasoning, and think step by step to provide best answer to the following question: \n\n"
     post_prompt: ""
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/mmvetv2/mmvetv2_group_img.yaml
+++ b/lmms_eval/tasks/mmvetv2/mmvetv2_group_img.yaml
@@ -1,6 +1,7 @@
 # This task differs from MMVet2 in that it combines multiple images into a single composite image, enabling compatibility with models that do not support multiple image inputs.
 
 dataset_path: whyu/mm-vet-v2
+local_dataset_path:
 dataset_kwargs:
   token: True
 task: "mmvetv2"
@@ -28,3 +29,4 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: "First please perform reasoning, and think step by step to provide best answer to the following question: \n\n"
     post_prompt: ""
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/mmworld/mmworld.yaml
+++ b/lmms_eval/tasks/mmworld/mmworld.yaml
@@ -1,4 +1,5 @@
 dataset_path: MMWorld/MMWorld
+local_dataset_path:
 dataset_kwargs:
   token: True
   cache_dir: mmworld
@@ -33,5 +34,6 @@ lmms_eval_specific_kwargs:
   xcomposer2_4khd:
     pre_prompt: "[UNUSED_TOKEN_146]user\n"
     post_prompt: " Answer this question with A, B, C, or D.[UNUSED_TOKEN_145]\n[UNUSED_TOKEN_146]assistant\n"
+  local_infer_dataset_path:
 metadata:
   - version: 0.0

--- a/lmms_eval/tasks/moviechat/_default_template_yaml
+++ b/lmms_eval/tasks/moviechat/_default_template_yaml
@@ -1,4 +1,5 @@
 dataset_path: Enxin/lmms_MovieChat_test
+local_dataset_path:
 dataset_kwargs:
   token: True
   video: True
@@ -7,6 +8,7 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: "You are able to understand the visual content that the user provides.Follow the instructions carefully and explain your answers in detail."
     post_prompt: ""
+  local_infer_dataset_path:
 
 metadata:
   version: 0.0

--- a/lmms_eval/tasks/moviechat/moviechat_breakpoint.yaml
+++ b/lmms_eval/tasks/moviechat/moviechat_breakpoint.yaml
@@ -1,5 +1,6 @@
 task: "moviechat_breakpoint"
 dataset_path: Enxin/lmms_MovieChat_test
+local_dataset_path:
 test_split: "test"
 output_type: generate_until
 doc_to_visual: !function utils.moviechat_doc_to_visual_breakpoint

--- a/lmms_eval/tasks/moviechat/moviechat_global.yaml
+++ b/lmms_eval/tasks/moviechat/moviechat_global.yaml
@@ -1,5 +1,6 @@
 task: "moviechat_global"
 dataset_path: Enxin/lmms_MovieChat_test
+local_dataset_path:
 test_split: test
 output_type: generate_until
 doc_to_visual: !function utils.moviechat_doc_to_visual

--- a/lmms_eval/tasks/muchomusic/muchomusic.yaml
+++ b/lmms_eval/tasks/muchomusic/muchomusic.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/muchomusic
+local_dataset_path:
 dataset_kwargs:
   token: True
 
@@ -13,6 +14,7 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: "\nAnswer with the option's letter from the given choices directly: "
+  local_infer_dataset_path:
 metric_list:
   - metric: accuracy
     aggregation: mean

--- a/lmms_eval/tasks/muirbench/muirbench.yaml
+++ b/lmms_eval/tasks/muirbench/muirbench.yaml
@@ -1,4 +1,5 @@
 dataset_path: MUIRBENCH/MUIRBENCH
+local_dataset_path:
 task: "muirbench"
 dataset_kwargs:
   token: True
@@ -13,6 +14,7 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: "\nAnswer with the option's letter from the given choices directly."
+  local_infer_dataset_path:
 
 
 generation_kwargs:

--- a/lmms_eval/tasks/multidocvqa/multidocvqa_test.yaml
+++ b/lmms_eval/tasks/multidocvqa/multidocvqa_test.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/MP-DocVQA
+local_dataset_path:
 task: "multidocvqa_test"
 test_split: test
 output_type: generate_until
@@ -17,4 +18,5 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: "\nAnswer the question using a single word or phrase."
+  local_infer_dataset_path:
   

--- a/lmms_eval/tasks/multidocvqa/multidocvqa_val.yaml
+++ b/lmms_eval/tasks/multidocvqa/multidocvqa_val.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/MP-DocVQA
+local_dataset_path:
 task: "multidocvqa_val"
 test_split: val
 output_type: generate_until
@@ -21,3 +22,4 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: "\nAnswer the question using a single word or phrase."
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/multilingual-llava-bench-in-the-wild/_default_template_yaml
+++ b/lmms_eval/tasks/multilingual-llava-bench-in-the-wild/_default_template_yaml
@@ -33,3 +33,4 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: ""
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/multilingual-llava-bench-in-the-wild/arabic_llava_in_the_wild.yaml
+++ b/lmms_eval/tasks/multilingual-llava-bench-in-the-wild/arabic_llava_in_the_wild.yaml
@@ -1,4 +1,5 @@
 dataset_path: "gagan3012/multilingual-llava-bench"
+local_dataset_path:
 dataset_kwargs:
     config: arabic
     token: True

--- a/lmms_eval/tasks/multilingual-llava-bench-in-the-wild/bengali_llava_in_the_wild.yaml
+++ b/lmms_eval/tasks/multilingual-llava-bench-in-the-wild/bengali_llava_in_the_wild.yaml
@@ -1,4 +1,5 @@
 dataset_path: "gagan3012/multilingual-llava-bench"
+local_dataset_path:
 dataset_kwargs:
     config: bengali
     token: True

--- a/lmms_eval/tasks/multilingual-llava-bench-in-the-wild/chinese_llava_in_the_wild.yaml
+++ b/lmms_eval/tasks/multilingual-llava-bench-in-the-wild/chinese_llava_in_the_wild.yaml
@@ -1,4 +1,5 @@
 dataset_path: "gagan3012/multilingual-llava-bench"
+local_dataset_path:
 dataset_kwargs:
     config: chinese
     token: True

--- a/lmms_eval/tasks/multilingual-llava-bench-in-the-wild/french_llava_in_the_wild.yaml
+++ b/lmms_eval/tasks/multilingual-llava-bench-in-the-wild/french_llava_in_the_wild.yaml
@@ -1,4 +1,5 @@
 dataset_path: "gagan3012/multilingual-llava-bench"
+local_dataset_path:
 dataset_kwargs:
     config: french
     token: True

--- a/lmms_eval/tasks/multilingual-llava-bench-in-the-wild/hindi_llava_in_the_wild.yaml
+++ b/lmms_eval/tasks/multilingual-llava-bench-in-the-wild/hindi_llava_in_the_wild.yaml
@@ -1,4 +1,5 @@
 dataset_path: "gagan3012/multilingual-llava-bench"
+local_dataset_path:
 dataset_kwargs:
     config: hindi
     token: True

--- a/lmms_eval/tasks/multilingual-llava-bench-in-the-wild/japanese_llava_in_the_wild.yaml
+++ b/lmms_eval/tasks/multilingual-llava-bench-in-the-wild/japanese_llava_in_the_wild.yaml
@@ -1,4 +1,5 @@
 dataset_path: "gagan3012/multilingual-llava-bench"
+local_dataset_path:
 dataset_kwargs:
     config: japanese
     token: True

--- a/lmms_eval/tasks/multilingual-llava-bench-in-the-wild/russian_llava_in_the_wild.yaml
+++ b/lmms_eval/tasks/multilingual-llava-bench-in-the-wild/russian_llava_in_the_wild.yaml
@@ -1,4 +1,5 @@
 dataset_path: "gagan3012/multilingual-llava-bench"
+local_dataset_path:
 dataset_kwargs:
     config: russian
     token: True

--- a/lmms_eval/tasks/multilingual-llava-bench-in-the-wild/spanish_llava_in_the_wild.yaml
+++ b/lmms_eval/tasks/multilingual-llava-bench-in-the-wild/spanish_llava_in_the_wild.yaml
@@ -1,4 +1,5 @@
 dataset_path: "gagan3012/multilingual-llava-bench"
+local_dataset_path:
 dataset_kwargs:
   config: spanish
   token: True

--- a/lmms_eval/tasks/multilingual-llava-bench-in-the-wild/urdu_llava_in_the_wild.yaml
+++ b/lmms_eval/tasks/multilingual-llava-bench-in-the-wild/urdu_llava_in_the_wild.yaml
@@ -1,4 +1,5 @@
 dataset_path: "gagan3012/multilingual-llava-bench"
+local_dataset_path:
 dataset_kwargs:
     config: urdu
     token: True

--- a/lmms_eval/tasks/mvbench/_default_template_yaml
+++ b/lmms_eval/tasks/mvbench/_default_template_yaml
@@ -1,4 +1,5 @@
 dataset_path: OpenGVLab/MVBench
+local_dataset_path:
 dataset_kwargs:
   token: True
   cache_dir: mvbench_video

--- a/lmms_eval/tasks/mvbench/mvbench_action_antonym.yaml
+++ b/lmms_eval/tasks/mvbench/mvbench_action_antonym.yaml
@@ -6,3 +6,4 @@ lmms_eval_specific_kwargs:
   default:
     sub_task: action_antonym
     post_prompt: "Only give the best option.\n"
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/mvbench/mvbench_action_count.yaml
+++ b/lmms_eval/tasks/mvbench/mvbench_action_count.yaml
@@ -6,3 +6,4 @@ lmms_eval_specific_kwargs:
   default:
     sub_task: action_count
     post_prompt: "Only give the best option.\n"
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/mvbench/mvbench_action_localization.yaml
+++ b/lmms_eval/tasks/mvbench/mvbench_action_localization.yaml
@@ -6,3 +6,4 @@ lmms_eval_specific_kwargs:
   default:
     sub_task: action_localization
     post_prompt: "Only give the best option.\n"
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/mvbench/mvbench_action_prediction.yaml
+++ b/lmms_eval/tasks/mvbench/mvbench_action_prediction.yaml
@@ -6,3 +6,4 @@ lmms_eval_specific_kwargs:
   default:
     sub_task: action_prediction
     post_prompt: "Only give the best option.\n"
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/mvbench/mvbench_action_sequence.yaml
+++ b/lmms_eval/tasks/mvbench/mvbench_action_sequence.yaml
@@ -6,3 +6,4 @@ lmms_eval_specific_kwargs:
   default:
     sub_task: action_sequence
     post_prompt: "Only give the best option.\n"
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/mvbench/mvbench_character_order.yaml
+++ b/lmms_eval/tasks/mvbench/mvbench_character_order.yaml
@@ -6,3 +6,4 @@ lmms_eval_specific_kwargs:
   default:
     sub_task: character_order
     post_prompt: "Only give the best option.\n"
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/mvbench/mvbench_counterfactual_inference.yaml
+++ b/lmms_eval/tasks/mvbench/mvbench_counterfactual_inference.yaml
@@ -6,3 +6,4 @@ lmms_eval_specific_kwargs:
   default:
     sub_task: counterfactual_inference
     post_prompt: "Only give the best option.\n"
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/mvbench/mvbench_egocentric_navigation.yaml
+++ b/lmms_eval/tasks/mvbench/mvbench_egocentric_navigation.yaml
@@ -6,3 +6,4 @@ lmms_eval_specific_kwargs:
   default:
     sub_task: egocentric_navigation
     post_prompt: "Only give the best option.\n"
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/mvbench/mvbench_episodic_reasoning.yaml
+++ b/lmms_eval/tasks/mvbench/mvbench_episodic_reasoning.yaml
@@ -14,6 +14,7 @@ lmms_eval_specific_kwargs:
   default:
     sub_task: episodic_reasoning
     post_prompt: "Only give the best option.\n"
+  local_infer_dataset_path:
 
 # metadata:
 #   task_type: video

--- a/lmms_eval/tasks/mvbench/mvbench_fine_grained_action.yaml
+++ b/lmms_eval/tasks/mvbench/mvbench_fine_grained_action.yaml
@@ -6,3 +6,4 @@ lmms_eval_specific_kwargs:
   default:
     sub_task: fine_grained_action
     post_prompt: "Only give the best option.\n"
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/mvbench/mvbench_fine_grained_pose.yaml
+++ b/lmms_eval/tasks/mvbench/mvbench_fine_grained_pose.yaml
@@ -6,3 +6,4 @@ lmms_eval_specific_kwargs:
   default:
     sub_task: fine_grained_pose
     post_prompt: "Only give the best option.\n"
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/mvbench/mvbench_moving_attribute.yaml
+++ b/lmms_eval/tasks/mvbench/mvbench_moving_attribute.yaml
@@ -6,3 +6,4 @@ lmms_eval_specific_kwargs:
   default:
     sub_task: moving_attribute
     post_prompt: "Only give the best option.\n"
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/mvbench/mvbench_moving_count.yaml
+++ b/lmms_eval/tasks/mvbench/mvbench_moving_count.yaml
@@ -6,3 +6,4 @@ lmms_eval_specific_kwargs:
   default:
     sub_task: moving_count
     post_prompt: "Only give the best option.\n"
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/mvbench/mvbench_moving_direction.yaml
+++ b/lmms_eval/tasks/mvbench/mvbench_moving_direction.yaml
@@ -6,3 +6,4 @@ lmms_eval_specific_kwargs:
   default:
     sub_task: moving_direction
     post_prompt: "Only give the best option.\n"
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/mvbench/mvbench_object_existence.yaml
+++ b/lmms_eval/tasks/mvbench/mvbench_object_existence.yaml
@@ -6,3 +6,4 @@ lmms_eval_specific_kwargs:
   default:
     sub_task: object_existence
     post_prompt: "Only give the best option.\n"
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/mvbench/mvbench_object_interaction.yaml
+++ b/lmms_eval/tasks/mvbench/mvbench_object_interaction.yaml
@@ -6,3 +6,4 @@ lmms_eval_specific_kwargs:
   default:
     sub_task: object_interaction
     post_prompt: "Only give the best option.\n"
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/mvbench/mvbench_object_shuffle.yaml
+++ b/lmms_eval/tasks/mvbench/mvbench_object_shuffle.yaml
@@ -6,3 +6,4 @@ lmms_eval_specific_kwargs:
   default:
     sub_task: object_shuffle
     post_prompt: "Only give the best option.\n"
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/mvbench/mvbench_scene_transition.yaml
+++ b/lmms_eval/tasks/mvbench/mvbench_scene_transition.yaml
@@ -6,3 +6,4 @@ lmms_eval_specific_kwargs:
   default:
     sub_task: scene_transition
     post_prompt: "Only give the best option.\n"
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/mvbench/mvbench_state_change.yaml
+++ b/lmms_eval/tasks/mvbench/mvbench_state_change.yaml
@@ -6,3 +6,4 @@ lmms_eval_specific_kwargs:
   default:
     sub_task: state_change
     post_prompt: "Only give the best option.\n"
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/mvbench/mvbench_unexpected_action.yaml
+++ b/lmms_eval/tasks/mvbench/mvbench_unexpected_action.yaml
@@ -6,3 +6,4 @@ lmms_eval_specific_kwargs:
   default:
     sub_task: unexpected_action
     post_prompt: "Only give the best option.\n"
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/naturalbench/naturalbench.yaml
+++ b/lmms_eval/tasks/naturalbench/naturalbench.yaml
@@ -1,4 +1,5 @@
 dataset_path: BaiqiL/NaturalBench-lmms-eval # The name of the dataset as listed by HF in the datasets Hub.
+local_dataset_path:
 dataset_kwargs:
   token: True # Auxiliary arguments that `datasets.load_dataset` accepts. This can be used to specify arguments such as `data_files` or `data_dir` if you want to use local datafiles such as json or csv.
 task: "naturalbench" # The name of the task, this should be registered in the task manager. If successful, you can call lmms_eval with this task name by setting `--tasks mme`.

--- a/lmms_eval/tasks/nextqa/_default_template_yaml
+++ b/lmms_eval/tasks/nextqa/_default_template_yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/NExTQA
+local_dataset_path:
 dataset_kwargs:
   token: True
   video: True

--- a/lmms_eval/tasks/nextqa/nextqa_oe_test.yaml
+++ b/lmms_eval/tasks/nextqa/nextqa_oe_test.yaml
@@ -15,3 +15,4 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: "\nAnswer a question using a short phrase or sentence."
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/nextqa/nextqa_oe_val.yaml
+++ b/lmms_eval/tasks/nextqa/nextqa_oe_val.yaml
@@ -15,3 +15,4 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: "\nAnswer a question using a short phrase or sentence."
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/nocaps/_default_template_nocaps_yaml
+++ b/lmms_eval/tasks/nocaps/_default_template_nocaps_yaml
@@ -1,3 +1,4 @@
 lmms_eval_specific_kwargs:
   default:
     prompt: "Provide a one-sentence caption for the provided image."
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/nocaps/nocaps_test.yaml
+++ b/lmms_eval/tasks/nocaps/nocaps_test.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/NoCaps
+local_dataset_path:
 dataset_kwargs:
   token: True
 task : "nocaps_test"

--- a/lmms_eval/tasks/nocaps/nocaps_val.yaml
+++ b/lmms_eval/tasks/nocaps/nocaps_val.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/NoCaps
+local_dataset_path:
 dataset_kwargs:
   token: True
 task: "nocaps_val"

--- a/lmms_eval/tasks/nocaps/nocaps_val_lite.yaml
+++ b/lmms_eval/tasks/nocaps/nocaps_val_lite.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/LMMs-Eval-Lite
+local_dataset_path:
 dataset_name: nocaps_val
 dataset_kwargs:
   token: True

--- a/lmms_eval/tasks/ocrbench/ocrbench.yaml
+++ b/lmms_eval/tasks/ocrbench/ocrbench.yaml
@@ -1,4 +1,5 @@
 dataset_path: echo840/OCRBench
+local_dataset_path:
 dataset_kwargs:
   token: True
 task: "ocrbench"

--- a/lmms_eval/tasks/ocrbench_v2/ocrbench_v2.yaml
+++ b/lmms_eval/tasks/ocrbench_v2/ocrbench_v2.yaml
@@ -1,4 +1,5 @@
 dataset_path: ling99/OCRBench_v2
+local_dataset_path:
 dataset_kwargs:
   token: True
 task: "ocrbench_v2"

--- a/lmms_eval/tasks/ok_vqa/_default_template_vqa_yaml
+++ b/lmms_eval/tasks/ok_vqa/_default_template_vqa_yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/OK-VQA
+local_dataset_path:
 output_type: generate_until
 doc_to_visual: !function utils.ok_vqa_doc_to_visual
 doc_to_text: !function utils.ok_vqa_doc_to_text
@@ -20,5 +21,6 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: "\nWhen the provided information is insufficient, respond with 'Unanswerable'.\nAnswer the question using a single word or phrase."
+  local_infer_dataset_path:
 metadata:
   - version: 0.0

--- a/lmms_eval/tasks/ok_vqa/ok_vqa_val2014_lite.yaml
+++ b/lmms_eval/tasks/ok_vqa/ok_vqa_val2014_lite.yaml
@@ -1,6 +1,7 @@
 task: ok_vqa_val2014_lite
 test_split: lite 
 dataset_path: lmms-lab/LMMs-Eval-Lite
+local_dataset_path:
 dataset_name: ok_vqa_val2014
 output_type: generate_until
 doc_to_visual: !function utils.ok_vqa_doc_to_visual
@@ -23,5 +24,6 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: "\nWhen the provided information is insufficient, respond with 'Unanswerable'.\nAnswer the question using a single word or phrase."
+  local_infer_dataset_path:
 metadata:
   - version: 0.0

--- a/lmms_eval/tasks/olympiadbench/olympiadbench_test_cn.yaml
+++ b/lmms_eval/tasks/olympiadbench/olympiadbench_test_cn.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/OlympiadBench
+local_dataset_path:
 dataset_kwargs:
   token: True
 task : "olympiadbench_test_cn"

--- a/lmms_eval/tasks/olympiadbench/olympiadbench_test_en.yaml
+++ b/lmms_eval/tasks/olympiadbench/olympiadbench_test_en.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/OlympiadBench
+local_dataset_path:
 dataset_kwargs:
   token: True
 task : "olympiadbench_test_en"

--- a/lmms_eval/tasks/openhermes/openhermes.yaml
+++ b/lmms_eval/tasks/openhermes/openhermes.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/openhermes_instruction
+local_dataset_path:
 dataset_kwargs:
   token: True
 
@@ -18,6 +19,7 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: "\nPlease give a detail answer to the question in the audio."
+  local_infer_dataset_path:
 metric_list:
   - metric: gpt_eval
     aggregation: !function utils.openhermes_aggregate_results

--- a/lmms_eval/tasks/people_speech/people_speech_val.yaml
+++ b/lmms_eval/tasks/people_speech/people_speech_val.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/peoples_speech
+local_dataset_path:
 dataset_kwargs:
   token: True
 task : "people_speech_val"
@@ -27,3 +28,4 @@ lmms_eval_specific_kwargs:
   qwen2_audio:
     pre_prompt: ""
     post_prompt: " <|en|>"
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/perceptiontest/test/_default_template_yaml
+++ b/lmms_eval/tasks/perceptiontest/test/_default_template_yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/PerceptionTest
+local_dataset_path:
 dataset_kwargs:
   token: True
   video: True
@@ -7,3 +8,4 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: ""
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/perceptiontest/val/_default_template_yaml
+++ b/lmms_eval/tasks/perceptiontest/val/_default_template_yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/PerceptionTest_Val
+local_dataset_path:
 dataset_kwargs:
   token: True
   video: True
@@ -7,3 +8,4 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: ""
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/pope/pope.yaml
+++ b/lmms_eval/tasks/pope/pope.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/POPE
+local_dataset_path:
 dataset_kwargs:
   token: True
 task: "pope"

--- a/lmms_eval/tasks/pope/pope_adv.yaml
+++ b/lmms_eval/tasks/pope/pope_adv.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/POPE
+local_dataset_path:
 dataset_name: Full
 dataset_kwargs:
   token: True

--- a/lmms_eval/tasks/pope/pope_pop.yaml
+++ b/lmms_eval/tasks/pope/pope_pop.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/POPE
+local_dataset_path:
 dataset_name: Full
 dataset_kwargs:
   token: True

--- a/lmms_eval/tasks/pope/pope_random.yaml
+++ b/lmms_eval/tasks/pope/pope_random.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/POPE
+local_dataset_path:
 dataset_name: Full
 dataset_kwargs:
   token: True

--- a/lmms_eval/tasks/qbench/abench_dev.yaml
+++ b/lmms_eval/tasks/qbench/abench_dev.yaml
@@ -1,4 +1,5 @@
 dataset_path: q-future/A-Bench-HF
+local_dataset_path:
 task: "abench_dev"
 test_split: dev
 output_type: generate_until
@@ -19,4 +20,5 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: "Answer with the option's letter from the given choices directly.\n"
+  local_infer_dataset_path:
   

--- a/lmms_eval/tasks/qbench/qbench2_dev.yaml
+++ b/lmms_eval/tasks/qbench/qbench2_dev.yaml
@@ -1,4 +1,5 @@
 dataset_path: q-future/Q-Bench2-HF
+local_dataset_path:
 task: "qbench2_dev"
 test_split: dev
 output_type: generate_until
@@ -19,4 +20,5 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: "Answer with the option's letter from the given choices directly.\n"
+  local_infer_dataset_path:
   

--- a/lmms_eval/tasks/qbench/qbench_dev.yaml
+++ b/lmms_eval/tasks/qbench/qbench_dev.yaml
@@ -1,4 +1,5 @@
 dataset_path: q-future/Q-Bench-HF
+local_dataset_path:
 task: "qbench_dev"
 test_split: dev
 output_type: generate_until
@@ -19,4 +20,5 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: "Answer with the option's letter from the given choices directly.\n"
+  local_infer_dataset_path:
   

--- a/lmms_eval/tasks/realworldqa/realworldqa.yaml
+++ b/lmms_eval/tasks/realworldqa/realworldqa.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/RealWorldQA
+local_dataset_path:
 dataset_kwargs:
   token: True
 task: "realworldqa"
@@ -42,5 +43,6 @@ lmms_eval_specific_kwargs:
   xcomposer2_4khd:
     pre_prompt: "[UNUSED_TOKEN_146]user\nQuestion: "
     post_prompt: "[UNUSED_TOKEN_145]\n[UNUSED_TOKEN_146]assistant\nThe answer is"
+  local_infer_dataset_path:
 metadata:
   - version: 0.0

--- a/lmms_eval/tasks/refcoco+/_default_template_bbox_rec_yaml
+++ b/lmms_eval/tasks/refcoco+/_default_template_bbox_rec_yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/RefCOCOPlus
+local_dataset_path:
 output_type: generate_until
 process_docs: !function utils_rec.refcoco_bbox_rec_preprocess_dataset
 doc_to_visual: !function utils_rec.refcoco_bbox_rec_doc_to_visual

--- a/lmms_eval/tasks/refcoco+/_default_template_bbox_yaml
+++ b/lmms_eval/tasks/refcoco+/_default_template_bbox_yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/RefCOCOplus
+local_dataset_path:
 output_type: generate_until
 doc_to_visual: !function utils.refcoco_bbox_doc_to_visual
 doc_to_text: !function utils.refcoco_doc_to_text

--- a/lmms_eval/tasks/refcoco+/_default_template_seg_yaml
+++ b/lmms_eval/tasks/refcoco+/_default_template_seg_yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/RefCOCOplus
+local_dataset_path:
 output_type: generate_until
 doc_to_visual: !function utils.refcoco_seg_doc_to_visual
 doc_to_text: !function utils.refcoco_doc_to_text

--- a/lmms_eval/tasks/refcoco/_default_template_bbox_rec_yaml
+++ b/lmms_eval/tasks/refcoco/_default_template_bbox_rec_yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/RefCOCO
+local_dataset_path:
 output_type: generate_until
 process_docs: !function utils_rec.refcoco_bbox_rec_preprocess_dataset
 doc_to_visual: !function utils_rec.refcoco_bbox_rec_doc_to_visual

--- a/lmms_eval/tasks/refcoco/_default_template_bbox_yaml
+++ b/lmms_eval/tasks/refcoco/_default_template_bbox_yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/RefCOCO
+local_dataset_path:
 output_type: generate_until
 doc_to_visual: !function utils.refcoco_bbox_doc_to_visual
 doc_to_text: !function utils.refcoco_doc_to_text

--- a/lmms_eval/tasks/refcoco/_default_template_seg_yaml
+++ b/lmms_eval/tasks/refcoco/_default_template_seg_yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/RefCOCO
+local_dataset_path:
 output_type: generate_until
 doc_to_visual: !function utils.refcoco_seg_doc_to_visual
 doc_to_text: !function utils.refcoco_doc_to_text

--- a/lmms_eval/tasks/refcoco/refcoco_bbox_val_lite.yaml
+++ b/lmms_eval/tasks/refcoco/refcoco_bbox_val_lite.yaml
@@ -1,6 +1,7 @@
 task: refcoco_bbox_val_lite
 test_split: lite
 dataset_path: lmms-lab/LMMs-Eval-Lite
+local_dataset_path:
 dataset_name: refcoco_bbox_val
 output_type: generate_until
 doc_to_visual: !function utils.refcoco_bbox_doc_to_visual

--- a/lmms_eval/tasks/refcocog/_default_template_bbox_rec_yaml
+++ b/lmms_eval/tasks/refcocog/_default_template_bbox_rec_yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/RefCOCOg
+local_dataset_path:
 output_type: generate_until
 process_docs: !function utils_rec.refcoco_bbox_rec_preprocess_dataset
 doc_to_visual: !function utils_rec.refcoco_bbox_rec_doc_to_visual

--- a/lmms_eval/tasks/refcocog/_default_template_bbox_yaml
+++ b/lmms_eval/tasks/refcocog/_default_template_bbox_yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/RefCOCOg
+local_dataset_path:
 output_type: generate_until
 doc_to_visual: !function utils.refcoco_bbox_doc_to_visual
 doc_to_text: !function utils.refcoco_doc_to_text

--- a/lmms_eval/tasks/refcocog/_default_template_seg_yaml
+++ b/lmms_eval/tasks/refcocog/_default_template_seg_yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/RefCOCOg
+local_dataset_path:
 output_type: generate_until
 doc_to_visual: !function utils.refcoco_seg_doc_to_visual
 doc_to_text: !function utils.refcoco_doc_to_text

--- a/lmms_eval/tasks/scienceqa/scienceqa.yaml
+++ b/lmms_eval/tasks/scienceqa/scienceqa.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/ScienceQA
+local_dataset_path:
 dataset_name: ScienceQA-FULL
 task: "scienceqa"
 dataset_kwargs:
@@ -29,6 +30,7 @@ lmms_eval_specific_kwargs:
     post_prompt: "\nAnswer with the option's letter from the given choices directly."
   qwen_vl:
     format: qwen_vl
+  local_infer_dataset_path:
   
 model_specific_generation_kwargs:
   llava:

--- a/lmms_eval/tasks/scienceqa/scienceqa_img.yaml
+++ b/lmms_eval/tasks/scienceqa/scienceqa_img.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/ScienceQA
+local_dataset_path:
 dataset_name: ScienceQA-IMG
 task: "scienceqa_img"
 dataset_kwargs:
@@ -33,6 +34,7 @@ lmms_eval_specific_kwargs:
     format: default
     pre_prompt: ""
     post_prompt: "\nAnswer:"
+  local_infer_dataset_path:
 model_specific_generation_kwargs:
   llava:
     image_aspect_ratio: original

--- a/lmms_eval/tasks/screenspot/_default_template_rec_yaml
+++ b/lmms_eval/tasks/screenspot/_default_template_rec_yaml
@@ -1,4 +1,5 @@
 dataset_path: rootsautomation/ScreenSpot
+local_dataset_path:
 output_type: generate_until
 doc_to_visual: !function utils_rec.screenspot_rec_doc_to_visual
 doc_to_text: !function utils_rec.screenspot_rec_doc_to_text

--- a/lmms_eval/tasks/screenspot/_default_template_reg_yaml
+++ b/lmms_eval/tasks/screenspot/_default_template_reg_yaml
@@ -1,4 +1,5 @@
 dataset_path: rootsautomation/ScreenSpot
+local_dataset_path:
 output_type: generate_until
 doc_to_visual: !function utils.screenspot_bbox_doc_to_visual
 doc_to_text: !function utils.screenspot_doc_to_text

--- a/lmms_eval/tasks/seedbench/seedbench.yaml
+++ b/lmms_eval/tasks/seedbench/seedbench.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/SEED-Bench
+local_dataset_path:
 dataset_kwargs:
   token: True
 task: "seedbench"

--- a/lmms_eval/tasks/seedbench/seedbench_ko.yaml
+++ b/lmms_eval/tasks/seedbench/seedbench_ko.yaml
@@ -1,4 +1,5 @@
 dataset_path: NCSOFT/K-SEED
+local_dataset_path:
 dataset_kwargs:
   token: True
 task: "seedbench_ko"

--- a/lmms_eval/tasks/seedbench/seedbench_lite.yaml
+++ b/lmms_eval/tasks/seedbench/seedbench_lite.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/LMMs-Eval-Lite
+local_dataset_path:
 dataset_name: seedbench
 dataset_kwargs:
   token: True

--- a/lmms_eval/tasks/seedbench/seedbench_ppl.yaml
+++ b/lmms_eval/tasks/seedbench/seedbench_ppl.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/SEED-Bench
+local_dataset_path:
 dataset_kwargs:
   token: True
 task: "seedbench_ppl"

--- a/lmms_eval/tasks/seedbench_2/seedbench_2.yaml
+++ b/lmms_eval/tasks/seedbench_2/seedbench_2.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/SEED-Bench-2
+local_dataset_path:
 dataset_kwargs:
   token: True
 task: "seedbench_2"
@@ -50,3 +51,4 @@ lmms_eval_specific_kwargs:
   gpt4V :
     img_token : <image>
     post_prompt : "Answer with the option's letter from the given choices directly."
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/seedbench_2_plus/seedbench_2_plus.yaml
+++ b/lmms_eval/tasks/seedbench_2_plus/seedbench_2_plus.yaml
@@ -1,4 +1,5 @@
 dataset_path: doolayer/SEED-Bench-2-Plus
+local_dataset_path:
 dataset_kwargs:
   token: True
 task: "seedbench_2_plus"
@@ -41,3 +42,4 @@ lmms_eval_specific_kwargs:
   default :
     img_token : <image>
     post_prompt : "Answer with the option's letter from the given choices directly."
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/stvqa/stvqa.yaml
+++ b/lmms_eval/tasks/stvqa/stvqa.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/ST-VQA
+local_dataset_path:
 task: "stvqa"
 test_split: test
 output_type: generate_until
@@ -17,4 +18,5 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: "\nAnswer the question using a single word or phrase."
+  local_infer_dataset_path:
   

--- a/lmms_eval/tasks/synthdog/synthdog_en.yaml
+++ b/lmms_eval/tasks/synthdog/synthdog_en.yaml
@@ -1,4 +1,5 @@
 dataset_path: naver-clova-ix/synthdog-en
+local_dataset_path:
 dataset_kwargs:
   token: True
 task: "synthdog_en"

--- a/lmms_eval/tasks/synthdog/synthdog_zh.yaml
+++ b/lmms_eval/tasks/synthdog/synthdog_zh.yaml
@@ -1,4 +1,5 @@
 dataset_path: naver-clova-ix/synthdog-zh
+local_dataset_path:
 dataset_kwargs:
   token: True
 task: "synthdog_zh"

--- a/lmms_eval/tasks/tedlium/tedlium_dev_test.yaml
+++ b/lmms_eval/tasks/tedlium/tedlium_dev_test.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/tedlium
+local_dataset_path:
 dataset_kwargs:
   token: True
 task : "tedlium_dev_test"
@@ -28,3 +29,4 @@ lmms_eval_specific_kwargs:
   qwen2_audio:
     pre_prompt: ""
     post_prompt: " <|en|>"
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/tedlium/tedlium_long_form.yaml
+++ b/lmms_eval/tasks/tedlium/tedlium_long_form.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/tedlium
+local_dataset_path:
 dataset_kwargs:
   token: True
 task : "tedlium_long_form"
@@ -28,3 +29,4 @@ lmms_eval_specific_kwargs:
   qwen2_audio:
     pre_prompt: ""
     post_prompt: " <|en|>"
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/tempcompass/_default_template_yaml
+++ b/lmms_eval/tasks/tempcompass/_default_template_yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/TempCompass
+local_dataset_path:
 dataset_kwargs:
   token: True
   video: True
@@ -11,4 +12,5 @@ lmms_eval_specific_kwargs:
     "yes_no": "\nPlease answer yes or no:",
     "caption_matching": "\nPlease directly give the best option:",
     "captioning": ""
+  local_infer_dataset_path:
 }

--- a/lmms_eval/tasks/temporalbench/temporalbench_long_qa.yaml
+++ b/lmms_eval/tasks/temporalbench/temporalbench_long_qa.yaml
@@ -1,4 +1,5 @@
 dataset_path: microsoft/TemporalBench
+local_dataset_path:
 
 
 dataset_kwargs:

--- a/lmms_eval/tasks/temporalbench/temporalbench_short_caption.yaml
+++ b/lmms_eval/tasks/temporalbench/temporalbench_short_caption.yaml
@@ -1,4 +1,5 @@
 dataset_path: microsoft/TemporalBench
+local_dataset_path:
 
 
 dataset_kwargs:

--- a/lmms_eval/tasks/temporalbench/temporalbench_short_qa.yaml
+++ b/lmms_eval/tasks/temporalbench/temporalbench_short_qa.yaml
@@ -1,4 +1,5 @@
 dataset_path: microsoft/TemporalBench
+local_dataset_path:
 
 
 dataset_kwargs:

--- a/lmms_eval/tasks/textcaps/_default_template_textcaps_yaml
+++ b/lmms_eval/tasks/textcaps/_default_template_textcaps_yaml
@@ -1,3 +1,4 @@
 lmms_eval_specific_kwargs:
   default:
     prompt: Provide a one-sentence caption for the provided image.
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/textcaps/textcaps_test.yaml
+++ b/lmms_eval/tasks/textcaps/textcaps_test.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/TextCaps
+local_dataset_path:
 dataset_kwargs:
   token: True
 task : "textcaps_test"

--- a/lmms_eval/tasks/textcaps/textcaps_train.yaml
+++ b/lmms_eval/tasks/textcaps/textcaps_train.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/TextCaps
+local_dataset_path:
 dataset_kwargs:
   token: True
 task : "textcaps_train"

--- a/lmms_eval/tasks/textcaps/textcaps_val.yaml
+++ b/lmms_eval/tasks/textcaps/textcaps_val.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/TextCaps
+local_dataset_path:
 dataset_kwargs:
   token: True
 task: "textcaps_val"

--- a/lmms_eval/tasks/textcaps/textcaps_val_lite.yaml
+++ b/lmms_eval/tasks/textcaps/textcaps_val_lite.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/LMMs-Eval-Lite
+local_dataset_path:
 dataset_name: textcaps_val
 dataset_kwargs:
   token: True
@@ -46,3 +47,4 @@ metadata:
 lmms_eval_specific_kwargs:
   default:
     prompt: Provide a one-sentence caption for the provided image.
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/textvqa/_default_template_textvqa_yaml
+++ b/lmms_eval/tasks/textvqa/_default_template_textvqa_yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/textvqa
+local_dataset_path:
 output_type: generate_until
 doc_to_visual: !function utils.textvqa_doc_to_visual
 doc_to_text: !function utils.textvqa_doc_to_text
@@ -15,3 +16,4 @@ lmms_eval_specific_kwargs:
   qwen_vl:
     pre_prompt: ""
     post_prompt: " Answer:"
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/textvqa/textvqa_val_lite.yaml
+++ b/lmms_eval/tasks/textvqa/textvqa_val_lite.yaml
@@ -10,6 +10,7 @@ metric_list:
     aggregation: !function utils.textvqa_aggregate_submissions
     higher_is_better: true
 dataset_path: lmms-lab/LMMs-Eval-Lite
+local_dataset_path:
 dataset_name: textvqa_val
 output_type: generate_until
 doc_to_visual: !function utils.textvqa_doc_to_visual
@@ -27,4 +28,5 @@ lmms_eval_specific_kwargs:
   qwen_vl:
     pre_prompt: ""
     post_prompt: " Answer:"
+  local_infer_dataset_path:
 

--- a/lmms_eval/tasks/vatex/vatex_test.yaml
+++ b/lmms_eval/tasks/vatex/vatex_test.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/VATEX
+local_dataset_path:
 dataset_name: vatex_test
 task: vatex_test
 test_split: test
@@ -37,6 +38,7 @@ lmms_eval_specific_kwargs:
     prompt: Provide a brief single-sentence caption for the last video below. Do not give any reasoning, just the caption. You must follow the captioning style of the preceding videos. Do not start your response with "Output:", just provide the caption.
   gemini_api:
     prompt: Provide a brief single-sentence caption for the last video below. Do not give any reasoning, just the caption. You must follow the captioning style of the preceding videos. Do not start your response with "Output:", just provide the caption.
+  local_infer_dataset_path:
 
 generation_kwargs:
   max_new_tokens: 64

--- a/lmms_eval/tasks/vatex/vatex_val_zh.yaml
+++ b/lmms_eval/tasks/vatex/vatex_val_zh.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/VATEX_ZH
+local_dataset_path:
 dataset_name: vatex_val_zh
 task: vatex_val_zh
 test_split: validation
@@ -18,6 +19,7 @@ lmms_eval_specific_kwargs:
 
   gemini_api:
     prompt: 请为提供的视频提供简短的描述。不要给出任何理由，只提供描述。您必须沿用前面视频的描述样式。不需要以 "输出"开头，只需提供描述即可.
+  local_infer_dataset_path:
 
 process_results: !function utils.vatex_process_CN_result
 # Note that the metric name can be either a registed metric function (such as the case for GQA) or a key name returned by process_results

--- a/lmms_eval/tasks/vcr_wiki/vcr_wiki_en_easy.yaml
+++ b/lmms_eval/tasks/vcr_wiki/vcr_wiki_en_easy.yaml
@@ -1,5 +1,6 @@
 "include": "_default_template_vcr_yaml"
 dataset_path: vcr-org/VCR-wiki-en-easy-test
+local_dataset_path:
 task: "vcr_wiki_en_easy"
 test_split: test
 process_results: !function utils.vcr_en_process_results
@@ -14,3 +15,4 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: "What is the covered texts in the image? Please restore the covered texts without outputting the explanations."
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/vcr_wiki/vcr_wiki_en_easy_100.yaml
+++ b/lmms_eval/tasks/vcr_wiki/vcr_wiki_en_easy_100.yaml
@@ -1,5 +1,6 @@
 "include": "_default_template_vcr_yaml"
 dataset_path: vcr-org/VCR-wiki-en-easy-test-100
+local_dataset_path:
 task: "vcr_wiki_en_easy_100"
 test_split: test
 process_results: !function utils.vcr_en_process_results
@@ -14,3 +15,4 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: "What is the covered texts in the image? Please restore the covered texts without outputting the explanations."
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/vcr_wiki/vcr_wiki_en_easy_500.yaml
+++ b/lmms_eval/tasks/vcr_wiki/vcr_wiki_en_easy_500.yaml
@@ -1,5 +1,6 @@
 "include": "_default_template_vcr_yaml"
 dataset_path: vcr-org/VCR-wiki-en-easy-test-500
+local_dataset_path:
 task: "vcr_wiki_en_easy_500"
 test_split: test
 process_results: !function utils.vcr_en_process_results
@@ -14,3 +15,4 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: "What is the covered texts in the image? Please restore the covered texts without outputting the explanations."
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/vcr_wiki/vcr_wiki_en_hard.yaml
+++ b/lmms_eval/tasks/vcr_wiki/vcr_wiki_en_hard.yaml
@@ -1,5 +1,6 @@
 "include": "_default_template_vcr_yaml"
 dataset_path: vcr-org/VCR-wiki-en-hard-test
+local_dataset_path:
 task: "vcr_wiki_en_hard"
 test_split: test
 process_results: !function utils.vcr_en_process_results
@@ -14,3 +15,4 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: "What is the covered texts in the image? Please restore the covered texts without outputting the explanations."
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/vcr_wiki/vcr_wiki_en_hard_100.yaml
+++ b/lmms_eval/tasks/vcr_wiki/vcr_wiki_en_hard_100.yaml
@@ -1,5 +1,6 @@
 "include": "_default_template_vcr_yaml"
 dataset_path: vcr-org/VCR-wiki-en-hard-test-100
+local_dataset_path:
 task: "vcr_wiki_en_hard_100"
 test_split: test
 process_results: !function utils.vcr_en_process_results
@@ -14,3 +15,4 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: "What is the covered texts in the image? Please restore the covered texts without outputting the explanations."
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/vcr_wiki/vcr_wiki_en_hard_500.yaml
+++ b/lmms_eval/tasks/vcr_wiki/vcr_wiki_en_hard_500.yaml
@@ -1,5 +1,6 @@
 "include": "_default_template_vcr_yaml"
 dataset_path: vcr-org/VCR-wiki-en-hard-test-500
+local_dataset_path:
 task: "vcr_wiki_en_hard_500"
 test_split: test
 process_results: !function utils.vcr_en_process_results
@@ -14,3 +15,4 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: "What is the covered texts in the image? Please restore the covered texts without outputting the explanations."
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/vcr_wiki/vcr_wiki_zh_easy.yaml
+++ b/lmms_eval/tasks/vcr_wiki/vcr_wiki_zh_easy.yaml
@@ -1,5 +1,6 @@
 "include": "_default_template_vcr_yaml"
 dataset_path: vcr-org/VCR-wiki-zh-easy-test
+local_dataset_path:
 task: "vcr_wiki_zh_easy"
 test_split: test
 process_results: !function utils.vcr_zh_process_results
@@ -14,3 +15,4 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: "图像中被覆盖的文本是什么？请在不输出解释的情况下还原被覆盖的文本。"
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/vcr_wiki/vcr_wiki_zh_easy_100.yaml
+++ b/lmms_eval/tasks/vcr_wiki/vcr_wiki_zh_easy_100.yaml
@@ -1,5 +1,6 @@
 "include": "_default_template_vcr_yaml"
 dataset_path: vcr-org/VCR-wiki-zh-easy-test-100
+local_dataset_path:
 task: "vcr_wiki_zh_easy_100"
 test_split: test
 process_results: !function utils.vcr_zh_process_results
@@ -14,3 +15,4 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: "图像中被覆盖的文本是什么？请在不输出解释的情况下还原被覆盖的文本。"
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/vcr_wiki/vcr_wiki_zh_easy_500.yaml
+++ b/lmms_eval/tasks/vcr_wiki/vcr_wiki_zh_easy_500.yaml
@@ -1,5 +1,6 @@
 "include": "_default_template_vcr_yaml"
 dataset_path: vcr-org/VCR-wiki-zh-easy-test-500
+local_dataset_path:
 task: "vcr_wiki_zh_easy_500"
 test_split: test
 process_results: !function utils.vcr_zh_process_results
@@ -14,3 +15,4 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: "图像中被覆盖的文本是什么？请在不输出解释的情况下还原被覆盖的文本。"
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/vcr_wiki/vcr_wiki_zh_hard.yaml
+++ b/lmms_eval/tasks/vcr_wiki/vcr_wiki_zh_hard.yaml
@@ -1,5 +1,6 @@
 "include": "_default_template_vcr_yaml"
 dataset_path: vcr-org/VCR-wiki-zh-hard-test
+local_dataset_path:
 task: "vcr_wiki_zh_hard"
 test_split: test
 process_results: !function utils.vcr_zh_process_results
@@ -14,3 +15,4 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: "图像中被覆盖的文本是什么？请在不输出解释的情况下还原被覆盖的文本。"
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/vcr_wiki/vcr_wiki_zh_hard_100.yaml
+++ b/lmms_eval/tasks/vcr_wiki/vcr_wiki_zh_hard_100.yaml
@@ -1,5 +1,6 @@
 "include": "_default_template_vcr_yaml"
 dataset_path: vcr-org/VCR-wiki-zh-hard-test-100
+local_dataset_path:
 task: "vcr_wiki_zh_hard_100"
 test_split: test
 process_results: !function utils.vcr_zh_process_results
@@ -14,3 +15,4 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: "图像中被覆盖的文本是什么？请在不输出解释的情况下还原被覆盖的文本。"
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/vcr_wiki/vcr_wiki_zh_hard_500.yaml
+++ b/lmms_eval/tasks/vcr_wiki/vcr_wiki_zh_hard_500.yaml
@@ -1,5 +1,6 @@
 "include": "_default_template_vcr_yaml"
 dataset_path: vcr-org/VCR-wiki-zh-hard-test-500
+local_dataset_path:
 task: "vcr_wiki_zh_hard_500"
 test_split: test
 process_results: !function utils.vcr_zh_process_results
@@ -14,3 +15,4 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: "图像中被覆盖的文本是什么？请在不输出解释的情况下还原被覆盖的文本。"
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/vdc/_default_template_yaml
+++ b/lmms_eval/tasks/vdc/_default_template_yaml
@@ -1,4 +1,5 @@
 dataset_path: wchai/lmms_VDC_test
+local_dataset_path:
 dataset_kwargs:
   token: True
   video: True

--- a/lmms_eval/tasks/vdc/background_test.yaml
+++ b/lmms_eval/tasks/vdc/background_test.yaml
@@ -1,5 +1,6 @@
 task: "background_test"
 dataset_path: wchai/lmms_VDC_test
+local_dataset_path:
 test_split: test
 output_type: generate_until
 doc_to_visual: !function utils.vdc_doc_to_visual

--- a/lmms_eval/tasks/vdc/camera_test.yaml
+++ b/lmms_eval/tasks/vdc/camera_test.yaml
@@ -1,5 +1,6 @@
 task: "camera_test"
 dataset_path: wchai/lmms_VDC_test
+local_dataset_path:
 test_split: test
 output_type: generate_until
 doc_to_visual: !function utils.vdc_doc_to_visual

--- a/lmms_eval/tasks/vdc/detailed_test.yaml
+++ b/lmms_eval/tasks/vdc/detailed_test.yaml
@@ -1,5 +1,6 @@
 task: "detailed_test"
 dataset_path: wchai/lmms_VDC_test
+local_dataset_path:
 test_split: test
 output_type: generate_until
 doc_to_visual: !function utils.vdc_doc_to_visual

--- a/lmms_eval/tasks/vdc/main_object_test.yaml
+++ b/lmms_eval/tasks/vdc/main_object_test.yaml
@@ -1,5 +1,6 @@
 task: "main_object_test"
 dataset_path: wchai/lmms_VDC_test
+local_dataset_path:
 test_split: test
 output_type: generate_until
 doc_to_visual: !function utils.vdc_doc_to_visual

--- a/lmms_eval/tasks/vdc/short_test.yaml
+++ b/lmms_eval/tasks/vdc/short_test.yaml
@@ -1,5 +1,6 @@
 task: "short_test"
 dataset_path: wchai/lmms_VDC_test
+local_dataset_path:
 test_split: test
 output_type: generate_until
 doc_to_visual: !function utils.vdc_doc_to_visual

--- a/lmms_eval/tasks/vibe_eval/vibe_eval.yaml
+++ b/lmms_eval/tasks/vibe_eval/vibe_eval.yaml
@@ -1,4 +1,5 @@
 dataset_path: RekaAI/VibeEval
+local_dataset_path:
 dataset_kwargs:
   token: True
 task: "vibe_eval"
@@ -33,3 +34,4 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: ""
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/video_detail_description/_default_template_yaml
+++ b/lmms_eval/tasks/video_detail_description/_default_template_yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/VideoDetailDescription
+local_dataset_path:
 dataset_kwargs:
   token: True
   video: True
@@ -7,6 +8,7 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: ""
+  local_infer_dataset_path:
 
 metadata:
   version: 0.0

--- a/lmms_eval/tasks/videochatgpt/_default_template_yaml
+++ b/lmms_eval/tasks/videochatgpt/_default_template_yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/VideoChatGPT
+local_dataset_path:
 dataset_kwargs:
   token: True
   video: True
@@ -7,6 +8,7 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: ""
+  local_infer_dataset_path:
 
 metadata:
   version: 0.0

--- a/lmms_eval/tasks/videomme/videomme.yaml
+++ b/lmms_eval/tasks/videomme/videomme.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/Video-MME
+local_dataset_path:
 dataset_kwargs:
   token: True
   cache_dir: videomme
@@ -42,5 +43,6 @@ lmms_eval_specific_kwargs:
   xcomposer2_4khd:
     pre_prompt: "[UNUSED_TOKEN_146]user\n"
     post_prompt: " Answer this question with A, B, C, or D.[UNUSED_TOKEN_145]\n[UNUSED_TOKEN_146]assistant\n"
+  local_infer_dataset_path:
 metadata:
   - version: 0.0

--- a/lmms_eval/tasks/videomme/videomme_w_subtitle.yaml
+++ b/lmms_eval/tasks/videomme/videomme_w_subtitle.yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/Video-MME
+local_dataset_path:
 dataset_kwargs:
   token: True
   cache_dir: videomme
@@ -46,5 +47,6 @@ lmms_eval_specific_kwargs:
   # xcomposer2_4khd:
   #   pre_prompt: "[UNUSED_TOKEN_146]user\n"
   #   post_prompt: " Answer this question with A, B, C, or D.[UNUSED_TOKEN_145]\n[UNUSED_TOKEN_146]assistant\n"
+  local_infer_dataset_path:
 metadata:
   - version: 0.0

--- a/lmms_eval/tasks/videommmu/_default_template_yaml
+++ b/lmms_eval/tasks/videommmu/_default_template_yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/VideoMMMU
+local_dataset_path:
 dataset_kwargs:
   token: True
   video: True
@@ -9,5 +10,6 @@ lmms_eval_specific_kwargs:
     perception_and_comprehension_prompt: "\nPlease ignore the Quiz question in last frame of the video."
     mcq_prompt: "answer the following multi-choice question. The image for this question is at the end of the video.\n"
     open_ended_prompt: "answer the following open-ended question. The image for this question is at the end of the video.\n"
+  local_infer_dataset_path:
 generation_kwargs:
   max_new_tokens: 1024

--- a/lmms_eval/tasks/vinoground/vinoground.yaml
+++ b/lmms_eval/tasks/vinoground/vinoground.yaml
@@ -1,4 +1,5 @@
 dataset_path: HanSolo9682/Vinoground
+local_dataset_path:
 dataset_kwargs:
   token: True
   cache_dir: vinoground

--- a/lmms_eval/tasks/vitatecs/_default_template_yaml
+++ b/lmms_eval/tasks/vitatecs/_default_template_yaml
@@ -1,4 +1,5 @@
 dataset_path: lscpku/VITATECS
+local_dataset_path:
 dataset_kwargs:
   token: True
   video: True
@@ -7,3 +8,4 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: "\nPlease response with a single letter (A or B):"
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/vizwiz_vqa/_default_template_vqa_yaml
+++ b/lmms_eval/tasks/vizwiz_vqa/_default_template_vqa_yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/VizWiz-VQA
+local_dataset_path:
 output_type: generate_until
 doc_to_visual: !function utils.vizwiz_vqa_doc_to_visual
 doc_to_text: !function utils.vizwiz_vqa_doc_to_text
@@ -12,4 +13,5 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: "\nWhen the provided information is insufficient, respond with 'Unanswerable'.\nAnswer the question using a single word or phrase."
+  local_infer_dataset_path:
 process_results: !function utils.vizwiz_vqa_process_results

--- a/lmms_eval/tasks/vizwiz_vqa/vizwiz_vqa_val_lite.yaml
+++ b/lmms_eval/tasks/vizwiz_vqa/vizwiz_vqa_val_lite.yaml
@@ -1,6 +1,7 @@
 task: vizwiz_vqa_val_lite
 test_split: lite 
 dataset_path: lmms-lab/LMMs-Eval-Lite
+local_dataset_path:
 dataset_name: vizwiz_vqa_val
 output_type: generate_until
 doc_to_visual: !function utils.vizwiz_vqa_doc_to_visual
@@ -15,6 +16,7 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: "\nWhen the provided information is insufficient, respond with 'Unanswerable'.\nAnswer the question using a single word or phrase."
+  local_infer_dataset_path:
 process_results: !function utils.vizwiz_vqa_process_results
 
 metric_list:

--- a/lmms_eval/tasks/vl_rewardbench/vl_rewardbench.yaml
+++ b/lmms_eval/tasks/vl_rewardbench/vl_rewardbench.yaml
@@ -1,4 +1,5 @@
 dataset_path: MMInstruction/VL-RewardBench
+local_dataset_path:
 dataset_kwargs:
   token: True
 task: "vl_rewardbench"

--- a/lmms_eval/tasks/vmcbench/vmcbench.yaml
+++ b/lmms_eval/tasks/vmcbench/vmcbench.yaml
@@ -1,4 +1,5 @@
 dataset_path: suyc21/VMCBench
+local_dataset_path:
 dataset_kwargs:
   token: True
 task: "vmcbench"
@@ -30,5 +31,6 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: "Answer with the option's letter from the given choices directly.\n"
+  local_infer_dataset_path:
 metadata:
   - version: 0.0

--- a/lmms_eval/tasks/vocalsound/_default_template_yaml
+++ b/lmms_eval/tasks/vocalsound/_default_template_yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/vocalsound
+local_dataset_path:
 dataset_kwargs:
   token: True
 doc_to_target: "answer"
@@ -9,6 +10,7 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: "Classify the human vocal sound to VocalSound in English: "
+  local_infer_dataset_path:
 
 metadata:
   version: 0.0

--- a/lmms_eval/tasks/vqav2/_default_template_vqav2_yaml
+++ b/lmms_eval/tasks/vqav2/_default_template_vqav2_yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/VQAv2
+local_dataset_path:
 dataset_kwargs:
   token: True
 output_type: generate_until
@@ -13,3 +14,4 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: "\nAnswer the question using a single word or phrase."
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/vqav2/vqav2_val_lite.yaml
+++ b/lmms_eval/tasks/vqav2/vqav2_val_lite.yaml
@@ -1,5 +1,6 @@
 task: "vqav2_val_lite"
 dataset_path: lmms-lab/LMMs-Eval-Lite
+local_dataset_path:
 dataset_name: vqav2_val
 dataset_kwargs:
   token: True
@@ -15,6 +16,7 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: "\nAnswer the question using a single word or phrase."
+  local_infer_dataset_path:
 test_split: lite
 metric_list:
   - metric: exact_match

--- a/lmms_eval/tasks/wavcaps/wavcaps.yaml
+++ b/lmms_eval/tasks/wavcaps/wavcaps.yaml
@@ -1,4 +1,5 @@
 dataset_path: AudioLLMs/wavcaps_test
+local_dataset_path:
 dataset_kwargs:
   token: True
 task : "wavcaps"
@@ -11,6 +12,7 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: ""
+  local_infer_dataset_path:
 generation_kwargs:
   max_new_tokens: 256
   temperature: 0

--- a/lmms_eval/tasks/websrc/websrc_test.yaml
+++ b/lmms_eval/tasks/websrc/websrc_test.yaml
@@ -1,4 +1,5 @@
 dataset_path: rootsautomation/websrc-test
+local_dataset_path:
 task: "websrc_test"
 test_split: test
 output_type: generate_until

--- a/lmms_eval/tasks/websrc/websrc_val.yaml
+++ b/lmms_eval/tasks/websrc/websrc_val.yaml
@@ -1,4 +1,5 @@
 dataset_path: rootsautomation/websrc
+local_dataset_path:
 task: "websrc_val"
 test_split: dev
 output_type: generate_until

--- a/lmms_eval/tasks/wild_vision_bench/_default_template_yaml
+++ b/lmms_eval/tasks/wild_vision_bench/_default_template_yaml
@@ -1,4 +1,5 @@
 dataset_path: WildVision/wildvision-arena-data
+local_dataset_path:
 dataset_kwargs:
   token: True
 output_type: generate_until

--- a/lmms_eval/tasks/wild_vision_bench/wild_vision_bench0617.yaml
+++ b/lmms_eval/tasks/wild_vision_bench/wild_vision_bench0617.yaml
@@ -10,4 +10,5 @@ lmms_eval_specific_kwargs:
   aria:
     pre_prompt: "Please provide a detailed answer on the following user instruction:\n"
     post_prompt: ""
+  local_infer_dataset_path:
   

--- a/lmms_eval/tasks/wild_vision_bench/wild_vision_bench0630.yaml
+++ b/lmms_eval/tasks/wild_vision_bench/wild_vision_bench0630.yaml
@@ -10,3 +10,4 @@ lmms_eval_specific_kwargs:
   aria:
     pre_prompt: "Please provide a detailed answer on the following user instruction:\n"
     post_prompt: ""
+  local_infer_dataset_path:

--- a/lmms_eval/tasks/worldqa/_default_template_yaml
+++ b/lmms_eval/tasks/worldqa/_default_template_yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/worldqa
+local_dataset_path:
 dataset_kwargs:
   token: True
   video: True

--- a/lmms_eval/tasks/worldqa/worldqa_generation.yaml
+++ b/lmms_eval/tasks/worldqa/worldqa_generation.yaml
@@ -17,4 +17,5 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: ""
+  local_infer_dataset_path:
 include: _default_template_yaml

--- a/lmms_eval/tasks/worldqa/worldqa_mc.yaml
+++ b/lmms_eval/tasks/worldqa/worldqa_mc.yaml
@@ -14,6 +14,7 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: "\nAnswer with the option's letter from the given choices directly."
+  local_infer_dataset_path:
 filter_list:
   - name: "flexible-extract"
     filter:

--- a/lmms_eval/tasks/worldqa/worldqa_mcppl.yaml
+++ b/lmms_eval/tasks/worldqa/worldqa_mcppl.yaml
@@ -12,4 +12,5 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: ""
+  local_infer_dataset_path:
 include: _default_template_yaml

--- a/lmms_eval/tasks/youcook2/_default_template_yaml
+++ b/lmms_eval/tasks/youcook2/_default_template_yaml
@@ -1,4 +1,5 @@
 dataset_path: lmms-lab/YouCook2
+local_dataset_path:
 dataset_kwargs:
   token: True
   video: True

--- a/lmms_eval/tasks/youcook2/youcook2_val.yaml
+++ b/lmms_eval/tasks/youcook2/youcook2_val.yaml
@@ -36,3 +36,4 @@ lmms_eval_specific_kwargs:
     prompt: Provide a one-sentence caption for the provided video.
   gemini_api:
     prompt: Provide a brief single-sentence caption for the last video below. Do not give any reasoning, just the caption. You must follow the captioning style of the preceding videos. Do not start your response with "Output:", just provide the caption.
+  local_infer_dataset_path:


### PR DESCRIPTION
### Summary

This PR improves the flexibility of specifying local datasets, addressing issues where it was inconvenient to do so.

### Changes Made

1.	Modified api.task.py
	 •	Added local_dataset_path to support loading datasets from a local directory.
2.	Updated YAML Files in tasks/
	•	Added local_dataset_path under dataset_path.
	•	If specified, data is loaded from os.path.join(local_dataset_path, dataset_path); otherwise, it is downloaded from Hugging Face.
3.	Added local_infer_dataset_path
	•	Applied the same logic as local_dataset_path for inference datasets.
	•	Updated relevant files (e.g., tasks.gqa.utils.py) to support this option.