### PR TITLE
[New Model] Aero-1-Audio

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@
 
 ## Annoucement
 
+- [2025-04] 🚀🚀 Introducing Aero-1-Audio — a compact yet mighty audio model. We have officially supports evaluation for Aero-1-Audio and it supports batched evaluations! Feel free to try out.
+
 - [2025-02] 🚀🚀 We have integrated [`vllm`](https://github.com/EvolvingLMMs-Lab/lmms-eval/pull/544) into our models, enabling accelerated evaluation for both multimodal and language models. Additionally, we have incorporated [`openai_compatible`](https://github.com/EvolvingLMMs-Lab/lmms-eval/pull/546) to support the evaluation of any API-based model that follows the OpenAI API format. Check the usages [here](https://github.com/EvolvingLMMs-Lab/lmms-eval/tree/main/miscs/model_dryruns).
 
 - [2025-01] 🎓🎓 We have released our new benchmark: [Video-MMMU: Evaluating Knowledge Acquisition from Multi-Discipline Professional Videos](https://arxiv.org/abs/2501.13826). Please refer to the [project page](https://videommmu.github.io/) for more details.

--- a/examples/models/aero_1_audio.sh
+++ b/examples/models/aero_1_audio.sh
@@ -1,0 +1,13 @@
+TASK=open_asr_tedlium
+CKPT_PATH=lmms-lab/Aero-1-Audio
+echo $TASK
+TASK_SUFFIX="${TASK//,/_}"
+echo $TASK_SUFFIX
+
+accelerate launch --num_processes 8 --main_process_port 30000 -m lmms_eval \
+    --model aero \
+    --model_args pretrained=$CKPT_PATH,attn_implementation="flash_attention_2" \
+    --tasks $TASK \
+    --batch_size 32 \
+    --log_samples_suffix $TASK_SUFFIX \
+    --output_path ./logs/ --verbosity DEBUG

--- a/lmms_eval/models/__init__.py
+++ b/lmms_eval/models/__init__.py
@@ -11,6 +11,7 @@ logger.remove()
 logger.add(sys.stdout, level="WARNING")
 
 AVAILABLE_MODELS = {
+    "aero": "Aero",
     "plm": "PerceptionLM",
     "aria": "Aria",
     "auroracap": "AuroraCap",

--- a/lmms_eval/models/aero.py
+++ b/lmms_eval/models/aero.py
@@ -1,0 +1,288 @@
+import os
+import warnings
+from typing import List, Optional, Tuple, Union
+
+import librosa
+import numpy as np
+import PIL
+import torch
+from accelerate import Accelerator, DistributedType
+from accelerate.state import AcceleratorState
+from tqdm import tqdm
+from transformers import AutoModelForCausalLM, AutoProcessor
+
+from lmms_eval import utils
+from lmms_eval.api.instance import Instance
+from lmms_eval.api.model import lmms
+from lmms_eval.api.registry import register_model
+from lmms_eval.models.model_utils.audio_processing import downsample_audio
+
+warnings.filterwarnings("ignore")
+
+from loguru import logger as eval_logger
+
+DEFAULT_IMAGE_TOKEN = "<image>"
+DEFAULT_VIDEO_TOKEN = "<video>"
+DEFAULT_AUDIO_TOKEN = "<|AUDIO|>"
+
+
+@register_model("aero")
+class Aero(lmms):
+    """
+
+    Example usage:
+
+    accelerate launch --num_processes 8 --main_process_port 30000 -m lmms_eval \
+        --model aero \
+        --model_args pretrained=$CKPT_PATH,attn_implementation="flash_attention_2" \
+        --tasks $TASK \
+        --batch_size 1 \
+        --log_samples_suffix $TASK_SUFFIX \
+        --output_path ./logs/ --verbosity DEBUG
+
+    """
+
+    def __init__(
+        self,
+        pretrained: str = "lmms-lab/Aero-1-Audio",
+        revision: str = "main",
+        device: str = "cuda",
+        dtype: Optional[Union[str, torch.dtype]] = "auto",
+        batch_size: int = 1,
+        trust_remote_code: Optional[bool] = True,
+        attn_implementation: Optional[str] = None,
+        device_map: str = "",
+        chat_template: Optional[str] = None,
+        use_cache: bool = True,
+        eos_token_id: int = 151645,
+        pad_token_id: int = 151643,
+        **kwargs,
+    ) -> None:
+        super().__init__()
+        # Do not use kwargs for now
+        assert kwargs == {}, f"Unexpected kwargs: {kwargs}"
+
+        accelerator = Accelerator()
+        if accelerator.num_processes > 1 and device_map == "":
+            self._device = torch.device(f"cuda:{accelerator.local_process_index}")
+            self.device_map = f"cuda:{accelerator.local_process_index}"
+        else:
+            self._device = torch.device(device)
+            self.device_map = device_map
+        if isinstance(dtype, str) and dtype != "auto":
+            dtype = getattr(torch, dtype)
+
+        self._model = AutoModelForCausalLM.from_pretrained(pretrained, revision=revision, torch_dtype=dtype, device_map=self.device_map, trust_remote_code=trust_remote_code, attn_implementation=attn_implementation)
+        self.pretrained = pretrained
+        self._processor = AutoProcessor.from_pretrained(pretrained, revision=revision, trust_remote_code=trust_remote_code)
+        # Pad from left for batched generation: https://huggingface.co/docs/transformers/v4.39.3/en/model_doc/llava#usage-tips
+        self._processor.tokenizer.padding_side = "left"
+        self._tokenizer = self._processor.tokenizer
+        self._config = self._model.config
+        self.batch_size_per_gpu = int(batch_size)
+        self.chat_template = chat_template
+        self.use_cache = use_cache
+        self.eos_token_id = eos_token_id
+        self.pad_token_id = pad_token_id
+        if accelerator.num_processes > 1 and device_map == "":
+            assert accelerator.distributed_type in [DistributedType.FSDP, DistributedType.MULTI_GPU, DistributedType.DEEPSPEED], "Unsupported distributed type provided. Only DDP and FSDP are supported."
+            # If you want to use DistributedType.DEEPSPEED, you have to run accelerate config before using the model
+            # Also, you have to select zero stage 0 (equivalent to DDP) in order to make the prepare model works
+            # I tried to set different parameters in the kwargs to let default zero 2 stage works, but it didn't work.
+            if accelerator.distributed_type == DistributedType.DEEPSPEED:
+                kwargs = {
+                    "train_micro_batch_size_per_gpu": self.batch_size_per_gpu,
+                    "train_batch_size": self.batch_size_per_gpu * accelerator.num_processes,
+                }
+                AcceleratorState().deepspeed_plugin.deepspeed_config_process(must_match=True, **kwargs)
+                eval_logger.info("Detected that you are using DistributedType.DEEPSPEED. Make sure you run `accelerate config` and set zero stage to 0")
+            if accelerator.distributed_type == DistributedType.FSDP or accelerator.distributed_type == DistributedType.DEEPSPEED:
+                self._model = accelerator.prepare(self.model)
+            else:
+                self._model = accelerator.prepare_model(self.model, evaluation_mode=True)
+            self.accelerator = accelerator
+            if self.accelerator.is_local_main_process:
+                eval_logger.info(f"Using {accelerator.num_processes} devices with data parallelism")
+            self._rank = self.accelerator.local_process_index
+            self._world_size = self.accelerator.num_processes
+        elif accelerator.num_processes == 1 and device_map == "auto":
+            eval_logger.info(f"Using {accelerator.num_processes} devices with pipeline parallelism")
+            self._rank = 0
+            self._word_size = 1
+        else:
+            eval_logger.info(f"Using single device: {self._device}")
+            self.model.to(self._device)
+            self._rank = 0
+            self._word_size = 1
+        self.accelerator = accelerator
+
+    @property
+    def config(self):
+        # return the associated transformers.AutoConfig for the given pretrained model.
+        return self._config
+
+    @property
+    def tokenizer(self):
+        return self._tokenizer
+
+    @property
+    def model(self):
+        # returns the model, unwrapping it if using Accelerate
+        if hasattr(self, "accelerator"):
+            return self.accelerator.unwrap_model(self._model)
+        else:
+            return self._model
+
+    def split_audio(self, audio_arrays):
+        CHUNK_LIM = 480000
+        SAMPLE_RATE = 16000
+        audio_splits = []
+        # Split the loaded audio to 30s chunks and extend the messages content
+        for i in range(
+            0,
+            len(audio_arrays),
+            CHUNK_LIM,
+        ):
+            audio_splits.append(audio_arrays[i : i + CHUNK_LIM])
+        return audio_splits
+
+    @property
+    def max_length(self):
+        return self._max_length
+
+    @property
+    def batch_size(self):
+        return self.batch_size_per_gpu
+
+    @property
+    def device(self):
+        return self._device
+
+    @property
+    def rank(self):
+        return self._rank
+
+    @property
+    def world_size(self):
+        return self._world_size
+
+    def tok_encode(self, string: str, left_truncate_len=None, add_special_tokens=None) -> List[int]:
+        """ """
+        add_special_tokens = False if add_special_tokens is None else add_special_tokens
+        encoding = self.tokenizer.encode(string, add_special_tokens=add_special_tokens)
+        # left-truncate the encoded context to be at most `left_truncate_len` tokens long
+        if left_truncate_len:
+            encoding = encoding[-left_truncate_len:]
+        return encoding
+
+    def tok_decode(self, tokens):
+        return self.tokenizer.decode(tokens)
+
+    def loglikelihood(self, requests: List[Instance]) -> List[Tuple[float, bool]]:
+        raise NotImplementedError("TODO: Implement loglikelihood for Kino")
+
+    def flatten(self, input):
+        new_list = []
+        for i in input:
+            for j in i:
+                new_list.append(j)
+        return new_list
+
+    def generate_until(self, requests: List[Instance]) -> List[str]:
+        res = []
+
+        def _collate(x):
+            # the negative sign on len(toks) sorts descending - this has a few advantages:
+            # - time estimates will always be over not underestimates, which is more useful for planning
+            # - to know the size of a batch when going through the list, you know the first one is always the batch
+            #   padded context length. this is useful to simplify the batching logic and more importantly to make
+            #   automatic adaptive batches much much easier to implement
+            # - any OOMs will happen right away rather than near the end
+            toks = self.tok_encode(x[0])
+            return -len(toks), x[0]
+
+        # we group requests by their generation_kwargs,
+        # so that we don't try to execute e.g. greedy sampling and temp=0.8 sampling
+        # in the same batch.
+        re_ords = utils.Collator([reg.args for reg in requests], _collate, grouping=True)
+        chunks = re_ords.get_batched(n=self.batch_size, batch_fn=None)
+        num_iters = len(requests) // self.batch_size if len(requests) % self.batch_size == 0 else len(requests) // self.batch_size + 1
+        pbar = tqdm(total=num_iters, disable=(self.rank != 0), desc="Model Responding")
+        for chunk in chunks:
+            contexts, all_gen_kwargs, doc_to_visual, doc_id, task, split = zip(*chunk)
+            task = task[0]
+            split = split[0]
+            batched_visuals = [doc_to_visual[0](self.task_dict[task][split][ids]) for ids in doc_id]
+            flattened_visuals = self.flatten(batched_visuals)
+            batched_messages = []
+            audios = []
+            for visuals in batched_visuals:
+                messages = [{"role": "user", "content": []}]
+                for visual in visuals:
+                    if isinstance(visual, dict) and "array" in visual:
+                        splited_video_audio = self.split_audio(downsample_audio(visual["array"], visual["sampling_rate"], self._processor.audio_processor.sampling_rate))
+                        audios.extend(splited_video_audio)
+                        for _ in range(len(splited_video_audio)):
+                            messages[0]["content"].append({"type": "audio", "audio_url": "<placeholder>"})
+                batched_messages.append(messages)
+            # we assume all gen kwargs in the batch are the same
+            # this is safe to assume because the `grouper` object ensures it.
+            gen_kwargs = all_gen_kwargs[0]
+
+            context = contexts[0]
+            for batch_number, context in enumerate(contexts):
+                batched_messages[batch_number][0]["content"].append({"type": "text", "text": context})
+
+            text = self._processor.apply_chat_template(batched_messages, tokenize=False, add_generation_prompt=True)
+
+            if self.accelerator.is_main_process and doc_id[0] % 100 == 0:
+                eval_logger.debug(f"Prompt for doc ID {doc_id[0]}:\n\n{text}\n")
+
+            if len(audios) == 0:
+                audios = None
+
+            inputs = self._processor(audios=audios, text=text, sampling_rate=self._processor.audio_processor.sampling_rate, return_tensors="pt", padding=True).to(self._device, self.model.dtype)
+            if "max_new_tokens" not in gen_kwargs:
+                gen_kwargs["max_new_tokens"] = 1024
+            if "temperature" not in gen_kwargs:
+                gen_kwargs["temperature"] = 0
+            if "top_p" not in gen_kwargs:
+                gen_kwargs["top_p"] = None
+            if "num_beams" not in gen_kwargs:
+                gen_kwargs["num_beams"] = 1
+            try:
+                cont = self.model.generate(
+                    **inputs,
+                    do_sample=True if gen_kwargs["temperature"] > 0 else False,
+                    temperature=gen_kwargs["temperature"],
+                    top_p=gen_kwargs["top_p"],
+                    num_beams=gen_kwargs["num_beams"],
+                    max_new_tokens=gen_kwargs["max_new_tokens"],
+                    use_cache=self.use_cache,
+                    pad_token_id=self.pad_token_id,
+                    eos_token_id=self.eos_token_id,
+                )
+                cont = cont[:, inputs["input_ids"].shape[-1] :]
+            except Exception as e:
+                eval_logger.error(f"Error {e} in generating")
+                text_outputs = ""
+                res.append(text_outputs)
+                pbar.update(1)
+                self.cache_hook.add_partial("generate_until", (context, gen_kwargs), text_outputs)
+                continue
+            text_outputs = self.tokenizer.batch_decode(cont, skip_special_tokens=True)
+            if self.accelerator.is_main_process and doc_id[0] % 100 == 0:
+                eval_logger.debug(f"Generated text for doc ID {doc_id[0]}:\n\n{text_outputs}\n")
+
+            for output, context in zip(text_outputs, contexts):
+                res.append(output)
+                self.cache_hook.add_partial("generate_until", (context, gen_kwargs), output)
+            pbar.update(1)
+        # reorder this group of results back to original unsorted form
+        res = re_ords.get_original(res)
+
+        pbar.close()
+        return res
+
+    def generate_until_multi_round(self, requests) -> List[str]:
+        raise NotImplementedError("TODO: Implement multi-round generation for LLaVAHF")


### PR DESCRIPTION
🚀 Introducing Aero-1-Audio — a compact yet mighty audio model.

🧠 Built on Qwen-2.5-1.5B
⚡ Trained in <24h on just 16×H100
🎧 Handles 15+ min audio seamlessly
💡 Outperforms bigger models like Whisper, Qwen-2-Audio & commercial services from ElevenLabs/Scribe

Aero shows: smart data > massive scale.


Github Repo: https://github.com/EvolvingLMMs-Lab/Aero-1
Model Checkpoints: https://huggingface.co/lmms-lab/Aero-1-Audio-1.5B
Evaluation Results: https://github.com/EvolvingLMMs-Lab/lmms-eval/tree/dev/aero
Cookbook: https://www.lmms-lab.com/posts/lmms-lab-docs/aero_audio/


## Evaluation Result

[20250424_092927_results.json](https://github.com/user-attachments/files/19959688/20250424_092927_results.json)
[20250421_203304_results.json](https://github.com/user-attachments/files/19959689/20250421_203304_results.json)
[20250421_202840_results.json](https://github.com/user-attachments/files/19959690/20250421_202840_results.json)
[20250421_170326_results.json](https://github.com/user-attachments/files/19959691/20250421_170326_results.json)

*Note: for some benchmarks, we use gpt-4o-2024-11-20 as judge model

## Examples

We supports batch evaluation for faster inference. Notice that the result might be slightly difference for different batch size

```bash
TASK=open_asr_tedlium
CKPT_PATH=lmms-lab/Aero-1-Audio
echo $TASK
TASK_SUFFIX="${TASK//,/_}"
echo $TASK_SUFFIX

accelerate launch --num_processes 8 --main_process_port 30000 -m lmms_eval \
    --model aero \
    --model_args pretrained=$CKPT_PATH,attn_implementation="flash_attention_2" \
    --tasks $TASK \
    --batch_size 32 \
    --log_samples_suffix $TASK_SUFFIX \
    --output_path ./logs/ --verbosity DEBUG
```
