### PR TITLE
[fix] vqav2 evaluation yaml

### DIFF
--- a/lmms_eval/tasks/vqav2/vqav2_test.yaml
+++ b/lmms_eval/tasks/vqav2/vqav2_test.yaml
@@ -9,7 +9,7 @@ process_results: !function utils.vqav2_process_results_test
 lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
-    post_prompt: ""
+    post_prompt: "\nAnswer the question using a single word or phrase."
   plm:
     pre_prompt: ""
-    post_prompt: "\nGive a very brief answer."
+    post_prompt: ""

--- a/lmms_eval/tasks/vqav2/vqav2_val.yaml
+++ b/lmms_eval/tasks/vqav2/vqav2_val.yaml
@@ -11,7 +11,7 @@ process_results: !function utils.vqav2_process_results_val
 lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
-    post_prompt: ""
+    post_prompt: "\nAnswer the question using a single word or phrase."
   plm:
     pre_prompt: ""
-    post_prompt: "\nGive a very brief answer."
+    post_prompt: ""


### PR DESCRIPTION
fixed the vqav2_val.yaml and vqav2_test.yaml post_prompt values to prevent the model from answering with longer responses than expected by the evaluation process, resuling in very low scores.

```diff
lmms_eval_specific_kwargs:
  default:
    pre_prompt: ""
-   post_prompt: ""
+   post_prompt: "\nAnswer the question using a single word or phrase."
  plm:
    pre_prompt: ""
-   post_prompt: "\nGive a very brief answer."
+   post_prompt: ""

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated instructions for answering questions in the VQAv2 test and validation tasks. The default setting now requests answers in a single word or phrase, while the brief answer instruction was removed from the alternative configuration. No functional changes were made.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->