### PR TITLE
[bugfix] Fix nested dictionary input for vllm mm_processor_kwargs

### DIFF
--- a/lmms_eval/utils.py
+++ b/lmms_eval/utils.py
@@ -117,13 +117,13 @@ def sanitize_list(sub):
 def _smart_comma_split(args_string):
     """
     Splits a string by comma, but not if inside quotes or braces.
-    
-    This is useful for parsing argument strings that may contain JSON or 
+
+    This is useful for parsing argument strings that may contain JSON or
     other structured values with nested commas.
-    
+
     Args:
         args_string: The string to split
-        
+
     Returns:
         List of split arguments
     """
@@ -160,7 +160,7 @@ def _smart_comma_split(args_string):
     arg = "".join(current_arg).strip()
     if arg:
         arg_list.append(arg)
-    
+
     return arg_list
 
 


### PR DESCRIPTION
### Description

Hi folks, I found parsing error as belows. please check this PR 😉 


**[Input Example]**
```
python -m lmms_eval \
        --model vllm \
        --model_args model=OpenGVLab/InternVL3-8B,tensor_parallel_size=1,data_parallel_size=1,gpu_memory_utilization=0.85,mm_processor_kwargs='{"max_dynamic_patch":4, "min_dynamic_patch":4}',limit_mm_per_prompt='{"image":32}',max_frame_num=8 \
        --tasks mvbench \
        --batch_size 2 \
        --output_path ./logs/log1 --log_samples --log_samples_suffix suffix
```

**[Error Detail]**
```
INFO 11-27 20:07:31 [__init__.py:235] Automatically detected platform cuda.
Traceback (most recent call last):
  File "/home/donguk.lim/edgefm-serve/.venv/lib/python3.12/site-packages/lmms_eval/__main__.py", line 349, in cli_evaluate
    results, samples = cli_evaluate_single(args)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/donguk.lim/edgefm-serve/.venv/lib/python3.12/site-packages/lmms_eval/__main__.py", line 484, in cli_evaluate_single
    results = evaluator.simple_evaluate(
              ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/donguk.lim/edgefm-serve/.venv/lib/python3.12/site-packages/lmms_eval/utils.py", line 536, in _wrapper
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
  File "/home/donguk.lim/edgefm-serve/.venv/lib/python3.12/site-packages/lmms_eval/evaluator.py", line 189, in simple_evaluate
    lm = lmms_eval.models.get_model(model, force_simple).create_from_arg_string(
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/donguk.lim/edgefm-serve/.venv/lib/python3.12/site-packages/lmms_eval/api/model.py", line 304, in create_from_arg_string
    args = utils.simple_parse_args_string(arg_string)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/donguk.lim/edgefm-serve/.venv/lib/python3.12/site-packages/lmms_eval/utils.py", line 127, in simple_parse_args_string
    args_dict = {k: handle_arg_string(v) for k, v in [arg.split("=") for arg in arg_list]}
                                             ^^^^
ValueError: not enough values to unpack (expected 2, got 1)
2025-11-27 20:07:31 | ERROR    | __main__:cli_evaluate:371 - Error during evaluation: not enough values to unpack (expected 2, got 1). Please set `--verbosity=DEBUG` to get more information.
```

The error occurs in the part '{"max_dynamic_patch":4, "min_dynamic_patch":4}' because it contains a nested dictionary.
However, vLLM CLI arguments allow dictionary inputs.
Therefore, apply the following changes to support nested dictionary parsing.

**[Reference Code]**
- vLLM mm_processor_kwargs parameter type: `dict`
https://docs.vllm.ai/en/latest/api/vllm/engine/arg_utils/#vllm.engine.arg_utils.EngineArgs.mm_processor_kwargs

### Ask for review
General: @Luodian @kcz358 @pufanyi
