### PR TITLE
[bug fix] fix a bug that occurs when needing to load local modeling_xxx_model.py

### DIFF
--- a/lmms_eval/models/chat/sglang.py
+++ b/lmms_eval/models/chat/sglang.py
@@ -63,7 +63,7 @@ class Sglang(lmms):
 
         # Set up sglang client
         self.client = Engine(model_path=model, tp_size=tensor_parallel_size, mem_fraction_static=gpu_memory_utilization, trust_remote_code=trust_remote_code, **kwargs)
-        self.processor = AutoProcessor.from_pretrained(model)
+        self.processor = AutoProcessor.from_pretrained(model, trust_remote_code=trust_remote_code)
 
         accelerator = Accelerator()
         if accelerator.num_processes > 1:


### PR DESCRIPTION
This bug occurs when using sglang to eval vlms and need to load local modeling_xxx_modeling.py file, the problem is that trust_remote_code argument do not correctly pass to the sglang Engine, the line I modified didn't pass the trust_remote_code argument, so I change the code to specifically pass this argument


Without this change, the error logs are as following:
Traceback (most recent call last):
  File "/data2/user/guangshuoqin/code/lmms-eval/lmms_eval/__main__.py", line 348, in cli_evaluate
    results, samples = cli_evaluate_single(args)
  File "/data2/user/guangshuoqin/code/lmms-eval/lmms_eval/__main__.py", line 482, in cli_evaluate_single
    results = evaluator.simple_evaluate(
  File "/data2/user/guangshuoqin/code/lmms-eval/lmms_eval/utils.py", line 536, in _wrapper
    return fn(*args, **kwargs)
  File "/data2/user/guangshuoqin/code/lmms-eval/lmms_eval/evaluator.py", line 189, in simple_evaluate
    lm = lmms_eval.models.get_model(model, force_simple).create_from_arg_string(
  File "/data2/user/guangshuoqin/code/lmms-eval/lmms_eval/api/model.py", line 307, in create_from_arg_string
    return cls(**args, **args2)
  File "/data2/user/guangshuoqin/code/lmms-eval/lmms_eval/models/chat/sglang.py", line 69, in __init__
    self.client = Engine(model_path=model, tp_size=tensor_parallel_size, mem_fraction_static=gpu_memory_utilization, **kwargs)
  File "/data2/user/guangshuoqin/code/lmms-eval/.venv/lib/python3.10/site-packages/sglang/api.py", line 46, in Engine
    return Engine(*args, **kwargs)
  File "/data2/user/guangshuoqin/code/lmms-eval/.venv/lib/python3.10/site-packages/sglang/srt/entrypoints/engine.py", line 124, in __init__
    tokenizer_manager, template_manager, scheduler_info = _launch_subprocesses(
  File "/data2/user/guangshuoqin/code/lmms-eval/.venv/lib/python3.10/site-packages/sglang/srt/entrypoints/engine.py", line 794, in _launch_subprocesses
    tokenizer_manager = TokenizerManager(server_args, port_args)
  File "/data2/user/guangshuoqin/code/lmms-eval/.venv/lib/python3.10/site-packages/sglang/srt/managers/tokenizer_manager.py", line 211, in __init__
    _processor = get_processor(
  File "/data2/user/guangshuoqin/code/lmms-eval/.venv/lib/python3.10/site-packages/sglang/srt/hf_transformers_utils.py", line 319, in get_processor
    processor = AutoProcessor.from_pretrained(
  File "/data2/user/guangshuoqin/code/lmms-eval/.venv/lib/python3.10/site-packages/transformers/models/auto/processing_auto.py", line 365, in from_pretrained
    trust_remote_code = resolve_trust_remote_code(
  File "/data2/user/guangshuoqin/code/lmms-eval/.venv/lib/python3.10/site-packages/transformers/dynamic_module_utils.py", line 748, in resolve_trust_remote_code
    raise ValueError(
ValueError: The repository /data/models/Kimi-VL-A3B-Instruct contains custom code which must be executed to correctly load the model. You can inspect the repository content at /data/models/Kimi-VL-A3B-Instruct .
 You can inspect the repository content at https://hf.co//data/models/Kimi-VL-A3B-Instruct.
Please pass the argument `trust_remote_code=True` to allow custom code to be run.

