### PR TITLE
[Bugfix] mlvu_doc_to_text  'NoneType' object has no attribute 'get'

### DIFF
--- a/lmms_eval/tasks/mlvu/utils.py
+++ b/lmms_eval/tasks/mlvu/utils.py
@@ -62,6 +62,8 @@ def mlvu_doc_to_visual_test(doc):
 
 
 def mlvu_doc_to_text(doc, lmms_eval_specific_kwargs=None):
+    if lmms_eval_specific_kwargs is None:
+        lmms_eval_specific_kwargs = {}
     question = doc["question"]
     pre_prompt = lmms_eval_specific_kwargs.get("pre_prompt", "")
     post_prompt = lmms_eval_specific_kwargs.get("post_prompt", "")


### PR DESCRIPTION
## Detailed Description

- Fix mlvu bug
- lmms_eval version: 0.5.0

when using get_task_dict function, I encountered `AttributeError: 'NoneType' object has no attribute 'get'` error.
```
from lmms_eval.tasks import get_task_dict
task_dict = get_task_dict(["mlvu_test"])
```

```
def mlvu_doc_to_text(doc, lmms_eval_specific_kwargs=None):
    question = doc["question"]
    pre_prompt = lmms_eval_specific_kwargs.get("pre_prompt", "")   # <----- None object could not have .get method
    post_prompt = lmms_eval_specific_kwargs.get("post_prompt", "")
    full_prompt = pre_prompt + question + post_prompt
    return full_prompt
```


<img width="597" height="69" alt="image" src="https://github.com/user-attachments/assets/a8b7605c-c2e7-4525-b4a1-b1b8f58d6e13" />


---


Before you open a pull-request, please check if a similar issue already exists or has been closed before.

### When you open a pull-request, please be sure to include the following

- [x] A descriptive title: [xxx] XXXX
- [x] A detailed description

If you meet the lint warnings, you can use following scripts to reformat code.

```sh
pip install pre-commit
pre-commit install
pre-commit run --all-files
```

Thank you for your contributions!
