### PR TITLE
[fix] Fix task listing in CLI evaluation by updating to use 'all_tasks' instead of 'list_all_tasks' for improved clarity.

### DIFF
--- a/lmms_eval/__main__.py
+++ b/lmms_eval/__main__.py
@@ -409,7 +409,7 @@ def cli_evaluate_single(args: Union[argparse.Namespace, None] = None) -> None:
         eval_logger.error("Need to specify task to evaluate.")
         sys.exit()
     elif args.tasks == "list":
-        eval_logger.info("Available Tasks:\n - {}".format(f"\n - ".join(sorted(task_manager.list_all_tasks()))))
+        eval_logger.info("Available Tasks:\n - {}".format(f"\n - ".join(sorted(task_manager.all_tasks))))
         sys.exit()
     elif args.tasks == "list_groups":
         eval_logger.info(task_manager.list_all_tasks(list_subtasks=False, list_tags=False))


### PR DESCRIPTION
The issue has been identified and fixed. The problem was in /opt/tiger/lmms-eval/lmms_eval/__main__.py:412 where task_manager.list_all_tasks() returns a formatted string, but the code was trying to
  join it as if it were a list, resulting in each character being printed separately.

  The fix was to change task_manager.list_all_tasks() to task_manager.all_tasks to get the actual list of task names.

### When you open a pull-request, please be sure to include the following

- [ ] A descriptive title: [xxx] XXXX
- [ ] A detailed description

If you meet the lint warnings, you can use following scripts to reformat code.

```sh
pip install pre-commit
pre-commit install
pre-commit run --all-files
```

Thank you for your contributions!
