### PR TITLE
[TASK] Fix task implementation: Vision Language Models are Blind

### DIFF
--- a/lmms_eval/tasks/vlmsareblind/README.md
+++ b/lmms_eval/tasks/vlmsareblind/README.md
@@ -1,98 +1,86 @@
-# VLMs Are Blind
+# Vision Language Models Are Blind
 
 ## Overview
-
-VLMs Are Blind is a benchmark designed to test the visual reasoning capabilities of Vision-Language Models (VLMs) through path-counting tasks in subway connection diagrams. The benchmark reveals fundamental limitations in VLMs' ability to process visual information, showing that many models struggle with basic visual tasks that are trivial for humans.
+This benchmark evaluates whether Vision-Language Models (VLMs) can perform simple low-level visual perception tasks that are trivial for humans but require some spatial reasoning. The dataset, called BlindTest, consists of synthetic images designed to probe basic geometric understanding, such as detecting overlaps, intersections, encircled characters, and small object counts. Despite their simplicity, these tasks reveal failures in state-of-the-art VLMs (SOTA as of June 2024), and highlight limitations in fine-grained visual perception.
 
 ## Paper Information
 
-- **Paper Title**: VLMs Are Blind
+- **Paper Title**: Vision Language Models Are Blind
 - **Paper**: https://arxiv.org/abs/2407.06581
 - **GitHub**: https://github.com/xai-org/vlmsareblind
 - **Dataset**: https://huggingface.co/datasets/XAI/vlmsareblind
 
 ## Dataset Details
 
-The benchmark consists of path-counting tasks where models must count the number of paths between two stations in subway-style connection diagrams. Each instance contains:
-- A subway map diagram image
-- A question asking for the number of paths between two specified stations
-- The correct answer in the format {N}
+The benchmark consists of 9 different tasks testing different visual reasoning capabilities:
 
-## Task Configuration
+| Task | Description |
+|------|-------------|
+| **Circled Letter** | Identify which letter is circled |
+| **Counting Grid** | Count rows and columns in blank and word grids |
+| **Line Plot Intersections** | Count line intersections |
+| **Nested Squares** | Count total squares in nested pattern |
+| **Olympic Counting - Circles** | Count circles (Olympic rings style) |
+| **Olympic Counting - Pentagons** | Count pentagons |
+| **Subway Connections** | Count single-color paths between stations |
+| **Touching Circles** | Determine if two circles touch |
 
-### Main Task
-- **Task Name**: `vlmsareblind`
-- **Split**: `valid`
-- **Output Type**: `generate_until`
-- **Metric**: Exact match accuracy
+**Note:** This implementation follows the paper's grouping of tasks as displayed in Table 1, i.e. the counting grid tasks (`Counting Grid - Blank Grids` and `Counting Grid - Word Grids`) are grouped into a single task (`Counting Grid`). 
 
-### Lite Version
-- **Task Name**: `vlmsareblind_lite`
-- A subset version for faster evaluation
+## Dataset Fields
 
-## Evaluation
+The benchmark uses the following fields from the huggingface dataset:
+- `task`: The task type (one of the 8 types above)
+- `image`: The visual input
+- `prompt`: The question with answer format instructions
+- `groundtruth`: The correct answer
 
-The benchmark uses exact match accuracy as the primary metric. Models must output their answer in the format `{N}` where N is the number of paths.
+## Metrics
+- **accuracy**: Mean accuracy across all samples (micro-averaged overall fraction correct).
+- **accuracy_by_task**: Per-task accuracy. Includes `task_mean`, the macro-average (unweighted mean) of per-task accuracies.
 
-### Metrics
-- **exact_match**: Binary score for each instance (1 if prediction matches ground truth, 0 otherwise)
-- **Aggregation**: Mean across all instances
-
-## Running the Benchmark
+## Usage
 
 ```bash
-# Run the full benchmark
-lmms-eval --model <model_name> --tasks vlmsareblind --batch_size 1
-
-# Run the lite version
-lmms-eval --model <model_name> --tasks vlmsareblind_lite --batch_size 1
+uv run -m lmms_eval \
+  --model vllm \
+  --model_args model=Qwen/Qwen3-VL-2B-Instruct \
+  --tasks vlmsareblind \
+  --batch_size 1 \
+  --device cuda:0
 ```
 
