### PR TITLE
Fix: Handle empty model responses in take_first_k filter to prevent index errors

### DIFF
--- a/lmms_eval/filters/selection.py
+++ b/lmms_eval/filters/selection.py
@@ -19,7 +19,7 @@ class TakeFirstFilter(Filter):
         """
         Assuming each entry of `resps` is a list of model responses, we discard all but the first response.
         """
-        return map(lambda r: r[0], resps)
+        return map(lambda r: r[0] if r else "", resps)
 
 
 @register_filter("take_first_k")


### PR DESCRIPTION
Before you open a pull-request, please check if a similar issue already exists or has been closed before.





### **PR Description**

This PR updates the `take_first_k` filter to safely handle cases where a model response list may be empty. Previously, the implementation directly accessed `r[0]`, which could raise an `IndexError` when `r` contained no elements.

####  Changes

* Updated the lambda function to return the first response **only if** the response list is non-empty
* Fallback to an empty string (`""`) when the response list is empty

```diff
-return map(lambda r: r[0], resps)
+return map(lambda r: r[0] if r else "", resps)
```

####  Why this matters

* Prevents runtime errors when evaluating model outputs with missing responses
* Improves robustness of the filtering mechanism across datasets and edge cases


### When you open a pull-request, please be sure to include the following

- [ ] A descriptive title: [xxx] XXXX
- [ ] A detailed description

If you meet the lint warnings, you can use following scripts to reformat code.

```sh
pip install pre-commit
pre-commit install
pre-commit run --all-files
```

### Ask for review
Once you feel comfortable for your PR, feel free to @ one of the contributors to review

General: @Luodian @kcz358 @pufanyi
Audio: @pbcong @ngquangtrung57

Thank you for your contributions!
