### PR TITLE
[New Task] Add support for benchmark PhyX

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@
 <details>
 <summary>We warmly welcome contributions from the open-source community! Below is a chronological list of recent tasks, models, and features added by our amazing contributors. </summary>
 
+- [2025-07] 🎉🎉 We welcome the new task [PhyX](https://phyx-bench.github.io/), the first large-scale benchmark designed to assess models capacity for physics-grounded reasoning in visual scenarios.
 - [2025-06] 🎉🎉 We welcome the new task [VideoMathQA](https://mbzuai-oryx.github.io/VideoMathQA), designed to evaluate mathematical reasoning in real-world educational videos.
 - [2024-10] 🎉🎉 We welcome the new task [NaturalBench](https://huggingface.co/datasets/BaiqiL/NaturalBench), a vision-centric VQA benchmark (NeurIPS'24) that challenges vision-language models with simple questions about natural imagery.
 - [2024-10] 🎉🎉 We welcome the new task [TemporalBench](https://huggingface.co/datasets/microsoft/TemporalBench) for fine-grained temporal understanding and reasoning for videos, which reveals a huge (>30%) human-AI gap.

--- a/lmms_eval/tasks/phyx/phyx.yaml
+++ b/lmms_eval/tasks/phyx/phyx.yaml
@@ -1,0 +1,10 @@
+group: phyx
+task:
+  - phyx_mc
+  - phyx_oe
+  - phyx_mini_mc
+  - phyx_mini_oe
+metadata:
+  version: 0.0
+  eval_model_name: "deepseek-chat"
+  quick_extract: false

--- a/lmms_eval/tasks/phyx/phyx_evals.py
+++ b/lmms_eval/tasks/phyx/phyx_evals.py
@@ -1,0 +1,419 @@
+import re
+import json
+import os
+import copy
+import argparse
+from tqdm import tqdm
+from collections import defaultdict
+import ast
+from pathlib import Path
+import yaml
+from openai import OpenAI
+from loguru import logger as eval_logger
+import time
+import pandas as pd
+
+FAIL_MSG = 'Failed to obtain answer via API.'
+
+with open(Path(__file__).parent / "phyx.yaml", "r") as f:
+    raw_data = f.readlines()
+    safe_data = []
+    for i, line in enumerate(raw_data):
+        # remove function definition since yaml load cannot handle it
+        if "!function" not in line:
+            safe_data.append(line)
+
+    config = yaml.safe_load("".join(safe_data))
+
+
+class PhyXEvaluator:
+    def __init__(self):
+        if not config["metadata"]["quick_extract"]:
+            self.juder_model = config["metadata"]["eval_model_name"]
+            API_URL = "https://api.deepseek.com/v1/chat/completions"
+            API_KEY = os.getenv("Deepseek_API", "YOUR_API_KEY")
+            self.headers = {
+                        "Authorization": f"Bearer {API_KEY}",
+                        "Content-Type": "application/json",
+                    }
+            self.client = OpenAI(api_key=API_KEY, base_url=API_URL.rstrip("chat/completions"))
+        else:
+            self.juder_model = None
+            self.headers = None
+            self.client = None
+
+
+    def judger_generate(self, prompt, temperature=0, max_tokens=128, n=1, patience=5, sleep_time=0):
+        assert config["metadata"]["quick_extract"]==False, "TO employ LLM to extract answer, please set `quick_extract=False`"
+        messages = [
+            {"role": "user", "content": prompt},
+        ]
+        payload = {"model": self.juder_model, "messages": messages, "temperature": temperature, "max_tokens": max_tokens}
+
+        while patience > 0:
+            patience -= 1
+            try:
+                response = self.client.chat.completions.create(**payload)
+                if n == 1:
+                    prediction = response.choices[0].message.content.strip()
+                    if prediction and prediction != "":
+                        return prediction
+                else:
+                    prediction = [choice.message.content.strip() for choice in response.choices]
+                    if prediction and prediction[0] != "":
+                        return prediction
+
+            except Exception as e:
+                if "Rate limit" not in str(e):
+                    eval_logger.error(e)
+
+                if "Please reduce the length of the messages" in str(e):
+                    eval_logger.error("!!Reduce prompt size")
+                    # reduce input prompt and keep the tail
+                    new_size = int(len(prompt) * 0.9)
+                    new_start = len(prompt) - new_size
+                    prompt = prompt[new_start:]
+                    payload["messages"] = [
+                        {"role": "user", "content": prompt},
+                    ]
+
+                if sleep_time > 0:
+                    time.sleep(sleep_time)
+        return FAIL_MSG
+
+    def get_ICE(self):
+        example_1 = """
+    Ground truth answer: 502 \n
+    Predicted answer: The mass of block (B) is:
+    [
+    \\boxed{ 50 \\sqrt{101} }
+    ] \n
+    Judegement: 1
+    """
+
+        example_2 = """
+    Ground truth answer: 46.3 kN \n
+    Predicted answer: The tension ( T_B ) in the cable is approximately:
+    [
+    \\boxed{46300 }
+    ] \n
+    Judegement: 1
+    """
+
+        example_3 = """
+    Ground truth answer: 12 m/s \n
+    Predicted answer: The speed of the box after 2.00 seconds is:
+    [
+    \\boxed{11.3, \\text{m/s}}
+    ] \n
+    Judegement: 0
+    """
+
+        example_4 = """
+    Ground truth answer: 36.00 kg \n
+    Predicted answer: The mass of the hanging block ( m_2 ) must be approximately:
+    [
+    \\boxed{36.1, \\text\\{kg\\}}
+    ] \n
+    Judegement: 1
+    """
+
+        example_5 = """
+    Ground truth answer: 3.2 m \n
+    Predicted answer: The stuntman and villain slide approximately \\frac\{10\}{3.1415} meters**.
+    Judegement: 1
+    """
+
+        return [example_1, example_2, example_3, example_4, example_5]
+
+
+    def get_ICE_MC(self):
+        example_1 = """
+    Ground truth answer: A \n
+    Predicted answer: A \n
+    Judegement: 1
+    """
+
+        example_2 = """
+    Ground truth answer: B \n
+    Predicted answer: A \n
+    Judegement: 0
+    """
+
+        example_3 = """
+    Ground truth answer: C \n
+    Predicted answer: ### Step 1: Calculate ( l_1 )
+    The lightbulb is ( 2.50, \\text\\{m\\}) above the floor, and the bottom of the mirror is (0.50, \\text\\{m\\}) \
+    above the floor. The vertical distance from the lightbulb to the bottom of the mirror is:
+    [
+    \\Delta y_1 = 2.50, \\text\\{m\\} - 0.50, \\text\\{m\\} = 2.00, \\text\\{m\\}.
+    ] \n
+    Judegement: 0
+    """
+
+        example_4 = """
+    Ground truth answer: D \n
+    Predicted answer: The correct option is D. \n
+    Judegement: 1
+    """
+
+        return [example_1, example_2, example_3, example_4]
+
+
+    def build_phyx_gpt4_prompt(self, line, pred):
+        task_description = """
+    Please read the following example. Given predicted answer and ground truth answer,
+    compare the these two answers, then ONLY output judegement 1/0 for matched/unmatched at the end of the prompt.
+    If the meaning is expressed in the same way, it is also considered consistent, for example, 0.5m and 50cm.
+    If the given predicted mentions "approximately", then allow the Approximation Error, \
+    such as 0.49 and approximately 0.5, 0.81 and approximately 0.8. \n
+    """
+        gt_answer = line['answer']
+        prompt = task_description
+        examples = self.get_ICE()
+        for example in examples:
+            prompt += example + '\n'
+        prompt += 'Ground truth answer: {} \n'.format(gt_answer)
+        prompt += 'Predicted answer: {} \n'.format(pred)
+        prompt += 'Judegement:'
+        return prompt
+
+
+    def build_phyx_gpt4_prompt_MC(self, line, pred):
+        task_description = """
+    Please read the following example. Given predicted answer and ground truth answer for Multi-Choice question.
+    The ground truth answer would be A/B/C/D. The predicted answer would be some words containing A/B/C/D.
+    Please compare the these two answers, then ONLY output judegement 1/0 for matched/unmatched at the end of the prompt. \n
+    """
+        gt_answer = line['answer']
+        prompt = task_description
+        examples = self.get_ICE_MC()
+        for example in examples:
+            prompt += example + '\n'
+        prompt += 'Ground truth answer: {} \n'.format(gt_answer)
+        prompt += 'Predicted answer: {} \n'.format(pred)
+        prompt += 'Judegement:'
+        return prompt
+
+
+    def mapping_str(self, input):
+        d = {"\dfrac": "\\frac", "\pi": "3.14"}
+        output = input
+        for k,v in d.items():
+            try:
+                output = output.replace(k, v)
+            except:
+                pass
+        return output
+
+    def safe_literal_eval(self, s):
+        s = s.strip()
+        try:
+            return ast.literal_eval(s)
+        except:
+            pass  
+        if not s.startswith("{"):
+            s = "{" + s
+        if not s.endswith("}"):
+            s = s + "}"
+        s = re.sub(r'([{,]\s*)([^"\{\}\:\,\s]+)\s*:', r'\1"\2":', s)
+        try:
+            return ast.literal_eval(s)
+        except Exception as e:
+            return None
+
+
+    def extract_boxed_content(self, s):
+        start = s.find(r'\boxed{')
+        if start == -1:
+            return None 
+        content_start = start + len(r'\boxed{')
+        rest = s[content_start:]
+        depth = 0
+        for i, ch in enumerate(rest):
+            if ch == '{':
+                depth += 1
+            elif ch == '}':
+                if depth == 0:
+                    return rest[:i]
+                else:
+                    depth -= 1
+        return None
+
+
+    def PhyX_auxeval(self, line):
+        log = ''
+        retry = 5
+
+        gt_answer = str(line['answer'])
+        prediction = line['prediction']
+
+        # try extract final answer using re rules
+        tmp = self.PhyX_process_line(line)
+
+        if tmp["extracted"] == "Fail to Call API":
+            log += "Fail to Call API"
+            prediction = "Fail to Call API"
+            return dict(log=log, res=0, extracted=prediction)
+
+        if tmp["extracted"] != "SAME as predict":
+            prediction = tmp["extracted"]
+
+        # judge via LLM
+        if gt_answer.strip().lower() == prediction.strip().lower():
+            return dict(log="Matched at string level", res=1, extracted=prediction)
+
+        prompt = self.build_phyx_gpt4_prompt(line, prediction)
+        for i in range(retry):
+            res = self.judger_generate(prompt, temperature=i * 0.5)
+            if FAIL_MSG in res:
+                log += f'Try {i}: answer and prediction are {gt_answer} and {prediction}, failed to compare.\n'
+            else:
+                log += 'Compared at semantic level. '
+                # print(res)
+                if "1" in res or 1 == res:
+                    log += "Semantic equal via LLM."
+                    return dict(log=log, res=1, extracted=prediction)
+                elif "0" in res or 0 == res:
+                    log += "LLM judgement {}".format(res)
+                    return dict(log=log, res=0, extracted=prediction)
+        log += 'All 5 retries failed.\n'
+        return dict(log=log, res=0, extracted=prediction)
+
+
+    def PhyX_auxeval_MC(self, line):
+        log = ''
+        retry = 5
+
+        gt_answer = str(line['answer'])
+        prediction = line['prediction']
+
+        tmp = self.PhyX_process_line_MC(line)
+
+        if tmp["extracted"] == "Fail to Call API":
+            log += "Fail to Call API"
+            prediction = "Fail to Call API"
+            return dict(log=log, res=0, extracted=prediction)
+            
+        if tmp["extracted"] != "SAME as predict":
+            prediction = tmp["extracted"]
+
+        # match at string level
+        if gt_answer.strip().lower() == prediction.strip().lower():
+            return dict(log="Matched at string level", res=1, extracted=prediction)
+        else:
+            # prediction is A/B/C/D, then labeled as unmatch
+            if prediction.strip() in ["A", "B", "C", "D"]:
+                return dict(log="Unmatched at string level", res=0, extracted=prediction)
+
+        prompt = self.build_phyx_gpt4_prompt_MC(line, prediction)
+        for i in range(retry):
+            res = self.judger_generate(prompt, temperature=i * 0.5)
+            if FAIL_MSG in res:
+                log += f'Try {i}: answer and prediction are {gt_answer} and {prediction}, failed to compare.\n'
+            else:
+                log += 'Compared at semantic level. '
+                if "1" in res or 1 == res:
+                    log += "Semantic equal via LLM."
+                    return dict(log=log, res=1, extracted=prediction)
+                elif "0" in res or 0 == res:
+                    log += "LLM judgement {}".format(res)
+                    return dict(log=log, res=0, extracted=prediction)
+        log += 'All 5 retries failed.\n'
+        return dict(log=log, res=0, extracted=prediction)
+
+
+    def PhyX_process_line(self, line):
+        ret = {}
+
+        answers = str(line['answer'])
+
+        ret["index"] = line["index"]
+        ret['gt'] = answers
+        
+        # with reasoning, extract content part
+        prediction_str = line['prediction']
+        with_reasoning = False
+        try:
+            pred_dict = self.safe_literal_eval(prediction_str)
+            if isinstance(pred_dict, dict) and 'content' in pred_dict and pred_dict['content']!="":
+                ret['pred'] = pred_dict['content'].strip()
+                with_reasoning = True
+        except:
+            pass
+
+        if not with_reasoning:
+            ret['pred'] = prediction_str.strip()
+        
+        if ret['pred'] == FAIL_MSG:
+            ret['match'] = 0
+            ret["extracted"] = "Fail to Call API"
+            return ret
+        
+        boxed_answer = self.extract_boxed_content(ret['pred'])
+        if boxed_answer != None:
+            boxed_answer = self.mapping_str(boxed_answer)
+            ret["extracted"] = boxed_answer
+        else:
+            pattern = r'\b(?:final\s+answer|correct\s+answer)\b[^:：]*[:：]\s*(.*?)(?=\n\n\n|\Z)'
+            flags = re.IGNORECASE | re.DOTALL
+            match = re.search(pattern, ret['pred'], flags=flags)
+            if match:
+                extracted_answer = match.group(1)
+                extracted_answer = self.mapping_str(extracted_answer)
+                ret["extracted"] = extracted_answer
+            else:
+                ret["extracted"] = "SAME as predict"
+
+
+        if ret['gt'].strip().lower() == ret["extracted"].strip().lower() or ret['gt'].strip().lower() == ret["pred"].strip().lower() or ret['gt'] in ret['pred']:
+            ret['match'] = 1
+            return ret
+
+        # unmatch at string level
+        ret['match'] = 0
+        return ret
+
+
+    def PhyX_process_line_MC(self, line):
+        ret = {}
+
+        answers = str(line['answer'])
+
+        ret["index"] = line["index"]
+        ret['gt'] = answers
+        ret['pred'] = line['prediction'].strip()
+
+        pattern = r'\b(?:correct|answer|option|Answer|Option|Correct)\b[\s\S]*?([A-D])'
+        match = re.search(pattern, ret['pred'])
+
+        if ret['pred'] == FAIL_MSG:
+            ret['match'] = 0
+            ret["extracted"] = "Fail to Call API"
+            return ret
+
+        if match:
+            extracted_answer = match.group(1)
+            # compare string
+            ret["extracted"] = extracted_answer
+            if ret['gt'].strip().lower() == extracted_answer.strip().lower():
+                ret['match'] = 1
+                return ret
+        else:
+            # try another match strategy
+            matches = re.findall(r'([ABCD]):', ret['pred'])
+            if matches:
+                extracted_answer = matches[-1]
+                ret["extracted"] = extracted_answer
+                if ret['gt'].strip().lower() == extracted_answer.strip().lower():
+                    ret['match'] = 1
+                    return ret
+            else:
+                ret["extracted"] = "SAME as predict"
+
+        if ret['gt'] + ":" in ret['pred'] or ret['gt'] + "**" in ret['pred'] or "**" + ret['gt'] in ret['pred']:
+            ret['match'] = 1
+        else:
+            ret['match'] = 0
+
+        return ret

--- a/lmms_eval/tasks/phyx/phyx_evals.py
+++ b/lmms_eval/tasks/phyx/phyx_evals.py
@@ -31,7 +31,10 @@ class PhyXEvaluator:
         if not config["metadata"]["quick_extract"]:
             self.juder_model = config["metadata"]["eval_model_name"]
             API_URL = "https://api.deepseek.com/v1/chat/completions"
-            API_KEY = os.getenv("Deepseek_API", "YOUR_API_KEY")
+            API_KEY = os.getenv("Deepseek_API", "")
+            if API_KEY == "":
+                import warnings
+                warnings.warn("To judge via Deepseek, please set api env following `export Deepseek_API=$Your_KEY`")
             self.headers = {
                         "Authorization": f"Bearer {API_KEY}",
                         "Content-Type": "application/json",
@@ -44,7 +47,7 @@ class PhyXEvaluator:
 
 
     def judger_generate(self, prompt, temperature=0, max_tokens=128, n=1, patience=5, sleep_time=0):
-        assert config["metadata"]["quick_extract"]==False, "TO employ LLM to extract answer, please set `quick_extract=False`"
+        assert config["metadata"]["quick_extract"]==False, "To employ LLM to extract answer, please set `quick_extract=False`"
         messages = [
             {"role": "user", "content": prompt},
         ]
@@ -364,7 +367,6 @@ class PhyXEvaluator:
                 ret["extracted"] = extracted_answer
             else:
                 ret["extracted"] = "SAME as predict"
-
 
         if ret['gt'].strip().lower() == ret["extracted"].strip().lower() or ret['gt'].strip().lower() == ret["pred"].strip().lower() or ret['gt'] in ret['pred']:
             ret['match'] = 1

--- a/lmms_eval/tasks/phyx/phyx_mc.yaml
+++ b/lmms_eval/tasks/phyx/phyx_mc.yaml
@@ -1,0 +1,15 @@
+dataset_path: Cloudriver/PhyX
+dataset_name: data_for_llms_eval
+dataset_kwargs:
+  token: True
+task: "phyx_mc"
+test_split: phyx_mc
+output_type: generate_until
+doc_to_visual: !function utils.phyx_doc_to_visual
+doc_to_text: !function utils.phyx_doc_to_text
+doc_to_target: "answer"
+process_results: !function utils.phyx_process_results_mc
+metric_list:
+  - metric: eval_results
+    aggregation: !function utils.phyx_aggregate_results
+    higher_is_better: true

--- a/lmms_eval/tasks/phyx/phyx_mini_mc.yaml
+++ b/lmms_eval/tasks/phyx/phyx_mini_mc.yaml
@@ -1,0 +1,15 @@
+dataset_path: Cloudriver/PhyX
+dataset_name: data_for_llms_eval
+dataset_kwargs:
+  token: True
+task: "phyx_mini_mc"
+test_split: phyx_mini_mc
+output_type: generate_until
+doc_to_visual: !function utils.phyx_doc_to_visual
+doc_to_text: !function utils.phyx_doc_to_text
+doc_to_target: "answer"
+process_results: !function utils.phyx_process_results_mc
+metric_list:
+  - metric: eval_results
+    aggregation: !function utils.phyx_aggregate_results
+    higher_is_better: true

--- a/lmms_eval/tasks/phyx/phyx_mini_oe.yaml
+++ b/lmms_eval/tasks/phyx/phyx_mini_oe.yaml
@@ -1,0 +1,15 @@
+dataset_path: Cloudriver/PhyX
+dataset_name: data_for_llms_eval
+dataset_kwargs:
+  token: True
+task: "phyx_mini_oe"
+test_split: phyx_mini_oe
+output_type: generate_until
+doc_to_visual: !function utils.phyx_doc_to_visual
+doc_to_text: !function utils.phyx_doc_to_text
+doc_to_target: "answer"
+process_results: !function utils.phyx_process_results
+metric_list:
+  - metric: eval_results
+    aggregation: !function utils.phyx_aggregate_results
+    higher_is_better: true

--- a/lmms_eval/tasks/phyx/phyx_oe.yaml
+++ b/lmms_eval/tasks/phyx/phyx_oe.yaml
@@ -1,0 +1,15 @@
+dataset_path: Cloudriver/PhyX
+dataset_name: data_for_llms_eval
+dataset_kwargs:
+  token: True
+task: "phyx_oe"
+test_split: phyx_oe
+output_type: generate_until
+doc_to_visual: !function utils.phyx_doc_to_visual
+doc_to_text: !function utils.phyx_doc_to_text
+doc_to_target: "answer"
+process_results: !function utils.phyx_process_results
+metric_list:
+  - metric: eval_results
+    aggregation: !function utils.phyx_aggregate_results
+    higher_is_better: true

--- a/lmms_eval/tasks/phyx/utils.py
+++ b/lmms_eval/tasks/phyx/utils.py
@@ -1,10 +1,12 @@
+import base64
 import io
 from pathlib import Path
-import base64
-from PIL import Image
+
+import numpy as np
 import yaml
 from loguru import logger as eval_logger
-import numpy as np
+from PIL import Image
+
 from lmms_eval.tasks.phyx.phyx_evals import PhyXEvaluator
 
 with open(Path(__file__).parent / "phyx.yaml", "r") as f:
@@ -41,22 +43,22 @@ def phyx_doc_to_text(doc, lmms_eval_specific_kwargs=None):
 
 def phyx_process_results_mc(doc, results):
     prediction = results[0].strip()
-    doc['prediction'] = str(prediction)
-    doc['answer'] = str(doc['answer'])
+    doc["prediction"] = str(prediction)
+    doc["answer"] = str(doc["answer"])
     if config["metadata"]["quick_extract"]:
         tmp = phyx_evaluator.PhyX_process_line_MC(doc)
         true_false = tmp["match"]
     else:
         llm_tmp = phyx_evaluator.PhyX_auxeval_MC(doc)
         true_false = llm_tmp["res"]
-    
+
     eval_result = {
         "index": doc["index"],
         "true_false": true_false,
         "category": doc["category"],
         "answer": doc["answer"],
     }
-        
+
     return {
         "eval_results": eval_result,
     }
@@ -64,28 +66,28 @@ def phyx_process_results_mc(doc, results):
 
 def phyx_process_results(doc, results):
     prediction = results[0].strip()
-    doc['prediction'] = str(prediction)
-    doc['answer'] = str(doc['answer'])
+    doc["prediction"] = str(prediction)
+    doc["answer"] = str(doc["answer"])
     if config["metadata"]["quick_extract"]:
         tmp = phyx_evaluator.PhyX_process_line(doc)
         true_false = tmp["match"]
     else:
         llm_tmp = phyx_evaluator.PhyX_auxeval(doc)
         true_false = llm_tmp["res"]
-    
+
     eval_result = {
         "index": doc["index"],
         "true_false": true_false,
         "category": doc["category"],
         "answer": doc["answer"],
     }
-        
+
     return {
         "eval_results": eval_result,
     }
 
 
 def phyx_aggregate_results(results):
-    hit = [x['true_false'] for x in results]
-    Overall_acc = np.mean(hit) 
+    hit = [x["true_false"] for x in results]
+    Overall_acc = np.mean(hit)
     return Overall_acc

--- a/lmms_eval/tasks/phyx/utils.py
+++ b/lmms_eval/tasks/phyx/utils.py
@@ -1,0 +1,91 @@
+import io
+from pathlib import Path
+import base64
+from PIL import Image
+import yaml
+from loguru import logger as eval_logger
+import numpy as np
+from lmms_eval.tasks.phyx.phyx_evals import PhyXEvaluator
+
+with open(Path(__file__).parent / "phyx.yaml", "r") as f:
+    raw_data = f.readlines()
+    safe_data = []
+    for i, line in enumerate(raw_data):
+        # remove function definition since yaml load cannot handle it
+        if "!function" not in line:
+            safe_data.append(line)
+
+    config = yaml.safe_load("".join(safe_data))
+
+
+phyx_evaluator = PhyXEvaluator()
+
+
+def decode_base64_to_image(base64_string, target_size=-1):
+    image_data = base64.b64decode(base64_string)
+    image = Image.open(io.BytesIO(image_data)).convert("RGB")
+    if target_size > 0:
+        image.thumbnail((target_size, target_size))
+    return image
+
+
+def phyx_doc_to_visual(doc):
+    image = decode_base64_to_image(doc["image"])
+    return [image]
+
+
+def phyx_doc_to_text(doc, lmms_eval_specific_kwargs=None):
+    query_prompt = doc["question"]
+    return query_prompt
+
+
+def phyx_process_results_mc(doc, results):
+    prediction = results[0].strip()
+    doc['prediction'] = str(prediction)
+    doc['answer'] = str(doc['answer'])
+    if config["metadata"]["quick_extract"]:
+        tmp = phyx_evaluator.PhyX_process_line_MC(doc)
+        true_false = tmp["match"]
+    else:
+        llm_tmp = phyx_evaluator.PhyX_auxeval_MC(doc)
+        true_false = llm_tmp["res"]
+    
+    eval_result = {
+        "index": doc["index"],
+        "true_false": true_false,
+        "category": doc["category"],
+        "answer": doc["answer"],
+    }
+        
+    return {
+        "eval_results": eval_result,
+    }
+
+
+def phyx_process_results(doc, results):
+    prediction = results[0].strip()
+    doc['prediction'] = str(prediction)
+    doc['answer'] = str(doc['answer'])
+    if config["metadata"]["quick_extract"]:
+        tmp = phyx_evaluator.PhyX_process_line(doc)
+        true_false = tmp["match"]
+    else:
+        llm_tmp = phyx_evaluator.PhyX_auxeval(doc)
+        true_false = llm_tmp["res"]
+    
+    eval_result = {
+        "index": doc["index"],
+        "true_false": true_false,
+        "category": doc["category"],
+        "answer": doc["answer"],
+    }
+        
+    return {
+        "eval_results": eval_result,
+    }
+
+
+def phyx_aggregate_results(results):
+    hit = [x['true_false'] for x in results]
+    Overall_acc = np.mean(hit) 
+    return Overall_acc


### PR DESCRIPTION
## Summary 

This PR adds support for the [PhyX](https://phyx-bench.github.io/), the first large-scale benchmark designed to assess models' capacity for physics-grounded reasoning in visual scenarios. PhyX includes 3K meticulously curated multimodal questions spanning 6 reasoning types across 25 sub-domains and 6 core physics domains: thermodynamics, electromagnetism, mechanics, modern physics, optics, and wave and acoustics. 

## Usage

The code is at: [here](https://github.com/wutaiqiang/lmms-eval/tree/main/lmms_eval/tasks/phyx)

There are four settings:   
  - phyx_mc
  - phyx_oe
  - phyx_mini_mc
  - phyx_mini_oe

`mc` denotes multiple-choice, `oe` for open-ended question. There are 3000 samples, while `mini` is for the mini version with 1000 samples.

After inference, you can set `quick_extract: false` or `quick_extract: true` at this [line](https://github.com/wutaiqiang/lmms-eval/blob/5b880bb855beae5034d018a2590527ec17c0201d/lmms_eval/tasks/phyx/phyx.yaml#L10). `True` denotes judging by rules, while `False` denotes llm-as-judge. We are using official Deepseek-V3 as the default judger. Please remember to set env variable `Deepseek_API`

