### PR TITLE
[Bug] fix a bug in post processing stage of ScienceQA.

### DIFF
--- a/lmms_eval/tasks/scienceqa/utils.py
+++ b/lmms_eval/tasks/scienceqa/utils.py
@@ -34,11 +34,11 @@ def sqa_doc_to_target(doc):
 def sqa_process_results(doc, results):
     # I know this is weird, but it's how llava parse it.
     target = sqa_doc_to_target(doc).strip().lower()
-    pred = results[0].strip().lower()
-    if pred == target:
+    pred = results[0].strip()
+    if pred.lower() == target:
         return {"exact_match": 1.0}
     # pattern: ^[A-Z]\. .*
     if len(pred) >= 2 and pred[0].isupper() and pred[1] == ".":
-        result = 1.0 if pred[0] == target else 0.0
+        result = 1.0 if pred[0].lower() == target else 0.0
         return {"exact_match": result}
     return {"exact_match": 0.0}


### PR DESCRIPTION
## Description

In a previous PR (https://github.com/EvolvingLMMs-Lab/lmms-eval/pull/174), a bug was introduced, causing predictions like `A.` to not receive the expected scores when the answer was `A`.