### PR TITLE
[TASK] Add VLMs Are Biased benchmark

### DIFF
--- a/lmms_eval/tasks/vlms_are_biased/README.md
+++ b/lmms_eval/tasks/vlms_are_biased/README.md
@@ -1,0 +1,68 @@
+# VLMs Are Biased
+
+## Description
+
+This benchmark tests how prior knowledge in Vision-Language Models (VLMs) affects their accuracy on standard, objective visual tasks of counting and identification. The dataset contains counterfactual images (e.g., an Adidas logo with 4 stripes instead of 3) across 7 diverse domains.
+
+**Paper**: [Vision Language Models are Biased](https://arxiv.org/abs/2505.23941)
+**Project Page**: [vlmsarebiased.github.io](https://vlmsarebiased.github.io)
+**Dataset**: [anvo25/vlms-are-biased](https://huggingface.co/datasets/anvo25/vlms-are-biased)
+
+## Domains
+
+The benchmark covers 7 domains:
+- **Chess/Games**: Chess pieces, Go boards, Xiangqi, Sudoku
+- **Logos**: Nike, Adidas, Maserati, Mercedes-Benz, Audi
+- **Animals**: Mammals and birds with modified limb counts
+- **Optical Illusions**: Ebbinghaus, Müller-Lyer, Ponzo, and others
+- **Patterned Grids**: Dice and tally mark patterns
+- **Flags**: Star and stripe count variations
+- **Game Boards**: Various board games with dimension variations
+
+## Metrics
+
+- **accuracy**: Overall accuracy - how often the model produces the correct answer (matches `ground_truth`)
+- **bias_ratio**: Bias measure - how often the model produces the biased answer (matches `expected_bias`). Lower is better!
+- **accuracy_by_topic**: Per-topic accuracy breakdown (logos, animals, optical illusions, etc.)
+
+## Usage
+
+```bash
+python -m lmms_eval \
+  --model qwen2_5_vl \
+  --model_args pretrained=Qwen/Qwen2.5-VL-3B-Instruct \
+  --tasks vlms_are_biased \
+  --batch_size 1 \
+  --device cuda:0
+```
+
+## Expected Results
+
+According to the paper, state-of-the-art VLMs achieve approximately **17.05% accuracy** on average across domains, indicating strong bias toward memorized knowledge over visual recognition.
+
+**Understanding the Metrics:**
+- **High accuracy, low bias_ratio**: Model correctly uses visual information
+- **Low accuracy, high bias_ratio**: Model is biased toward prior knowledge
+- The paper shows most VLMs have low accuracy and high bias_ratio
+
+## Dataset Fields
+
+The benchmark uses these key fields from the dataset:
+- `prompt`: The question to ask the model (e.g., "Are the horizontal and vertical lines equal in length? Answer in curly brackets, e.g., {Yes} or {No}.")
+- `ground_truth`: The correct answer based on the image (e.g., "Yes" for equal-length lines)
+- `expected_bias`: The answer a biased model would give based on prior knowledge (e.g., "No" for vertical-horizontal illusion)
+- `topic`: The domain/category (e.g., "Optical Illusion", "Logos", "Animals")
+
+## Citation
+
+```bibtex
+@misc{vlmsarebiased,
+  title={Vision Language Models are Biased},
+  author={An Vo and Khai-Nguyen Nguyen and Mohammad Reza Taesiri and Vy Tuong Dang and Anh Totti Nguyen and Daeyoung Kim},
+  year={2025},
+  eprint={2505.23941},
+  archivePrefix={arXiv},
+  primaryClass={cs.LG},
+  url={https://arxiv.org/abs/2505.23941},
+}
+```

--- a/lmms_eval/tasks/vlms_are_biased/__init__.py
+++ b/lmms_eval/tasks/vlms_are_biased/__init__.py
@@ -1,0 +1,1 @@
+"""VLMs Are Biased task implementation."""

--- a/lmms_eval/tasks/vlms_are_biased/utils.py
+++ b/lmms_eval/tasks/vlms_are_biased/utils.py
@@ -1,0 +1,119 @@
+"""Utility functions for VLMs Are Biased benchmark."""
+
+from collections import defaultdict
+from typing import Any, Dict, Optional
+
+
+def vlms_are_biased_doc_to_visual(doc: dict[str, Any]) -> list:
+    """Extract image from document.
+
+    Args:
+        doc: Document containing image field
+
+    Returns:
+        List containing the RGB image
+    """
+    return [doc["image"].convert("RGB")]
+
+
+def vlms_are_biased_doc_to_text(doc: dict[str, Any], lmms_eval_specific_kwargs: Optional[Dict[str, str]] = None) -> str:
+    """Format question text with optional prompt additions.
+
+    Args:
+        doc: Document containing prompt field
+        lmms_eval_specific_kwargs: Optional pre/post prompts
+
+    Returns:
+        Formatted question string
+    """
+    if lmms_eval_specific_kwargs is None:
+        lmms_eval_specific_kwargs = {}
+
+    # Use the prompt field directly from the dataset
+    prompt = doc.get("prompt", "")
+
+    # Allow optional pre/post prompts (for experimental variations)
+    pre_prompt = lmms_eval_specific_kwargs.get("pre_prompt", "")
+    post_prompt = lmms_eval_specific_kwargs.get("post_prompt", "")
+
+    return f"{pre_prompt}{prompt}{post_prompt}"
+
+
+def vlms_are_biased_process_results(doc: dict[str, Any], results: list[str]) -> dict[str, Any]:
+    """Process model results and compute accuracy and bias ratio.
+
+    Args:
+        doc: Document containing ground truth and expected bias
+        results: List containing model prediction
+
+    Returns:
+        Dictionary with accuracy and bias_ratio metrics
+    """
+    pred = results[0].strip()
+    ground_truth = str(doc["ground_truth"]).strip()
+    expected_bias = str(doc["expected_bias"]).strip()
+    topic = doc.get("topic", "unknown")
+
+    # Normalize for comparison (case-insensitive, handle Yes/No in braces)
+    pred_normalized = pred.lower().strip("{}").strip()
+    gt_normalized = ground_truth.lower().strip("{}").strip()
+    bias_normalized = expected_bias.lower().strip("{}").strip()
+
+    # Check for exact match with ground truth
+    is_correct = pred_normalized == gt_normalized
+
+    # Also check if prediction matches expected bias (measures bias)
+    matches_bias = pred_normalized == bias_normalized
+
+    # Try to extract and compare numbers if exact match fails
+    if not is_correct and not matches_bias:
+        pred_numbers = "".join(c for c in pred_normalized if c.isdigit())
+        gt_numbers = "".join(c for c in gt_normalized if c.isdigit())
+        bias_numbers = "".join(c for c in bias_normalized if c.isdigit())
+
+        if pred_numbers and gt_numbers:
+            is_correct = pred_numbers == gt_numbers
+        if pred_numbers and bias_numbers:
+            matches_bias = pred_numbers == bias_numbers
+
+    return {
+        "accuracy": float(is_correct),
+        "bias_ratio": float(matches_bias),
+        "accuracy_by_topic": {"topic": topic, "correct": is_correct},
+    }
+
+
+def vlms_are_biased_aggregate_by_topic(
+    results: list[dict[str, Any]],
+) -> dict[str, float]:
+    """Aggregate results by topic.
+
+    Args:
+        results: List of result dictionaries with topic and correctness
+
+    Returns:
+        Dictionary mapping topic names to accuracy scores
+    """
+    topic_correct: dict[str, int] = defaultdict(int)
+    topic_total: dict[str, int] = defaultdict(int)
+
+    for result in results:
+        topic = result["topic"]
+        correct = result["correct"]
+
+        topic_total[topic] += 1
+        if correct:
+            topic_correct[topic] += 1
+
+    # Calculate accuracy per topic
+    topic_accuracy = {}
+    for topic in topic_total:
+        accuracy = topic_correct[topic] / topic_total[topic]
+        topic_accuracy[topic] = accuracy
+
+    # Add overall accuracy
+    total_correct = sum(topic_correct.values())
+    total = sum(topic_total.values())
+    topic_accuracy["overall"] = total_correct / total if total > 0 else 0.0
+
+    return topic_accuracy

--- a/lmms_eval/tasks/vlms_are_biased/vlms_are_biased.yaml
+++ b/lmms_eval/tasks/vlms_are_biased/vlms_are_biased.yaml
@@ -1,0 +1,40 @@
+dataset_path: anvo25/vlms-are-biased
+task: "vlms_are_biased"
+test_split: main
+output_type: generate_until
+
+doc_to_visual: !function utils.vlms_are_biased_doc_to_visual
+doc_to_text: !function utils.vlms_are_biased_doc_to_text
+doc_to_target: "ground_truth"
+
+process_results: !function utils.vlms_are_biased_process_results
+
+generation_kwargs:
+  max_new_tokens: 32
+  temperature: 0
+  top_p: 1.0
+  num_beams: 1
+  do_sample: false
+
+metric_list:
+  - metric: accuracy
+    aggregation: mean
+    higher_is_better: true
+  - metric: bias_ratio
+    aggregation: mean
+    higher_is_better: false
+  - metric: accuracy_by_topic
+    aggregation: !function utils.vlms_are_biased_aggregate_by_topic
+    higher_is_better: true
+
+lmms_eval_specific_kwargs:
+  default:
+    pre_prompt: ""
+    post_prompt: ""
+    use_dataset_prompt: true  # Use the prompt field directly from dataset
+
+metadata:
+  version: 1.0
+  description: "Vision Language Models are Biased benchmark"
+  paper_url: "https://arxiv.org/abs/2505.23941"
+  project_page: "https://vlmsarebiased.github.io"


### PR DESCRIPTION
## “VLMs Are Biased” Benchmark

### Description

This PR adds support for the **VLMs Are Biased** benchmark to `lmms-eval`.

**VLMs Are Biased** is a recent benchmark introduced in  
*Vo et al., 2025 – “Vision Language Models Are Biased”*  
that evaluates a key failure mode in modern VLMs: **bias-driven miscounting and misidentification on counterfactual (CF) images**, where common prior knowledge overrides the actual visual evidence.

The benchmark spans **7 domains**:

1. **Animals** — counting legs on counterfactual 3-legged/5-legged animals  
2. **Logos** — modified signature elements (e.g., 4-stripe Adidas, 5-ring Audi)  
3. **Flags** — added/removed stars and stripes  
4. **Chess** — missing or added pieces in standard setups  
5. **Game boards** — modified Sudoku, Go, xiangqi, and chess boards  
6. **Optical illusions** — original vs. counterfactual illusions
7. **Patterned grids** — anomaly-cell counting biased by global patterns


### Why this benchmark is relevant for LMMS-Eval

- VLMs Are Biased exposes **visual bias** in state-of-the-art VLMs, showing that even top models (GPT-4.1, Sonnet-3.7, Gemini-2.5 Pro, o3, o4-mini) achieve **only 17.05% mean accuracy**, defaulting to prior knowledge **75.7% of the time**.  
- The benchmark includes **systematic counterfactual generation**, strong annotation quality control, and broad domain coverage.  
- It is already being used in industry:  
  **Google DeepMind used VLMs Are Biased to evaluate *Gemini 3 Pro*** (see [their official blog post](https://blog.google/technology/developers/gemini-3-pro-vision/)).  
- Adding this benchmark strengthens lmms-eval’s coverage of robustness, bias, and systematic failure-mode analysis.  
- Its evaluation metrics (accuracy, bias ratio, topic-level accuracy) integrate cleanly into the existing lmms-eval pipeline.

### What this PR includes

**What's included:**

- **`vlms_are_biased.yaml`** — Task configuration file defining:
  - Dataset source and split  
  - Prompt template for visual question answering  
  - Output type and metric definitions  
  - Generation parameters  

- **`utils.py`** — Utility functions implementing:
  - `vlms_are_biased_doc_to_visual()` — extracts image(s) from dataset samples  
  - `vlms_are_biased_doc_to_text()` — formats the question prompt  
  - `vlms_are_biased_process_results()` — parses model outputs and compares against ground truth  
  - `vlms_are_biased_aggregate_results()` — computes aggregate metrics:  
    - **Accuracy:** proportion of correct answers
    - **Bias Ratio:** proportion of expected/biased answers
    - **Accuracy by Topic:** per-category breakdown

- **`README.md`** — Documentation describing:
  - Benchmark overview  
  - Metrics  
  - Usage instructions  

I would be super grateful for your review, @Luodian @kcz358 @pufanyi! Thank you so much for contributing and reviewing!
