### PR TITLE
[Fix] Add padding_side="left" for Qwen2.5 to enable flash_attention

### DIFF
--- a/lmms_eval/models/qwen2_5_vl.py
+++ b/lmms_eval/models/qwen2_5_vl.py
@@ -85,9 +85,7 @@ class Qwen2_5_VL(lmms):
         self.max_pixels = max_pixels
         self.min_pixels = min_pixels
         self.max_num_frames = max_num_frames
-        self.processor = AutoProcessor.from_pretrained(
-            pretrained, max_pixels=max_pixels, min_pixels=min_pixels, padding_side="left"
-        )
+        self.processor = AutoProcessor.from_pretrained(pretrained, max_pixels=max_pixels, min_pixels=min_pixels, padding_side="left")
         self._tokenizer = AutoTokenizer.from_pretrained(pretrained, padding_side="left")
 
         self._config = self.model.config

--- a/lmms_eval/models/qwen2_5_vl.py
+++ b/lmms_eval/models/qwen2_5_vl.py
@@ -82,12 +82,13 @@ class Qwen2_5_VL(lmms):
             ).eval()
         else:
             self._model = Qwen2_5_VLForConditionalGeneration.from_pretrained(pretrained, torch_dtype="auto", device_map=self.device_map).eval()
-        self.processor = AutoProcessor.from_pretrained(pretrained, max_pixels=max_pixels, min_pixels=min_pixels)
         self.max_pixels = max_pixels
         self.min_pixels = min_pixels
         self.max_num_frames = max_num_frames
-        self.processor = AutoProcessor.from_pretrained(pretrained, max_pixels=max_pixels, min_pixels=min_pixels)
-        self._tokenizer = AutoTokenizer.from_pretrained(pretrained)
+        self.processor = AutoProcessor.from_pretrained(
+            pretrained, max_pixels=max_pixels, min_pixels=min_pixels, padding_side="left"
+        )
+        self._tokenizer = AutoTokenizer.from_pretrained(pretrained, padding_side="left")
 
         self._config = self.model.config
         self.batch_size_per_gpu = int(batch_size)


### PR DESCRIPTION
Hello, for some reason by default Qwen2.5 models don't have correct padding side set, which prevents them from running with flash_attention enabled