### PR TITLE
feat: Add max_frame_num parameter to encode_video

### DIFF
--- a/lmms_eval/protocol.py
+++ b/lmms_eval/protocol.py
@@ -111,10 +111,10 @@ class ChatMessages(BaseModel):
         return base64_str
 
     # Function to encode the video
-    def encode_video(self, video_path):
+    def encode_video(self, video_path, max_frame_num=32):
         vr = VideoReader(video_path, ctx=cpu(0))
         total_frame_num = len(vr)
-        uniform_sampled_frames = np.linspace(0, total_frame_num - 1, self.max_frame_num, dtype=int)
+        uniform_sampled_frames = np.linspace(0, total_frame_num - 1, max_frame_num, dtype=int)
 
         # Ensure the last frame is included
         if total_frame_num - 1 not in uniform_sampled_frames:


### PR DESCRIPTION
Before you open a pull-request, please check if a similar issue already exists or has been closed before.

### When you open a pull-request, please be sure to include the following

- [ ] A descriptive title: [xxx] XXXX
- [ ] A detailed description

If you meet the lint warnings, you can use following scripts to reformat code.

```sh
pip install pre-commit
pre-commit install
pre-commit run --all-files
```

Thank you for your contributions!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to specify the maximum number of video frames to process when encoding videos. The default is set to 32 frames.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->