### PR TITLE
Update simple qwen3_vl.py  processor

### DIFF
--- a/lmms_eval/tasks/mmstar/utils.py
+++ b/lmms_eval/tasks/mmstar/utils.py
@@ -50,6 +50,7 @@ def mmstar_oc_doc_to_text(doc, lmms_eval_specific_kwargs=None):
     post_prompt = lmms_eval_specific_kwargs.get("post_prompt", "")
 
     question = doc["question"]
+    question = question.replace("<image 1>", "")
     options = {cand: doc[cand] for cand in string.ascii_uppercase if cand in doc}
 
     options_prompt = "Options:\n"


### PR DESCRIPTION
Update qwen3_vl processor (simple version) with image_patch_size=16
Minor update for MMstar bench (remove <image 1> token from the question)

MMStar results:

**Qwen3-VL-2B-Instruct: 57.03 (vs 58.3 reported)**
```
qwen3_vl (pretrained=Qwen/Qwen3-VL-2B-Instruct,attn_implementation=flash_attention_2,max_pixels=8388608,min_pixels=1048576), gen_kwargs: (), limit: None, num_fewshot: None, batch_size: 1
|  Tasks  |Version|Filter|n-shot|        Metric         |   |Value |   |Stderr|
|---------|-------|------|-----:|-----------------------|---|-----:|---|------|
|mmstar_oc|Yaml   |none  |     0|average                |↑  |0.5703|±  |   N/A|
|mmstar_oc|Yaml   |none  |     0|coarse perception      |↑  |0.7495|±  |   N/A|
|mmstar_oc|Yaml   |none  |     0|fine-grained perception|↑  |0.5888|±  |   N/A|
|mmstar_oc|Yaml   |none  |     0|instance reasoning     |↑  |0.6615|±  |   N/A|
|mmstar_oc|Yaml   |none  |     0|logical reasoning      |↑  |0.4454|±  |   N/A|
|mmstar_oc|Yaml   |none  |     0|math                   |↑  |0.5450|±  |   N/A|
|mmstar_oc|Yaml   |none  |     0|science & technology   |↑  |0.4315|±  |   N/A|
```

**Qwen3-VL-4B-Instruct: 63.32 (vs 69.8 reported)**
```
qwen3_vl (pretrained=Qwen/Qwen3-VL-4B-Instruct,attn_implementation=flash_attention_2,max_pixels=8388608,min_pixels=1179648), gen_kwargs: (), limit: None, num_fewshot: None, batch_size: 1
|  Tasks  |Version|Filter|n-shot|        Metric         |   |Value |   |Stderr|
|---------|-------|------|-----:|-----------------------|---|-----:|---|------|
|mmstar_oc|Yaml   |none  |     0|average                |↑  |0.6332|±  |   N/A|
|mmstar_oc|Yaml   |none  |     0|coarse perception      |↑  |0.7816|±  |   N/A|
|mmstar_oc|Yaml   |none  |     0|fine-grained perception|↑  |0.6267|±  |   N/A|
|mmstar_oc|Yaml   |none  |     0|instance reasoning     |↑  |0.7160|±  |   N/A|
|mmstar_oc|Yaml   |none  |     0|logical reasoning      |↑  |0.6472|±  |   N/A|
|mmstar_oc|Yaml   |none  |     0|math                   |↑  |0.5147|±  |   N/A|
|mmstar_oc|Yaml   |none  |     0|science & technology   |↑  |0.5133|±  |   N/A|
```
**Qwen3-VL-8B-Instruct: 67.41 (vs 70.9 reported)**
```
qwen3_vl (pretrained=Qwen/Qwen3-VL-8B-Instruct,attn_implementation=flash_attention_2,max_pixels=8388608,min_pixels=2490368), gen_kwargs: (), limit: None, num_fewshot: None, batch_size: 1
|  Tasks  |Version|Filter|n-shot|        Metric         |   |Value |   |Stderr|
|---------|-------|------|-----:|-----------------------|---|-----:|---|------|
|mmstar_oc|Yaml   |none  |     0|average                |↑  |0.6741|±  |   N/A|
|mmstar_oc|Yaml   |none  |     0|coarse perception      |↑  |0.7734|±  |   N/A|
|mmstar_oc|Yaml   |none  |     0|fine-grained perception|↑  |0.6698|±  |   N/A|
|mmstar_oc|Yaml   |none  |     0|instance reasoning     |↑  |0.7755|±  |   N/A|
|mmstar_oc|Yaml   |none  |     0|logical reasoning      |↑  |0.6389|±  |   N/A|
|mmstar_oc|Yaml   |none  |     0|math                   |↑  |0.6675|±  |   N/A|
|mmstar_oc|Yaml   |none  |     0|science & technology   |↑  |0.5192|±  |   N/A|
```

Side note regarding the recently released [Qwen3 technical report](https://arxiv.org/pdf/2511.21631)
- I tried their prompt, it does not work with our greedy decoding strategy. 
- For instruct models, and for the sake of comparison, it’s fairer to use the same sampling strategy.

<img width="512" height="100" alt="Screenshot 2025-12-03 at 11 16 48 PM" src="https://github.com/user-attachments/assets/8e11b833-8b19-45c8-9522-7d530d3757e0" />

<img width="954" height="99" alt="Screenshot 2025-12-03 at 5 31 54 PM" src="https://github.com/user-attachments/assets/ad7c6be3-7816-44b0-b6e0-69a1358af5ce" />