### PR TITLE
[Fix] Enable the ignored API_URL in the MathVista evaluation.

### DIFF
--- a/lmms_eval/tasks/mathvista/mathvista_evals.py
+++ b/lmms_eval/tasks/mathvista/mathvista_evals.py
@@ -167,7 +167,7 @@ class MathVistaEvaluator:
             "Authorization": f"Bearer {API_KEY}",
             "Content-Type": "application/json",
         }
-        client = OpenAI(api_key=API_KEY)
+        client = OpenAI(api_key=API_KEY, base_url=API_URL.rstrip("chat/completions"))
         gpt_model = config["metadata"]["gpt_eval_model_name"]
 
     elif API_TYPE == "azure":


### PR DESCRIPTION
The `API_URL` variable was not used in the MathVista evaluation, which could cause a mismatch between the key and the url in some cases.