### PR TITLE
Add ability to pass options to VLLM

### DIFF
--- a/lmms_eval/models/vllm.py
+++ b/lmms_eval/models/vllm.py
@@ -54,6 +54,15 @@ class VLLM(lmms):
         self.max_frame_num = max_frame_num
         self.threads = threads
 
+        init_params = [
+            'model_version', 'tensor_parallel_size', 'gpu_memory_utilization', 
+            'batch_size', 'timeout', 'max_images', 'max_videos', 'max_audios',
+            'max_frame_num', 'threads', 'trust_remote_code'
+        ]
+        
+        # filter out the parameters already defined in __init__ to pass options to VLLM
+        filtered_kwargs = {k: v for k, v in kwargs.items() if k not in init_params}
+
         accelerator = Accelerator()
         self.client = LLM(
             model=self.model_version,
@@ -61,6 +70,7 @@ class VLLM(lmms):
             gpu_memory_utilization=gpu_memory_utilization,
             limit_mm_per_prompt={"image": max_images, "video": max_videos, "audio": max_audios},
             trust_remote_code=trust_remote_code,
+            **filtered_kwargs
         )
         if accelerator.num_processes > 1:
             assert accelerator.distributed_type in [DistributedType.FSDP, DistributedType.MULTI_GPU, DistributedType.DEEPSPEED], "Unsupported distributed type provided. Only DDP and FSDP are supported."

--- a/lmms_eval/models/vllm.py
+++ b/lmms_eval/models/vllm.py
@@ -54,13 +54,11 @@ class VLLM(lmms):
         self.max_frame_num = max_frame_num
         self.threads = threads
 
-        init_params = [
-            'model_version', 'tensor_parallel_size', 'gpu_memory_utilization', 
-            'batch_size', 'timeout', 'max_images', 'max_videos', 'max_audios',
-            'max_frame_num', 'threads', 'trust_remote_code'
-        ]
-        
+        init_params = ["model_version", "tensor_parallel_size", "gpu_memory_utilization", "batch_size", "timeout", "max_images", "max_videos", "max_audios", "max_frame_num", "threads", "trust_remote_code"]
+
         # filter out the parameters already defined in __init__ to pass options to VLLM
+        # this enables support for all VLLM Engine args:
+        # https://github.com/vllm-project/vllm/blob/3147586ebdb36ceae653e9dceec8cf9922fe2c28/vllm/engine/arg_utils.py#L93
         filtered_kwargs = {k: v for k, v in kwargs.items() if k not in init_params}
 
         accelerator = Accelerator()
@@ -70,7 +68,7 @@ class VLLM(lmms):
             gpu_memory_utilization=gpu_memory_utilization,
             limit_mm_per_prompt={"image": max_images, "video": max_videos, "audio": max_audios},
             trust_remote_code=trust_remote_code,
-            **filtered_kwargs
+            **filtered_kwargs,
         )
         if accelerator.num_processes > 1:
             assert accelerator.distributed_type in [DistributedType.FSDP, DistributedType.MULTI_GPU, DistributedType.DEEPSPEED], "Unsupported distributed type provided. Only DDP and FSDP are supported."


### PR DESCRIPTION
This pull request enables passing options to VLLM directly. This is useful for the following scenario:
1. gemma-3-12b-it model, which can fit in 2x24G GPU, but has a long-context of 128k tokens. User can then specify max_model_len directly like:
```VLLM_USE_V1=0 VLLM_WORKER_MULTIPROC_METHOD=spawn lmms-eval --tasks mmmu --model vllm --model_args model_version=google/gemma-3-12b-it,tensor_parallel_size=2,gpu_memory_utilization=0.95,max_images=1,max_videos=0,max_audios=0,max_model_len=4096 --batch_size 100 --log_samples --output_path lmms-results```

It enables support for all VLLM engine args.