### PR TITLE
[fix] modify the GPT evaluation model

### DIFF
--- a/lmms_eval/tasks/llava-in-the-wild/llava-in-the-wild_ko.yaml
+++ b/lmms_eval/tasks/llava-in-the-wild/llava-in-the-wild_ko.yaml
@@ -32,7 +32,7 @@ metric_list:
     higher_is_better: true
 metadata:
   version: 0.0
-  gpt_eval_model_name: "gpt-4-0613"
+  gpt_eval_model_name: "gpt-4o-2024-08-06"
 lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""


### PR DESCRIPTION
Modify the GPT evaluation model in K-LLaVA-W from "gpt-4-0613" to "gpt-4o-2024-08-06".


* The GPT evaluation model used to measure this benchmark can be found in https://arxiv.org/pdf/2411.19103 (Page 5).