### PR TITLE
Fix test_llava for pytest

### DIFF
--- a/miscs/test_llava.py
+++ b/miscs/test_llava.py
@@ -9,13 +9,26 @@ prompt_1 = "USER: <image>\nWhat does this image show?\nASSISTANT:"
 prompt_2 = "USER: <image> <image> \nWhat is the difference between these two images?\nASSISTANT:"
 image_file_1 = "image1.png"
 image_file_2 = "image2.png"
-model = LlavaForConditionalGeneration.from_pretrained(model_id, torch_dtype=torch.float16, low_cpu_mem_usage=True, use_flash_attention_2=True).to(0)
-processor = AutoProcessor.from_pretrained(model_id)
-raw_image_1 = Image.open(image_file_1)
-raw_image_2 = Image.open(image_file_2)
-inputs = processor([prompt_1, prompt_2], [raw_image_1, raw_image_1, raw_image_2], padding=True, return_tensors="pt").to(0, torch.float16)
-import pdb
 
-pdb.set_trace()
-output = model.generate(**inputs, max_new_tokens=200, do_sample=False)
-print(processor.batch_decode(output, skip_special_tokens=True))
+
+def test_llava_generation():
+    model = LlavaForConditionalGeneration.from_pretrained(
+        model_id,
+        torch_dtype=torch.float16,
+        low_cpu_mem_usage=True,
+        use_flash_attention_2=True,
+    ).to(0)
+    processor = AutoProcessor.from_pretrained(model_id)
+    raw_image_1 = Image.open(image_file_1)
+    raw_image_2 = Image.open(image_file_2)
+    inputs = processor(
+        [prompt_1, prompt_2],
+        [raw_image_1, raw_image_1, raw_image_2],
+        padding=True,
+        return_tensors="pt",
+    ).to(0, torch.float16)
+    output = model.generate(**inputs, max_new_tokens=200, do_sample=False)
+    decoded = processor.batch_decode(output, skip_special_tokens=True)
+    print(decoded)
+    assert len(decoded) == 2
+    assert all(isinstance(s, str) for s in decoded)


### PR DESCRIPTION
## Summary
- remove leftover pdb calls
- wrap execution in test function
- assert two strings are produced when decoding model output

## Testing
- `pytest -k test_llava.py -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_684509d567dc8324bfe10d7220c38c7a