### PR TITLE
[Fix] Fix evaluator crash with accelerate backend when num_processes=1

### DIFF
--- a/lmms_eval/evaluator.py
+++ b/lmms_eval/evaluator.py
@@ -13,6 +13,7 @@ from typing import List, Optional, Union
 import numpy as np
 import torch
 import torch.distributed as dist
+from accelerate import Accelerator
 from datasets import Image, Sequence
 from loguru import logger as eval_logger
 from tqdm import tqdm
@@ -660,8 +661,9 @@ def evaluate(
     else:
         results_dict = None
 
-    if hasattr(lm, "accelerator") and distributed_executor_backend == "accelerate":
-        lm.accelerator.wait_for_everyone()
+    if distributed_executor_backend == "accelerate":
+        # this should work for torchrun as well since it internally calls torch.distributed.barrier()
+        Accelerator().wait_for_everyone()
     elif distributed_executor_backend == "torchrun":
         dist.barrier()
     else:


### PR DESCRIPTION
Fixes #695 where `num_processes=1` with accelerate (running Qwen2.5-VL) leads to error.

This PR updates the synchronization logic in the evaluator to avoid depending on a potentially unset model attribute `lm.accelerator`. It instead uses `Accelerator().wait_for_everyone()` from a new instance, which is safe for single process runs and should behave the same as before for multi-process runs.

### Note
- Tested with accelerate on a single-GPU setup. The problem only occurs when `num_processes=1`, so this scenario was reproducible and fixed. Although the fix should behave correctly under both single- and multi-process settings, multi-GPU testing would be recommended.
- `Accelerator().wait_for_everyone()` should work for both backends (`accelerate` and `torchrun`), so the if statement could potentially be further simplified to one line if there are no other reasons to check backend here.
- Other parts of the codebase (e.g., `Qwen2_5_VL`) re-create `Accelerator` instance instead of passing them around, so I followed that pattern for consistency.