### PR TITLE
Fix Qwen2.5VL and Qwen3VL  to handle batch size >1

### DIFF
--- a/lmms_eval/models/chat/qwen2_5_vl.py
+++ b/lmms_eval/models/chat/qwen2_5_vl.py
@@ -66,7 +66,7 @@ class Qwen2_5_VL(Qwen2_5_VLSimple):
             else:
                 video_kwargs["nframes"] = self.max_num_frames
             batched_messages = [chat_message.to_hf_messages(video_kwargs=video_kwargs) for chat_message in chat_messages]
-            texts = [self.processor.apply_chat_template(msg, tokenize=False, add_generation_prompt=True) for msg in batched_messages]
+            texts = self.processor.apply_chat_template(batched_messages, tokenize=False, add_generation_prompt=True)
             image_inputs, video_inputs = process_vision_info(batched_messages)
             if video_inputs is not None:
                 total_frames = video_inputs[0].shape[0]
@@ -75,7 +75,8 @@ class Qwen2_5_VL(Qwen2_5_VLSimple):
                 if total_frames - 1 not in indices:
                     indices = np.append(indices, total_frames - 1)
                 video_inputs[0] = video_inputs[0][indices]
-            inputs = self.processor(text=texts, images=image_inputs, videos=video_inputs, padding=True, return_tensors="pt")
+            padding_side = "left" if self.batch_size > 1 else "right"
+            inputs = self.processor(text=texts, images=image_inputs, videos=video_inputs, padding=True, padding_side=padding_side, return_tensors="pt")
 
             if self.device_map == "auto":
                 inputs = inputs.to("cuda")

--- a/lmms_eval/models/simple/qwen2_5_vl.py
+++ b/lmms_eval/models/simple/qwen2_5_vl.py
@@ -282,7 +282,7 @@ class Qwen2_5_VL(lmms):
 
                 batched_messages.append(message)
 
-            texts = [self.processor.apply_chat_template(msg, tokenize=False, add_generation_prompt=True) for msg in batched_messages]
+            texts = self.processor.apply_chat_template(batched_messages, tokenize=False, add_generation_prompt=True)
             image_inputs, video_inputs = process_vision_info(batched_messages)
             if video_inputs is not None:
                 total_frames = video_inputs[0].shape[0]
@@ -294,8 +294,8 @@ class Qwen2_5_VL(lmms):
                     indices = np.append(indices, total_frames - 1)
                     indices = np.unique(indices)  # Ensure uniqueness again
                 video_inputs[0] = video_inputs[0][indices]
-            inputs = self.processor(text=texts, images=image_inputs, videos=video_inputs, padding=True, return_tensors="pt")
-
+            padding_side = "left" if self.batch_size > 1 else "right"
+            inputs = self.processor(text=texts, images=image_inputs, videos=video_inputs, padding=True, padding_side=padding_side, return_tensors="pt")
             if self.device_map == "auto":
                 inputs = inputs.to("cuda")
             else:

--- a/lmms_eval/models/simple/qwen3_vl.py
+++ b/lmms_eval/models/simple/qwen3_vl.py
@@ -285,8 +285,7 @@ class Qwen3_VL(lmms):
                     )
 
                 batched_messages.append(message)
-
-            texts = [self.processor.apply_chat_template(msg, tokenize=False, add_generation_prompt=True) for msg in batched_messages]
+            texts = self.processor.apply_chat_template(batched_messages, tokenize=False, add_generation_prompt=True)
             image_inputs, video_inputs = process_vision_info(batched_messages)
             if video_inputs is not None:
                 total_frames = video_inputs[0].shape[0]
@@ -298,7 +297,8 @@ class Qwen3_VL(lmms):
                     indices = np.append(indices, total_frames - 1)
                     indices = np.unique(indices)  # Ensure uniqueness again
                 video_inputs[0] = video_inputs[0][indices]
-            inputs = self.processor(text=texts, images=image_inputs, videos=video_inputs, padding=True, return_tensors="pt")
+            padding_side = "left" if self.batch_size > 1 else "right"
+            inputs = self.processor(text=texts, images=image_inputs, videos=video_inputs, padding=True, padding_side=padding_side, return_tensors="pt")
 
             if self.device_map == "auto":
                 inputs = inputs.to("cuda")


### PR DESCRIPTION
Tiny fix for padding_side='right' when batch_size > 1

Example results with batch_size=32
```
qwen3_vl (pretrained=Qwen/Qwen3-VL-4B-Instruct,max_pixels=1605632,attn_implementation=flash_attention_2,interleave_visuals=False), gen_kwargs: (max_new_tokens=512,top_p=0.8,top_k=20,temperature=0.7,repetition_penalty=1.0,presence_penalty=1.5), limit: None, num_fewshot: None, batch_size: 32
|   Tasks   |Version|     Filter     |n-shot|        Metric         |   |Value |   |Stderr|
|-----------|-------|----------------|-----:|-----------------------|---|-----:|---|------|
|mmmu_val   |      0|none            |     0|mmmu_acc               |↑  |0.5256|±  |   N/A|
|mmstar     |Yaml   |none            |     0|average                |↑  |0.5850|±  |   N/A|
|ocrbench   |Yaml   |none            |     0|ocrbench_accuracy      |↑  |0.8650|±  |   N/A|
|realworldqa|Yaml   |flexible-extract|     0|exact_match            |↑  |0.7098|±  |0.0164|
```