### PR TITLE
[FIX] Fix parameter name in qwen25vl.sh

### DIFF
--- a/examples/models/qwen25vl.sh
+++ b/examples/models/qwen25vl.sh
@@ -7,12 +7,12 @@ export HF_HOME="~/.cache/huggingface"
 
 # accelerate launch --num_processes=8 --main_process_port=12346 -m lmms_eval \
 #     --model qwen2_vl \
-#     --model_args=pretrained=Qwen/Qwen2-VL-7B-Instruct,max_pixels=12845056,use_flash_attention_2=True,interleave_visuals=True \
+#     --model_args=pretrained=Qwen/Qwen2-VL-7B-Instruct,max_pixels=12845056,attn_implementation=flash_attention_2,interleave_visuals=True \
 #     --tasks mmmu_pro \
 #     --batch_size 1
 
 accelerate launch --num_processes=8 --main_process_port=12346 -m lmms_eval \
     --model qwen2_5_vl \
-    --model_args=pretrained=Qwen/Qwen2.5-VL-7B-Instruct,max_pixels=12845056,use_flash_attention_2=True,interleave_visuals=False \
+    --model_args=pretrained=Qwen/Qwen2.5-VL-7B-Instruct,max_pixels=12845056,attn_implementation=flash_attention_2,interleave_visuals=False \
     --tasks mme \
     --batch_size 1


### PR DESCRIPTION
## Description
Following the changes in PR #683, the flash attention parameter interface was updated from `use_flash_attention_2` to `attn_implementation`. This PR updates the shell script to use the correct parameter format.

## Changes Made
- Updated `use_flash_attention_2=True` to `attn_implementation=flash_attention_2` 


