### PR TITLE
Add Omni Bench

### DIFF
--- a/lmms_eval/tasks/omni_bench/_default_template_yaml
+++ b/lmms_eval/tasks/omni_bench/_default_template_yaml
@@ -1,0 +1,23 @@
+dataset_path: ngqtrung/OmniBench
+test_split: train
+output_type: generate_until
+
+generation_kwargs:
+  max_new_tokens: 128
+  temperature: 0
+  top_p: 0.7
+  num_beams: 1
+  do_sample: false
+
+metric_list:
+  - metric: accuracy
+    aggregation: !function utils.omni_bench_aggregate_results
+    higher_is_better: true
+
+lmms_eval_specific_kwargs:
+  default:
+    pre_prompt: ""
+    post_prompt: "Answer with the option's letter from the given choices directly."
+
+metadata:
+  version: 0.0

--- a/lmms_eval/tasks/omni_bench/_default_template_yaml
+++ b/lmms_eval/tasks/omni_bench/_default_template_yaml
@@ -1,4 +1,4 @@
-dataset_path: ngqtrung/OmniBench
+dataset_path: lmms-lab/Omni_Bench_fix
 test_split: train
 output_type: generate_until
 

--- a/lmms_eval/tasks/omni_bench/omni_bench.yaml
+++ b/lmms_eval/tasks/omni_bench/omni_bench.yaml
@@ -1,4 +1,4 @@
-task: "omni_bench_original"
+task: "omni_bench"
 
 doc_to_visual: !function utils.omni_bench_original_doc_to_visual
 doc_to_text: !function utils.omni_bench_original_doc_to_text

--- a/lmms_eval/tasks/omni_bench/omni_bench.yaml
+++ b/lmms_eval/tasks/omni_bench/omni_bench.yaml
@@ -1,0 +1,9 @@
+task: "omni_bench_original"
+
+doc_to_visual: !function utils.omni_bench_original_doc_to_visual
+doc_to_text: !function utils.omni_bench_original_doc_to_text
+doc_to_choice: !function utils.omni_bench_doc_to_choice
+doc_to_target: !function utils.omni_bench_doc_to_target
+process_results: !function utils.omni_bench_process_results
+
+include: _default_template_yaml

--- a/lmms_eval/tasks/omni_bench/omni_bench_audio_transcript.yaml
+++ b/lmms_eval/tasks/omni_bench/omni_bench_audio_transcript.yaml
@@ -1,0 +1,9 @@
+task: "omni_bench_audio_transcript"
+
+doc_to_visual: !function utils.omni_bench_audio_transcript_doc_to_visual
+doc_to_text: !function utils.omni_bench_audio_transcript_doc_to_text
+doc_to_choice: !function utils.omni_bench_doc_to_choice
+doc_to_target: !function utils.omni_bench_doc_to_target
+process_results: !function utils.omni_bench_process_results
+
+include: _default_template_yaml

--- a/lmms_eval/tasks/omni_bench/omni_bench_image_caption.yaml
+++ b/lmms_eval/tasks/omni_bench/omni_bench_image_caption.yaml
@@ -1,0 +1,9 @@
+task: "omni_bench_image_caption"
+
+doc_to_visual: !function utils.omni_bench_image_caption_doc_to_visual
+doc_to_text: !function utils.omni_bench_image_caption_doc_to_text
+doc_to_choice: !function utils.omni_bench_doc_to_choice
+doc_to_target: !function utils.omni_bench_doc_to_target
+process_results: !function utils.omni_bench_process_results
+
+include: _default_template_yaml

--- a/lmms_eval/tasks/omni_bench/utils.py
+++ b/lmms_eval/tasks/omni_bench/utils.py
@@ -1,8 +1,10 @@
-import random
-import numpy as np
-from collections import defaultdict
 import logging
+import random
+from collections import defaultdict
+
+import numpy as np
 from loguru import logger as eval_logger
+
 
 def omni_bench_original_doc_to_visual(doc):
     return [doc["audio"], doc["image"]]
