### PR TITLE
Pass in the 'cache_dir' to use local cache

### DIFF
--- a/lmms_eval/api/task.py
+++ b/lmms_eval/api/task.py
@@ -942,10 +942,17 @@ class ConfigurableTask(Task):
                     force_unzip = dataset_kwargs.get("force_unzip", False)
                     revision = dataset_kwargs.get("revision", "main")
                     create_link = dataset_kwargs.get("create_link", False)
-                    cache_path = snapshot_download(repo_id=self.DATASET_PATH, cache_dir= cache_dir, revision=revision, repo_type="dataset", force_download=force_download, etag_timeout=60)
+                    cache_path = snapshot_download(
+                        repo_id=self.DATASET_PATH,
+                        cache_dir=cache_dir,
+                        revision=revision,
+                        repo_type="dataset",
+                        force_download=force_download,
+                        etag_timeout=60,
+                    )
                     zip_files = glob(os.path.join(cache_path, "**/*.zip"), recursive=True)
                     tar_files = glob(os.path.join(cache_path, "**/*.tar*"), recursive=True)
-
+                    
                     def unzip_video_data(zip_file):
                         import os
                         import zipfile

--- a/lmms_eval/api/task.py
+++ b/lmms_eval/api/task.py
@@ -942,7 +942,7 @@ class ConfigurableTask(Task):
                     force_unzip = dataset_kwargs.get("force_unzip", False)
                     revision = dataset_kwargs.get("revision", "main")
                     create_link = dataset_kwargs.get("create_link", False)
-                    cache_path = snapshot_download(repo_id=self.DATASET_PATH, revision=revision, repo_type="dataset", force_download=force_download, etag_timeout=60)
+                    cache_path = snapshot_download(repo_id=self.DATASET_PATH, cache_dir= cache_dir, revision=revision, repo_type="dataset", force_download=force_download, etag_timeout=60)
                     zip_files = glob(os.path.join(cache_path, "**/*.zip"), recursive=True)
                     tar_files = glob(os.path.join(cache_path, "**/*.tar*"), recursive=True)
 


### PR DESCRIPTION
Hi, thank you for your awesome project.
I recently wanted to modify the yaml file to use my local dataset since I already have them on my machine.
So I set the 'cache_dir' in the 'dataset_kwargs' and noticed that the lmms-eval is still trying to fetch dataset from huggingface instead of using the local one.
After throughly check, I noticed we can pass in the 'cache_dir' to the huggingface snapshot_download function in the tasks.py if we have 'videos' in dataset_kwargs to avoid force-redownloading.

