### PR TITLE
[New Benchmark] Request for supporting TimeScope

### DIFF
--- a/lmms_eval/tasks/longtimescope/longtimescope.yaml
+++ b/lmms_eval/tasks/longtimescope/longtimescope.yaml
@@ -1,0 +1,47 @@
+dataset_path: Apollo-LMMs/LongTimeScope2
+dataset_kwargs:
+  token: True
+  cache_dir: longtimescope
+  video: True
+  # force_unzip: True
+  # From_YouTube: True
+task: longtimescope
+test_split: test
+output_type: generate_until
+doc_to_visual: !function utils.timescope_doc_to_visual
+doc_to_text: input
+doc_to_target: "answer"
+generation_kwargs:
+  max_new_tokens: 16
+  temperature: 0
+  top_p: 1.0
+  num_beams: 1
+  do_sample: false
+# The return value of process_results will be used by metrics
+process_results: !function utils.timescope_process_results
+# Note that the metric name can be either a registed metric function (such as the case for GQA) or a key name returned by process_results
+metric_list:
+  - metric: timescope_perception_score
+    aggregation: !function utils.timescope_aggregate_results
+    higher_is_better: true
+lmms_eval_specific_kwargs:
+  default:
+    pre_prompt: ""
+    post_prompt: "\nAnswer with the option's letter from the given choices directly."
+  gpt4v:
+    pre_prompt: ""
+    post_prompt: "Answer the question with A, B, C, or D."
+  llava_vid:
+    pre_prompt: ""
+    post_prompt: "The best answer is:"
+  # qwen_vl:  
+  #   pre_prompt: ""
+  #   post_prompt: " Answer:"
+  # otterhd:
+  #   pre_prompt: ""
+  #   post_prompt: " Answer:"
+  xcomposer2_4khd:
+    pre_prompt: "[UNUSED_TOKEN_146]user\n"
+    post_prompt: " Answer this question with A, B, C, or D.[UNUSED_TOKEN_145]\n[UNUSED_TOKEN_146]assistant\n"
+metadata:
+  - version: 0.0