@@ -15,13 +17,9 @@ def omni_bench_original_doc_to_text(doc, lmms_eval_specific_kwargs):
     options = doc["options"]
     letters = ["A", "B", "C", "D"]
     enumerated_opts = [f"{letters[i]}. {opt}" for i, opt in enumerate(options)]
-    prompt_text = (
-        f"{pre_prompt}"
-        f"Question:\n{question}\n\n"
-        f"Options:\n" + "\n".join(enumerated_opts) +
-        f"\n\n{post_prompt}"
-    )
+    prompt_text = f"{pre_prompt}" f"Question:\n{question}\n\n" f"Options:\n" + "\n".join(enumerated_opts) + f"\n\n{post_prompt}"
     return prompt_text
+
 
 def omni_bench_image_caption_doc_to_visual(doc):
     return [doc["audio"]]
@@ -35,14 +33,9 @@ def omni_bench_image_caption_doc_to_text(doc, lmms_eval_specific_kwargs):
     options = doc["options"]
     letters = ["A", "B", "C", "D"]
     enumerated_opts = [f"{letters[i]}. {opt}" for i, opt in enumerate(options)]
-    prompt_text = (
-        f"{pre_prompt}"
-        f"Visual Context for the audio:\n{image_caption}\n\n"
-        f"Question:\n{question}\n\n"
-        f"Options:\n" + "\n".join(enumerated_opts) + "\n\n"
-        f"{post_prompt}"
-    )
+    prompt_text = f"{pre_prompt}" f"Visual Context for the audio:\n{image_caption}\n\n" f"Question:\n{question}\n\n" f"Options:\n" + "\n".join(enumerated_opts) + "\n\n" f"{post_prompt}"
     return prompt_text
+
 
 def omni_bench_audio_transcript_doc_to_visual(doc):
     return [doc["image"]]
@@ -56,14 +49,9 @@ def omni_bench_audio_transcript_doc_to_text(doc, lmms_eval_specific_kwargs):
     options = doc["options"]
     letters = ["A", "B", "C", "D"]
     enumerated_opts = [f"{letters[i]}. {opt}" for i, opt in enumerate(options)]
-    prompt_text = (
-        f"{pre_prompt}"
-        f"Audio context for the images:\n{audio_transcript}\n\n"
-        f"Question:\n{question}\n\n"
-        f"Options:\n" + "\n".join(enumerated_opts) + "\n\n"
-        f"{post_prompt}"
-    )
+    prompt_text = f"{pre_prompt}" f"Audio context for the images:\n{audio_transcript}\n\n" f"Question:\n{question}\n\n" f"Options:\n" + "\n".join(enumerated_opts) + "\n\n" f"{post_prompt}"
     return prompt_text
+
 
 def omni_bench_doc_to_choice(doc):
     return doc["options"]
@@ -77,18 +65,13 @@ def omni_bench_doc_to_target(doc):
 def omni_bench_process_results(doc, results):
     response_text = results[0].strip()
     all_choices = ["A", "B", "C", "D"]
-    eval_logger.debug(results)
-    eval_logger.debug(f"Raw model output: {results[0]}")
     pred = parse_multi_choice_response(response_text, all_choices)
     letter_map = {0: "A", 1: "B", 2: "C", 3: "D"}
     gold_index = omni_bench_doc_to_target(doc)
     gold_letter = letter_map.get(gold_index, "X")
     overall_correct = 1 if pred == gold_letter else 0
     category = doc.get("task type", "unknown")
-    accuracy_dict = {
-        "overall": overall_correct, 
-        category: overall_correct
-    }
+    accuracy_dict = {"overall": overall_correct, category: overall_correct}
     return {"accuracy": accuracy_dict}
 
 
@@ -106,14 +89,10 @@ def omni_bench_aggregate_results(results):
                 category_correct[category] += score
                 category_total[category] += 1
     overall_accuracy = (total_correct / total_examples) * 100 if total_examples > 0 else 0.0
