### PR TITLE
[Task] Add vsibench multi-image variant

### DIFF
--- a/lmms_eval/tasks/vsibench/multi_image_input/utils.py
+++ b/lmms_eval/tasks/vsibench/multi_image_input/utils.py
@@ -1,0 +1,56 @@
+import os
+
+import numpy as np
+from decord import VideoReader, cpu
+from loguru import logger as eval_logger
+from PIL import Image
+
+from lmms_eval.tasks.vsibench.utils import (
+    base_cache_dir,
+    cache_name,
+    vsibench_aggregate_results,
+    vsibench_doc_to_text,
+    vsibench_process_results,
+)
+
+
+def vsibench_doc_to_visual_as_images(doc, lmms_eval_specific_kwargs=None):
+    """
+    Return video frames as a list of PIL Images instead of video path.
+    This allows the model to process the video as multi-image input.
+
+    Args:
+        doc: Document containing video metadata
+        lmms_eval_specific_kwargs: Optional kwargs containing 'num_frames' (default: 32)
+
+    Returns:
+        List of PIL.Image objects sampled uniformly from the video
+    """
+    cache_dir = os.path.join(base_cache_dir, cache_name)
+    video_path = doc["dataset"] + "/" + doc["scene_name"] + ".mp4"
+    video_path = os.path.join(cache_dir, video_path)
+
+    if not os.path.exists(video_path):
+        raise FileExistsError(f"video path:{video_path} does not exist.")
+
+    # Get number of frames from lmms_eval_specific_kwargs or default to 32
+    num_frames = 32
+    if lmms_eval_specific_kwargs:
+        num_frames = lmms_eval_specific_kwargs.get("num_frames", 32)
+
+    # Load video and sample frames uniformly
+    vr = VideoReader(video_path, ctx=cpu(0))
+    total_frames = len(vr)
+
+    # Ensure we don't request more frames than available
+    num_frames = min(num_frames, total_frames)
+
+    indices = np.linspace(0, total_frames - 1, num_frames, dtype=int)
+    frames = vr.get_batch(indices).asnumpy()
+
+    # Convert to PIL Images
+    pil_images = [Image.fromarray(frame) for frame in frames]
+
+    eval_logger.info(f"Loaded {len(pil_images)} frames from video as images (total_frames={total_frames})")
+
+    return pil_images

--- a/lmms_eval/tasks/vsibench/multi_image_input/vsibench_multiimage.yaml
+++ b/lmms_eval/tasks/vsibench/multi_image_input/vsibench_multiimage.yaml
@@ -1,0 +1,32 @@
+# VSIBench Multi-Image Task Configuration
+# to support evaluation of SenseNova-SI models  
+# that is evaluated on multiple images as input
+# see https://github.com/EvolvingLMMs-Lab/EASI/issues/20
+dataset_name: full
+test_split: test
+task: "vsibench_multiimage"
+dataset_kwargs:
+  token: True
+  cache_dir: vsibench
+  video: True
+include: ../_default_template_yaml
+
+# Override doc_to_visual to return frames as images instead of video path
+doc_to_visual: !function utils.vsibench_doc_to_visual_as_images
+
+lmms_eval_specific_kwargs:
+  default:
+    pre_prompt: "These are frames of a video."
+    mca_post_prompt: "Answer with the option's letter from the given choices directly."
+    na_post_prompt: "Please answer the question using a single word or phrase."
+    num_frames: 32  # Number of frames to sample from the video
+  gemini_api:
+    pre_prompt: ""
+    mca_post_prompt: "Answer with the option's letter from the given choices directly."
+    na_post_prompt: "Do not response anything other than a single number!"
+    num_frames: 32
+  gpt4v:
+    pre_prompt: ""
+    mca_post_prompt: "Answer with the option's letter from the given choices directly."
+    na_post_prompt: "Do not response anything other than a single number!"
+    num_frames: 32


### PR DESCRIPTION
Added task variant to input video as multi-image instead to support evaluation of SenseNova-SI model series with Qwen base model. See https://github.com/EvolvingLMMs-Lab/EASI/issues/20

sample result:
<img width="946" height="396" alt="image" src="https://github.com/user-attachments/assets/17eb8fe7-4777-459f-ad53-1fbdedaf3260" />
