### PR TITLE
[fix] reord back to original for openai_compatible

### DIFF
--- a/lmms_eval/models/simple/openai_compatible.py
+++ b/lmms_eval/models/simple/openai_compatible.py
@@ -319,6 +319,7 @@ class OpenAICompatible(lmms):
             res.extend([r for r in batch_responses if r is not None])
             pbar.update(1)
 
+        res = re_ords.get_original(res)
         pbar.close()
         return res
 


### PR DESCRIPTION
this pr fixes the bug introduced by #835, where the resps are in random order and cannot match the original docs. reord back to original for openai_compatible fixes this bug.

please consider bumping version after the pr is merged, as the current openai_compatible is not functional.