--- a/lmms_eval/tasks/longtimescope/utils.py
+++ b/lmms_eval/tasks/longtimescope/utils.py
@@ -1,0 +1,160 @@
+import datetime
+import json
+import os
+import re
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Dict, List, Optional, Union
+
+import cv2
+import numpy as np
+import yaml
+from loguru import logger as eval_logger
+
+from lmms_eval.tasks._task_utils.file_utils import generate_submission_file
+
+TASK_CATEGORIES = ["QA","OCR",'temporal']
+
+
+
+
+
+
+
+# with open(Path(__file__).parent / "_default_template_yaml", "r") as f:
+#     raw_data = f.readlines()
+#     safe_data = []
+#     for i, line in enumerate(raw_data):
+#         # remove function definition since yaml load cannot handle it
+#         if "!function" not in line:
+#             safe_data.append(line)
+
+#     config = yaml.safe_load("".join(safe_data))
+
+hf_home = os.getenv("HF_HOME", "~/.cache/huggingface/")
+# cache_dir = os.path.join(hf_home, cache_dir)
+# base_cache_dir = config["dataset_kwargs"]["cache_dir"]
+base_cache_dir = os.path.expanduser(hf_home)
+with open(Path(__file__).parent / "longtimescope.yaml", "r") as f:
+    raw_data = f.readlines()
+    safe_data = []
+    for i, line in enumerate(raw_data):
+        # remove function definition since yaml load cannot handle it
+        if "!function" not in line:
+            safe_data.append(line)
+cache_name = yaml.safe_load("".join(safe_data))["dataset_kwargs"]["cache_dir"]
+
+
+def convert_time_to_frame(time_in_seconds, fps):
+    return int(time_in_seconds * fps)
+
+
+
+def timescope_doc_to_visual(doc):
+
+    cache_dir = os.path.join(base_cache_dir, cache_name)
+    eval_logger.info(f"base_cache_dir",base_cache_dir,'cache_name',cache_name)
+    video_path = doc["video"] 
+    video_path = os.path.join(cache_dir, video_path)
+    if os.path.exists(video_path):
+        video_path = video_path
+    elif os.path.exists(video_path.replace("mp4", "MP4")):
+        video_path = video_path.replace("mp4", "MP4")
+    elif os.path.exists(video_path.replace("mp4", "mkv")):
+        video_path = video_path.replace("mp4", "mkv")
+    else:
+        sys.exit(f"video path:{video_path} does not exist, please check")
+    return [video_path]
+
+
+
+
+def extract_characters_regex(s):
+    s = s.strip()
+    answer_prefixes = [
+        "The best answer is",
+        "The correct answer is",
+        "The answer is",
+        "The answer",
+        "The best option is" "The correct option is",
+        "Best answer:" "Best option:",
+    ]
+    for answer_prefix in answer_prefixes:
+        s = s.replace(answer_prefix, "")
+
+    if len(s.split()) > 10 and not re.search("[ABCDEF]", s):
+        return ""
+
+    matches = re.search(r"[ABCDEF]", s)
+    if matches is None:
+        return ""
+    return matches[0]
+
+
+
+def timescope_process_results(doc, results):
+    """
+    Args:
+        doc: a instance of the eval dataset
+        results: [pred]
+    Returns:
+        a dictionary with key: metric name (in this case timescope score), value: metric value
+    """
+    pred = results[0]
+    task_type = doc["type"]
+    # if task_type=="QA" or task_type=="temporal":
+    pred_ans = extract_characters_regex(pred)
+    # elif task_type=="OCR":
+    #     pred_ans = re.sub(r'^\.+|\.+$', '', pred.replace("The answer is ","").split(" ")[0].split(":")[0].strip()) if pred else pred
+    # gt_ans = doc["answer"].lower().strip().replace(".", "")
+
+    
+    length=doc['length']
+    video=doc['video']
+    data_dict = {"id": doc["id"] ,"length":length,"video":video, "task_type": task_type, "pred_answer": pred_ans, 'pred':pred,"answer": doc["answer"]}
+
+    return {f"timescope_perception_score": data_dict}
+
+
+def timescope_aggregate_results(results):
+    """
+    Args:
+        results: a list of values returned by process_results
+    Returns:
+        A score
+    """
+    category2score = {}
+
+    lengths=[]
+    for result in results:
+        task_type = result["task_type"]
+        length=result['length']
+        lengths.append(length)
+        # print(result)
+        key = f"{length}_{task_type}"
+        if key not in category2score:
+            category2score[key]={"correct": 0, "answered": 0}
+        # print(key)
+        category2score[key]["answered"] += 1
+        # print(result["pred_answer"],result["answer"])
+        category2score[key]["correct"] += result["pred_answer"].lower() == result["answer"].lower()
+    print(category2score)
+    for  cur_key in category2score:
+        length,task_type=cur_key.split("_")
+        eval_logger.info(f"Evaluation on Video Length: {str(length)} and Task: {task_type}: {100 * category2score[cur_key]['correct'] / category2score[cur_key]['answered'] if category2score[cur_key]['answered'] > 0 else 0 : .1f}%")
+    for cur_length in lengths:
+        total_correct = 0
+        total_answered = 0
+        for k, v in category2score.items():
+            if str(cur_length) == k.split("_")[0]:
+                total_correct += v["correct"]
+                total_answered += v["answered"]
+        eval_logger.info(f"Evaluation on Video Length: {str(cur_length)}: {100 * total_correct / total_answered if total_answered > 0 else 0 : .1f}%")
+
+    total_correct = 0
+    total_answered = 0
+    for k, v in category2score.items():
+        total_correct += v["correct"]
+        total_answered += v["answered"]
+    return 100 * total_correct / total_answered if total_answered > 0 else 0

--- a/lmms_eval/tasks/longtimescope/utils.py
+++ b/lmms_eval/tasks/longtimescope/utils.py
@@ -14,12 +14,7 @@ from loguru import logger as eval_logger
 
 from lmms_eval.tasks._task_utils.file_utils import generate_submission_file
 
-TASK_CATEGORIES = ["QA","OCR",'temporal']
-
-
-
-
-
+TASK_CATEGORIES = ["QA", "OCR", "temporal"]
 
 
 # with open(Path(__file__).parent / "_default_template_yaml", "r") as f:
@@ -36,7 +31,7 @@ hf_home = os.getenv("HF_HOME", "~/.cache/huggingface/")
 # cache_dir = os.path.join(hf_home, cache_dir)
 # base_cache_dir = config["dataset_kwargs"]["cache_dir"]
 base_cache_dir = os.path.expanduser(hf_home)
-with open(Path(__file__).parent / "timescope.yaml", "r") as f:
+with open(Path(__file__).parent / "longtimescope.yaml", "r") as f:
     raw_data = f.readlines()
     safe_data = []
     for i, line in enumerate(raw_data):
