### PR TITLE
fix: add missing 'all' extra to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,6 +125,13 @@ mmsearch = [
     "FlagEmbedding",
     "rouge",
 ]
+all = [
+    "lmms_eval[core]",
+    "lmms_eval[gemini]",
+    "lmms_eval[reka]",
+    "lmms_eval[qwen]",
+    "lmms_eval[mmsearch]",
+]
 
 [tool.setuptools.packages.find]
 include = ["lmms_eval*"]


### PR DESCRIPTION
## Description
This PR adds the missing `all` key to `[project.optional-dependencies]` in `pyproject.toml`. 

Previously, running `uv pip install -e ".[all]"` (or standard pip) would trigger a warning because the `all` extra was not defined, even though it was referenced in documentation or usage patterns. This change ensures that installing with `[all]` correctly installs all optional dependencies (core, gemini, reka, qwen, mmsearch).

## Related Issue
Fixes #976

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/EvolvingLMMs-Lab/lmms-eval/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.