### PR TITLE
[vLLM] centralize VLLM_WORKER_MULTIPROC_METHOD

### DIFF
--- a/examples/models/vllm_qwen2vl.sh
+++ b/examples/models/vllm_qwen2vl.sh
@@ -4,7 +4,6 @@
 
 # cd ~/prod/lmms-eval-public
 # pip3 install -e .
-export VLLM_WORKER_MULTIPROC_METHOD=spawn
 export NCCL_BLOCKING_WAIT=1
 export NCCL_TIMEOUT=18000000
 export NCCL_DEBUG=DEBUG

--- a/lmms_eval/models/vllm.py
+++ b/lmms_eval/models/vllm.py
@@ -60,6 +60,7 @@ class VLLM(lmms):
                     eval_logger.warning(f"Failed to parse JSON-like string for argument '{key}': {value}")
 
         # Set up vllm client
+        os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
         self.client = LLM(
             model=self.model_version,
             tensor_parallel_size=tensor_parallel_size,


### PR DESCRIPTION
## Purpose ##
* Better support evaluating vllm outside of example scripts

```bash
python3 -m lmms_eval \
    --model vllm \
    --model_args model_version=Qwen/Qwen2-VL-7B-Instruct,tensor_parallel_size=4 \
    --tasks mme,gsm8k_cot_self_consistency,mmmu_val \
    --batch_size 64 \
    --log_samples \
    --log_samples_suffix vllm \
    --output_path ./logs \
    --limit=64
```

## Background ##
The latest releases of vLLM require that the user specify `VLLM_WORKER_MULTIPROC_METHOD=spawn` for scripts which run vllm in subprocesses

## Changes ##
*  Set the `VLLM_WORKER_MULTIPROC_METHOD` environment variable within the vllm model definition directly, rather than at each entrypoint script

## Testing ##
* Running `python3 -m lmms_eval --model vllm` now works without having to set the environment variable.