### PR TITLE
Add snsbench: Benchmarking Multimodal Large Language Models in Social Networking Services

### DIFF
--- a/lmms_eval/tasks/snsbench/metrics.py
+++ b/lmms_eval/tasks/snsbench/metrics.py
@@ -1,0 +1,139 @@
+"""
+Modified from: https://github.com/HC-Guo/SNS-Bench-VL/blob/main/code/metrics.py
+"""
+
+import re
+import string
+
+import yaml
+from nltk.translate.bleu_score import SmoothingFunction, sentence_bleu
+from rouge_score import rouge_scorer
+from sentence_transformers import SentenceTransformer, util
+
+semantic_model = SentenceTransformer("BAAI/bge-large-en-v1.5")
+
+
+def calculate_answer_accuracy(pred, gt):
+    """
+    计算答案完全匹配准确率
+    """
+    # letters_digits = string.digits + string.ascii_lowercase
+    # pred = "".join([x for x in pred.lower() if x in letters_digits])
+    # gt = "".join([x for x in gt.lower() if x in letters_digits])
+
+    # 'C. Free shipping within the UK...' -> 'C'
+    matches = re.findall(r"\b([A-Za-z])\.", pred)
+    if matches:
+        pred = matches[0]
+    return 1 if pred in gt else 0
+
+
+def calculate_three_level_accuracy(pred, gt):
+    """
+    计算三级准确率（词级别匹配）
+    """
+    ground_truth = gt.split(" ")
+    model_output = pred
+
+    # parse model output: "<text>A C D<text>" -> "A C D"
+    match = re.search(r"([A-Z])\s+([A-Z])\s+([A-Z])", model_output)
+    if match:
+        model_output = match.group(0)
+
+    model_output = model_output.split(" ")
+    match_count = 0
+    max_length = min(len(ground_truth), len(model_output))
+
+    for i in range(max_length):
+        if ground_truth[i] in model_output[i]:
+            match_count += 1
+
+    return match_count / 3 if max_length >= 3 else 0
+
+
+def calculate_multiple_choice_f1(pred, gt):
+    """
+    计算多选题F1分数
+    """
+    # 处理标准答案
+    reference_answers = gt.split(" ")
+    reference_set = set(reference_answers)
+
+    # 处理模型预测结果
+    try:
+        predicted_answers = pred.split(" ")
+    except Exception as e:
+        print(f"处理模型结果时出错: {e}")
+        predicted_answers = []
+
+    predicted_set = set(predicted_answers)
+
+    # 计算TP、FP、FN
+    true_positives = len(reference_set & predicted_set)
+    false_positives = len(predicted_set - reference_set)
+    false_negatives = len(reference_set - predicted_set)
+
+    # 计算精确率、召回率和F1分数
+    precision = true_positives / (true_positives + false_positives) if (true_positives + false_positives) > 0 else 0
+    recall = true_positives / (true_positives + false_negatives) if (true_positives + false_negatives) > 0 else 0
+    f1_score = (2 * precision * recall) / (precision + recall) if (precision + recall) > 0 else 0
+
+    return f1_score
+
+
+def calculate_semantic_similarity(pred, gt):
+    """
+    计算答案和模型输出的语义相似度分数
+    """
+    reference_text = gt
+    predicted_text = pred
+
+    # 生成向量表示
+    embedding1 = semantic_model.encode(reference_text, normalize_embeddings=True)
+    embedding2 = semantic_model.encode(predicted_text, normalize_embeddings=True)
+
+    # 计算余弦相似度
+    similarity_score = float(util.cos_sim(embedding1, embedding2).item())
+
+    return similarity_score
+
+
+def calculate_ocr_metrics(pred, gt, return_detailed=False):
+    """
+    计算答案质量的综合评估指标（ROUGE、BLEU和BGE语义相似度）
+    """
+    reference_text = gt
+    predicted_text = pred
+
+    # 1. 计算ROUGE分数
+    scorer = rouge_scorer.RougeScorer(["rouge1", "rougeL"], use_stemmer=True)
+    rouge_scores = scorer.score(reference_text, predicted_text)
+    rouge_1 = rouge_scores["rouge1"].fmeasure
+    rouge_l = rouge_scores["rougeL"].fmeasure
+    avg_rouge = (rouge_1 + rouge_l) / 2
+
+    # 2. 计算BLEU分数
+    reference_tokens = [list(reference_text)]
+    predicted_tokens = list(predicted_text)
+    bleu_score = sentence_bleu(reference_tokens, predicted_tokens, smoothing_function=SmoothingFunction().method1)
+
+    # 3. 计算BGE语义相似度
+    embedding1 = semantic_model.encode(reference_text, normalize_embeddings=True)
+    embedding2 = semantic_model.encode(predicted_text, normalize_embeddings=True)
+    semantic_score = float(util.cos_sim(embedding1, embedding2).item())
+
+    # 计算综合得分
+    overall_score = (avg_rouge + bleu_score + semantic_score) / 3.0
+
+    if return_detailed:
+        return {"average_rouge": avg_rouge, "bleu_score": bleu_score, "semantic_similarity": semantic_score, "overall_quality": overall_score}
+    else:
+        return overall_score
+
+
+if __name__ == "__main__":
+
+    res = calculate_answer_accuracy("A. ", "A")
+    res = calculate_three_level_accuracy("A C B", "A B C")
+    res = calculate_multiple_choice_f1("A C B", "A B C")
+    res = calculate_semantic_similarity("helly my friends", "hello buddies")

