### PR TITLE
Revert "Pass in the 'cache_dir' to use local cache"

### DIFF
--- a/lmms_eval/api/task.py
+++ b/lmms_eval/api/task.py
@@ -942,14 +942,7 @@ class ConfigurableTask(Task):
                     force_unzip = dataset_kwargs.get("force_unzip", False)
                     revision = dataset_kwargs.get("revision", "main")
                     create_link = dataset_kwargs.get("create_link", False)
-                    cache_path = snapshot_download(
-                        repo_id=self.DATASET_PATH,
-                        cache_dir=cache_dir,
-                        revision=revision,
-                        repo_type="dataset",
-                        force_download=force_download,
-                        etag_timeout=60,
-                    )
+                    cache_path = snapshot_download(repo_id=self.DATASET_PATH, revision=revision, repo_type="dataset", force_download=force_download, etag_timeout=60)
                     zip_files = glob(os.path.join(cache_path, "**/*.zip"), recursive=True)
                     tar_files = glob(os.path.join(cache_path, "**/*.tar*"), recursive=True)
 


### PR DESCRIPTION
Reverts EvolvingLMMs-Lab/lmms-eval#690

Directly setting cache dir to be the cache dir of the video will skip the unzipping logic from a new and clean cache home for huggingface.

Later todos:
- allow skip snapshot download and directly load from local cache

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the process for downloading video datasets, with no changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->