@@ -50,11 +45,10 @@ def convert_time_to_frame(time_in_seconds, fps):
     return int(time_in_seconds * fps)
 
 
-
 def timescope_doc_to_visual(doc):
     cache_dir = os.path.join(base_cache_dir, cache_name)
-    eval_logger.info(f"base_cache_dir",base_cache_dir,'cache_name',cache_name)
-    video_path = doc["video"] 
+    eval_logger.info(f"base_cache_dir", base_cache_dir, "cache_name", cache_name)
+    video_path = doc["video"]
     video_path = os.path.join(cache_dir, video_path)
     if os.path.exists(video_path):
         video_path = video_path
@@ -65,8 +59,6 @@ def timescope_doc_to_visual(doc):
     else:
         sys.exit(f"video path:{video_path} does not exist, please check")
     return [video_path]
-
-
 
 
 def extract_characters_regex(s):
@@ -91,7 +83,6 @@ def extract_characters_regex(s):
     return matches[0]
 
 
-
 def timescope_process_results(doc, results):
     """
     Args:
@@ -102,10 +93,10 @@ def timescope_process_results(doc, results):
     """
     pred = results[0]
     task_type = doc["type"]
-    pred_ans = extract_characters_regex(pred)   
-    length=doc['length']
-    video=doc['video']
-    data_dict = {"id": doc["id"] ,"length":length,"video":video, "task_type": task_type, "pred_answer": pred_ans, 'pred':pred,"answer": doc["answer"]}
+    pred_ans = extract_characters_regex(pred)
+    length = doc["length"]
+    video = doc["video"]
+    data_dict = {"id": doc["id"], "length": length, "video": video, "task_type": task_type, "pred_answer": pred_ans, "pred": pred, "answer": doc["answer"]}
 
     return {f"timescope_perception_score": data_dict}
 
