### PR TITLE
[Bugfix] Fix handling of encode_video output in vllm.py so each frame’s Base64

### DIFF
--- a/lmms_eval/models/vllm.py
+++ b/lmms_eval/models/vllm.py
@@ -153,7 +153,7 @@ class VLLM(lmms):
             if isinstance(i, (list, tuple)):
                 new_list.extend(i)
             else:
-                new_list.append(j)
+                new_list.append(i)
         return new_list
 
     def generate_until(self, requests) -> List[str]:


### PR DESCRIPTION
## Description:
This PR addresses a [bug](https://github.com/EvolvingLMMs-Lab/lmms-eval/issues/738) in the VLLM model integration whereby encode_video() returns a List[str] of Base64‐encoded frames, but the caller treats it as a single string. As a result, the model receives invalid URLs like data:image/png;base64,['AAA','BBB',…].

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of image inputs to prevent errors with non-iterable elements and ensure all images, including those in nested lists or tuples, are processed correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->