### PR TITLE
[bugfix] fix bug in srt_api.py

### DIFF
--- a/lmms_eval/models/simple/srt_api.py
+++ b/lmms_eval/models/simple/srt_api.py
@@ -182,7 +182,7 @@ class SRT_API(lmms):
                     imgs = None
                     break
 
-        time_instruciton = f"The video lasts for {video_time:.2f} seconds, and {len(frames)} frames are uniformly sampled from it. These frames are located at {frame_time}.Please answer the following questions related to this video."
+                time_instruciton = f"The video lasts for {video_time:.2f} seconds, and {len(frames)} frames are uniformly sampled from it. These frames are located at {frame_time}.Please answer the following questions related to this video."
         if self.add_time_instruction:
             contexts = f"{time_instruciton}\n{contexts}"
         else:
@@ -243,7 +243,7 @@ class SRT_API(lmms):
                     imgs = None
                     break
 
-        time_instruciton = f"The video lasts for {video_time:.2f} seconds, and {len(frames)} frames are uniformly sampled from it. These frames are located at {frame_time}.Please answer the following questions related to this video."
+                time_instruciton = f"The video lasts for {video_time:.2f} seconds, and {len(frames)} frames are uniformly sampled from it. These frames are located at {frame_time}.Please answer the following questions related to this video."
         if self.add_time_instruction:
             contexts = f"{time_instruciton}\n{contexts}"
         else:

--- a/lmms_eval/models/simple/srt_api.py
+++ b/lmms_eval/models/simple/srt_api.py
@@ -182,9 +182,9 @@ class SRT_API(lmms):
                     imgs = None
                     break
 
-                time_instruciton = f"The video lasts for {video_time:.2f} seconds, and {len(frames)} frames are uniformly sampled from it. These frames are located at {frame_time}.Please answer the following questions related to this video."
-        if self.add_time_instruction:
-            contexts = f"{time_instruciton}\n{contexts}"
+                time_instruction = f"The video lasts for {video_time:.2f} seconds, and {len(frames)} frames are uniformly sampled from it. These frames are located at {frame_time}.Please answer the following questions related to this video."
+        if self.add_time_instruction and self.modality == "video" and imgs is not None:
+            contexts = f"{time_instruction}\n{contexts}"
         else:
             contexts = f"{contexts}"
         # Handling video decode error
@@ -243,9 +243,9 @@ class SRT_API(lmms):
                     imgs = None
                     break
 
-                time_instruciton = f"The video lasts for {video_time:.2f} seconds, and {len(frames)} frames are uniformly sampled from it. These frames are located at {frame_time}.Please answer the following questions related to this video."
-        if self.add_time_instruction:
-            contexts = f"{time_instruciton}\n{contexts}"
+                time_instruction = f"The video lasts for {video_time:.2f} seconds, and {len(frames)} frames are uniformly sampled from it. These frames are located at {frame_time}.Please answer the following questions related to this video."
+        if self.add_time_instruction and self.modality == "video" and imgs is not None:
+            contexts = f"{time_instruction}\n{contexts}"
         else:
             contexts = f"{contexts}"
         # Handling video decode error


### PR DESCRIPTION
Fix bug in `srt_api.py`, after fixing it, the problem in https://github.com/EvolvingLMMs-Lab/lmms-eval/issues/823 is solved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed a typo and corrected behavior so the time annotation is only inserted for video inputs when the "add time instruction" option is enabled and image frames are present; non-video modalities remain unchanged.

- **Chores**
  - Minor formatting/indentation cleanup across generation paths. No changes to error handling, outputs, or public interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->