@@ -119,20 +110,20 @@ def timescope_aggregate_results(results):
     """
     category2score = {}
 
-    lengths=[]
+    lengths = []
     for result in results:
         task_type = result["task_type"]
-        length=result['length']
+        length = result["length"]
         if length not in lengths:
             lengths.append(length)
         key = f"{length}_{task_type}"
         if key not in category2score:
-            category2score[key]={"correct": 0, "answered": 0}
+            category2score[key] = {"correct": 0, "answered": 0}
         category2score[key]["answered"] += 1
         category2score[key]["correct"] += result["pred_answer"].lower() == result["answer"].lower()
 
-    for  cur_key in category2score:
-        length,task_type=cur_key.split("_")
+    for cur_key in category2score:
+        length, task_type = cur_key.split("_")
         eval_logger.info(f"Evaluation on Video Length: {str(length)} and Task: {task_type}: {100 * category2score[cur_key]['correct'] / category2score[cur_key]['answered'] if category2score[cur_key]['answered'] > 0 else 0 : .1f}%")
     for cur_length in lengths:
         total_correct = 0

--- a/lmms_eval/tasks/timescope/timescope.yaml
+++ b/lmms_eval/tasks/timescope/timescope.yaml
@@ -1,0 +1,47 @@
+dataset_path: Apollo-LMMs/TimeScope
+dataset_kwargs:
+  token: True
+  cache_dir: timescope
+  video: True
+  # force_unzip: True
+  # From_YouTube: True
+task: timescope
+test_split: test
+output_type: generate_until
+doc_to_visual: !function utils.timescope_doc_to_visual
+doc_to_text: input
+doc_to_target: "answer"
+generation_kwargs:
+  max_new_tokens: 16
+  temperature: 0
+  top_p: 1.0
+  num_beams: 1
+  do_sample: false
+# The return value of process_results will be used by metrics
+process_results: !function utils.timescope_process_results
+# Note that the metric name can be either a registed metric function (such as the case for GQA) or a key name returned by process_results
+metric_list:
+  - metric: timescope_perception_score
+    aggregation: !function utils.timescope_aggregate_results
+    higher_is_better: true
+lmms_eval_specific_kwargs:
+  default:
+    pre_prompt: ""
+    post_prompt: "\nAnswer with the option's letter from the given choices directly."
+  gpt4v:
+    pre_prompt: ""
+    post_prompt: "Answer the question with A, B, C, or D."
+  llava_vid:
+    pre_prompt: ""
+    post_prompt: "The best answer is:"
+  # qwen_vl:  
+  #   pre_prompt: ""
+  #   post_prompt: " Answer:"
+  # otterhd:
+  #   pre_prompt: ""
+  #   post_prompt: " Answer:"
+  xcomposer2_4khd:
+    pre_prompt: "[UNUSED_TOKEN_146]user\n"
+    post_prompt: " Answer this question with A, B, C, or D.[UNUSED_TOKEN_145]\n[UNUSED_TOKEN_146]assistant\n"
+metadata:
+  - version: 0.0

--- a/lmms_eval/tasks/timescope/utils.py
+++ b/lmms_eval/tasks/timescope/utils.py
@@ -1,0 +1,159 @@
+import datetime
+import json
+import os
+import re
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Dict, List, Optional, Union
+
+import cv2
+import numpy as np
+import yaml
+from loguru import logger as eval_logger
+
+from lmms_eval.tasks._task_utils.file_utils import generate_submission_file
+
+TASK_CATEGORIES = ["QA","OCR",'temporal']
+
+
+
+
+
+
+
+# with open(Path(__file__).parent / "_default_template_yaml", "r") as f:
+#     raw_data = f.readlines()
+#     safe_data = []
+#     for i, line in enumerate(raw_data):
+#         # remove function definition since yaml load cannot handle it
+#         if "!function" not in line:
+#             safe_data.append(line)
+
+#     config = yaml.safe_load("".join(safe_data))
+
+hf_home = os.getenv("HF_HOME", "~/.cache/huggingface/")
+# cache_dir = os.path.join(hf_home, cache_dir)
+# base_cache_dir = config["dataset_kwargs"]["cache_dir"]
+base_cache_dir = os.path.expanduser(hf_home)
+with open(Path(__file__).parent / "timescope.yaml", "r") as f:
+    raw_data = f.readlines()
+    safe_data = []
+    for i, line in enumerate(raw_data):
+        # remove function definition since yaml load cannot handle it
+        if "!function" not in line:
+            safe_data.append(line)
+cache_name = yaml.safe_load("".join(safe_data))["dataset_kwargs"]["cache_dir"]
+
+
+def convert_time_to_frame(time_in_seconds, fps):
+    return int(time_in_seconds * fps)
+
+
+
+def timescope_doc_to_visual(doc):
+    cache_dir = os.path.join(base_cache_dir, cache_name)
+    eval_logger.info(f"base_cache_dir",base_cache_dir,'cache_name',cache_name)
+    video_path = doc["video"] 
+    video_path = os.path.join(cache_dir, video_path)
+    if os.path.exists(video_path):
+        video_path = video_path
+    elif os.path.exists(video_path.replace("mp4", "MP4")):
+        video_path = video_path.replace("mp4", "MP4")
+    elif os.path.exists(video_path.replace("mp4", "mkv")):
+        video_path = video_path.replace("mp4", "mkv")
+    else:
+        sys.exit(f"video path:{video_path} does not exist, please check")
+    return [video_path]
+
+
+
+
+def extract_characters_regex(s):
+    s = s.strip()
+    answer_prefixes = [
+        "The best answer is",
+        "The correct answer is",
+        "The answer is",
+        "The answer",
+        "The best option is" "The correct option is",
+        "Best answer:" "Best option:",
+    ]
+    for answer_prefix in answer_prefixes:
+        s = s.replace(answer_prefix, "")
+
+    if len(s.split()) > 10 and not re.search("[ABCDEF]", s):
+        return ""
+
+    matches = re.search(r"[ABCDEF]", s)
+    if matches is None:
+        return ""
+    return matches[0]
+
+
+
+def timescope_process_results(doc, results):
+    """
+    Args:
+        doc: a instance of the eval dataset
+        results: [pred]
+    Returns:
+        a dictionary with key: metric name (in this case timescope score), value: metric value
+    """
+    pred = results[0]
+    task_type = doc["type"]
+    # if task_type=="QA" or task_type=="temporal":
+    pred_ans = extract_characters_regex(pred)
+    # elif task_type=="OCR":
+    #     pred_ans = re.sub(r'^\.+|\.+$', '', pred.replace("The answer is ","").split(" ")[0].split(":")[0].strip()) if pred else pred
+    # gt_ans = doc["answer"].lower().strip().replace(".", "")
+
+    
+    length=doc['length']
+    video=doc['video']
+    data_dict = {"id": doc["id"] ,"length":length,"video":video, "task_type": task_type, "pred_answer": pred_ans, 'pred':pred,"answer": doc["answer"]}
+
+    return {f"timescope_perception_score": data_dict}
+
+
+def timescope_aggregate_results(results):
+    """
+    Args:
+        results: a list of values returned by process_results
+    Returns:
+        A score
+    """
+    category2score = {}
+
+    lengths=[]
+    for result in results:
+        task_type = result["task_type"]
+        length=result['length']
+        lengths.append(length)
+        # print(result)
+        key = f"{length}_{task_type}"
+        if key not in category2score:
+            category2score[key]={"correct": 0, "answered": 0}
+        # print(key)
+        category2score[key]["answered"] += 1
+        # print(result["pred_answer"],result["answer"])
+        category2score[key]["correct"] += result["pred_answer"].lower() == result["answer"].lower()
+    print(category2score)
+    for  cur_key in category2score:
+        length,task_type=cur_key.split("_")
+        eval_logger.info(f"Evaluation on Video Length: {str(length)} and Task: {task_type}: {100 * category2score[cur_key]['correct'] / category2score[cur_key]['answered'] if category2score[cur_key]['answered'] > 0 else 0 : .1f}%")
+    for cur_length in lengths:
+        total_correct = 0
+        total_answered = 0
+        for k, v in category2score.items():
+            if str(cur_length) == k.split("_")[0]:
+                total_correct += v["correct"]
+                total_answered += v["answered"]
+        eval_logger.info(f"Evaluation on Video Length: {str(cur_length)}: {100 * total_correct / total_answered if total_answered > 0 else 0 : .1f}%")
+
+    total_correct = 0
+    total_answered = 0
+    for k, v in category2score.items():
+        total_correct += v["correct"]
+        total_answered += v["answered"]
+    return 100 * total_correct / total_answered if total_answered > 0 else 0

--- a/lmms_eval/tasks/timescope/utils.py
+++ b/lmms_eval/tasks/timescope/utils.py
@@ -68,8 +68,10 @@ def extract_characters_regex(s):
         "The correct answer is",
         "The answer is",
         "The answer",
-        "The best option is" "The correct option is",
-        "Best answer:" "Best option:",
+        "The best option is",
+        "The correct option is",
+        "Best answer:",
+        "Best option:",
     ]
     for answer_prefix in answer_prefixes:
         s = s.replace(answer_prefix, "")

--- a/lmms_eval/tasks/timescope/utils.py
+++ b/lmms_eval/tasks/timescope/utils.py
@@ -102,13 +102,7 @@ def timescope_process_results(doc, results):
     """
     pred = results[0]
     task_type = doc["type"]
