### PR TITLE
Fix TypeError when using write_out with log_samples

### DIFF
--- a/lmms_eval/evaluator_utils.py
+++ b/lmms_eval/evaluator_utils.py
@@ -180,9 +180,11 @@ def print_writeout(task) -> None:
     for inst in task.instances:
         # print the prompt for the first few documents
         if inst.doc_id < 1:
+            # Handle cases where inst.doc might be None (e.g., when using log_samples)
+            target = "N/A (document is None)" if inst.doc is None else task.doc_to_target(inst.doc)
             eval_logger.info(
                 f"Task: {task}; document {inst.doc_id}; context prompt (starting on next line):\
-    \n{inst.args[0]}\n(end of prompt on previous line)\ntarget string or answer choice index (starting on next line):\n{task.doc_to_target(inst.doc)}\n(end of target on previous line)"
+    \n{inst.args[0]}\n(end of prompt on previous line)\ntarget string or answer choice index (starting on next line):\n{target}\n(end of target on previous line)"
             )
             eval_logger.info(f"Request: {str(inst)}")
 


### PR DESCRIPTION
## Summary
- Fixed TypeError that occurs when both `--write_out` and `--log_samples` flags are used together
- Added null check for `inst.doc` before calling `doc_to_target()`
- Provides fallback message "N/A (document is None)" when document is None

## Problem
When using both `--write_out` and `--log_samples` flags, the `print_writeout` function in `evaluator_utils.py` encounters instances where `inst.doc` is `None`. This causes a TypeError when the code tries to call `task.doc_to_target(inst.doc)`, as the method attempts to access `doc[doc_to_target]` on a None object.

Error message:
```
File "/lmms_eval/api/task.py", line 1347, in doc_to_target
    return doc[doc_to_target]
TypeError: 'NoneType' object is not subscriptable
```

## Solution
Added a conditional check in the `print_writeout` function to handle None documents gracefully. When `inst.doc` is None, it displays "N/A (document is None)" instead of attempting to call `doc_to_target()`.

## Test plan
- [x] Code change is minimal and focused
- [x] Fix prevents the TypeError from occurring
- [x] Maintains existing functionality when document is not None
- [ ] Users should test with their specific task configurations that previously failed

This issue was reported by multiple users running various multimodal evaluation tasks with both flags enabled.

Fixes #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)