### PR TITLE
Fix accuracy computation for VQAv2

### DIFF
--- a/lmms_eval/tasks/vqav2/utils.py
+++ b/lmms_eval/tasks/vqav2/utils.py
@@ -29,14 +29,12 @@ def vqav2_process_results(doc, result):
         resAns = resAns.replace("\t", " ")
         resAns = resAns.strip()
         gtAcc = []
-        gtAnswers = [ans["answer"] for ans in doc["answers"]]
 
-        if len(set(gtAnswers)) > 1:
-            for ansDic in doc["answers"]:
-                ansDic["answer"] = eval_ai_processor.process_punctuation(ansDic["answer"])
-                ansDic["answer"] = eval_ai_processor.process_digit_article(ansDic["answer"])
-            resAns = eval_ai_processor.process_punctuation(resAns)
-            resAns = eval_ai_processor.process_digit_article(resAns)
+        for ansDic in doc["answers"]:
+            ansDic["answer"] = eval_ai_processor.process_punctuation(ansDic["answer"])
+            ansDic["answer"] = eval_ai_processor.process_digit_article(ansDic["answer"])
+        resAns = eval_ai_processor.process_punctuation(resAns)
+        resAns = eval_ai_processor.process_digit_article(resAns)
 
         for gtAnsDatum in doc["answers"]:
             otherGTAns = [item for item in doc["answers"] if item != gtAnsDatum]


### PR DESCRIPTION
The current implementation doesn't normalize reference and candidate answers when all the reference answers are identical (i.e., when `len(set(gtAnswers)) == 1`). However, this could be the case while a correct candidate answer has a different format compared to the references, incorrectly leading to an `exact_match` score of 0.

Example:
```
reference answers: ['black', 'black', 'black', 'black', 'black', 'black', 'black', 'black', 'black', 'black']
candidate answer: 'Black.'
expected score: 1.0
current score: 0.0
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Standardized answer normalization in VQAv2 evaluation, applying punctuation and digit/article handling to all predictions and ground truths. This removes edge-case discrepancies when ground-truth answers vary, resulting in more consistent and reliable accuracy scores across runs and datasets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->