-    # if task_type=="QA" or task_type=="temporal":
-    pred_ans = extract_characters_regex(pred)
-    # elif task_type=="OCR":
-    #     pred_ans = re.sub(r'^\.+|\.+$', '', pred.replace("The answer is ","").split(" ")[0].split(":")[0].strip()) if pred else pred
-    # gt_ans = doc["answer"].lower().strip().replace(".", "")
-
-    
+    pred_ans = extract_characters_regex(pred)   
     length=doc['length']
     video=doc['video']
     data_dict = {"id": doc["id"] ,"length":length,"video":video, "task_type": task_type, "pred_answer": pred_ans, 'pred':pred,"answer": doc["answer"]}
@@ -129,16 +123,14 @@ def timescope_aggregate_results(results):
     for result in results:
         task_type = result["task_type"]
         length=result['length']
-        lengths.append(length)
-        # print(result)
+        if length not in lengths:
+            lengths.append(length)
         key = f"{length}_{task_type}"
         if key not in category2score:
             category2score[key]={"correct": 0, "answered": 0}
-        # print(key)
         category2score[key]["answered"] += 1
-        # print(result["pred_answer"],result["answer"])
         category2score[key]["correct"] += result["pred_answer"].lower() == result["answer"].lower()
-    print(category2score)
+
     for  cur_key in category2score:
         length,task_type=cur_key.split("_")
         eval_logger.info(f"Evaluation on Video Length: {str(length)} and Task: {task_type}: {100 * category2score[cur_key]['correct'] / category2score[cur_key]['answered'] if category2score[cur_key]['answered'] > 0 else 0 : .1f}%")

--- a/lmms_eval/tasks/timescope/utils.py
+++ b/lmms_eval/tasks/timescope/utils.py
@@ -14,12 +14,7 @@ from loguru import logger as eval_logger
 
 from lmms_eval.tasks._task_utils.file_utils import generate_submission_file
 
