### PR TITLE
[feat] Add LongVT evaluation tasks for long video understanding with tool calling

### DIFF
--- a/examples/mcp_server/crop_video_mcp_server.py
+++ b/examples/mcp_server/crop_video_mcp_server.py
@@ -1,0 +1,123 @@
+import base64
+import logging
+import os
+from io import BytesIO
+from typing import Annotated
+
+import cv2
+import torch
+from mcp.server.fastmcp import FastMCP
+from mcp.types import ImageContent
+from pydantic import Field
+from qwen_vl_utils import fetch_video
+from torchvision.transforms.functional import to_pil_image
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [MCP_SERVER] %(levelname)s: %(message)s",
+    handlers=[logging.FileHandler("/tmp/mcp_server_debug.log"), logging.StreamHandler()],
+)
+logger = logging.getLogger(__name__)
+
+app = FastMCP("Video Tools MCP Server", "0.1.0")
+
+
+@app.tool(name="crop_video", description="Crop a video to a specified duration.")
+def crop_video(
+    video_path: Annotated[str, Field(description="Path to the video file")] = None,
+    start_time: Annotated[float, Field(description="Start time in seconds")] = None,
+    end_time: Annotated[float, Field(description="End time in seconds, must be > start_time")] = None,
+) -> list[ImageContent]:
+    """
+    Crop a video to a specified duration.
+
+    Args:
+        video_path (str): Path to the video file.
+        start_time (float): Start time in seconds.
+        end_time (float): End time in seconds.
+
+    Returns:
+        str: Path to the cropped video file.
+    """
+    # Validate input parameters - now we control all validation logic
+    logger.info(f"Validating parameters: video_path={video_path}, start_time={start_time}, end_time={end_time}")
+
+    # Check required parameters
+    if video_path is None:
+        logger.error("Missing video_path parameter")
+        raise ValueError("video_path parameter is required")
+
+    if start_time is None:
+        logger.error("Missing start_time parameter")
+        raise ValueError("start_time parameter is required")
+
+    if end_time is None:
+        logger.error("Missing end_time parameter")
+        raise ValueError("end_time parameter is required")
+
+    # Check parameter values
+    if not video_path or video_path.strip() == "":
+        logger.error(f"Empty video_path parameter: '{video_path}'")
+        raise ValueError("video_path cannot be empty")
+
+    if start_time < 0:
+        logger.error(f"Invalid start_time: {start_time}")
+        raise ValueError(f"start_time must be non-negative, got {start_time}")
+
+    if end_time <= start_time:
+        logger.error(f"Invalid time range: start_time={start_time}, end_time={end_time}")
+        raise ValueError(f"end_time ({end_time}) must be greater than start_time ({start_time})")
+
+    # Check file existence
+    if not os.path.exists(video_path):
+        logger.error(f"Video file not found: {video_path}")
+        raise FileNotFoundError(f"Video file not found: {video_path}")
+
+    # verify video duration
+    cap = cv2.VideoCapture(video_path)
+    if not cap.isOpened():
+        raise RuntimeError(f"Cannot open video file: {video_path}")
+
+    fps = cap.get(cv2.CAP_PROP_FPS)
+    frame_count = cap.get(cv2.CAP_PROP_FRAME_COUNT)
+    duration = frame_count / fps if fps > 0 else 0
+    print(f"video duration: {duration:.2f}s")
+    cap.release()
+
+    # validate time range
+    if start_time >= duration:
+        raise ValueError(f"start_time ({start_time}s) exceeds video duration ({duration:.2f}s)")
+    if end_time > duration:
+        raise ValueError(f"end_time ({end_time}s) exceeds video duration ({duration:.2f}s)")
+
+    try:
+        video_ele = {
+            "type": "video",
+            "video": f"file://{video_path}",
+            "fps": 1,  # 1fps
+            "min_frames": 1,
+            "max_frames": 128,
+            "max_pixels": 224 * 224,
+            "video_start": start_time,
+            "video_end": end_time,
+        }
+        video_frames = fetch_video(video_ele)
+        video_frames = video_frames.to(torch.uint8)
+        images = [to_pil_image(frame) for frame in video_frames]
+        # Encode images to base64
+        image_contents = []
+        for img in images:
+            output_buffer = BytesIO()
+            img.save(output_buffer, format="PNG")
+            byte_data = output_buffer.getvalue()
+            base64_str = base64.b64encode(byte_data).decode("utf-8")
+            image_contents.append(ImageContent(type="image", data=base64_str, mimeType="image/png"))
+
+        return image_contents
+    except Exception as e:
+        raise RuntimeError(f"Failed to process video {video_path}: {str(e)}") from e
+
+
+if __name__ == "__main__":
+    app.run()

