### PR TITLE
Add min image resolution requirement for vLLM Qwen-VL models

### DIFF
--- a/lmms_eval/models/vllm.py
+++ b/lmms_eval/models/vllm.py
@@ -53,7 +53,7 @@ class VLLM(lmms):
         self.chat_template = chat_template
         self.min_image_pixels = min_image_pixels
         # Qwen 2/2.5-VL models enforce minimum image dimensions
-        self._enforce_image_resize = all(k in model_version.lower() for k in ["qwen", "vl"])
+        self._enforce_image_resize = self._is_qwen_vl_model(model_version)
 
         # Convert any string arguments that start with { and end with } to dictionaries
         for key, value in kwargs.items():
@@ -88,6 +88,10 @@ class VLLM(lmms):
 
         self.device = self.accelerator.device
         self.batch_size_per_gpu = int(batch_size)
+
+    def _is_qwen_vl_model(self, model_version: str) -> bool:
+        qwen_vl_patterns = ["qwen2-vl", "qwen2.5-vl"]
+        return any(pattern in model_version.lower() for pattern in qwen_vl_patterns)
 
     def _maybe_resize_image(self, img: Image.Image) -> Image.Image:
         if not self._enforce_image_resize or min(img.size) >= self.min_image_pixels:


### PR DESCRIPTION
# Purpose
Add minimum image resolution requirement for Qwen 2/2.5-VL models in `vllm.py` to prevent evaluation errors with undersized images.

# Background
Qwen 2/2.5-VL models require minimum image dimensions for proper inference. This addresses issue #598 (where Qwen2.5-VL evaluation fails with images below 28 pixels resolution).

# Changes
- Added `min_image_pixels` parameter (default: 28) to `VLLM` class
- Implemented automatic image resizing for undersized images while maintaining aspect ratio
- Added automatic Qwen-VL model detection via model version string matching to ensure this fix only affects Qwen models

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Images and video frames are now automatically resized to ensure a minimum dimension for certain models, improving compatibility and consistency in processing.
* **Enhancements**
  * Added an option to specify the minimum allowed image size for supported models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->