### PR TITLE
[Feat] Fix MEGA-Bench evaluator, update doc

### DIFF
--- a/docs/current_tasks.md
+++ b/docs/current_tasks.md
@@ -200,6 +200,11 @@
   - Q-Bench2-HF (qbench2_dev)
   - Q-Bench-HF (qbench_dev)
   - A-Bench-HF (abench_dev)
+- [MEGA-Bench](https://tiger-ai-lab.github.io/MEGA-Bench/) (megabench)
+  - MEGA-Bench Core (megabench_core)
+  - MEGA-Bench Open (megabench_open)
+  - MEGA-Bench Core single-image subset (megabench_core_si)
+  - MEGA-Bench Open single-image subset (megabench_open_si)
 
 ## 3. Videos tasks:
 

--- a/lmms_eval/tasks/megabench/README.md
+++ b/lmms_eval/tasks/megabench/README.md
@@ -1,10 +1,10 @@
-# MEGA-Bench: Scaling Multimodal Evaluation to over 500 Real-World Tasks
+# MEGA-Bench: Scaling Multimodal Evaluation to over 500 Real-World Tasks [ICLR 2025]
 
 ![image](https://github.com/user-attachments/assets/5fd44fa9-0ec2-4298-ad0c-e883cb1edf7f)
 
 MEGA-Bench contains 505 multimodal tasks with diverse data sources, input/output formats, and skill requirements. The taxonomy tree is derived from the application dimension, which guides and calibrates the annotation process. The benchmark is equiped with a suite of 45 evaluation metrics to handle various output formats beyond multiple-choice questions.
 
-Following this doc, the final evaluation file has a consistent format with [MEGA-Bench Leaderboard](https://huggingface.co/spaces/TIGER-Lab/MEGA-Bench).
+Following this doc, the evaluation result contains the final scores and multi-dimensional breakdown, which has a consistent format as [MEGA-Bench Leaderboard](https://huggingface.co/spaces/TIGER-Lab/MEGA-Bench).
 
 
 ## Step-1: Get the model response files with lmms-eval
@@ -51,6 +51,8 @@ Evaluate the submission file with stand-alone evaluator adapted from [MEGA-Bench
 # Run the metrics for the core set
 python lmms_eval/tasks/megabench/evaluator.py --subset_name core --submission_file logs/llava-ov-7b/submissions/megabench_core_all_query_responses.json  --output_file logs/llava-ov-7b/megabench_scores/megabench_core_data_with_scores.json
 ```
+
+Note: please set up the OpenAI API key in the environment variable `OPENAI_API_KEY` to evaluate the open set.
 
 ```bash
 # Run the metrics for the open-ended set

--- a/lmms_eval/tasks/megabench/README.md
+++ b/lmms_eval/tasks/megabench/README.md
@@ -4,7 +4,51 @@
 
 MEGA-Bench contains 505 multimodal tasks with diverse data sources, input/output formats, and skill requirements. The taxonomy tree is derived from the application dimension, which guides and calibrates the annotation process. The benchmark is equiped with a suite of 45 evaluation metrics to handle various output formats beyond multiple-choice questions.
 
-Following this doc, the evaluation result contains the final scores and multi-dimensional breakdown, which has a consistent format as [MEGA-Bench Leaderboard](https://huggingface.co/spaces/TIGER-Lab/MEGA-Bench).
+Following this doc, the evaluation result contains the final scores and multi-dimensional breakdown, which has a consistent format as [MEGA-Bench Leaderboard](https://huggingface.co/spaces/TIGER-Lab/MEGA-Bench). Below is an example from evaluating `llava-ov-7b` on the core set.
+
+```json
+{
+    "model_summary": {
+        "core": {
+            "num_eval_tasks": 440,
+            "num_eval_samples": 6531,
+            "macro_mean_score": 0.21890499112354772
+        },
+        "open": ...,
+        "overall_score": 0.21890499112354772
+    },
+    "keyword_stats": {
+        "skills": {
+            "Object Recognition and Classification": {
+                "count": 272,
+                "num_samples": 4193,
+                "tasks": [],
+                "average_score": 0.237467941941504
+            },
+            "Domain-Specific Knowledge and Skills": {
+                "count": 66,
+                "num_samples": 1153,
+                "tasks": [],
+                "average_score": 0.2134904060117354
+            },
+            "Mathematical and Logical Reasoning": {
+                "count": 103,
+                "num_samples": 1762,
+                "tasks": [],
+                "average_score": 0.19061988965845886
+            },
+            "Spatial and Temporal Reasoning": {
+                "count": 144,
+                "num_samples": 2278,
+                "tasks": [],
+                "average_score": 0.1953679420247293
+            },
+            ...
+        }
+    }
+}
+```
+
 
 
 ## Step-1: Get the model response files with lmms-eval

--- a/lmms_eval/tasks/megabench/README.md
+++ b/lmms_eval/tasks/megabench/README.md
@@ -45,6 +45,7 @@ Following this doc, the evaluation result contains the final scores and multi-di
             },
             ...
         }
+        ...
     }
 }
 ```

--- a/lmms_eval/tasks/megabench/metrics/metric_type.py
+++ b/lmms_eval/tasks/megabench/metrics/metric_type.py
@@ -178,7 +178,11 @@ class MetricType(Enum):
         return implementations[self]
 
     def match(self, response: str, correct_answer: str):
-        return self.class_impl.match(response, correct_answer)
+        try:
+            return self.class_impl.match(response, correct_answer)
+        except Exception as e:
+            logging.error(f"Assign 0 score - errors in metric {self.name}, likely the response has unexpected answer format. Response: {response}, Correct Answer: {correct_answer}, Error: {e}")
+            return 0
 
     @classmethod
     def from_string(cls, s):


### PR DESCRIPTION
This PR fixes MEGA-Bench's evaluator to handle some corner cases where the responses with unexpected formats can break up the metric. This usually only happens for small models (<7B) or old models with poor instruction-following capacity. The doc is also updated.

---
Before you open a pull-request, please check if a similar issue already exists or has been closed before.

### When you open a pull-request, please be sure to include the following

- [ ] A descriptive title: [xxx] XXXX
- [ ] A detailed description

If you meet the lint warnings, you can use following scripts to reformat code.

```sh
pip install pre-commit
pre-commit install
pre-commit run --all-files
```

Thank you for your contributions!