--- a/lmms_eval/tasks/snsbench/snsbench.yaml
+++ b/lmms_eval/tasks/snsbench/snsbench.yaml
@@ -1,0 +1,69 @@
+dataset_path: morpheushoc/SNS-Bench-VL
+dataset_kwargs:
+  token: True
+task: "snsbench"
+test_split: test
+output_type: generate_until
+doc_to_visual: !function utils.doc_to_visual
+doc_to_text: !function utils.doc_to_text
+doc_to_target: "answer"
+generation_kwargs:
+  max_new_tokens: 2048 # longest answer has 1769 chars
+  temperature: 0
+  top_p: 1.0
+  num_beams: 1
+  do_sample: false
+process_results: !function utils.process_results
+metric_list:
+  - metric: average
+    aggregation: !function utils.sns_aggregate_results
+    higher_is_better: true
+  - metric: note_mrc
+    aggregation: !function utils.sns_aggregate_results
+    higher_is_better: true
+  - metric: note_hashtag_single
+    aggregation: !function utils.sns_aggregate_results
+    higher_is_better: true
+  - metric: note_query_gen
+    aggregation: !function utils.sns_aggregate_results
+    higher_is_better: true
+  - metric: note_taxonomy_three_levels
+    aggregation: !function utils.sns_aggregate_results
+    higher_is_better: true
+  - metric: note_hashtag_multi
+    aggregation: !function utils.sns_aggregate_results
+    higher_is_better: true
+  - metric: note_taxonomy_one_level
+    aggregation: !function utils.sns_aggregate_results
+    higher_is_better: true
+  - metric: note_ocr
+    aggregation: !function utils.sns_aggregate_results
+    higher_is_better: true
+  - metric: note_comment_sub_level
+    aggregation: !function utils.sns_aggregate_results
+    higher_is_better: true
+  - metric: note_querycorr_two_levels
+    aggregation: !function utils.sns_aggregate_results
+    higher_is_better: true
+  - metric: note_comment_primary
+    aggregation: !function utils.sns_aggregate_results
+    higher_is_better: true
+  - metric: note_gender
+    aggregation: !function utils.sns_aggregate_results
+    higher_is_better: true
+  - metric: note_querycorr_five_levels
+    aggregation: !function utils.sns_aggregate_results
+    higher_is_better: true
+lmms_eval_specific_kwargs:
+  default:
+    pre_prompt: ""
+    post_prompt: ""
+  qwen3_vl:
+    format: "qwen3_vl"
+    pre_prompt: ""
+    post_prompt: ""
+metadata:
+  - version: 0.0
+
+
+