-## Implementation Details
+## Expected Results
+Below are example results for several Qwen3-VL models plus the original-paper baselines (italicized).
 
-### Generation Configuration
+| Model | Line Plot Intersections | Touching Circles | Circled Letter | Olympic Counting - Circles | Olympic Counting - Pentagons | Nested Squares | Grid Counting | Subway Connections | Task Mean |
+|-------|--------------------------|------------------|----------------|----------------------------|-----------------------------|---------------|--------------|--------------------|-----------|
+| _GPT-4o_ | _41.61_ | _75.91_ | _74.23_ | _41.25_ | _20.21_ | _55.83_ | _39.58_ | _53.19_ | ***50.23*** |
+| _Gemini-1.5_ | _66.94_ | _93.62_ | _83.29_ | _20.25_ | _24.17_ | _87.08_ | _39.39_ | _53.13_ | ***58.48*** |
+| _Sonnet-3_ | _43.41_ | _86.46_ | _72.06_ | _29.79_ | _1.87_ | _65.00_ | _36.17_ | _31.11_ | ***45.73*** |
+| _Sonnet-3.5_ | _75.36_ | _90.82_ | _87.88_ | _66.46_ | _77.71_ | _92.08_ | _74.26_ | _58.19_ | ***77.84*** |
+| Qwen3-VL-2B-Instruct | 55.08 | 72.54 | 75.32 | 20.21 | 4.58 | 66.67 | 21.21 | 20.28 | **41.99** |
+| Qwen3-VL-4B-Instruct | 77.11 | 72.32 | 92.79 | 21.04 | 11.88 | 97.08 | 50.19 | 40.42 | **57.85** |
+| Qwen3-VL-8B-Instruct | 72.64 | 88.69 | 86.06 | 20.00 | 12.08 | 89.17 | 66.29 | 40.14 | **59.38** |
+
+
+## Generation Configuration
+
 - **max_new_tokens**: 32
 - **temperature**: 0
 - **top_p**: 1.0
 - **num_beams**: 1
 - **do_sample**: false
 
-### Answer Extraction
-The evaluation expects answers in the format `{N}`. The answer extraction logic:
-1. First looks for numbers within curly brackets: `{3}`
-2. If not found, looks for standalone numbers and adds brackets
-3. Falls back to the raw response if no pattern matches
-
-### Prompt Format
-```
-[Image of subway diagram]
-[Question about counting paths]
-Answer with a number in curly brackets, e.g., {3}.
-```
-
-## File Structure
-```
-vlmsareblind/
-├── README.md           # This file
-├── utils.py           # Evaluation utilities
-├── vlmsareblind.yaml  # Main task configuration
-└── vlmsareblind_lite.yaml  # Lite version configuration
-```
-
 ## Citation
 
 ```bibtex
-@article{vlmsareblind2024,
-  title={VLMs Are Blind},
-  author={XAI Team},
-  journal={arXiv preprint arXiv:2407.06581},
-  year={2024}
+@InProceedings{Rahmanzadehgervi_2024_ACCV,
+    author    = {Rahmanzadehgervi, Pooyan and Bolton, Logan and Taesiri, Mohammad Reza and Nguyen, Anh Totti},
+    title     = {Vision language models are blind},
+    booktitle = {Proceedings of the Asian Conference on Computer Vision (ACCV)},
+    month     = {December},
+    year      = {2024},
+    pages     = {18-34}
 }
 ```
-
-## Notes
-
-- The benchmark is designed to test fundamental visual reasoning capabilities
-- Results often reveal significant gaps between VLM performance and human abilities
-- The simple counting task format makes it easy to verify model outputs
-- Temperature is set to 0 for deterministic outputs

