### PR TITLE
Whisper + vLLM: FLEURS Evaluation Fixes and Language Prompt Injection

### DIFF
--- a/lmms_eval/models/whisper_vllm.py
+++ b/lmms_eval/models/whisper_vllm.py
@@ -108,13 +108,15 @@ class WhisperVllm(lmms):
                 task_name = str(task).strip()
                 if task_name.startswith("fleurs"):
                     language = self.task_dict[task][split][doc_id]["language"]
+                    language_to_token = {
+                        "Mandarin Chinese": "zh",
+                        "Cantonese Chinese": "zh",
+                        "English": "en"
+                    }
 
-                    if language in ["Mandarin Chinese", "Cantonese Chinese"]:
-                        whisper_prompt = f"<|startoftranscript|><|zh|><|transcribe|><|notimestamps|>"
-                        prompt_text = f"{pre_prompt}{whisper_prompt}{post_prompt}"
-                    elif language == "en":
-                        whisper_prompt = f"<|startoftranscript|><|en|><|transcribe|><|notimestamps|>"
-                        prompt_text = f"{pre_prompt}{whisper_prompt}{post_prompt}"
+                    if language in language_to_token:
+                        token = language_to_token[language]
+                        prompt_text = f"{pre_prompt}<|startoftranscript|><|{token}|><|transcribe|><|notimestamps|>{post_prompt}"
                     else:
                         prompt_text = f"{pre_prompt}Please recognize the speech and only output the recognized content:{post_prompt}"
                 else:

--- a/lmms_eval/models/whisper_vllm.py
+++ b/lmms_eval/models/whisper_vllm.py
@@ -100,8 +100,29 @@ class WhisperVllm(lmms):
                 audio = doc_to_visual(self.task_dict[task][split][doc_id])
                 assert len(audio) == 1
                 audio = audio[0]
+
+                pre_prompt = gen_kwargs.get("pre_prompt", "")
+                post_prompt = gen_kwargs.get("post_prompt", "")
+
+                # prepare prompt for task "fleurs"
+                task_name = str(task).strip()
+                if task_name.startswith("fleurs"):
+                    language = self.task_dict[task][split][doc_id]["language"]
+
+                    if language in ["Mandarin Chinese", "Cantonese Chinese"]:
+                        whisper_prompt = f"<|startoftranscript|><|zh|><|transcribe|><|notimestamps|>"
+                        prompt_text = f"{pre_prompt}{whisper_prompt}{post_prompt}"
+                    elif language == "en":
+                        whisper_prompt = f"<|startoftranscript|><|en|><|transcribe|><|notimestamps|>"
+                        prompt_text = f"{pre_prompt}{whisper_prompt}{post_prompt}"
+                    else:
+                        prompt_text = f"{pre_prompt}Please recognize the speech and only output the recognized content:{post_prompt}"
+                else:
+                    prompt_text = "<|startoftranscript|>"
+
+                # prepare input
                 prompt = {
-                    "prompt": "<|startoftranscript|>",
+                    "prompt": prompt_text,
                     "multi_modal_data": {
                         "audio": (audio["array"], audio["sampling_rate"]),
                     },

--- a/lmms_eval/models/whisper_vllm.py
+++ b/lmms_eval/models/whisper_vllm.py
@@ -108,11 +108,7 @@ class WhisperVllm(lmms):
                 task_name = str(task).strip()
                 if task_name.startswith("fleurs"):
                     language = self.task_dict[task][split][doc_id]["language"]
-                    language_to_token = {
-                        "Mandarin Chinese": "zh",
-                        "Cantonese Chinese": "zh",
-                        "English": "en"
-                    }
+                    language_to_token = {"Mandarin Chinese": "zh", "Cantonese Chinese": "zh", "English": "en"}
 
                     if language in language_to_token:
                         token = language_to_token[language]

--- a/lmms_eval/tasks/fleurs/utils.py
+++ b/lmms_eval/tasks/fleurs/utils.py
@@ -264,7 +264,7 @@ def compute_wer(refs, hyps, language):
             pred = basic_normalizer(pred)
         ref_items = tokenizer.tokenize(ref).split()
         pred_items = tokenizer.tokenize(pred).split()
-        if language in ["zh", "yue"]:
+        if language in ["cmn_hans", "yue_hant"]:
             ref_items = [x for x in "".join(ref_items)]
             pred_items = [x for x in "".join(pred_items)]
         if i == 0:


### PR DESCRIPTION
This PR introduces fixes and enhancements to support accurate evaluation of Whisper models (via vLLM backend) on the FLEURS benchmark.

Task-Aware Prompt Injection for FLEURS:

- Detects if a task starts with fleurs and injects Whisper-style prompts based on the language field in the sample metadata. For example:
  - <|zh|> for Mandarin and Cantonese (same token for both languages as using `yue` for Cantonese actually ends with worse `WER`)
  - <|en|> for English (many whisper models do fine without a specific `en` token but some need it for e.g `openai/whisper-large-v3`)

- These prompts are crucial for Whisper’s multilingual ASR, as vLLM requires the correct prompt prefix to trigger language-specific decoding.

Fix character-level tokenization for Mandarin and Cantonese: 

- Replaces the language condition from` ["zh", "yue"]` to `["cmn_hans", "yue_hant"]` to correctly match the language tags used in the FLEURS dataset.

Testing done using the command:

```
lmms-eval \
  --model whisper_vllm \
  --model_args pretrained=openai/whisper-medium \
  --batch_size 92 \
  --tasks fleurs

```

Results for `whisper/medium` 
```
whisper_vllm (pretrained=openai/whisper-large-v2), gen_kwargs: (), limit: None, num_fewshot: None, batch_size: 92
|        Tasks        |Version|Filter|n-shot|Metric|   | Value |   |Stderr|
|---------------------|-------|------|-----:|------|---|------:|---|------|
|fleurs               |    N/A|      |      |      |   |       |   |      |
| - fleurs_cmn_hans_cn|Yaml   |none  |     0|wer   |↓  |15.2148|±  |   N/A|
| - fleurs_en         |Yaml   |none  |     0|wer   |↓  | 4.4081|±  |   N/A|
| - fleurs_yue_hant_hk|Yaml   |none  |     0|wer   |↓  | 8.5106|±  |   N/A|
```
Note: The `fleurs_yue_hant_hk` subtask was manually added to `fleurs.yaml` for testing. This config edit is not part of this PR.