--- a/lmms_eval/tasks/snsbench/utils.py
+++ b/lmms_eval/tasks/snsbench/utils.py
@@ -1,0 +1,105 @@
+"""
+SNS-Bench-VL: Benchmarking Multimodal Large Language Models in Social Networking Services
+- HuggingFace dataset: https://huggingface.co/datasets/morpheushoc/SNS-Bench-VL
+- Converted from: https://github.com/HC-Guo/SNS-Bench-VL
+
+@article{guo2025sns,
+  title={SNS-Bench-VL: Benchmarking Multimodal Large Language Models in Social Networking Services},
+  author={Guo, Hongcheng and Xie, Zheyong and Cao, Shaosheng and Wang, Boyang and Liu, Weiting and Le, Anjie and Li, Lei and Li, Zhoujun},
+  journal={arXiv preprint arXiv:2505.23065},
+  year={2025}
+}
+"""
+
+import pandas as pd
+from PIL import Image
+
+from lmms_eval.tasks.snsbench import metrics
+
+metrics_map = {
+    # MRC
+    "note_mrc": "calculate_semantic_similarity",
+    # Hash-tag
+    "note_hashtag_single": "calculate_answer_accuracy",
+    "note_hashtag_multi": "calculate_multiple_choice_f1",
+    # Note-Taxonomy
+    "note_taxonomy_one_level": "calculate_answer_accuracy",
+    "note_taxonomy_three_levels": "calculate_three_level_accuracy",
+    # Note-gender
+    "note_gender": "calculate_answer_accuracy",
+    # Query-corr
+    "note_querycorr_two_levels": "calculate_answer_accuracy",
+    "note_querycorr_five_levels": "calculate_answer_accuracy",
+    # Note-comment
+    "note_comment_primary": "calculate_answer_accuracy",
+    "note_comment_sub_level": "calculate_answer_accuracy",
+    # Note-OCR
+    "note_ocr": "calculate_ocr_metrics",
+    # Note-Query_Gen
+    "note_query_gen": "calculate_answer_accuracy",
+}
+
+
+def doc_to_visual(doc):
+
+    # list of images
+    images = doc["images"]
+    return images
+
+
+def doc_to_text(doc, lmms_eval_specific_kwargs=None):
+
+    if "format" in lmms_eval_specific_kwargs and lmms_eval_specific_kwargs["format"] == "qwen3_vl":
+        return doc_to_text_qwen3vl(doc, lmms_eval_specific_kwargs)
+
+    # already contains everything: intro, question and options
+    question = doc["question"]
+    pre_prompt = lmms_eval_specific_kwargs.get("pre_prompt", "")
+    post_prompt = lmms_eval_specific_kwargs.get("post_prompt", "")
+    prompt = f"{pre_prompt}{question}{post_prompt}"
+    return prompt
+
+
+def doc_to_text_qwen3vl(doc, lmms_eval_specific_kwargs=None):
+    pre_prompt = lmms_eval_specific_kwargs.get("pre_prompt", "")
+    post_prompt = lmms_eval_specific_kwargs.get("post_prompt", "")
+
+    question = doc["question"]
+    prompt = f"{pre_prompt}{question}{post_prompt}"
+    return prompt
+
+
+def process_results(doc, results):
+    """
+    Args:
+        doc: a instance of the eval dataset
+        results: [pred]
+    Returns:
+        a dictionary with key: metric name, value: metric value
+    """
+    pred = results[0]
+    gt = doc["answer"]
+    category = doc["category"]
+
+    metric_func = getattr(metrics, metrics_map[category])
+    score = metric_func(pred, gt)
+    return {category: {"question": doc["question"], "prediction": pred, "ground_truth": gt, "score": score}, "average": {"question": doc["question"], "prediction": pred, "ground_truth": gt, "score": score, "category": category}}
+
+
+def sns_aggregate_results(results):
+    df = pd.DataFrame(results)
+    avg_score = df["score"].mean()
+    return avg_score
+
+
+if __name__ == "__main__":
+
+    from datasets import load_dataset
+
+    ds = load_dataset("morpheushoc/SNS-Bench-VL")["test"]
+
+    doc = ds[10]
+    text = doc_to_text(doc, {})
+    lmms_eval_specific_kwargs = {"format": "qwen3_vl", "pre_prompt": "Question: ", "post_prompt": ""}
+    text1 = doc_to_text(doc, lmms_eval_specific_kwargs)
+    df = ds.to_pandas()


