### PR TITLE
[bugfix] Filter unsupported model_kwargs for LLaVA-OneVision-1.5

### DIFF
--- a/lmms_eval/models/chat/llava_onevision1_5.py
+++ b/lmms_eval/models/chat/llava_onevision1_5.py
@@ -100,8 +100,14 @@ class Llava_OneVision1_5(LlavaOneVisionSimple):
             pad_token_id = self.tokenizer.pad_token_id or self.tokenizer.eos_token_id
             do_sample = bool(gen_kwargs.get("temperature", 0) and gen_kwargs["temperature"] > 0)
 
+            # Filter out keys not supported by model.generate()
+            # LLaVA-OneVision-1.5 uses Qwen2_5_VLProcessor which produces second_per_grid_ts,
+            # but the model's forward method does not accept this parameter
+            unsupported_keys = ["second_per_grid_ts"]
+            filtered_inputs = {k: v for k, v in inputs.items() if k not in unsupported_keys}
+
             gen_args = {
-                **inputs,
+                **filtered_inputs,
                 "eos_token_id": self.tokenizer.eos_token_id,
                 "pad_token_id": pad_token_id,
                 "num_beams": gen_kwargs["num_beams"],


### PR DESCRIPTION
## Description

Hi folks, I found a `model_kwargs` error when evaluating LLaVA-OneVision-1.5 on video tasks. Please check this PR 😉

**[Error Detail]**
lmms_eval.models.chat.llava_onevision1_5:generate_until:129 - Error The following `model_kwargs` are not used by the model: ['second_per_grid_ts']
<img width="3287" height="1246" alt="image" src="https://github.com/user-attachments/assets/e13c308a-b2b2-4967-a94c-4b5577e11879" />

**[Root Cause]**

LLaVA-OneVision-1.5 uses `Qwen2_5_VLProcessor` which generates `second_per_grid_ts` (video timestamp info) when processing videos. However, the model's `forward` method (`modeling_llavaonevision1_5.py` line 1801) does not accept this parameter, while the original Qwen2.5-VL does.

This is a model-side inconsistency: using Qwen2.5-VL's processor but not fully implementing its interface.

**[Solution]**

Filter out unsupported keys before passing inputs to `model.generate()`:

```
unsupported_keys = ["second_per_grid_ts"]
filtered_inputs = {k: v for k, v in inputs.items() if k not in unsupported_keys}
```

**[Impact]**

No functional impact. The model's forward method never uses `second_per_grid_ts`, so filtering it only suppresses the error without affecting evaluation results.

### Ask for review

General: @Luodian @kcz358 @pufanyi