### PR TITLE
Mathvision bug fixes , Reproduce Qwen2.5VL results

### DIFF
--- a/lmms_eval/models/qwen2_5_vl.py
+++ b/lmms_eval/models/qwen2_5_vl.py
@@ -195,18 +195,18 @@ class Qwen2_5_VL(lmms):
             split = split[0]
             visual_list = [doc_to_visual[0](self.task_dict[task][split][ids]) for ids in doc_id]
             gen_kwargs = all_gen_kwargs[0]
-
-            # Set default values for until and max_new_tokens
-            until = [self.tokenizer.decode(self.eot_token_id)]
-
-            # Update values from gen_kwargs if present
-            if "until" in gen_kwargs:
-                until = gen_kwargs.pop("until")
-                if isinstance(until, str):
-                    until = [until]
-                elif not isinstance(until, list):
-                    raise ValueError(f"Expected `gen_kwargs['until']` to be of type Union[str,list] but got {type(until)}")
-
+            
+            # Set default until or update values from gen_kwargs if present
+            until = gen_kwargs.get("until", [self.tokenizer.decode(self.eot_token_id)])
+            
+            if isinstance(until, str):
+                until = [until]
+            elif not isinstance(until, list):
+                raise ValueError(f"Expected `gen_kwargs['until']` to be of type Union[str, list], but got {type(until)}")
+            
+            # Avoid using '\n\n' as a stopper for Qwen2.5VL to prevent truncation, which can lead to incorrect results
+            until = [item for item in until if item != "\n\n"]
+            
             if isinstance(contexts, tuple):
                 contexts = list(contexts)
 

--- a/lmms_eval/tasks/mathvision/utils.py
+++ b/lmms_eval/tasks/mathvision/utils.py
@@ -101,11 +101,12 @@ def mathvision_doc_to_text(doc, lmms_eval_specific_kwargs=None):
     mc_prompt = ""
     if lmms_eval_specific_kwargs is not None:
         mc_prompt = "\n" + lmms_eval_specific_kwargs["mc_prompt"]
-        
+    
+    query_prompt = 'Please solve the problem step by step and put your answer in one "\\boxed{}".'
     if choices_str:
-        query_prompt = f"{question}\nChoices: {choices_str}"
+        query_prompt += f"{question}\nChoices: {choices_str}" + mc_prompt
     else:
-        query_prompt = question
+        query_prompt += question
     return query_prompt
 
 

--- a/lmms_eval/tasks/mathvision/utils.py
+++ b/lmms_eval/tasks/mathvision/utils.py
@@ -92,11 +92,16 @@ def mathvision_doc_to_visual(doc):
     return [doc["decoded_image"].convert("RGB")]
 
 
-def mathvision_doc_to_text(doc):
+def mathvision_doc_to_text(doc, lmms_eval_specific_kwargs=None):
     question, choices = doc["question"], doc["options"]
     len_choices = len(choices)
     options = [chr(ord("A") + i) for i in range(len_choices)]
     choices_str = "\n".join([f"{option}. {choice}" for option, choice in zip(options, choices)])
+    
+    mc_prompt = ""
+    if lmms_eval_specific_kwargs is not None:
+        mc_prompt = "\n" + lmms_eval_specific_kwargs["mc_prompt"]
+        
     if choices_str:
         query_prompt = f"{question}\nChoices: {choices_str}"
     else:


### PR DESCRIPTION
**Description :** 
This PR fixes a bug in MathVision evaluation and includes improvements to reproduce the MathVision evaluation for Qwen2.5-VL.

The current MathVision evaluation codebase breaks due to the following issues:

- The value for "until" is incorrectly set to "\n\n" by default, which causes the response to be truncated incorrectly.
[Reference](https://github.com/EvolvingLMMs-Lab/lmms-eval/blob/a7b7c8dfc874fea13b8036741f456650e36a01ea/lmms_eval/models/qwen2_5_vl.py#L204)

- The mathvision_doc_to_text(doc) function needs to accept lmms_eval_specific_kwargs as an argument.
[Reference](https://github.com/EvolvingLMMs-Lab/lmms-eval/blob/a7b7c8dfc874fea13b8036741f456650e36a01ea/lmms_eval/tasks/mathvision/utils.py#L95)

**Reproducing MathVision Results on Qwen2.5-3B-Instruct :**

The current implementation produces a MathVision Standard Eval score of 0.46, which is incorrect. This issue occurs due to parsing only a truncated response (see Bug 1 above).

With the changes introduced in this PR and using a max_token_len of 2048, the official result of 21.68 for the Qwen2.5-3B-Instruct model can be reproduced.

|     Tasks     |Version|Filter|n-shot|         Metric         |   |Value|   |Stderr|
|---------------|-------|------|-----:|------------------------|---|----:|---|------|
|mathvision_test|Yaml   |none  |     0|mathvision_standard_eval|↑  |21.68|±  |   N/A|
