### PR TITLE
[fix] update korean benchmark's post_prompt

### DIFF
--- a/lmms_eval/tasks/dtcbench/utils.py
+++ b/lmms_eval/tasks/dtcbench/utils.py
@@ -5,7 +5,7 @@ def dtcbench_doc_to_visual(doc):
 def dtcbench_doc_to_text(doc):
     question = doc["question"]
     question += f"\nOptions: A: {doc['choice_a']}, B: {doc['choice_b']}, C: {doc['choice_c']}, D: {doc['choice_d']}"
-    return f"{question}\n한 단어 또는 구를 사용하여 질문에 답하세요."
+    return f"{question}\n주어진 선택지 중 해당 옵션의 문자로 바로 답하세요."
 
 
 def dtcbench_process_result(doc, result):

--- a/lmms_eval/tasks/mmbench/_default_template_mmbench_ko_yaml
+++ b/lmms_eval/tasks/mmbench/_default_template_mmbench_ko_yaml
@@ -5,7 +5,7 @@ doc_to_target: "answer"
 lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
-    post_prompt: "\n한 단어 또는 구를 사용하여 질문에 답하세요."
+    post_prompt: "\n주어진 선택지 중 해당 옵션의 문자로 바로 답하세요."
 doc_to_visual: !function ko_utils.mmbench_doc_to_visual
 doc_to_text: !function ko_utils.mmbench_doc_to_text
 doc_to_target: "answer"

--- a/lmms_eval/tasks/seedbench/ko_utils.py
+++ b/lmms_eval/tasks/seedbench/ko_utils.py
@@ -11,7 +11,7 @@ def seed_doc_to_text(doc):
     question += f"B. {doc['choice_b']}\n"
     question += f"C. {doc['choice_c']}\n"
     question += f"D. {doc['choice_d']}"
-    return f"{question}\n한 단어 또는 구를 사용하여 질문에 답하세요."
+    return f"{question}\n주어진 선택지 중 해당 옵션의 문자로 바로 답하세요."
 
 
 def seed_process_result(doc, result):


### PR DESCRIPTION
The post_prompt used in some Korean multiple-choice benchmarks does not sufficiently convey the intent of asking the model to spit out the letter of the choice in a short answer. As a result, many models were observed to give narrative responses, which is not the intent of the post_prompt.

Therefore, we recommend replacing the post prompt with “주어진 선택지 중 해당 옵션의 문자로 바로 답하세요.”, which is the Korean version of “Answer with the given options directly.” used in many English multiple-choice benchmarks, which fully captures this intent.
(In our internal experiments, we found that this post prompt caused models to give short-answer responses as intended by the benchmarks.)

Thank you :)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated user prompts to instruct answering directly with the letter of the correct option from the given choices, instead of using a word or phrase. This change affects prompts in multiple areas of the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->