### PR TITLE
Fix loading datasets from disk

### DIFF
--- a/lmms_eval/api/task.py
+++ b/lmms_eval/api/task.py
@@ -1037,7 +1037,6 @@ class ConfigurableTask(Task):
                 dataset_kwargs.pop("create_link")
 
         if dataset_kwargs is not None and "load_from_disk" in dataset_kwargs and dataset_kwargs["load_from_disk"]:
-            dataset_kwargs.pop("load_from_disk")
             # using local task in offline environment, need to process the online dataset into local format via
             # `ds = load_datasets("lmms-lab/MMMU")`
             self.dataset = datasets.load_from_disk(path=self.DATASET_PATH, name=self.DATASET_NAME)

--- a/lmms_eval/api/task.py
+++ b/lmms_eval/api/task.py
@@ -1039,7 +1039,7 @@ class ConfigurableTask(Task):
         if dataset_kwargs is not None and "load_from_disk" in dataset_kwargs and dataset_kwargs["load_from_disk"]:
             # using local task in offline environment, need to process the online dataset into local format via
             # `ds = load_datasets("lmms-lab/MMMU")`
-            self.dataset = datasets.load_from_disk(path=self.DATASET_PATH, name=self.DATASET_NAME)
+            self.dataset = datasets.load_from_disk(dataset_path=self.DATASET_PATH)
         else:
             self.dataset = datasets.load_dataset(
                 path=self.DATASET_PATH,


### PR DESCRIPTION
If you want to load a dataset from a local location there were 2 bugs: 
- the kwargs you needed for a later call would get popped since a copy isn't made of the kwargs
-  Params for datasets.load_dataset were used instead of datasets.load_from_disk
Related to https://github.com/EvolvingLMMs-Lab/lmms-eval/pull/584
