### PR TITLE
fix hallusionbench processing for distributed eval

### DIFF
--- a/lmms_eval/tasks/hallusion_bench/evaluate_hb.py
+++ b/lmms_eval/tasks/hallusion_bench/evaluate_hb.py
@@ -34,8 +34,7 @@ def hb_doc_to_visual(doc):
 
 
 def hb_process_results(doc, result):
-    sample = doc
-    doc.pop("image")
+    sample = {k: v for k, v in doc.items() if k != "image"}
     sample["model_prediction"] = result[0]
     return {k: sample for k in metric}
 


### PR DESCRIPTION
The previous code uses an unsafe way to remove the image key from the sample set. Yet, since the same image is used multiple times for eval the script fails, specifically when doing a distributed eval across several GPUs. Instead the new function remove just from the copy not from the original dict.
