### PR TITLE
Fix data loading for coco_karpathy_test

### DIFF
--- a/lmms_eval/tasks/coco_cap/coco_karpathy_test.yaml
+++ b/lmms_eval/tasks/coco_cap/coco_karpathy_test.yaml
@@ -4,7 +4,7 @@ dataset_kwargs:
 task: "coco_karpathy_test"
 test_split: test
 output_type: generate_until
-doc_to_visual: !function utils.coco_doc_to_visual
+doc_to_visual: !function utils.coco_doc_to_visual_karpathy
 doc_to_text: "Describe the image briefly."
 doc_to_target: "answer"
 generation_kwargs:


### PR DESCRIPTION
Change doc_to_visual function() for Karpathy test to coco_doc_to_visual_karpathy(). Previously it used the coco2014/2017 split doc_to_visual function which expects images but the karpathy split has only urls and hence fails. This fix solves the problem.