--- a/lmms_eval/tasks/vlmsareblind/utils.py
+++ b/lmms_eval/tasks/vlmsareblind/utils.py
@@ -1,58 +1,140 @@
 import re
-from typing import Dict, List
+from collections import defaultdict
 
 
-def vlmsareblind_doc_to_visual(doc: Dict) -> List:
+TASKS = [
+    "circled letter",
+    "counting grid - blank grids",
+    "counting grid - word grids",
+    "line plot intersections",
+    "nested squares",
+    "olympic counting - circles",
+    "olympic counting - pentagons",
+    "subway connections",
+    "touching circles",
+]
+
+TASK_MAP = {
+    "counting grid - blank grids": "counting grid",
+    "counting grid - word grids": "counting grid",
+}
+
+
+def vlmsareblind_doc_to_visual(doc: dict) -> list:
     """Extract image from the document."""
     if "image" in doc:
         return [doc["image"]]
     return []
 
 
-def vlmsareblind_doc_to_text(doc: Dict, lmms_eval_specific_kwargs: Dict) -> str:
+def vlmsareblind_doc_to_text(doc: dict, lmms_eval_specific_kwargs: dict | None = None) -> str:
     """Format the prompt for the model."""
+    if lmms_eval_specific_kwargs is None:
+        lmms_eval_specific_kwargs = {}
+
     prompt = doc.get("prompt", "")
+
     pre_prompt = lmms_eval_specific_kwargs.get("pre_prompt", "")
     post_prompt = lmms_eval_specific_kwargs.get("post_prompt", "")
+
     return f"{pre_prompt}{prompt}{post_prompt}"
 
 
-def vlmsareblind_doc_to_target(doc: Dict) -> str:
-    """Extract the expected answer from the document."""
-    # The answer should be a number in curly brackets like {3}
-    answer = doc.get("answer", "")
-    return str(answer)
+def parse_response(response: str, task: str) -> str | None:
+    """Parse the response based on the task type.
+
+    Return None if the response does not follow the expected format.
+    """
+    response = response.strip().lower()
+    task = task.lower()
+    
+    if task == "touching circles":
+        if response in ["yes", "no"]:
+            return response
+
+    if task in [
+        "line plot intersections", 
+        "subway connections", 
+        "olympic counting - circles", 
+        "olympic counting - pentagons", 
+        "nested squares"
+    ]:
+        match = re.search(r"\{?(\d+)\}?", response)
+        if match:
+            return match.group(1)
+
+    if task == "circled letter":
+        match = re.search(r"\{?([a-z])\}?", response)
+        if match:
+            return match.group(1)
+
+    if task.startswith("counting grid"):
+        match = re.search(r"\{(\d+)\}\s*\{(\d+)\}", response) # {3}{4}, {3} {4}, etc.
+        if match:
+            return f"{match.group(1)},{match.group(2)}"
+        match = re.search(r"\((\d+)\s*,\s*(\d+)\)", response) # (3,4), (3, 4), etc.
+        if match:
+            return f"{match.group(1)},{match.group(2)}"
+        match = re.search(r"rows=\{(\d+)\}\scolumns=\{(\d+)\}", response) # rows={3} columns={4}, rows={3} columns={4}, etc.
+        if match:
+            return f"{match.group(1)},{match.group(2)}"
+    
+    return None
 
 
-def extract_answer(response: str) -> str:
-    """Extract the number from a response containing {N} format."""
-    # Look for pattern {number}
-    match = re.search(r"\{(\d+)\}", response)
-    if match:
-        return match.group(0)  # Return the full match including brackets
-
-    # If no brackets found, try to find just a number
-    match = re.search(r"\b(\d+)\b", response)
-    if match:
-        return f"{{{match.group(1)}}}"  # Add brackets
-
-    return response.strip()
-
-
-def vlmsareblind_process_result(doc: Dict, result) -> Dict:
+def vlmsareblind_process_results(doc: dict, results: list[str]) -> dict:
     """Process the model's response and compare with ground truth."""
