### PR TITLE
fix: add version-aware audio loading for datasets >= 4.0 compatibility

### DIFF
--- a/lmms_eval/models/model_utils/audio_processing.py
+++ b/lmms_eval/models/model_utils/audio_processing.py
@@ -66,10 +66,7 @@ def load_audio_safe(
             else:
                 audio_array = np.array(audio_data)
                 sample_rate = 16000
-                eval_logger.warning(
-                    f"Unexpected audio format with datasets {datasets_version}, "
-                    f"attempting conversion. Type: {type(audio_data)}"
-                )
+                eval_logger.warning(f"Unexpected audio format with datasets {datasets_version}, " f"attempting conversion. Type: {type(audio_data)}")
         else:
             if isinstance(audio_data, dict):
                 audio_array = np.array(audio_data["array"])
@@ -82,26 +79,17 @@ def load_audio_safe(
             audio_array = audio_array.mean(axis=-1)
 
         if target_sr is not None and target_sr != sample_rate:
-            audio_array = resample(
-                audio_array, orig_sr=sample_rate, target_sr=target_sr
-            )
+            audio_array = resample(audio_array, orig_sr=sample_rate, target_sr=target_sr)
             sample_rate = target_sr
 
         return audio_array, sample_rate
 
     except Exception as e:
-        raise ValueError(
-            f"Failed to load audio from document. datasets version: {datasets_version}, "
-            f"audio_data type: {type(audio_data)}, error: {e}"
-        ) from e
+        raise ValueError(f"Failed to load audio from document. datasets version: {datasets_version}, " f"audio_data type: {type(audio_data)}, error: {e}") from e
 
 
-def downsample_audio(
-    audio_array: np.ndarray, original_sr: int, target_sr: int
-) -> np.ndarray:
-    audio_resample_array = resample(
-        audio_array, orig_sr=original_sr, target_sr=target_sr
-    )
+def downsample_audio(audio_array: np.ndarray, original_sr: int, target_sr: int) -> np.ndarray:
+    audio_resample_array = resample(audio_array, orig_sr=original_sr, target_sr=target_sr)
     return audio_resample_array
 
 


### PR DESCRIPTION
## Summary

Adds version-aware audio loading utilities to handle breaking changes in `datasets >= 4.0` where audio loading uses `torchcodec` and returns tensors instead of dictionaries.

## Problem

- `datasets >= 4.0` uses `torchcodec` for audio loading by default
- Audio data is returned as tensors instead of the previous `{"array": ..., "sampling_rate": ...}` dict format
- This causes `KeyError` or `AttributeError` when existing code tries to access `audio["array"]`

## Changes

Added new utilities in `lmms_eval/models/model_utils/audio_processing.py`:

- `get_datasets_version()`: Detects installed datasets library version
- `load_audio_safe()`: Version-aware audio loading that:
  - Detects datasets version at runtime
  - Handles both old dict format and new tensor format
  - Provides automatic stereo-to-mono conversion
  - Supports optional resampling to target sample rate
  - Returns unified `(waveform, sample_rate)` tuple

## Usage

```python
from lmms_eval.models.model_utils.audio_processing import load_audio_safe

# Works with both datasets < 4.0 and >= 4.0
waveform, sample_rate = load_audio_safe(audio_data, target_sr=16000)
```

## Related Issues

Fixes #836

## Testing

- Tested with datasets 3.x (dict format)
- Tested with datasets 4.x (tensor format)
- Tested stereo-to-mono conversion
- Tested resampling functionality