### PR TITLE
[FIX]: Fix question_for_eval key in MathVerse evaluator for Vision-Only data

### DIFF
--- a/lmms_eval/tasks/mathverse/mathverse_evals.py
+++ b/lmms_eval/tasks/mathverse/mathverse_evals.py
@@ -281,7 +281,7 @@ class MathVerseEvaluator:
             problem = {
                 "question_type": inst["question_type"],
                 "answer": inst["answer"] if "answer" in inst else None,
-                "question_for_eval": inst["question"],
+                "question_for_eval": inst["question_for_eval"],
             }
             if config["metadata"].get("trunk_response", -1) > 0:
                 prediction = " ".join(full_prediction.split(" ")[-config["metadata"]["trunk_response"] :])

--- a/lmms_eval/tasks/mathverse/utils.py
+++ b/lmms_eval/tasks/mathverse/utils.py
@@ -57,6 +57,7 @@ def mathverse_process_results(doc, results):
         "metadata": doc["metadata"],
         "query_wo": doc["query_wo"],
         "query_cot": doc["query_cot"],
+        "question_for_eval": doc["question_for_eval"],
     }
 
     return {


### PR DESCRIPTION

This PR addresses an issue in the MathVerse evaluation system where the scoring model fails to correctly judge answers for Vision-Only data.

Previously, when evaluating Vision-Only data, the question field was empty, causing the scoring model to fail when attempting to determine the correctness of answers following multiple-choice options.

## Example:

**Before fix:**
```
[Question]: 
[Standard Answer]: B
[Model_answer]: yyy
Judgement: 0  # Incorrect scoring due to empty question field
```

**After fix:**
```
[Question]: As shown in the figure, circle O has a radius 1.0, if angle BAC = 60.0, then the length of BC is () A. xxx B. yyy
[Standard Answer]: B
[Model_answer]: yyy
Judgement: 1  # Correctly scored as matching
```

The fix ensures the correct key is used for question_for_eval, enabling proper answer validation across all evaluation scenarios.
