### PR TITLE
[Fix] Correct rating logic for VITATECS benchmark

### DIFF
--- a/lmms_eval/tasks/vitatecs/utils.py
+++ b/lmms_eval/tasks/vitatecs/utils.py
@@ -130,7 +130,7 @@ def vitatecs_process_results(doc, result):
     elif any(pred.startswith(prefix) for prefix in ["A)", "B)"]):
         rating = 1 if pred.split(")")[0] == answer[1] else 0
     elif any(pred.startswith(prefix) for prefix in ["(A)", "(B)"]):
-        rating = 1 if pred.split(")")[1] == answer[1] else 0
+        rating = 1 if pred.split(")")[0][1] == answer[1] else 0
     else:
         # Fail to match answer in the video-llm response. Use ChatGPT to evaluate.
         match_success = False


### PR DESCRIPTION
This pull request addresses an issue in the hand-crafted matching rules for VITATECS benchmark. The change fixes the extraction of the answer choice from the prediction string when it starts with prefixes like "(A)" or "(B)".

Old behavior incorrectly used the text after the closing parenthesis, which lead to incorrect rating.
New behavior extracts the second character of the prefix (e.g., "A" or "B").