### PR TITLE
feat: add VLMEvalKit-compatible Qwen task variants for MMMU and MMStar

### DIFF
--- a/lmms_eval/tasks/mmmu/mmmu_val_qwen.yaml
+++ b/lmms_eval/tasks/mmmu/mmmu_val_qwen.yaml
@@ -1,0 +1,22 @@
+dataset_path: lmms-lab/MMMU
+task: "mmmu_val_qwen"
+test_split: validation
+output_type: generate_until
+doc_to_visual: !function utils.mmmu_doc_to_visual
+doc_to_text: !function utils.mmmu_doc_to_text
+doc_to_target: "answer"
+doc_to_messages: !function utils.mmmu_doc_to_messages
+process_results: !function utils.mmmu_process_results
+
+metric_list:
+  - metric: mmmu_acc
+    aggregation: !function utils.mmmu_aggregate_results
+    higher_is_better: true
+
+lmms_eval_specific_kwargs:
+  default:
+    format: "qwen3_vl"
+    pre_prompt: "Question: "
+    post_prompt: "Answer with the option letter only."
+    open_ended_prompt: "Please answer the question directly."
+include: _default_template_yaml

--- a/lmms_eval/tasks/mmstar/mmstar_qwen.yaml
+++ b/lmms_eval/tasks/mmstar/mmstar_qwen.yaml
@@ -1,0 +1,11 @@
+dataset_path: Lin-Chen/MMStar
+task: "mmstar_qwen"
+doc_to_visual: !function utils.mmstar_doc_to_visual
+doc_to_text: !function utils.mmstar_doc_to_text
+process_results: !function utils.mmstar_process_results
+
+lmms_eval_specific_kwargs:
+  default:
+    pre_prompt: "Question: "
+    post_prompt: "Answer with the option letter only."
+include: _default_template_yaml


### PR DESCRIPTION
## Summary

Adds VLMEvalKit-compatible task variants for Qwen models to address the 10-20% score gaps reported between lmms-eval and VLMEvalKit.

## Problem

Users reported significant score differences when evaluating Qwen models:
- MMMU: 10-15% lower scores in lmms-eval vs VLMEvalKit
- MMStar: Similar gaps observed

Root cause: Different prompt formatting between the two frameworks:
- **lmms-eval default**: `"Options: A: option1\nB: option2"`
- **VLMEvalKit**: `"Question: ...\nOptions:\nA. option1\nB. option2\nAnswer with the option letter only."`

## Changes

Added new task variants:

### `mmmu_val_qwen` (lmms_eval/tasks/mmmu/mmmu_val_qwen.yaml)
- Uses `pre_prompt: "Question: "`
- Uses `post_prompt: "Answer with the option letter only."`
- Format: `qwen3_vl` for proper prompt construction

### `mmstar_qwen` (lmms_eval/tasks/mmstar/mmstar_qwen.yaml)
- Same VLMEvalKit-style prompts
- Maintains compatibility with existing metrics

## Usage

```bash
# Use VLMEvalKit-compatible prompts for Qwen models
python -m lmms_eval --model qwen2_5_vl \
  --model_args pretrained=Qwen/Qwen2.5-VL-3B-Instruct \
  --tasks mmmu_val_qwen,mmstar_qwen
```

## Related Issues

Addresses #935, #932, #881, #901

## Testing

- Verified YAML syntax validity
- Verified task registration works
- Prompt format matches VLMEvalKit implementation