-    # Handle case where result is a list (common with generate_until)
-    if isinstance(result, list):
-        result = result[0] if result else ""
+    result = results[0]
+    task: str = doc.get("task", "")
+    target: str = doc.get("groundtruth", "")
 
-    pred = extract_answer(str(result))
-    target = doc.get("answer", "")
+    normalized_target = target.strip().lower()
+    normalized_result = result.strip().lower()
+    prediction = parse_response(normalized_result, task)
 
-    # Exact match comparison
-    correct = pred == target
+    if prediction is None:
+        is_correct = False
+    else:
+        is_correct = prediction.strip().lower() == normalized_target
 
     return {
-        "exact_match": correct,
-        "pred": pred,
-        "target": target,
+        "accuracy": float(is_correct),
+        "accuracy_by_task": {"task": task, "is_correct": is_correct}
     }
+
+
+def vlmsareblind_aggregate_by_task(results: list[dict]) -> dict[str, float]:
+    task_correct = defaultdict(int)
+    task_total = defaultdict(int)
+
+    for result in results:
+        task = result["task"].lower()
+        task = TASK_MAP.get(task, task)
+
+        is_correct = result["is_correct"]
+        task_total[task] += 1
+        if is_correct:
+            task_correct[task] += 1
+        
+    task_accuracy = {task: task_correct[task] / task_total[task] for task in task_correct}
+    task_accuracy["task_mean"] = sum(task_accuracy.values()) / len(task_accuracy)
+
+    return task_accuracy
+
+
+def vlmsareblind_sample_100_per_task(dataset: object) -> object:
+    """Subsample the dataset to at most 100 examples per task."""
+    indices_by_task: dict[str, list[int]] = defaultdict(list)
+
+    for idx, row in enumerate(dataset):
+        task = str(row.get("task", ""))
+        if not task:
+            continue
+        if len(indices_by_task[task]) < 100:
+            indices_by_task[task].append(idx)
+
+    selected_indices: list[int] = []
+    for indices in indices_by_task.values():
+        selected_indices.extend(indices)
+
+    return dataset.select(selected_indices)

--- a/lmms_eval/tasks/vlmsareblind/vlmsareblind.yaml
+++ b/lmms_eval/tasks/vlmsareblind/vlmsareblind.yaml
@@ -4,8 +4,8 @@ test_split: valid
 output_type: generate_until
 doc_to_visual: !function utils.vlmsareblind_doc_to_visual
 doc_to_text: !function utils.vlmsareblind_doc_to_text
-doc_to_target: !function utils.vlmsareblind_doc_to_target
-process_results: !function utils.vlmsareblind_process_result
+doc_to_target: "groundtruth"
+process_results: !function utils.vlmsareblind_process_results
 generation_kwargs:
   max_new_tokens: 32
   temperature: 0
@@ -13,15 +13,17 @@ generation_kwargs:
   num_beams: 1
   do_sample: false
 metric_list:
-  - metric: exact_match
+  - metric: accuracy
     aggregation: mean
+    higher_is_better: true
+  - metric: accuracy_by_task
+    aggregation: !function utils.vlmsareblind_aggregate_by_task
     higher_is_better: true
 metadata:
   - version: 0.0
-  - description: "VLMs Are Blind: A benchmark testing visual reasoning capabilities of VLMs through path-counting tasks in subway connection diagrams."
+  - description: " Vision language models are blind"
   - reference: "https://arxiv.org/abs/2407.06581"
-  
 lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
-    post_prompt: "\nAnswer with a number in curly brackets, e.g., {3}."
+    post_prompt: "\nAnswer only in the required format."

--- a/lmms_eval/tasks/vlmsareblind/vlmsareblind_lite.yaml
+++ b/lmms_eval/tasks/vlmsareblind/vlmsareblind_lite.yaml
@@ -4,27 +4,27 @@ test_split: valid
 output_type: generate_until
 doc_to_visual: !function utils.vlmsareblind_doc_to_visual
 doc_to_text: !function utils.vlmsareblind_doc_to_text