-    category_accuracy = {
-        category: (category_correct[category] / category_total[category]) * 100 
-        if category_total[category] > 0 else 0.0 
-        for category in category_correct
-    }
+    category_accuracy = {category: (category_correct[category] / category_total[category]) * 100 if category_total[category] > 0 else 0.0 for category in category_correct}
     eval_logger.info("=" * 50)
     eval_logger.info(f"Overall Accuracy: {overall_accuracy:.2f}%")
-    
+
     if category_accuracy:
         eval_logger.info("Category-wise Accuracy:")
         for category, acc in category_accuracy.items():
@@ -121,13 +100,9 @@ def omni_bench_aggregate_results(results):
     eval_logger.info("=" * 50)
     return round(overall_accuracy, 5)
 
-def parse_multi_choice_response(response, all_choices):
-    """
-    Parse the prediction from the generated response.
-    Return the predicted letter (e.g., "A", "B", "C", "D") or None if not found.
-    """
-    response = " " + response.strip() + " " 
 
+def parse_multi_choice_response(response, all_choices):
+    response = " " + response.strip() + " "
     index_ans = True
     ans_with_brack = False
     candidates = []

--- a/lmms_eval/tasks/omni_bench/utils.py
+++ b/lmms_eval/tasks/omni_bench/utils.py
@@ -1,0 +1,163 @@
+import random
+import numpy as np
+from collections import defaultdict
+import logging
+from loguru import logger as eval_logger
+
+def omni_bench_original_doc_to_visual(doc):
+    return [doc["audio"], doc["image"]]
+
+
+def omni_bench_original_doc_to_text(doc, lmms_eval_specific_kwargs):
+    pre_prompt = lmms_eval_specific_kwargs.get("pre_prompt", "")
+    post_prompt = lmms_eval_specific_kwargs.get("post_prompt", "")
+    question = doc["question"]
+    options = doc["options"]
+    letters = ["A", "B", "C", "D"]
+    enumerated_opts = [f"{letters[i]}. {opt}" for i, opt in enumerate(options)]
+    prompt_text = (
+        f"{pre_prompt}"
+        f"Question:\n{question}\n\n"
+        f"Options:\n" + "\n".join(enumerated_opts) +
+        f"\n\n{post_prompt}"
+    )
+    return prompt_text
+
+def omni_bench_image_caption_doc_to_visual(doc):
+    return [doc["audio"]]
+
+
+def omni_bench_image_caption_doc_to_text(doc, lmms_eval_specific_kwargs):
+    pre_prompt = lmms_eval_specific_kwargs.get("pre_prompt", "")
+    post_prompt = lmms_eval_specific_kwargs.get("post_prompt", "")
+    image_caption = doc["image content"]
+    question = doc["question"]
+    options = doc["options"]
+    letters = ["A", "B", "C", "D"]
+    enumerated_opts = [f"{letters[i]}. {opt}" for i, opt in enumerate(options)]
+    prompt_text = (
+        f"{pre_prompt}"
+        f"Visual Context for the audio:\n{image_caption}\n\n"
+        f"Question:\n{question}\n\n"
+        f"Options:\n" + "\n".join(enumerated_opts) + "\n\n"
+        f"{post_prompt}"
+    )
+    return prompt_text
+
+def omni_bench_audio_transcript_doc_to_visual(doc):
+    return [doc["image"]]
+
+
+def omni_bench_audio_transcript_doc_to_text(doc, lmms_eval_specific_kwargs):
+    pre_prompt = lmms_eval_specific_kwargs.get("pre_prompt", "")
+    post_prompt = lmms_eval_specific_kwargs.get("post_prompt", "")
+    audio_transcript = doc.get("audio content", "")
+    question = doc["question"]
+    options = doc["options"]
+    letters = ["A", "B", "C", "D"]
+    enumerated_opts = [f"{letters[i]}. {opt}" for i, opt in enumerate(options)]
+    prompt_text = (
+        f"{pre_prompt}"
+        f"Audio context for the images:\n{audio_transcript}\n\n"
+        f"Question:\n{question}\n\n"
+        f"Options:\n" + "\n".join(enumerated_opts) + "\n\n"
+        f"{post_prompt}"
+    )
+    return prompt_text
+
+def omni_bench_doc_to_choice(doc):
+    return doc["options"]
+
+
+def omni_bench_doc_to_target(doc):
+    correct_answer_str = doc["answer"]
+    return doc["options"].index(correct_answer_str)
+
+
+def omni_bench_process_results(doc, results):
+    response_text = results[0].strip()
+    all_choices = ["A", "B", "C", "D"]
+    eval_logger.debug(results)
+    eval_logger.debug(f"Raw model output: {results[0]}")
+    pred = parse_multi_choice_response(response_text, all_choices)
+    letter_map = {0: "A", 1: "B", 2: "C", 3: "D"}
+    gold_index = omni_bench_doc_to_target(doc)
+    gold_letter = letter_map.get(gold_index, "X")
+    overall_correct = 1 if pred == gold_letter else 0
+    category = doc.get("task type", "unknown")
+    accuracy_dict = {
+        "overall": overall_correct, 
+        category: overall_correct
+    }
+    return {"accuracy": accuracy_dict}
+
+
+def omni_bench_aggregate_results(results):
+    total_correct = 0
+    total_examples = 0
+    category_correct = defaultdict(int)
+    category_total = defaultdict(int)
+    for i, result in enumerate(results, 1):
+        overall_score = result["overall"]
+        total_correct += overall_score
+        total_examples += 1
+        for category, score in result.items():
+            if category != "overall":
+                category_correct[category] += score
+                category_total[category] += 1
+    overall_accuracy = (total_correct / total_examples) * 100 if total_examples > 0 else 0.0
+    category_accuracy = {
+        category: (category_correct[category] / category_total[category]) * 100 
+        if category_total[category] > 0 else 0.0 
+        for category in category_correct
+    }
+    eval_logger.info("=" * 50)
+    eval_logger.info(f"Overall Accuracy: {overall_accuracy:.2f}%")
+    
+    if category_accuracy:
+        eval_logger.info("Category-wise Accuracy:")
+        for category, acc in category_accuracy.items():
+            eval_logger.info(f"  {category}: {acc:.2f}%")
+    eval_logger.info("=" * 50)
+    return round(overall_accuracy, 5)
+
+def parse_multi_choice_response(response, all_choices):
+    """
+    Parse the prediction from the generated response.
+    Return the predicted letter (e.g., "A", "B", "C", "D") or None if not found.
+    """
+    response = " " + response.strip() + " " 
+
+    index_ans = True
+    ans_with_brack = False
+    candidates = []
+
+    for choice in all_choices:
+        if f"({choice})" in response:
+            candidates.append(choice)
+            ans_with_brack = True
+
+    if not candidates:
+        for choice in all_choices:
+            if f"{choice} " in response:
+                candidates.append(choice)
+
+    if not candidates:
+        for choice in all_choices:
+            if f"{choice}." in response:
+                candidates.append(choice)
+
+    if not candidates:
+        return None
+
+    if len(candidates) > 1:
+        start_indexes = []
+        if ans_with_brack:
+            for can in candidates:
+                start_indexes.append(response.rfind(f"({can})"))
+        else:
+            for can in candidates:
+                start_indexes.append(response.rfind(f" {can} "))
+        return candidates[np.argmax(start_indexes)]
+    else:
+        return candidates[0]


### PR DESCRIPTION
Add Omni Bench with 3 settings:
- Original
- Replace audio with provided audio transcript ( for vlm)
- Replace image with provided image caption (for alm)
During evaluation, there are 12 samples that soundfile unable to load the audio.

I try to work around this but cannot fix. Hence I remove those samples and upload to lmms-lab/Omni_Bench_fix. The full set is at lmms-lab/Omni_Bench. The original has 1342 samples, the fixed one has 1330 samples. 