### PR TITLE
[fix] Fixed applying process_* twice on resAns for VQAv2

### DIFF
--- a/lmms_eval/tasks/vqav2/utils.py
+++ b/lmms_eval/tasks/vqav2/utils.py
@@ -17,7 +17,7 @@ def vqav2_doc_to_visual(doc):
 def vqav2_process_results(doc, result):
     eval_ai_processor = EvalAIAnswerProcessor()
     assert len(result) == 1, f"The result should be a list of length 1, but got {len(result)}."
-    resAns = eval_ai_processor(result[0])
+    resAns = result[0]
     accuracy = 0
 
     if "answers" in doc and doc["answers"] is not None:
@@ -25,6 +25,9 @@ def vqav2_process_results(doc, result):
             ansDic["answer"] = ansDic["answer"].replace("\n", " ")
             ansDic["answer"] = ansDic["answer"].replace("\t", " ")
             ansDic["answer"] = ansDic["answer"].strip()
+        resAns = resAns.replace("\n", " ")
+        resAns = resAns.replace("\t", " ")
+        resAns = resAns.strip()
         gtAcc = []
         gtAnswers = [ans["answer"] for ans in doc["answers"]]
 


### PR DESCRIPTION
This PR fixes the VQAv2 results processing to be in line with the official VQAv2 evaluation code.

The original (wrong) behaviour calls the following:
```py
resAns = eval_ai_processor(result[0])
...
resAns = eval_ai_processor.process_punctuation(resAns)
resAns = eval_ai_processor.process_digit_article(resAns)
```
which is equivalent to:
```py
resAns = result[0].replace("\n", " ").replace("\t", " ").strip()
resAns = eval_ai_processor.process_punctuation(resAns)
resAns = eval_ai_processor.process_digit_article(resAns)
...
resAns = eval_ai_processor.process_punctuation(resAns)
resAns = eval_ai_processor.process_digit_article(resAns)
```

This is in fact incorrect and can occasionally lead weird behaviour where a processing rule that removes/changes/pads some text produces words which would be further altered when applying the same processing a second time.

The code has now been changed to have identical behaviour to the original evaluation script here: https://github.com/GT-Vision-Lab/VQA/blob/a013f0043c1e2cdc995922dfe257f7149aa9af06/PythonEvaluationTools/vqaEvaluation/vqaEval.py#L69

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved answer formatting by cleaning up whitespace and special characters for more consistent evaluation results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->