-TASK_CATEGORIES = ["QA","OCR",'temporal']
-
-
-
-
-
+TASK_CATEGORIES = ["QA", "OCR", "temporal"]
 
 
 # with open(Path(__file__).parent / "_default_template_yaml", "r") as f:
@@ -50,11 +45,10 @@ def convert_time_to_frame(time_in_seconds, fps):
     return int(time_in_seconds * fps)
 
 
-
 def timescope_doc_to_visual(doc):
     cache_dir = os.path.join(base_cache_dir, cache_name)
-    eval_logger.info(f"base_cache_dir",base_cache_dir,'cache_name',cache_name)
-    video_path = doc["video"] 
+    eval_logger.info(f"base_cache_dir", base_cache_dir, "cache_name", cache_name)
+    video_path = doc["video"]
     video_path = os.path.join(cache_dir, video_path)
     if os.path.exists(video_path):
         video_path = video_path
@@ -65,8 +59,6 @@ def timescope_doc_to_visual(doc):
     else:
         sys.exit(f"video path:{video_path} does not exist, please check")
     return [video_path]
-
-
 
 
 def extract_characters_regex(s):
@@ -91,7 +83,6 @@ def extract_characters_regex(s):
     return matches[0]
 
 
-
 def timescope_process_results(doc, results):
     """
     Args:
@@ -102,10 +93,10 @@ def timescope_process_results(doc, results):
     """
     pred = results[0]
     task_type = doc["type"]
-    pred_ans = extract_characters_regex(pred)   
-    length=doc['length']
-    video=doc['video']
-    data_dict = {"id": doc["id"] ,"length":length,"video":video, "task_type": task_type, "pred_answer": pred_ans, 'pred':pred,"answer": doc["answer"]}
+    pred_ans = extract_characters_regex(pred)
+    length = doc["length"]
+    video = doc["video"]
+    data_dict = {"id": doc["id"], "length": length, "video": video, "task_type": task_type, "pred_answer": pred_ans, "pred": pred, "answer": doc["answer"]}
 
     return {f"timescope_perception_score": data_dict}
 
@@ -119,20 +110,20 @@ def timescope_aggregate_results(results):
     """
     category2score = {}
 
-    lengths=[]
+    lengths = []
     for result in results:
         task_type = result["task_type"]
-        length=result['length']
+        length = result["length"]
         if length not in lengths:
             lengths.append(length)
         key = f"{length}_{task_type}"
         if key not in category2score:
-            category2score[key]={"correct": 0, "answered": 0}
+            category2score[key] = {"correct": 0, "answered": 0}
         category2score[key]["answered"] += 1
         category2score[key]["correct"] += result["pred_answer"].lower() == result["answer"].lower()
 
-    for  cur_key in category2score:
-        length,task_type=cur_key.split("_")
+    for cur_key in category2score:
+        length, task_type = cur_key.split("_")
         eval_logger.info(f"Evaluation on Video Length: {str(length)} and Task: {task_type}: {100 * category2score[cur_key]['correct'] / category2score[cur_key]['answered'] if category2score[cur_key]['answered'] > 0 else 0 : .1f}%")
     for cur_length in lengths:
         total_correct = 0


### PR DESCRIPTION
Before you open a pull-request, please check if a similar issue already exists or has been closed before.

### When you open a pull-request, please be sure to include the following

- [x] A descriptive title: [xxx] XXXX
- [x] A detailed description

If you meet the lint warnings, you can use following scripts to reformat code.

```sh
pip install pre-commit
pre-commit install
pre-commit run --all-files
```

Thank you for your contributions!

## Summary for the Request

Hi EvolvingLMMs-Lab,

This pull request introduces support for the TimeScope benchmark, a new benchmark for evaluating long-form video comprehension in Large Multimodal Models. Further information on the design and methodology of TimeScope is available here: https://github.com/orrzohar/blog/blob/main/timescope.md.

Please let us know any changes or additions are needed. We're happy to adjust to align with the repo's standards.

We appreciate your efforts in reviewing this contribution.

Best Regards,
The Apollo Team

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced configuration files for the "longtimescope" and "timescope" video evaluation tasks, enabling dataset selection, evaluation settings, and model-specific prompt templates.
  * Added utility modules for both tasks, supporting video frame conversion, answer extraction, robust video file resolution, and detailed accuracy metric aggregation with per-category reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->