### PR TITLE
Fix issue with killing process in sglang

### DIFF
--- a/lmms_eval/models/srt_api.py
+++ b/lmms_eval/models/srt_api.py
@@ -14,7 +14,7 @@ from decord import VideoReader, cpu
 from loguru import logger as eval_logger
 from openai import AsyncOpenAI, OpenAI
 from PIL import Image
-from sglang.srt.utils import kill_child_process
+from sglang.srt.utils import kill_process_tree
 from sglang.test.test_utils import (
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
     popen_launch_server,
@@ -313,7 +313,7 @@ class SRT_API(lmms):
                 pbar.update(1)
         else:
             asyncio.run(run(requests))
-        kill_child_process(self.process.pid)
+        kill_process_tree(self.process.pid)
 
         return res
 


### PR DESCRIPTION
PR to fix process killing in sglang.

`kill_child_process` is changed to `kill_process_tree` in sglang. [Reference](https://github.com/ravi03071991/sglang/blob/00c2c1f08b169c9239c77bf1dc5a97ea7d29d5e4/python/sglang/srt/utils.py#L697).

Thank You.
