### PR TITLE
openai chat.completions uses max_completion_tokens

### DIFF
--- a/lmms_eval/models/openai_compatible.py
+++ b/lmms_eval/models/openai_compatible.py
@@ -186,11 +186,11 @@ class OpenAICompatible(lmms):
             if "num_beams" not in gen_kwargs:
                 gen_kwargs["num_beams"] = 1
 
-            payload["max_output_tokens"] = gen_kwargs["max_new_tokens"]
+            payload["max_completion_tokens"] = gen_kwargs["max_new_tokens"]
             payload["temperature"] = gen_kwargs["temperature"]
 
             if "o1" in self.model_version or "o3" in self.model_version:
-                del payload["max_output_tokens"]
+                # del payload["max_output_tokens"]
                 del payload["temperature"]
                 payload["reasoning_effort"] = "medium"
                 payload["response_format"] = {"type": "text"}


### PR DESCRIPTION
- Parameter is call max_completion_tokens for chat completions; the `https://api.openai.com/v1/chat/completions` api.   https://platform.openai.com/docs/api-reference/chat/create#:~:text=An%20upper%20bound%20for%20the%20number%20of%20tokens%20that%20can%20be%20generated%20for%20a%20completion%2C%20including%20visible%20output%20tokens%20and  
- max_output_tokens is for response api: `https://api.openai.com/v1/responses`. 
- `                    response = self.client.chat.completions.create(**payload)` is only version called.


Fixing https://github.com/EvolvingLMMs-Lab/lmms-eval/pull/614 