### PR TITLE
Adds VideoMathQA - Task Designed to Evaluate Mathematical Reasoning in Real-World Educational Videos

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@
 <details>
 <summary>We warmly welcome contributions from the open-source community! Below is a chronological list of recent tasks, models, and features added by our amazing contributors. </summary>
 
+- [2025-06] 🎉🎉 We welcome the new task [VideoMathQA](https://mbzuai-oryx.github.io/VideoMathQA), designed to evaluate mathematical reasoning in real-world educational videos.
 - [2024-10] 🎉🎉 We welcome the new task [NaturalBench](https://huggingface.co/datasets/BaiqiL/NaturalBench), a vision-centric VQA benchmark (NeurIPS'24) that challenges vision-language models with simple questions about natural imagery.
 - [2024-10] 🎉🎉 We welcome the new task [TemporalBench](https://huggingface.co/datasets/microsoft/TemporalBench) for fine-grained temporal understanding and reasoning for videos, which reveals a huge (>30%) human-AI gap.
 - [2024-10] 🎉🎉 We welcome the new tasks [VDC](https://rese1f.github.io/aurora-web/) for video detailed captioning, [MovieChat-1K](https://rese1f.github.io/MovieChat/) for long-form video understanding, and [Vinoground](https://vinoground.github.io/), a temporal counterfactual LMM benchmark composed of 1000 short natural video-caption pairs. We also welcome the new models: [AuroraCap](https://github.com/rese1f/aurora) and [MovieChat](https://github.com/rese1f/MovieChat).

--- a/lmms_eval/tasks/videomathqa/README.md
+++ b/lmms_eval/tasks/videomathqa/README.md
@@ -1,0 +1,81 @@
+# VideoMathQA: Benchmarking Mathematical Reasoning via Multimodal Understanding in Videos
+VideoMathQA is a benchmark designed to evaluate mathematical reasoning in real-world educational videos. It requires models to interpret and integrate information from three modalities, visuals, audio, and text, across time. The benchmark tackles the “needle-in-a-multimodal-haystack” problem, where key information is sparse and spread across different formats and moments in the video.
+
+[![Website](https://img.shields.io/badge/🌐_Project-Website-87CEEB)](https://mbzuai-oryx.github.io/VideoMathQA)
+[![Dataset](https://img.shields.io/badge/🤗_Dataset-Access-green)](https://huggingface.co/datasets/MBZUAI/VideoMathQA)
+[![🏅 Leaderboard (Reasoning)](https://img.shields.io/badge/🏅_Leaderboard-Reasoning-red)](https://hanoonar.github.io/VideoMathQA/#leaderboard-2)
+[![🏅 Leaderboard (Direct)](https://img.shields.io/badge/🏅_Leaderboard-Direct-yellow)](https://hanoonar.github.io/VideoMathQA/#leaderboard)
+[![GitHub](https://img.shields.io/badge/📂_GitHub-VideoMathQA-green)](https://github.com/mbzuai-oryx/VideoMathQA)
+
+## Evaluation Strategies
+
+**VideoMathQA** supports the following **evaluation strategies** to comprehensively assess model performance:
+
+1. **MCQ and Multi-Binary (MBin)**  
+   - Tasks with `mcq` use a 5-way multiple-choice format.  
+   - Tasks with `mbin` use a stricter binary-pairwise evaluation format (correct vs each distractor).  
+   - Both formats are available *with* and *without subtitles*, indicated by `_w_subtitles` in the task name.
+
+2. **Direct Answering vs. Chain-of-Thought (CoT)**  
+   - Each task can be evaluated under **Direct** or **CoT** prompting.  
+   - Tasks containing `_cot` use CoT prompting, where models generate reasoning before the final answer.  
+   - Direct answering tasks expect the final answer only, without intermediate reasoning.  
+   - CoT tasks require post-processing to extract the final answer (see [Post Processing](#post-processing)).  
+   - We maintain **separate leaderboards** for Direct and CoT settings.
+
+3. **Step-wise CoT Evaluation**  
+   - For CoT tasks, we additionally evaluate the quality of generated reasoning.  
+   - Each response is scored by comparing against annotated solution steps (typically 4–10 steps).  
+   - Scoring is done using a small open-source model (Qwen-3-4B in thinking mode), which returns a score (0–10) and rationale.
+
+
+## Run Evaluation
+
+Please run the following command to start evaluation.
+
+```python
+accelerate launch --num_processes=8 -m lmms_eval \
+    --model qwen2_5_vl \
+    --model_args=pretrained=Qwen/Qwen2.5-VL-7B-Instruct,max_pixels=151200,min_pixels=100352,use_flash_attention_2=True,device_map=auto \
+    --tasks videomathqa_mbin \
+    --batch_size 1 --log_samples --log_samples_suffix qwen_2_5_vl \
+    --output_path output
+```
+
+This command starts evaluating the Qwen2.5-VL-3B model on `VideoMathQA` for multi-binary accuracy. The other available `VideoMathQA` tasks are:
+
+1. videomathqa\_mcq
+2. videomathqa\_mcq\_w\_subtitles
+3. videomathqa\_mcq\_cot
+4. videomathqa\_mcq\_cot\_w\_subtitles
+5. videomathqa\_mbin
+6. videomathqa\_mbin\_w\_subtitles
+7. videomathqa\_mbin\_cot
+8. videomathqa\_mbin\_cot\_w\_subtitles
+
+`w_subtitles` tasks additionally use subtitles during evaluation. `cot` tasks prompt the model to think step-by-step before answering the question.
+
+
+## Post Processing
+- For tasks with CoT prompting (`_cot`), model outputs typically contain both reasoning and the final answer.
+- To enable standardized scoring, we post-process the responses using Qwen-3-4B (in non-thinking mode) to extract only the final answer. This ensures format consistency and removes ambiguity in final answer extraction.
+
+```shell
+# Install VLLM
+pip install vllm
+
+# Run post-processing
+python videomathqa/cot_postprocess.py --input_file <path/to/your/raw_cot_results.jsonl> --output_file <path/to/save/processed_results.jsonl>
+```
+
+## CoT Step Evaluation
+
+We provide a [VLLM](https://github.com/vllm-project/vllm)-based script to run CoT step evaluation after inference. The self-contained script is available at [cot\_step\_evaluation.py](cot_step_evaluation.py).
+
+```shell
+# Install VLLM
+pip install vllm
+
+# Run CoT step evaluation
+python videomathqa/cot_step_evaluation.py --gt_file <path/to/the/annotation/parquet_file> --res_file <path/to/the/results/file/generated/after/running/inference/using/lmms_eval>
+```

--- a/lmms_eval/tasks/videomathqa/cot_postprocess.py
+++ b/lmms_eval/tasks/videomathqa/cot_postprocess.py
@@ -1,0 +1,137 @@
+import os
+import re
+import sys
+import json
+import random
+import argparse
+from tqdm import tqdm
+from vllm import LLM, SamplingParams
+from transformers import AutoTokenizer
+from videomathqa.utils import (extract_characters_regex,
+                            videomathqa_process_results,
+                            videomathqa_mcq_aggregate_results,
+                            videomathqa_multi_binary_aggregate_results)
+
+
+mcq_prompt = (
+    "Given the original multiple-choice options and a model-generated answer containing reasoning and a final answer, identify the option that best matches the final answer and return only the corresponding letter (A, B, C, D, or E)."
+)
+mbin_prommpt = "Given the original binary options and a model-generated answer containing reasoning and a final answer, identify the option that best matches the final answer and return only the corresponding letter (A or B)."
+
+
+def extract_choice_vllm(llm, sampling_params, tokenizer, model_prompt, mcq=True):
+    if mcq:
+        prompt_type = mcq_prompt
+    else:
+        prompt_type = mbin_prommpt
+    chat_prompt = [
+        {
+            "role": "user",
+            "content": f"""{prompt_type}:
+
+Text:
+{model_prompt}
+
+Only return the letter A, B, C, D, or E. If none is found, return "None".""",
+        }
+    ]
+    text = tokenizer.apply_chat_template(chat_prompt, tokenize=False, add_generation_prompt=True, enable_thinking=False)
+    output = llm.generate([text], sampling_params=sampling_params)
+    reply = output[0].outputs[0].text.strip().upper()
+    if mcq:
+        if re.fullmatch(r"[A-E]", reply):
+            return reply
+    else:
+        if re.fullmatch(r"[A-B]", reply):
+            return reply
+    return None
+
+
+def refine_samples_vllm(llm, sampling_params, tokenizer, sample_jsonl, output_jsonl, mcq=True):
+    raw_samples = []
+    with open(sample_jsonl, "r") as f:
+        for line in f:
+            raw_samples.append(json.loads(line))
+    print(f"Loaded {len(raw_samples)} samples from {sample_jsonl}")
+
+    updated_samples = []
+    for sample in tqdm(raw_samples, desc="Postprocessing samples with Qwen"):
+        options = sample["doc"]["options"]
+        raw_pred = sample["resps"][0][0]
+        input_text = f"The options are: {options}\n\n The model response is: {raw_pred}"
+        try:
+            choice = extract_choice_vllm(llm, sampling_params, tokenizer, input_text, mcq)
+        except Exception as e:
+            choice = None
+        if choice is None:
+            answer = sample["target"]
+            if mcq:
+                options = ["A", "B", "C", "D", "E"]
+            else:
+                options = ["A", "B"]
+            options.remove(answer)
+            random.shuffle(options)
+            choice = options[0]
+        sample["resps"][0][0] = choice
+        updated_samples.append(sample)
+
+    with open(output_jsonl, "w") as f:
+        for sample in updated_samples:
+            f.write(json.dumps(sample) + "\n")
+    print(f"Saved {len(updated_samples)} updated samples to {output_jsonl}")
+    return updated_samples
+
+
+def postprocess_jsonl(llm, sampling_params, tokenizer, sample_jsonl, output_jsonl):
+    if "mcq" in sample_jsonl:
+        mcq = True
+    elif "mbin" in sample_jsonl:
+        mcq = False
+
+    updated_samples = refine_samples_vllm(llm, sampling_params, tokenizer, sample_jsonl, output_jsonl, mcq)
+
+    print(f"Computing score ...")
+    processed = []
+    for item in tqdm(updated_samples, desc="Computing scores..."):
+        pred_raw = item["resps"][0][0] if isinstance(item["resps"][0], list) else item["resps"][0]
+        pred_clean = extract_characters_regex(pred_raw)
+        item["filtered_resps"] = [pred_clean]
+        result = videomathqa_process_results(item["doc"], [pred_clean])
+        processed.append(result["videomathqa_perception_score"])
+
+    if mcq:
+        final_score = videomathqa_mcq_aggregate_results(processed)
+    else:
+        final_score = videomathqa_multi_binary_aggregate_results(processed)
+    print(f"Final Postprocessed VideoMathQA Score: {final_score:.2f}")
+    print(f"Saved {len(updated_samples)} updated samples to {output_jsonl}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Postprocess a CoT predictions using the Qwen model.")
+    parser.add_argument("--input_file", type=str, required=True, help="Path to the input JSONL file.")
+    parser.add_argument("--output_file", type=str, required=True, help="Path to save the postprocessed output JSONL file.")
+    parser.add_argument("--model_path", type=str, default="Qwen/Qwen3-4B", help="Path to the pretrained Qwen model (default: Qwen3-4B).")
+
+    args = parser.parse_args()
+
+    if not os.path.exists(args.input_file):
+        print(f"Input file '{args.input_file}' does not exist.")
+        return
+
+    if os.path.exists(args.output_file):
+        print(f"Output file '{args.output_file}' already exists. Skipping.")
+        return
+
+    print("Loading Qwen-3 model...")
+    tokenizer = AutoTokenizer.from_pretrained(args.model_path)
+    llm = LLM(model=args.model_path)
+    sampling_params = SamplingParams(temperature=0.7, top_p=0.8, top_k=20, min_p=0, max_tokens=16)
+
+    print(f"Processing {args.input_file} ...")
+    postprocess_jsonl(llm, sampling_params, tokenizer, args.input_file, args.output_file)
+    print(f"Saved postprocessed output to {args.output_file}")
+
+
+if __name__ == "__main__":
+    main()

--- a/lmms_eval/tasks/videomathqa/cot_step_evaluation.py
+++ b/lmms_eval/tasks/videomathqa/cot_step_evaluation.py
@@ -1,0 +1,197 @@
+import os
+import ast
+import json
+import argparse
+import pandas as pd
+from tqdm import tqdm
+from vllm import LLM, SamplingParams
+from transformers import AutoTokenizer
+
+system_prompt = """
+You are a intelligent assistant for grading math question solutions. You will be given:
+- A mathematical question (question) with multiple-choice options (options).
+- A list of numbered ground truth steps (gt_steps) showing the correct reasoning to solve a math problem.
+- A answer (answer) that is the correct final solution to the question.
+- A model prediction (prediction) that includes the steps the model followed and possibly the final answer.
+
+TASK: Compare the prediction to gt_steps and assign a score out of 10 using the rubric below. You must reward both matching logic and valid alternative reasoning. Avoid overly strict step-by-step comparison, instead focus if the model follows a coherent and plausible mathematical approach.
+
+---
+
+### Scoring Rubric:
+
+#### 1. Relative Step Matching (Main Criterion)
+- Count the total number of ground truth steps: N
+- Evaluate how many predicted steps correctly align with gt_steps in terms of mathematical logic, reasoning, or computations. 
+- Score = (matching steps / N) × 10, rounded to nearest whole number. 
+- Remember: A step MATCHES if it serves the same mathematical purpose, even if phrased or ordered differently.
+
+#### 2. Correct Final Answer via Different Reasoning
+- If the model's final answer is correct, and the steps are logically valid (even if they differ from gt_steps), assign a full score of 10.
+- Ignore number of matching steps in this case unless the reasoning is clearly flawed or incoherent.
+- Carefully analyze if predicted alternative reasoning includes incorrect observations that contradict parts of the ground truth. Reduce the score proportionally even if the final answer is correct.
+- Remember: Reward even PARTIALLY correct reasoning if the steps are accurate, meaningful and follow a valid alternative path to the correct answer.
+
+#### 3. **Implicit or Inferred Steps**
+- Do NOT penalize if early steps are skipped, but later logic clearly depends on them.
+- E.g., if a model does not mention "identify the chart," but proceeds to use values from that chart correctly, assume the step was completed implicitly.
+- Remember: ALWAYS check for implied steps before reducing the score. Credit should be given when logic shows the step was likely understood.
+
+#### 4. **Ignore Superficial Differences**  
+- Do NOT deduct score for formatting, using a different notation or variable names, or additional clarifications.
+- Remember: FOCUS on the underlying mathematical meaning rather than literal step-by-step matching.
+
+---
+
+**Output Format: Score Dict (strict):**  
+SCORE_CARD: {"matched_steps": "X/N", "final_answer_correct": <0 or 1>, "critique": "<2–3 sentence summary>", "score": <0–10>}
+
+Be strict when awarding credit. Do NOT be lenient. Carefully evaluate how far the model's reasoning aligns with the ground truth steps before assigning a score.
+"""
+
+response_format = """SCORE_CARD: {"matched_steps": "X/N", "final_answer_correct": <0 or 1>, "critique": "<2–3 sentence summary>", "score": <0–10>}"""
+
+
+def get_user_prompt(question, options, gt_steps, gt_answer, prediction):
+    user_prompt = f"""
+INSTRUCTIONS: {system_prompt}
+
+QUESTION: {question}
+
+OPTIONS: {options}
+
+GROUND TRUTH STEPS:
+{json.dumps(gt_steps, indent=2)}
+
+CORRECT FINAL ANSWER:
+{gt_answer}
+
+PREDICTION:
+{prediction}
+
+Now evaluate this prediction and return the response in the specified format: {response_format}
+
+"""
+    return user_prompt
+
+
+def safe_parse_response(reply):
+    try:
+        return json.loads(reply)
+    except json.JSONDecodeError:
+        try:
+            parsed = ast.literal_eval(reply)
+            return json.loads(json.dumps(parsed))
+        except Exception as e:
+            print("Failed to parse GPT response:", e)
+            return None
+
+
+def prepare_input(sample, matched):
+    qid = sample["question_id"]
+    question = sample["question"]
+    gt_answer = sample["answer"]
+    gt_steps = sample["steps"]
+    options = sample["options"]
+    prediction = matched["resps"][0][0]
+    input = {"qid": qid, "category": sample["category"], "question": question, "options": options, "gt_answer": gt_answer, "gt_steps": gt_steps, "prediction": prediction}
+    return input
+
+
+def prepare_batch_prompts(batch):
+    prompts = []
+    for sample in batch:
+        prompt = get_user_prompt(sample["question"], sample["options"], sample["gt_steps"], sample["gt_answer"], sample["prediction"])
+        prompts.append(prompt)
+    return prompts
+
+
+def compute_score(gt_data, res_data, res_file, tokenizer, llm, sampling_params, bs=64):
+    batch = []
+    scored_samples = []
+    for sample in tqdm(gt_data, desc="Assigning scores with Qwen3"):
+
+        qid = sample["question_id"]
+        matched = [res for res in res_data if res["doc"]["question_id"] == qid]
+        if not matched:
+            print(f"Sample with qid {qid} not found in results.")
+            continue
+        input_sample = prepare_input(sample, matched[0])
+        batch.append(input_sample)
+
+        if len(batch) == bs:
+            batch_prompt = prepare_batch_prompts(batch)
+            messages = [{"role": "user", "content": p} for p in batch_prompt]
+            texts = [tokenizer.apply_chat_template([msg], tokenize=False, add_generation_prompt=True, enable_thinking=True) for msg in messages]
+            outputs = llm.generate(texts, sampling_params=sampling_params)
+
+            for input_sample, output in zip(batch, outputs):
+                score_dict = {"matched_steps": "0/0", "final_answer_correct": 0, "critique": "Error", "score": 0}
+                raw_reply = ""
+                try:
+                    raw_reply = output.outputs[0].text.strip()
+                    parsed_reply = raw_reply.split("SCORE_CARD: ")[-1]
+                    result = safe_parse_response(parsed_reply)
+                    if result is not None:
+                        score_dict = {"matched_steps": result.get("matched_steps", ""), "final_answer_correct": result.get("final_answer_correct", 0), "critique": result.get("critique", "").strip(), "score": int(result.get("score", 0))}
+                        raw_reply = None
+
+                except Exception as e:
+                    print("Scoring error:", e)
+
+                input_sample["score"] = score_dict["score"]
+                input_sample["score_dict"] = score_dict
+                input_sample["score_reply"] = raw_reply
+                scored_samples.append(input_sample)
+
+            batch = []
+
+    # Save scored samples
+    output_file = res_file.replace(".jsonl", "_step_scored_samples_qwen3_batch_think.jsonl")
+    with open(output_file, "w", encoding="utf-8") as f:
+        for sample in scored_samples:
+            f.write(json.dumps(sample) + "\n")
+    print(f"Saved scored samples to {output_file}")
+
+    # Compute mean score
+    scores = [sample["score"] for sample in scored_samples]
+    mean_score = sum(scores) / len(scores)
+    print(f"Step evaluation score: {mean_score}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Compute step evaluation score for CoT evaluation.")
+    parser.add_argument("--model_path", type=str, default="Qwen/Qwen3-4B", help="Path to the model or model identifier (default: Qwen/Qwen3-4B)")
+    parser.add_argument("--gt_file", type=str, required=True, help="Path to ground truth file (Parquet format)")
+    parser.add_argument("--res_file", type=str, required=True, help="Path to results file (JSONL format)")
+
+    args = parser.parse_args()
+
+    # Load tokenizer and model
+    tokenizer = AutoTokenizer.from_pretrained(args.model_path)
+    llm = LLM(model=args.model_path)
+    sampling_params = SamplingParams(temperature=0.6, top_p=0.95, top_k=20, min_p=0, max_tokens=32768)
+
+    # Load ground truth data from parquet
+    if not os.path.exists(args.gt_file):
+        print(f"Ground truth file {args.gt_file} does not exist.")
+        return
+    gt_df = pd.read_parquet(args.gt_file)
+    gt_data = gt_df.to_dict(orient="records")
+
+    # Load result data from jsonl
+    if not os.path.exists(args.res_file):
+        print(f"Result file {args.res_file} does not exist.")
+        return
+    print(f"Processing {args.res_file} ...")
+    res_data = []
+    with open(args.res_file, "r", encoding="utf-8") as f:
+        for line in f:
+            res_data.append(json.loads(line))
+
+    # Compute score
+    compute_score(gt_data, res_data, args.res_file, tokenizer, llm, sampling_params, bs=8)
+
+
+if __name__ == "__main__":
+    main()

--- a/lmms_eval/tasks/videomathqa/utils.py
+++ b/lmms_eval/tasks/videomathqa/utils.py
@@ -1,0 +1,349 @@
+import os
+import re
+import cv2
+import sys
+import yaml
+import numpy as np
+
+from pathlib import Path
+from typing import List
+from collections import defaultdict
+from loguru import logger as eval_logger
+
+VIDEO_LENGTH = ["short", "medium", "long"]
+CATEGORIES = ["Geometry Angle", "Geometry Area", "Geometry Length", "Chart", "Statistics", "Arithmetic", "Topology", "Graph Theory", "Counting", "Puzzle"]
+
+
+def decode_video(video_path: str) -> List[np.ndarray]:
+    video = cv2.VideoCapture(video_path)
+    video_frames = []
+    while video.isOpened():
+        ret, frame = video.read()
+        if ret:
+            frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+            video_frames.append(frame)
+        else:
+            break
+    return video_frames
+
+
+def load_video(video_path, max_frames, annot_sample_rate=1):
+
+    def uniform_sample(m, n):
+        assert n <= m
+        stride = (m - 1) / (n - 1) if n > 1 else 0  # Calculate the stride
+        return [int(round(i * stride)) for i in range(n)]
+
+    frames = decode_video(video_path)
+    frames = frames[::annot_sample_rate]
+
+    sample_pos = uniform_sample(len(frames), max_frames)
+    all_frames = [frames[pos] for pos in sample_pos]
+
+    return all_frames, sample_pos
+
+
+hf_home = os.getenv("HF_HOME", "~/.cache/huggingface/")
+base_cache_dir = os.path.expanduser(hf_home)
+with open(Path(__file__).parent / "videomathqa_mcq.yaml", "r") as f:
+    raw_data = f.readlines()
+    safe_data = []
+    for i, line in enumerate(raw_data):
+        # remove function definition since yaml load cannot handle it
+        if "!function" not in line:
+            safe_data.append(line)
+cache_name = yaml.safe_load("".join(safe_data))["dataset_kwargs"]["cache_dir"]
+
+
+def parse_subtitle_time(time_str):
+    h, m, s_ms = time_str.split(":")
+    s, ms = s_ms.split(",")
+    return int(h) * 3600 + int(m) * 60 + int(s) + int(ms) / 1000
+
+
+def load_subtitles(subtitle_path):
+    subtitles = {}
+    with open(subtitle_path, "r", encoding="utf-8") as file:
+        content = file.read().split("\n\n")
+        for section in content:
+            if section.strip():
+                lines = section.split("\n")
+                if len(lines) >= 3:
+                    time_range = lines[1].split(" --> ")
+                    start_time = parse_subtitle_time(time_range[0])
+                    end_time = parse_subtitle_time(time_range[1])
+                    text = " ".join(line for line in lines[2:])
+                    subtitles[(start_time, end_time)] = text
+    return subtitles
+
+
+def convert_time_to_frame(time_in_seconds, fps):
+    return int(time_in_seconds * fps)
+
+
+def extract_subtitles(video_path, subtitle_path):
+    video = cv2.VideoCapture(video_path)
+    fps = video.get(cv2.CAP_PROP_FPS)
+    total_frame = int(video.get(cv2.CAP_PROP_FRAME_COUNT))
+    subtitles = load_subtitles(subtitle_path)
+
+    subtitle_frames = []
+    for (start_time, end_time), text in subtitles.items():
+        start_frame = convert_time_to_frame(start_time, fps)
+        end_frame = convert_time_to_frame(end_time, fps)
+        subtitle_frames.append((start_frame, end_frame, text))
+
+    return subtitle_frames, total_frame
+
+
+def videomathqa_doc_to_visual(doc):
+    cache_dir = os.path.join(base_cache_dir, cache_name)
+    video_path = doc["videoID"] + ".mp4"
+    video_path = os.path.join(cache_dir, "videos", video_path)
+    if os.path.exists(video_path):
+        video_path = video_path
+    elif os.path.exists(video_path.replace("mp4", "MP4")):
+        video_path = video_path.replace("mp4", "MP4")
+    elif os.path.exists(video_path.replace("mp4", "mkv")):
+        video_path = video_path.replace("mp4", "mkv")
+    else:
+        sys.exit(f"video path:{video_path} does not exist, please check {doc}")
+    return [video_path]
+
+
+def videomathqa_doc_to_text(doc, lmms_eval_specific_kwargs=None):
+    if len(doc["options"]) == 2:
+        option_prompt = "Select the best answer to the following multiple-choice question based on the video. Respond with the letter (A or B) of the correct option."
+    else:
+        option_prompt = "Select the best answer to the following multiple-choice question based on the video. Respond with the letter (A, B, C, D or E) of the correct option."
+
+    question = doc["question"]
+    option = "\n".join([f"{opt}" for i, opt in enumerate(doc["options"])])
+    question = question + "\n" + option
+    post_prompt = lmms_eval_specific_kwargs["post_prompt"] if "post_prompt" in lmms_eval_specific_kwargs else "The best answer is:"
+    full_prompt = option_prompt + "\n" + question + "\n" + post_prompt
+    return full_prompt
+
+
+def videomathqa_doc_to_text_subtitle(doc, lmms_eval_specific_kwargs=None):
+    cache_dir = os.path.join(base_cache_dir, cache_name)
+    video_path = doc["videoID"] + ".mp4"
+    video_path = os.path.join(cache_dir, "videos", video_path)
+    subtitle_path = os.path.join(cache_dir, "subtitles", doc["videoID"] + ".srt")
+    video_path = os.path.join(cache_dir, video_path)
+    if os.path.exists(subtitle_path):  # Denote have subtitle
+        subtitle = open(subtitle_path).readlines()
+    else:
+        subtitle = ""
+    subtitles_prompt = "This video's subtitles are listed below: \n"
+    if subtitle == "":
+        subtitle = "No subtitles available"
+    else:
+        if "gemini_api_flag" in lmms_eval_specific_kwargs:  # specific for gemini_api
+            if lmms_eval_specific_kwargs["gemini_api_flag"] == "full subtitle":
+                textlist = []
+
+                subtitle_by_frame, total_frame = extract_subtitles(video_path, subtitle_path)
+                frame_num = total_frame
+                uniform_sampled_frames = np.linspace(0, total_frame - 1, frame_num, dtype=int).tolist()
+                subtitle_by_frame_idx = []
+                for frame_idx in uniform_sampled_frames:
+                    for idx, title in enumerate(subtitle_by_frame):
+                        if frame_idx < title[1] and frame_idx >= title[0]:
+                            subtitle_by_frame_idx.append(idx)
+                subtitle_by_frame_idx = list(set(subtitle_by_frame_idx))
+                textlist = []
+                for idx in subtitle_by_frame_idx:
+                    raw_text = subtitle_by_frame[idx][2]
+                    try:
+                        textlist.append(raw_text)
+                    except:
+                        continue
+                subtitle_text = "\n".join(textlist)
+        else:
+            if "frame_num" in lmms_eval_specific_kwargs:
+                frame_num = lmms_eval_specific_kwargs["frame_num"]
+                subtitle_by_frame, total_frame = extract_subtitles(video_path, subtitle_path)
+                if frame_num == -1:
+                    frame_num = total_frame
+                uniform_sampled_frames = np.linspace(0, total_frame - 1, frame_num, dtype=int).tolist()
+
+                subtitle_by_frame_idx = []
+                for frame_idx in uniform_sampled_frames:
+                    for idx, title in enumerate(subtitle_by_frame):
+                        if frame_idx < title[1] and frame_idx >= title[0]:
+                            subtitle_by_frame_idx.append(idx)
+                subtitle_by_frame_idx = list(set(subtitle_by_frame_idx))
+
+                textlist = []
+                for idx in subtitle_by_frame_idx:
+                    raw_text = subtitle_by_frame[idx][2]
+                    try:
+                        textlist.append(raw_text)
+                    except:
+                        continue
+                subtitle_text = "\n".join(textlist)
+        subtitle = subtitle_text
+
+    if len(doc["options"]) == 2:
+        option_prompt = "Select the best answer to the following multiple-choice question based on the video and the subtitles. Respond with the letter (A or B) of the correct option."
+    else:
+        option_prompt = "Select the best answer to the following multiple-choice question based on the video and the subtitles. Respond with the letter (A, B, C, D or E) of the correct option."
+
+    question = doc["question"]
+    option = "\n".join([f"{opt}" for i, opt in enumerate(doc["options"])])
+    question = question + "\n" + option
+    post_prompt = lmms_eval_specific_kwargs["post_prompt"] if "post_prompt" in lmms_eval_specific_kwargs else "The best answer is:"
+    full_prompt = subtitles_prompt + subtitle + "\n" + option_prompt + "\n" + question + "\n" + post_prompt
+    return full_prompt
+
+
+def extract_characters_regex(s):
+    s = s.strip()
+    answer_prefixes = [
+        "The best answer is",
+        "The correct answer is",
+        "The answer is",
+        "The answer",
+        "The best option is" "The correct option is",
+        "Best answer:" "Best option:",
+    ]
+    for answer_prefix in answer_prefixes:
+        s = s.replace(answer_prefix, "")
+
+    if len(s.split()) > 10 and not re.search("[ABCDE]", s):
+        return ""
+
+    matches = re.search(r"[ABCDE]", s)
+    if matches is None:
+        return ""
+    return matches[0]
+
+
+matrices = []
+
+for i in VIDEO_LENGTH:
+    for j in CATEGORIES:
+        matrices.append(f"{i}_{j}")
+
+
+def videomathqa_process_results(doc, results):
+    """
+    Args:
+        doc: a instance of the eval dataset
+        results: [pred]
+    Returns:
+        a dictionary with key: metric name (in this case videomathqa score), value: metric value
+    """
+    pred = results[0]
+    pred_ans = extract_characters_regex(pred)
+
+    category = doc["category"]
+    doc["duration"] = doc["length"]
+    data_dict = {"question_id": doc["question_id"], "duration": doc["duration"], "category": category, "pred_answer": pred_ans, "answer": doc["answer"]}
+
+    return {f"videomathqa_perception_score": data_dict}
+
+
+def videomathqa_mcq_aggregate_results(results):
+    """
+    Args:
+        results: a list of values returned by process_results
+    Returns:
+        A score
+    """
+    category2score = {}
+
+    for video_length in VIDEO_LENGTH:
+        for category in CATEGORIES:
+            key = f"{video_length}_{category}"
+            category2score[key] = {"correct": 0, "answered": 0}
+
+    for result in results:
+        video_length = result["duration"]
+        category = result["category"]
+        key = f"{video_length}_{category}"
+        category2score[key]["answered"] += 1
+        category2score[key]["correct"] += result["pred_answer"] == result["answer"]
+
+    for video_length in VIDEO_LENGTH:
+        total_correct = 0
+        total_answered = 0
+        for k, v in category2score.items():
+            if video_length in k:
+                total_correct += v["correct"]
+                total_answered += v["answered"]
+        score = 100 * total_correct / total_answered if total_answered > 0 else 0
+        eval_logger.info(f"Evaluation on Video Length: {video_length}: {score:.1f}%")
+
+    for category in CATEGORIES:
+        total_correct = 0
+        total_answered = 0
+        for k, v in category2score.items():
+            if category in k:
+                total_correct += v["correct"]
+                total_answered += v["answered"]
+        score = 100 * total_correct / total_answered if total_answered > 0 else 0
+        eval_logger.info(f"Evaluation on Categories: {category}: {score:.1f}%")
+
+    total_correct = 0
+    total_answered = 0
+    for k, v in category2score.items():
+        total_correct += v["correct"]
+        total_answered += v["answered"]
+    overall_score = 100 * total_correct / total_answered if total_answered > 0 else 0
+    eval_logger.info(f"Overall Performance: {overall_score:.1f}%")
+
+    return 100 * total_correct / total_answered if total_answered > 0 else 0
+
+
+def videomathqa_multi_binary_aggregate_results(results):
+
+    grouped = defaultdict(list)
+    for result in results:
+        grouped[result["question_id"]].append(result)
+
+    category2score = {}
+    for video_length in VIDEO_LENGTH:
+        for category in CATEGORIES:
+            key = f"{video_length}_{category}"
+            category2score[key] = {"correct": 0, "answered": 0}
+
+    for qid, group in grouped.items():
+        # Use first element to get metadata
+        sample_meta = group[0]
+        video_length = sample_meta["duration"]
+        category = sample_meta["category"]
+        key = f"{video_length}_{category}"
+
+        all_correct = all(g["pred_answer"] == g["answer"] for g in group)
+        category2score[key]["answered"] += 1
+        if all_correct:
+            category2score[key]["correct"] += 1
+
+    for video_length in VIDEO_LENGTH:
+        total_correct = 0
+        total_answered = 0
+        for k, v in category2score.items():
+            if video_length in k:
+                total_correct += v["correct"]
+                total_answered += v["answered"]
+        score = 100 * total_correct / total_answered if total_answered > 0 else 0
+        eval_logger.info(f"Evaluation on Video Length: {video_length}: {score:.1f}%")
+
+    for category in CATEGORIES:
+        total_correct = 0
+        total_answered = 0
+        for k, v in category2score.items():
+            if category in k:
+                total_correct += v["correct"]
+                total_answered += v["answered"]
+        score = 100 * total_correct / total_answered if total_answered > 0 else 0
+        eval_logger.info(f"Evaluation on Categories: {category}: {score:.1f}%")
+
+    total_correct = sum(v["correct"] for v in category2score.values())
+    total_answered = sum(v["answered"] for v in category2score.values())
+    overall_score = 100 * total_correct / total_answered if total_answered > 0 else 0
+    eval_logger.info(f"Overall Performance: {overall_score:.1f}%")
+
+    return overall_score

--- a/lmms_eval/tasks/videomathqa/videomathqa_mbin.yaml
+++ b/lmms_eval/tasks/videomathqa/videomathqa_mbin.yaml
@@ -1,0 +1,29 @@
+dataset_path: MBZUAI/VideoMathQA
+dataset_name: multi_binary
+test_split: test
+dataset_kwargs:
+  token: False
+  cache_dir: videomathqa
+  video: True
+task: videomathqa_mbin
+output_type: generate_until
+doc_to_visual: !function utils.videomathqa_doc_to_visual
+doc_to_text: !function utils.videomathqa_doc_to_text
+doc_to_target: "answer"
+generation_kwargs:
+  max_new_tokens: 16
+  temperature: 0
+  top_p: 1.0
+  num_beams: 1
+  do_sample: false
+process_results: !function utils.videomathqa_process_results
+metric_list:
+  - metric: videomathqa_perception_score
+    aggregation: !function utils.videomathqa_multi_binary_aggregate_results
+    higher_is_better: true
+lmms_eval_specific_kwargs:
+  default:
+    pre_prompt: ""
+    post_prompt: "\nAnswer with the option's letter (A or B) from the given choices directly."
+metadata:
+  - version: 0.0

--- a/lmms_eval/tasks/videomathqa/videomathqa_mbin_cot.yaml
+++ b/lmms_eval/tasks/videomathqa/videomathqa_mbin_cot.yaml
@@ -1,0 +1,29 @@
+dataset_path: MBZUAI/VideoMathQA
+dataset_name: multi_binary
+test_split: test
+dataset_kwargs:
+  token: False
+  cache_dir: videomathqa
+  video: True
+task: videomathqa_mbin_cot
+output_type: generate_until
+doc_to_visual: !function utils.videomathqa_doc_to_visual
+doc_to_text: !function utils.videomathqa_doc_to_text
+doc_to_target: "answer"
+generation_kwargs:
+  max_new_tokens: 8096
+  temperature: 0
+  top_p: 1.0
+  num_beams: 1
+  do_sample: false
+process_results: !function utils.videomathqa_process_results
+metric_list:
+  - metric: videomathqa_perception_score
+    aggregation: !function utils.videomathqa_multi_binary_aggregate_results
+    higher_is_better: true
+lmms_eval_specific_kwargs:
+  default:
+    pre_prompt: ""
+    post_prompt: "First please perform reasoning, and think step by step to provide best answer to the following question with the option's letter (A or B) from the given choices."
+metadata:
+  - version: 0.0

--- a/lmms_eval/tasks/videomathqa/videomathqa_mbin_cot_w_subtitle.yaml
+++ b/lmms_eval/tasks/videomathqa/videomathqa_mbin_cot_w_subtitle.yaml
@@ -1,0 +1,38 @@
+dataset_path: MBZUAI/VideoMathQA
+dataset_name: multi_binary
+test_split: test
+dataset_kwargs:
+  token: False
+  cache_dir: videomathqa
+  video: True
+task: videomathqa_mbin_cot_w_subtitles
+output_type: generate_until
+doc_to_visual: !function utils.videomathqa_doc_to_visual
+doc_to_text: !function utils.videomathqa_doc_to_text_subtitle
+doc_to_target: "answer"
+generation_kwargs:
+  max_new_tokens: 8096
+  temperature: 0
+  top_p: 1.0
+  num_beams: 1
+  do_sample: false
+process_results: !function utils.videomathqa_process_results
+metric_list:
+  - metric: videomathqa_perception_score
+    aggregation: !function utils.videomathqa_multi_binary_aggregate_results
+    higher_is_better: true
+lmms_eval_specific_kwargs:
+  default:
+    frame_num: 32
+    pre_prompt: ""
+    post_prompt: "First please perform reasoning, and think step by step to provide best answer to the following question with the option's letter (A or B) from the given choices."
+  qwen2_5_vl:
+    frame_num: 768
+    pre_prompt: ""
+    post_prompt: "First please perform reasoning, and think step by step to provide best answer to the following question with the option's letter (A or B) from the given choices."
+  gemini_api:
+    gemini_api_flag: "full subtitle"
+    pre_prompt: ""
+    post_prompt: "First please perform reasoning, and think step by step to provide best answer to the following question with the option's letter (A or B) from the given choices."
+metadata:
+  - version: 0.0

--- a/lmms_eval/tasks/videomathqa/videomathqa_mbin_w_subtitle.yaml
+++ b/lmms_eval/tasks/videomathqa/videomathqa_mbin_w_subtitle.yaml
@@ -1,0 +1,38 @@
+dataset_path: MBZUAI/VideoMathQA
+dataset_name: multi_binary
+test_split: test
+dataset_kwargs:
+  token: False
+  cache_dir: videomathqa
+  video: True
+task: videomathqa_mbin_w_subtitles
+output_type: generate_until
+doc_to_visual: !function utils.videomathqa_doc_to_visual
+doc_to_text: !function utils.videomathqa_doc_to_text_subtitle
+doc_to_target: "answer"
+generation_kwargs:
+  max_new_tokens: 16
+  temperature: 0
+  top_p: 1.0
+  num_beams: 1
+  do_sample: false
+process_results: !function utils.videomathqa_process_results
+metric_list:
+  - metric: videomathqa_perception_score
+    aggregation: !function utils.videomathqa_multi_binary_aggregate_results
+    higher_is_better: true
+lmms_eval_specific_kwargs:
+  default:
+    frame_num: 32
+    pre_prompt: ""
+    post_prompt: "\nAnswer with the option's letter (A or B) from the given choices directly."
+  qwen2_5_vl:
+    frame_num: 768
+    pre_prompt: ""
+    post_prompt: "\nAnswer with the option's letter (A or B) from the given choices directly."
+  gemini_api:
+    gemini_api_flag: "full subtitle"
+    pre_prompt: ""
+    post_prompt: "\nAnswer with the option's letter (A or B) from the given choices directly."
+metadata:
+  - version: 0.0

--- a/lmms_eval/tasks/videomathqa/videomathqa_mcq.yaml
+++ b/lmms_eval/tasks/videomathqa/videomathqa_mcq.yaml
@@ -1,0 +1,29 @@
+dataset_path: MBZUAI/VideoMathQA
+dataset_name: mcq
+test_split: test
+dataset_kwargs:
+  token: False
+  cache_dir: videomathqa
+  video: True
+task: videomathqa_mcq
+output_type: generate_until
+doc_to_visual: !function utils.videomathqa_doc_to_visual
+doc_to_text: !function utils.videomathqa_doc_to_text
+doc_to_target: "answer"
+generation_kwargs:
+  max_new_tokens: 16
+  temperature: 0
+  top_p: 1.0
+  num_beams: 1
+  do_sample: false
+process_results: !function utils.videomathqa_process_results
+metric_list:
+  - metric: videomathqa_perception_score
+    aggregation: !function utils.videomathqa_mcq_aggregate_results
+    higher_is_better: true
+lmms_eval_specific_kwargs:
+  default:
+    pre_prompt: ""
+    post_prompt: "\nAnswer with the option's letter (A, B, C, D or E) from the given choices directly."
+metadata:
+  - version: 0.0

--- a/lmms_eval/tasks/videomathqa/videomathqa_mcq_cot.yaml
+++ b/lmms_eval/tasks/videomathqa/videomathqa_mcq_cot.yaml
@@ -1,0 +1,29 @@
+dataset_path: MBZUAI/VideoMathQA
+dataset_name: mcq
+test_split: test
+dataset_kwargs:
+  token: False
+  cache_dir: videomathqa
+  video: True
+task: videomathqa_mcq_cot
+output_type: generate_until
+doc_to_visual: !function utils.videomathqa_doc_to_visual
+doc_to_text: !function utils.videomathqa_doc_to_text
+doc_to_target: "answer"
+generation_kwargs:
+  max_new_tokens: 8096
+  temperature: 0
+  top_p: 1.0
+  num_beams: 1
+  do_sample: false
+process_results: !function utils.videomathqa_process_results
+metric_list:
+  - metric: videomathqa_perception_score
+    aggregation: !function utils.videomathqa_mcq_aggregate_results
+    higher_is_better: true
+lmms_eval_specific_kwargs:
+  default:
+    pre_prompt: ""
+    post_prompt: "First please perform reasoning, and think step by step to provide best answer to the following question with the option's letter (A, B, C, D or E) from the given choices."
+metadata:
+  - version: 0.0

--- a/lmms_eval/tasks/videomathqa/videomathqa_mcq_cot_w_subtitle.yaml
+++ b/lmms_eval/tasks/videomathqa/videomathqa_mcq_cot_w_subtitle.yaml
@@ -1,0 +1,38 @@
+dataset_path: MBZUAI/VideoMathQA
+dataset_name: mcq
+test_split: test
+dataset_kwargs:
+  token: False
+  cache_dir: videomathqa
+  video: True
+task: videomathqa_mcq_cot_w_subtitles
+output_type: generate_until
+doc_to_visual: !function utils.videomathqa_doc_to_visual
+doc_to_text: !function utils.videomathqa_doc_to_text_subtitle
+doc_to_target: "answer"
+generation_kwargs:
+  max_new_tokens: 8096
+  temperature: 0
+  top_p: 1.0
+  num_beams: 1
+  do_sample: false
+process_results: !function utils.videomathqa_process_results
+metric_list:
+  - metric: videomathqa_perception_score
+    aggregation: !function utils.videomathqa_mcq_aggregate_results
+    higher_is_better: true
+lmms_eval_specific_kwargs:
+  default:
+    frame_num: 32
+    pre_prompt: ""
+    post_prompt: "First please perform reasoning, and think step by step to provide best answer to the following question with the option's letter (A, B, C, D or E) from the given choices."
+  qwen2_5_vl:
+    frame_num: 768
+    pre_prompt: ""
+    post_prompt: "First please perform reasoning, and think step by step to provide best answer to the following question with the option's letter (A, B, C, D or E) from the given choices."
+  gemini_api:
+    gemini_api_flag: "full subtitle"
+    pre_prompt: ""
+    post_prompt: "First please perform reasoning, and think step by step to provide best answer to the following question with the option's letter (A, B, C, D or E) from the given choices."
+metadata:
+  - version: 0.0

--- a/lmms_eval/tasks/videomathqa/videomathqa_mcq_w_subtitle.yaml
+++ b/lmms_eval/tasks/videomathqa/videomathqa_mcq_w_subtitle.yaml
@@ -1,0 +1,38 @@
+dataset_path: MBZUAI/VideoMathQA
+dataset_name: mcq
+test_split: test
+dataset_kwargs:
+  token: False
+  cache_dir: videomathqa
+  video: True
+task: videomathqa_mcq_w_subtitles
+output_type: generate_until
+doc_to_visual: !function utils.videomathqa_doc_to_visual
+doc_to_text: !function utils.videomathqa_doc_to_text_subtitle
+doc_to_target: "answer"
+generation_kwargs:
+  max_new_tokens: 16
+  temperature: 0
+  top_p: 1.0
+  num_beams: 1
+  do_sample: false
+process_results: !function utils.videomathqa_process_results
+metric_list:
+  - metric: videomathqa_perception_score
+    aggregation: !function utils.videomathqa_mcq_aggregate_results
+    higher_is_better: true
+lmms_eval_specific_kwargs:
+  default:
+    frame_num: 32
+    pre_prompt: ""
+    post_prompt: "\nAnswer with the option's letter (A, B, C, D or E) from the given choices directly."
+  qwen2_5_vl:
+    frame_num: 768
+    pre_prompt: ""
+    post_prompt: "\nAnswer with the option's letter (A, B, C, D or E) from the given choices directly."
+  gemini_api:
+    gemini_api_flag: "full subtitle"
+    pre_prompt: ""
+    post_prompt: "\nAnswer with the option's letter (A, B, C, D or E) from the given choices directly."
+metadata:
+  - version: 0.0


### PR DESCRIPTION
This pull request adds VideoMathQA task to lmms-eval.

### VideoMathQA Overview
VideoMathQA is a benchmark designed to evaluate mathematical reasoning in real-world educational videos. It requires models to interpret and integrate information from three modalities, visuals, audio, and text, across time. The benchmark tackles the needle-in-a-multimodal-haystack problem, where key information is sparse and spread across different modalities and moments in the video.

### Resources
- 🌐 Project Website: https://mbzuai-oryx.github.io/VideoMathQA
- 🤗 Dataset Access: https://huggingface.co/datasets/MBZUAI/VideoMathQA
- 🏅 Leaderboard (Reasoning): https://hanoonar.github.io/VideoMathQA/#leaderboard-2
- 🏅 Leaderboard (Direct): https://hanoonar.github.io/VideoMathQA/#leaderboard
- 📂 GitHub Repository: https://github.com/mbzuai-oryx/VideoMathQA

### Evaluation
VideoMathQA supports the following **evaluation strategies** to comprehensively assess model performance:

1. **MCQ and Multi-Binary (MBin)**  
   - Tasks with `mcq` use a 5-way multiple-choice format.  
   - Tasks with `mbin` use a stricter binary-pairwise evaluation format (correct vs each distractor).  
   - Both formats are available *with* and *without subtitles*, indicated by `_w_subtitles` in the task name.

2. **Direct Answering vs. Chain-of-Thought (CoT)**  
   - Each task can be evaluated under **Direct** or **CoT** prompting.  
   - Tasks containing `_cot` use CoT prompting, where models generate reasoning before the final answer.  
   - Direct answering tasks expect the final answer only, without intermediate reasoning.  
   - CoT tasks require post-processing to extract the final answer (see [Post Processing](#post-processing)).  
   - We maintain **separate leaderboards** for Direct and CoT settings.

3. **Step-wise CoT Evaluation**  
   - For CoT tasks, we additionally evaluate the quality of generated reasoning.  
   - Each response is scored by comparing against annotated solution steps (typically 4–10 steps).  
   - Scoring is done using a small open-source model (Qwen-3-4B in thinking mode), which returns a score (0–10) and rationale.


### Run Evaluation

We provide a sample command to run the evaluation using the Qwen2.5-VL model, as a reference.

```python
accelerate launch --num_processes=8 -m lmms_eval \
    --model qwen2_5_vl \
    --model_args=pretrained=Qwen/Qwen2.5-VL-7B-Instruct,max_pixels=151200,min_pixels=100352,use_flash_attention_2=True,device_map=auto \
    --tasks videomathqa_mbin \
    --batch_size 1 --log_samples --log_samples_suffix qwen_2_5_vl \
    --output_path output
```

This command starts evaluating the Qwen2.5-VL-3B model on `VideoMathQA` for multi-binary accuracy. The other available `VideoMathQA` tasks are:

1. videomathqa\_mcq
2. videomathqa\_mcq\_w\_subtitles
3. videomathqa\_mcq\_cot
4. videomathqa\_mcq\_cot\_w\_subtitles
5. videomathqa\_mbin
6. videomathqa\_mbin\_w\_subtitles
7. videomathqa\_mbin\_cot
8. videomathqa\_mbin\_cot\_w\_subtitles

`w_subtitles` tasks additionally use subtitles during evaluation. `cot` tasks prompt the model to think step-by-step before answering the question.



