### PR TITLE
Fix handling of encode_video output in vllm.py so each frame’s Base64

### DIFF
--- a/lmms_eval/models/vllm.py
+++ b/lmms_eval/models/vllm.py
@@ -203,7 +203,7 @@ class VLLM(lmms):
                 messages = [{"role": "user", "content": []}]
                 # When there is no image token in the context, append the image to the text
                 messages[0]["content"].append({"type": "text", "text": contexts})
-                for img in imgs:
+                for img in self.flatten(imgs):
                     messages[0]["content"].append({"type": "image_url", "image_url": {"url": f"data:image/png;base64,{img}"}})
 
                 batched_messages.append(messages)

--- a/lmms_eval/models/vllm.py
+++ b/lmms_eval/models/vllm.py
@@ -150,7 +150,9 @@ class VLLM(lmms):
     def flatten(self, input):
         new_list = []
         for i in input:
-            for j in i:
+            if isinstance(i, (list, tuple)):
+                new_list.extend(i)
+            else:
                 new_list.append(j)
         return new_list
 


### PR DESCRIPTION
## Description:
This PR addresses a [bug](https://github.com/EvolvingLMMs-Lab/lmms-eval/issues/738) in the VLLM model integration whereby encode_video() returns a List[str] of Base64‐encoded frames, but the caller treats it as a single string. As a result, the model receives invalid URLs like data:image/png;base64,['AAA','BBB',…].