### PR DESCRIPTION
Adding this Multi Image QA benchmark with good reproductible results.


- paper: [SNS-Bench-VL: Benchmarking Multimodal Large Language Models in Social Networking Services](https://arxiv.org/pdf/2505.23065)
- official repo: https://github.com/HC-Guo/SNS-Bench-VL/tree/main
- dataset: https://huggingface.co/datasets/morpheushoc/SNS-Bench-VL

Abstract:
```
With the increasing integration of visual and textual content in Social Networking
Services (SNS), evaluating the multimodal capabilities of Large Language Models (LLMs) is crucial for enhancing user experience, content understanding, and
platform intelligence. Existing benchmarks primarily focus on text-centric tasks,
lacking coverage of the multimodal contexts prevalent in modern SNS ecosystems.
In this paper, we introduce SNS-Bench-VL, a comprehensive multimodal benchmark designed to assess the performance of Vision-Language LLMs in real-world
social media scenarios. SNS-Bench-VL incorporates images and text across 8
multimodal tasks, including note comprehension, user engagement analysis, information retrieval, and personalized recommendation. It comprises 4,001 carefully
curated multimodal question-answer pairs, covering single-choice, multiple-choice,
and open-ended tasks. We evaluate over 25 state-of-the-art multimodal LLMs, analyzing their performance across tasks. Our findings highlight persistent challenges
in multimodal social context comprehension. We hope SNS-Bench-VL will inspire
future research towards robust, context-aware, and human-aligned multimodal
intelligence for next-generation social networking services.
```

Requirements
```
pip3 install ".[qwen]"
pip3 install transformers==4.57.3 flash_attn==2.8.3 rouge_score
```
```
CKPT_PATH='Qwen/Qwen3-VL-2B-Instruct'
MODEL_NAME="qwen3_vl"
TASK='snsbench'
MAX_PIXELS=$((4096 * 32 * 32))
MIN_PIXELS=$((1024 * 32 * 32))


accelerate launch --num_processes 8 --main_process_port 12380 -m lmms_eval \
    --model "$MODEL_NAME" \
    --model_args "pretrained=${CKPT_PATH},attn_implementation=flash_attention_2,max_pixels=${MAX_PIXELS},min_pixels=${MIN_PIXELS}" \
    --tasks "$TASK" \
    --batch_size 1 \
    --log_samples \
    --log_samples_suffix "$TASK_SUFFIX" \
    --output_path ./logs/ \
    --force_simple
```


Results w/ Qwen3VL:
- Qwen3-VL-2B-Instruct
```
qwen3_vl (pretrained=Qwen/Qwen3-VL-2B-Instruct,attn_implementation=flash_attention_2,max_pixels=4194304,min_pixels=1048576), gen_kwargs: (), limit: None, num_fewshot: None, batch_size: 1

| Tasks  |Version|Filter|n-shot|          Metric          |   |Value |   |Stderr|
|--------|-------|------|-----:|--------------------------|---|-----:|---|------|
|snsbench|Yaml   |none  |     0|average                   |↑  |0.6856|±  |   N/A|
|snsbench|Yaml   |none  |     0|note_comment_primary      |↑  |0.3217|±  |   N/A|
|snsbench|Yaml   |none  |     0|note_comment_sub_level    |↑  |0.4550|±  |   N/A|
|snsbench|Yaml   |none  |     0|note_gender               |↑  |0.8571|±  |   N/A|
|snsbench|Yaml   |none  |     0|note_hashtag_multi        |↑  |0.5338|±  |   N/A|
|snsbench|Yaml   |none  |     0|note_hashtag_single       |↑  |0.7974|±  |   N/A|
|snsbench|Yaml   |none  |     0|note_mrc                  |↑  |0.7066|±  |   N/A|
|snsbench|Yaml   |none  |     0|note_ocr                  |↑  |0.8076|±  |   N/A|
|snsbench|Yaml   |none  |     0|note_query_gen            |↑  |0.9318|±  |   N/A|
|snsbench|Yaml   |none  |     0|note_querycorr_five_levels|↑  |0.2817|±  |   N/A|
|snsbench|Yaml   |none  |     0|note_querycorr_two_levels |↑  |0.6024|±  |   N/A|
|snsbench|Yaml   |none  |     0|note_taxonomy_one_level   |↑  |0.7810|±  |   N/A|
|snsbench|Yaml   |none  |     0|note_taxonomy_three_levels|↑  |0.4776|±  |   N/A|
```

- Qwen3-VL-4B-Instruct
```
qwen3_vl (pretrained=Qwen/Qwen3-VL-4B-Instruct,attn_implementation=flash_attention_2,max_pixels=4194304,min_pixels=1048576), gen_kwargs: (), limit: None, num_fewshot: None, batch_size: 1
| Tasks  |Version|Filter|n-shot|          Metric          |   |Value |   |Stderr|
|--------|-------|------|-----:|--------------------------|---|-----:|---|------|
|snsbench|Yaml   |none  |     0|average                   |↑  |0.7381|±  |   N/A|
|snsbench|Yaml   |none  |     0|note_comment_primary      |↑  |0.4957|±  |   N/A|
|snsbench|Yaml   |none  |     0|note_comment_sub_level    |↑  |0.5873|±  |   N/A|
|snsbench|Yaml   |none  |     0|note_gender               |↑  |0.8312|±  |   N/A|
|snsbench|Yaml   |none  |     0|note_hashtag_multi        |↑  |0.6507|±  |   N/A|
|snsbench|Yaml   |none  |     0|note_hashtag_single       |↑  |0.8686|±  |   N/A|
|snsbench|Yaml   |none  |     0|note_mrc                  |↑  |0.7219|±  |   N/A|
|snsbench|Yaml   |none  |     0|note_ocr                  |↑  |0.8520|±  |   N/A|
|snsbench|Yaml   |none  |     0|note_query_gen            |↑  |0.9504|±  |   N/A|
|snsbench|Yaml   |none  |     0|note_querycorr_five_levels|↑  |0.4085|±  |   N/A|
|snsbench|Yaml   |none  |     0|note_querycorr_two_levels |↑  |0.6145|±  |   N/A|
|snsbench|Yaml   |none  |     0|note_taxonomy_one_level   |↑  |0.7896|±  |   N/A|
|snsbench|Yaml   |none  |     0|note_taxonomy_three_levels|↑  |0.5525|±  |   N/A|
```
- Qwen3-VL-8B-Instruct
```
qwen3_vl (pretrained=Qwen/Qwen3-VL-8B-Instruct,attn_implementation=flash_attention_2,max_pixels=4194304,min_pixels=1048576), gen_kwargs: (), limit: None, num_fewshot: None, batch_size: 1
| Tasks  |Version|Filter|n-shot|          Metric          |   |Value |   |Stderr|
|--------|-------|------|-----:|--------------------------|---|-----:|---|------|
|snsbench|Yaml   |none  |     0|average                   |↑  |0.7634|±  |   N/A|
|snsbench|Yaml   |none  |     0|note_comment_primary      |↑  |0.5304|±  |   N/A|
|snsbench|Yaml   |none  |     0|note_comment_sub_level    |↑  |0.7249|±  |   N/A|
|snsbench|Yaml   |none  |     0|note_gender               |↑  |0.8701|±  |   N/A|
|snsbench|Yaml   |none  |     0|note_hashtag_multi        |↑  |0.7162|±  |   N/A|
|snsbench|Yaml   |none  |     0|note_hashtag_single       |↑  |0.8540|±  |   N/A|
|snsbench|Yaml   |none  |     0|note_mrc                  |↑  |0.7259|±  |   N/A|
|snsbench|Yaml   |none  |     0|note_ocr                  |↑  |0.8631|±  |   N/A|
|snsbench|Yaml   |none  |     0|note_query_gen            |↑  |0.9649|±  |   N/A|
|snsbench|Yaml   |none  |     0|note_querycorr_five_levels|↑  |0.3944|±  |   N/A|
|snsbench|Yaml   |none  |     0|note_querycorr_two_levels |↑  |0.5904|±  |   N/A|
|snsbench|Yaml   |none  |     0|note_taxonomy_one_level   |↑  |0.8040|±  |   N/A|
|snsbench|Yaml   |none  |     0|note_taxonomy_three_levels|↑  |0.6331|±  |   N/A|
```



