### PR TITLE
fix: add `max_frames_num` to `OpenAICompatible`

### DIFF
--- a/lmms_eval/models/openai_compatible.py
+++ b/lmms_eval/models/openai_compatible.py
@@ -38,6 +38,7 @@ class OpenAICompatible(lmms):
         continual_mode: bool = False,
         response_persistent_folder: str = None,
         azure_openai: bool = False,
+        max_frames_num: int = 10,
         **kwargs,
     ) -> None:
         super().__init__()
@@ -46,6 +47,7 @@ class OpenAICompatible(lmms):
         self.max_retries = max_retries
         self.max_size_in_mb = max_size_in_mb  # some models have a limit on the size of the image
         self.continual_mode = continual_mode
+        self.max_frames_num = max_frames_num
         if self.continual_mode:
             if response_persistent_folder is None:
                 raise ValueError("Continual mode requires a persistent path for the response. Please provide a valid path.")


### PR DESCRIPTION
The `openai_compatible` implementation requires the `self.max_frames_num` attribute for video input processing, as seen in [this line](https://github.com/EvolvingLMMs-Lab/lmms-eval/blob/8ada80501d0e284abc2821d3a2454e1944fc133c/lmms_eval/models/openai_compatible.py#L165). However, this attribute was missing in the `OpenAICompatible` class. This PR adds the missing `max_frames_num` attribute to resolve the issue.