--- a/lmms_eval/tasks/longvt/README.md
+++ b/lmms_eval/tasks/longvt/README.md
@@ -1,0 +1,112 @@
+# LongVT Evaluation Tasks
+
+This directory contains evaluation tasks for [LongVT](https://github.com/EvolvingLMMs-Lab/LongVT), an agentic framework for long video understanding via native tool calling.
+
+## Available Tasks
+
+| Task | Description |
+|------|-------------|
+| `longvt_non_think` | Direct answer mode |
+| `longvt_reasoning` | Thinking mode with `<think>` and `<answer>` tags |
+| `longvt_tool` | Tool calling mode with MCP server |
+
+## Dataset
+
+The benchmark uses [VideoSIAH-Eval](https://huggingface.co/datasets/longvideotool/VideoSIAH-Eval) from Hugging Face.
+
+## Usage
+
+### Environment Variables
+
+```bash
+# Environment variables
+export OPENAI_API_BASE="http://localhost:8000/v1"
+export OPENAI_MODEL_NAME="judge"
+export OPENAI_BASE_URL="http://your-judge-server-ip:8000/v1"
+export OPENAI_API_KEY="EMPTY"
+export USE_LLM_JUDGE=True
+export DECORD_EOF_RETRY_MAX=409600
+
+# Cache enabled (optional)
+# export LMMS_EVAL_USE_CACHE=True
+# export LMMS_EVAL_HOME="your_cache_directory"
+```
+
+### Arguments
+
+```bash
+CKPT_PATH=$1                # Path to model checkpoint
+TASK_NAME=$2                # Evaluation task name (longvt_non_think / longvt_reasoning / longvt_tool)
+IS_QWEN3_VL=$3              # Whether using Qwen3-VL model (True/False)
+MAX_FRAME_NUM=${4:-768}     # Number of frames (Default: 768)
+
+# Path to MCP server for tool calling (only needed for longvt_tool)
+MCP_PATH="examples/mcp_server/crop_video_mcp_server.py"
+```
+
+---
+
+### 1. Direct Answer / Thinking Mode (`longvt_non_think`, `longvt_reasoning`)
+
+```bash
+accelerate launch --num_processes=8 --main_process_port 12345 -m lmms_eval \
+    --model async_openai \
+    --model_args model_version=$CKPT_PATH,fps=1,max_frames=$MAX_FRAME_NUM,max_pixels=50176,base_url=$OPENAI_API_BASE,api_key=$OPENAI_API_KEY,num_cpus=1,timeout=12000,is_qwen3_vl=$IS_QWEN3_VL \
+    --tasks $TASK_NAME \
+    --batch_size 1 \
+    --output_path ./eval_logs \
+    --log_samples
+```
+
+---
+
+### 2. Tool Calling (`longvt_tool`)
+
+#### Step 1: Start MCP Server
+
+```bash
+# Qwen3-VL does not need additional chat template
+if [ "$IS_QWEN3_VL" == "False" ]; then
+    vllm serve $CKPT_PATH \
+        --chat-template examples/chat_templates/tool_call_qwen2_5_vl.jinja \
+        --tool-call-parser hermes \
+        --enable-auto-tool-choice \
+        --data-parallel-size 8 \
+        --trust-remote-code &
+else
+    vllm serve $CKPT_PATH \
+        --tool-call-parser hermes \
+        --enable-auto-tool-choice \
+        --data-parallel-size 8 \
+        --trust-remote-code &
+fi
+sleep 240  # Wait for vLLM server to be ready
+```
+
+#### Step 2: Run Evaluation
+
+```bash
+accelerate launch --num_processes=8 --main_process_port 12345 -m lmms_eval \
+    --model async_openai \
+    --model_args model_version=$CKPT_PATH,mcp_server_path=$MCP_PATH,fps=1,max_frames=$MAX_FRAME_NUM,max_pixels=50176,base_url=$OPENAI_API_BASE,api_key=$OPENAI_API_KEY,num_cpus=1,timeout=12000,is_qwen3_vl=$IS_QWEN3_VL \
+    --tasks $TASK_NAME \
+    --batch_size 1 \
+    --output_path ./eval_logs \
+    --log_samples
+```
+
+## Citation
+
+```bibtex
+@article{yang2025longvt,
+  title={LongVT: Incentivizing "Thinking with Long Videos" via Native Tool Calling},
+  author={Yang, Zuhao and Wang, Sudong and Zhang, Kaichen and Wu, Keming and Leng, Sicong and Zhang, Yifan and Li, Bo and Qin, Chengwei and Lu, Shijian and Li, Xingxuan and Bing, Lidong},
+  journal={arXiv preprint arXiv:2511.20785},
+  year={2025}
+}
+```
+
+## References
+
+- [LongVT Repo](https://github.com/EvolvingLMMs-Lab/LongVT)
+- [LongVT Paper](https://arxiv.org/abs/2511.20785)

--- a/lmms_eval/tasks/longvt/longvt_non_think.yaml
+++ b/lmms_eval/tasks/longvt/longvt_non_think.yaml
@@ -1,0 +1,31 @@
+dataset_path: longvideotool/VideoSIAH-Eval
+dataset_kwargs:
+  token: True
+  cache_dir: longvt_benchmark
+  video: True
+  # From_YouTube: True
+test_split: test
+task: longvt_non_think
+output_type: generate_until
+doc_to_visual: !function utils.longvt_doc_to_visual
+doc_to_text: !function utils.longvt_doc_to_text
+doc_to_target: "answer"
+generation_kwargs:
+  max_new_tokens: 128
+# The return value of process_results will be used by metrics
+process_results: !function utils.longvt_process_results
+# Note that the metric name can be either a registed metric function (such as the case for GQA) or a key name returned by process_results
+metric_list:
+  - metric: acc_score
+    aggregation: mean
+    higher_is_better: true
+  - metric: format_score
+    aggregation: mean
+    higher_is_better: true
+lmms_eval_specific_kwargs:
+  default:
+    pre_prompt: ""
+    post_prompt: "Answer the question directly with a short answer or phrase"
+metadata:
+  - version: 0.0
+

--- a/lmms_eval/tasks/longvt/longvt_reasoning.yaml
+++ b/lmms_eval/tasks/longvt/longvt_reasoning.yaml
@@ -1,0 +1,32 @@
+dataset_path: longvideotool/VideoSIAH-Eval
+dataset_kwargs:
+  token: True
+  cache_dir: longvt_benchmark
+  video: True
+  # From_YouTube: True
+test_split: test
+task: longvt_reasoning
+output_type: generate_until
+doc_to_visual: !function utils.longvt_doc_to_visual
+doc_to_text: !function utils.longvt_doc_to_text
+doc_to_messages: !function utils.longvt_doc_to_messages
+doc_to_target: "answer"
+generation_kwargs:
+  max_new_tokens: 4096
+# The return value of process_results will be used by metrics
+process_results: !function utils.longvt_process_results
+# Note that the metric name can be either a registed metric function (such as the case for GQA) or a key name returned by process_results
+metric_list:
+  - metric: acc_score
+    aggregation: mean
+    higher_is_better: true
+  - metric: format_score
+    aggregation: mean
+    higher_is_better: true
+lmms_eval_specific_kwargs:
+  default:
+    pre_prompt: ""
+    post_prompt: ""
+metadata:
+  - version: 0.0
+

--- a/lmms_eval/tasks/longvt/longvt_tool.yaml
+++ b/lmms_eval/tasks/longvt/longvt_tool.yaml
@@ -1,0 +1,32 @@
+dataset_path: longvideotool/VideoSIAH-Eval
+dataset_kwargs:
+  token: True
+  cache_dir: longvt_benchmark
+  video: True
+  # From_YouTube: True
+test_split: test
+task: longvt
+output_type: generate_until
+doc_to_visual: !function utils.longvt_doc_to_visual
+doc_to_text: !function utils.longvt_doc_to_text
+doc_to_messages: !function utils.longvt_tool_doc_to_messages
+doc_to_target: "answer"
+generation_kwargs:
+  max_new_tokens: 4096
+# The return value of process_results will be used by metrics
+process_results: !function utils.longvt_process_results
+# Note that the metric name can be either a registed metric function (such as the case for GQA) or a key name returned by process_results
+metric_list:
+  - metric: acc_score
+    aggregation: mean
+    higher_is_better: true
+  - metric: format_score
+    aggregation: mean
+    higher_is_better: true
+lmms_eval_specific_kwargs:
+  default:
+    pre_prompt: ""
+    post_prompt: ""
+metadata:
+  - version: 0.0
+

--- a/lmms_eval/tasks/longvt/utils.py
+++ b/lmms_eval/tasks/longvt/utils.py
@@ -1,0 +1,100 @@
+import os
+import re
+from pathlib import Path
+
+import yaml
+
+from lmms_eval.tasks._task_utils.reasoning_utils import compute_score
+
+hf_home = os.getenv("HF_HOME", "~/.cache/huggingface/")
+base_cache_dir = os.path.expanduser(hf_home)
+with open(Path(__file__).parent / "longvt_reasoning.yaml", "r") as f:
+    raw_data = f.readlines()
+    safe_data = []
+    for i, line in enumerate(raw_data):
+        # remove function definition since yaml load cannot handle it
+        if "!function" not in line:
+            safe_data.append(line)
+cache_name = yaml.safe_load("".join(safe_data))["dataset_kwargs"]["cache_dir"]
+
+SYSTEM_PROMPT = (
+    "You are a helpful assistant. When the user asks a question, your response must include two parts: "
+    "first, the reasoning process enclosed in <think>...</think> tags, then the final answer enclosed in <answer>...</answer> tags."
+    "Please provide a clear, concise response within <answer> </answer> tags that directly addresses the question."
+)
+
+TOOL_PROMPT = "Think first, call **crop_video** if needed, then answer. Format strictly as:  <think>...</think>  " "<tool_call>...</tool_call> (if tools needed)  <answer>...</answer>."
+
+
+def longvt_doc_to_visual(doc):
+    cache_dir = os.path.join(base_cache_dir, cache_name)
+    video_path = doc["video_path"]
+    assert os.path.exists(os.path.join(cache_dir, video_path))
+    video_path = os.path.join(cache_dir, video_path)
+    return [video_path]
+
+
+def longvt_doc_to_text(doc, lmms_eval_specific_kwargs=None):
+    if lmms_eval_specific_kwargs is not None:
+        post_prompt = lmms_eval_specific_kwargs.get("post_prompt", "")
+        if post_prompt:
+            return doc["question"] + " " + post_prompt
+        return doc["question"]
+    else:
+        return doc["question"]
+
+
+def longvt_doc_to_messages(doc, lmms_eval_specific_kwargs=None):
+    question = longvt_doc_to_text(doc, lmms_eval_specific_kwargs)
+    visuals = longvt_doc_to_visual(doc)
+    system_messages = [{"role": "system", "content": [{"type": "text", "text": SYSTEM_PROMPT}]}]
+    messages = [{"role": "user", "content": []}]
+    messages[0]["content"].append({"type": "video", "url": visuals[0]})
+    messages[0]["content"].append({"type": "text", "text": question.strip()})
+    messages = system_messages + messages
+    return messages
+
+
+def longvt_tool_doc_to_messages(doc, lmms_eval_specific_kwargs=None):
+    question = longvt_doc_to_text(doc, lmms_eval_specific_kwargs)
+    visuals = longvt_doc_to_visual(doc)
+    messages = [{"role": "user", "content": []}]
+    messages[0]["content"].append({"type": "video", "url": visuals[0]})
+    messages[0]["content"].append({"type": "text", "text": question.strip() + " " + TOOL_PROMPT})
+    return messages
+
+
+def extract_characters_regex(s):
+    s = s.strip()
+    answer_prefixes = [
+        "The best answer is",
+        "The correct answer is",
+        "The answer is",
+        "The answer",
+        "The best option is" "The correct option is",
+        "Best answer:" "Best option:",
+    ]
+    for answer_prefix in answer_prefixes:
+        s = s.replace(answer_prefix, "")
+
+    if len(s.split()) > 10 and not re.search("[ABCD]", s):
+        return ""
+
+    matches = re.search(r"[ABCD]", s)
+    if matches is None:
+        return ""
+    return matches[0]
+
+
+def longvt_process_results(doc, results):
+    acc_score = 0
+    format_score = 0
+    question = longvt_doc_to_text(doc, lmms_eval_specific_kwargs=None)
+    extra_info = {"question": question}
+    answer = doc["answer"]
+    for pred in results:
+        score_dict = compute_score(data_source="longvt", solution_str=pred.strip(), ground_truth=answer, extra_info=extra_info)
+        acc_score += score_dict["acc_score"]
+        format_score += score_dict.get("format_reward_score", 0.0)
+
+    return {"acc_score": acc_score / len(results) if results else 0.0, "format_score": format_score / len(results) if results else 0.0}


### PR DESCRIPTION
## Description

This PR adds evaluation tasks for [LongVT](https://github.com/EvolvingLMMs-Lab/LongVT), an agentic framework for long video understanding via native tool calling.

### Added Tasks

| Task | Description |
|------|-------------|
| `longvt_non_think` | Direct answer mode |
| `longvt_reasoning` | Thinking mode with `<think>` and `<answer>` tags |
| `longvt_tool` | Tool calling mode with MCP server |

### Dataset

The benchmark uses [VideoSIAH-Eval](https://huggingface.co/datasets/longvideotool/VideoSIAH-Eval) from Hugging Face.

### Files Added

- `lmms_eval/tasks/longvt/` - LongVT evaluation task configurations and utilities
- `examples/mcp_server/crop_video_mcp_server.py` - MCP server for video cropping tool

### Usage

See `lmms_eval/tasks/longvt/README.md` for detailed usage instructions.

### References

- Paper: [LongVT: Incentivizing "Thinking with Long Videos" via Native Tool Calling](https://arxiv.org/abs/2511.20785)
- Code: https://github.com/EvolvingLMMs-Lab/LongVT