-doc_to_target: !function utils.vlmsareblind_doc_to_target
-process_results: !function utils.vlmsareblind_process_result
+doc_to_target: "groundtruth"
+process_docs: !function utils.vlmsareblind_sample_100_per_task
+process_results: !function utils.vlmsareblind_process_results
 generation_kwargs:
   max_new_tokens: 32
   temperature: 0
   top_p: 1.0
   num_beams: 1
   do_sample: false
-# Sample only 100 examples for lite version
-dataset_kwargs:
-  num_examples: 100
 metric_list:
-  - metric: exact_match
+  - metric: accuracy
     aggregation: mean
+    higher_is_better: true
+  - metric: accuracy_by_task
+    aggregation: !function utils.vlmsareblind_aggregate_by_task
     higher_is_better: true
 metadata:
   - version: 0.0
-  - description: "VLMs Are Blind (Lite): A smaller subset for quick testing. Tests visual reasoning through path-counting in subway diagrams."
+  - description: "Vision language models are blind: Failing to translate detailed visual features into words"
   - reference: "https://arxiv.org/abs/2407.06581"
-  
 lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
-    post_prompt: "\nAnswer with a number in curly brackets, e.g., {3}."
+    post_prompt: "\nAnswer only in the required format."


### PR DESCRIPTION
### Description
The current lmms-eval implementation of the Vision-Language Models Are Blind benchmark is incorrect. All benchmark tasks are mistakenly evaluated as subway connection counting tasks, even though the benchmark as well as the currently used huggingface dataset includes multiple distinct task types.

As a result, all tasks except for the subway connection counting tasks are evaluated naively and incorrectly, leading to invalid aggregate scores and misleading benchmark results.

This PR fixes the evaluation logic to correctly handle each task type according to the original benchmark specification. The implementation closely follows the methodology described in the paper and aims to reproduces results as reported in Table 1 of the paper.

### Paper Information
- **Paper Title**: Vision Language Models Are Blind
- **Paper**: https://arxiv.org/abs/2407.06581
- **GitHub**: https://github.com/xai-org/vlmsareblind
- **Dataset**: https://huggingface.co/datasets/XAI/vlmsareblind

### Benchmark Scores
Below are example results for several Qwen3-VL models using this PR's implementation plus the original-paper baselines (italicized).

| Model | Line Plot Intersections | Touching Circles | Circled Letter | Olympic Counting - Circles | Olympic Counting - Pentagons | Nested Squares | Grid Counting | Subway Connections | Task Mean |
|-------|--------------------------|------------------|----------------|----------------------------|-----------------------------|---------------|--------------|--------------------|-----------|
| _GPT-4o_ | _41.61_ | _75.91_ | _74.23_ | _41.25_ | _20.21_ | _55.83_ | _39.58_ | _53.19_ | ***50.23*** |
| _Gemini-1.5_ | _66.94_ | _93.62_ | _83.29_ | _20.25_ | _24.17_ | _87.08_ | _39.39_ | _53.13_ | ***58.48*** |
| _Sonnet-3_ | _43.41_ | _86.46_ | _72.06_ | _29.79_ | _1.87_ | _65.00_ | _36.17_ | _31.11_ | ***45.73*** |
| _Sonnet-3.5_ | _75.36_ | _90.82_ | _87.88_ | _66.46_ | _77.71_ | _92.08_ | _74.26_ | _58.19_ | ***77.84*** |
| Qwen3-VL-2B-Instruct | 55.08 | 72.54 | 75.32 | 20.21 | 4.58 | 66.67 | 21.21 | 20.28 | **41.99** |
| Qwen3-VL-4B-Instruct | 77.11 | 72.32 | 92.79 | 21.04 | 11.88 | 97.08 | 50.19 | 40.42 | **57.85** |
| Qwen3-VL-8B-Instruct | 72.64 | 88.69 | 86.06 | 20.00 | 12.08 | 89.17 | 66.29 | 40.14 | **59.38** |
