### PR TITLE
fix: replace hardcoded .cuda() with .to(self._device) for multi-GPU support

### DIFF
--- a/lmms_eval/models/simple/auroracap.py
+++ b/lmms_eval/models/simple/auroracap.py
@@ -37,9 +37,7 @@ try:
     )
     from lmms_eval.models.aurora_xtuner.utils import PROMPT_TEMPLATE
 except ImportError:
-    eval_logger.error(
-        "AuroraCap is not installed. Please install AuroraCap to use this model by `git clone https://github.com/rese1f/aurora.git` and link `src/xtuner/xtuner` to `lmms_eval/models/aurora_xtuner`"
-    )
+    eval_logger.error("AuroraCap is not installed. Please install AuroraCap to use this model by `git clone https://github.com/rese1f/aurora.git` and link `src/xtuner/xtuner` to `lmms_eval/models/aurora_xtuner`")
 import warnings
 
 warnings.filterwarnings("ignore")
@@ -92,11 +90,7 @@ class AuroraCap(lmms):
         else:
             self._device = device
 
-        pretrained_pth = (
-            snapshot_download(repo_id=pretrained)
-            if not osp.isdir(pretrained)
-            else pretrained
-        )
+        pretrained_pth = snapshot_download(repo_id=pretrained) if not osp.isdir(pretrained) else pretrained
         pretrained_llm = pretrained_pth
         pretrained_vit = osp.join(pretrained_pth, "visual_encoder")
 
@@ -114,9 +108,7 @@ class AuroraCap(lmms):
         )
 
         projector_path = osp.join(pretrained_pth, "projector")
-        self.model.projector = AutoModel.from_pretrained(
-            projector_path, torch_dtype=torch.float16, trust_remote_code=True
-        )
+        self.model.projector = AutoModel.from_pretrained(projector_path, torch_dtype=torch.float16, trust_remote_code=True)
 
         self._image_processor = CLIPImageProcessor.from_pretrained(
             pretrained_model_name_or_path="laion/CLIP-ViT-bigG-14-laion2B-39B-b160k",  # use standard CLIP processor
@@ -151,39 +143,21 @@ class AuroraCap(lmms):
             if accelerator.distributed_type == DistributedType.DEEPSPEED:
                 kwargs = {
                     "train_micro_batch_size_per_gpu": self.batch_size_per_gpu,
-                    "train_batch_size": self.batch_size_per_gpu
-                    * accelerator.num_processes,
+                    "train_batch_size": self.batch_size_per_gpu * accelerator.num_processes,
                 }
-                AcceleratorState().deepspeed_plugin.deepspeed_config_process(
-                    must_match=True, **kwargs
-                )
-                eval_logger.info(
-                    "Detected that you are using DistributedType.DEEPSPEED. Make sure you run `accelerate config` and set zero stage to 0"
-                )
-            if (
-                accelerator.distributed_type == DistributedType.FSDP
-                or accelerator.distributed_type == DistributedType.DEEPSPEED
-            ):
+                AcceleratorState().deepspeed_plugin.deepspeed_config_process(must_match=True, **kwargs)
+                eval_logger.info("Detected that you are using DistributedType.DEEPSPEED. Make sure you run `accelerate config` and set zero stage to 0")
+            if accelerator.distributed_type == DistributedType.FSDP or accelerator.distributed_type == DistributedType.DEEPSPEED:
                 self._model = accelerator.prepare(self.model)
-                self._model.visual_encoder = accelerator.prepare(
-                    self.model.visual_encoder
-                )
+                self._model.visual_encoder = accelerator.prepare(self.model.visual_encoder)
                 self._model.projector = accelerator.prepare(self.model.projector)
             else:  # DistributedType.MULTI_GPU
-                self._model = accelerator.prepare_model(
-                    self.model, evaluation_mode=True
-                )
-                self._model.visual_encoder = accelerator.prepare_model(
-                    self.model.visual_encoder, evaluation_mode=True
-                )
-                self._model.projector = accelerator.prepare_model(
-                    self.model.projector, evaluation_mode=True
-                )
+                self._model = accelerator.prepare_model(self.model, evaluation_mode=True)
+                self._model.visual_encoder = accelerator.prepare_model(self.model.visual_encoder, evaluation_mode=True)
+                self._model.projector = accelerator.prepare_model(self.model.projector, evaluation_mode=True)
             self.accelerator = accelerator
             if self.accelerator.is_local_main_process:
-                eval_logger.info(
-                    f"Using {accelerator.num_processes} devices with data parallelism"
-                )
+                eval_logger.info(f"Using {accelerator.num_processes} devices with data parallelism")
             self._rank = self.accelerator.local_process_index
             self._world_size = self.accelerator.num_processes
         else:
@@ -224,9 +198,7 @@ class AuroraCap(lmms):
     def pad_sequence(self, input_ids, batch_first, padding_value):
         if self.tokenizer.padding_side == "left":
             input_ids = [torch.flip(_input_ids, [0]) for _input_ids in input_ids]
-        input_ids = torch.nn.utils.rnn.pad_sequence(
-            input_ids, batch_first=batch_first, padding_value=padding_value
-        )
+        input_ids = torch.nn.utils.rnn.pad_sequence(input_ids, batch_first=batch_first, padding_value=padding_value)
         if self.tokenizer.padding_side == "left":
             input_ids = torch.flip(input_ids, [1])
         return input_ids
@@ -252,18 +224,12 @@ class AuroraCap(lmms):
         new_images = []
         if image_aspect_ratio == "pad":
             for image in images:
-                image = expand2square(
-                    image, tuple(int(x * 255) for x in image_processor.image_mean)
-                )
-                image = image_processor.preprocess(image, return_tensors="pt")[
-                    "pixel_values"
-                ][0]
+                image = expand2square(image, tuple(int(x * 255) for x in image_processor.image_mean))
+                image = image_processor.preprocess(image, return_tensors="pt")["pixel_values"][0]
                 new_images.append(image)
         elif image_aspect_ratio == "anyres":
             for image in images:
-                image = process_anyres_image(
-                    image, image_processor, model_cfg.image_grid_pinpoints
-                )
+                image = process_anyres_image(image, image_processor, model_cfg.image_grid_pinpoints)
                 new_images.append(image)
         else:
             return image_processor(images, return_tensors="pt")["pixel_values"]
@@ -271,9 +237,7 @@ class AuroraCap(lmms):
             new_images = torch.stack(new_images, dim=0)
         return new_images
 
-    def tok_encode(
-        self, string: str, left_truncate_len=None, add_special_tokens=None
-    ) -> List[int]:
+    def tok_encode(self, string: str, left_truncate_len=None, add_special_tokens=None) -> List[int]:
         """ """
         add_special_tokens = False if add_special_tokens is None else add_special_tokens
         encoding = self.tokenizer.encode(string, add_special_tokens=add_special_tokens)
@@ -287,13 +251,9 @@ class AuroraCap(lmms):
 
     def loglikelihood(self, requests: List[Instance]) -> List[Tuple[float, bool]]:
         res = []
-        pbar = tqdm(
-            total=len(requests), disable=(self.rank != 0), desc="Model Responding"
-        )
+        pbar = tqdm(total=len(requests), disable=(self.rank != 0), desc="Model Responding")
 
-        for contexts, doc_to_target, doc_to_visual, doc_id, task, split in [
-            reg.args for reg in requests
-        ]:
+        for contexts, doc_to_target, doc_to_visual, doc_id, task, split in [reg.args for reg in requests]:
             # encode, pad, and truncate contexts for this batch
             if type(doc_to_target) == str:
                 continuation = doc_to_target
@@ -302,14 +262,9 @@ class AuroraCap(lmms):
             visuals = [doc_to_visual(self.task_dict[task][split][doc_id])]
             visuals = self.flatten(visuals)
             if visuals:
-                image = self.process_images(
-                    visuals, self._image_processor, self._config
-                )
+                image = self.process_images(visuals, self._image_processor, self._config)
                 if type(image) is list:
-                    image = [
-                        _image.to(dtype=torch.float16, device=self.device)
-                        for _image in image
-                    ]
+                    image = [_image.to(dtype=torch.float16, device=self.device) for _image in image]
                 else:
                     image = image.to(dtype=torch.float16, device=self.device)
             else:
@@ -317,11 +272,7 @@ class AuroraCap(lmms):
 
             prompts_input = contexts[0]
 
-            if (
-                image is not None
-                and len(image) != 0
-                and DEFAULT_IMAGE_TOKEN not in prompts_input
-            ):
+            if image is not None and len(image) != 0 and DEFAULT_IMAGE_TOKEN not in prompts_input:
                 """
                 Three senarios:
                 1. No image, and there for, no image token should be added.
@@ -335,29 +286,13 @@ class AuroraCap(lmms):
             conv.append_message(conv.roles[0], prompts_input)
             conv.append_message(conv.roles[1], None)
             prompt = conv.get_prompt()
-            pad_token_id = (
-                self.tokenizer.pad_token_id
-                if self.tokenizer.pad_token_id is not None
-                else self.tokenizer.eos_token_id
-            )
-            contxt_id = (
-                tokenizer_image_token(
-                    prompt, self.tokenizer, IMAGE_TOKEN_INDEX, return_tensors="pt"
-                )
-                .unsqueeze(0)
-                .to(self.device)
-            )
+            pad_token_id = self.tokenizer.pad_token_id if self.tokenizer.pad_token_id is not None else self.tokenizer.eos_token_id
+            contxt_id = tokenizer_image_token(prompt, self.tokenizer, IMAGE_TOKEN_INDEX, return_tensors="pt").unsqueeze(0).to(self.device)
             # Add the answer of the second role
             conv.messages[1][1] = continuation
 
             prompt = conv.get_prompt()
-            input_ids = (
-                tokenizer_image_token(
-                    prompt, self.tokenizer, IMAGE_TOKEN_INDEX, return_tensors="pt"
-                )
-                .unsqueeze(0)
-                .to(self.device)
-            )
+            input_ids = tokenizer_image_token(prompt, self.tokenizer, IMAGE_TOKEN_INDEX, return_tensors="pt").unsqueeze(0).to(self.device)
             labels = input_ids.clone()
             # Context part no need to calculate for loss
             labels[0, : contxt_id.shape[1]] = -100
@@ -374,9 +309,7 @@ class AuroraCap(lmms):
             logits = outputs["logits"]
             greedy_tokens = logits.argmax(dim=-1)
             cont_toks = input_ids[:, contxt_id.shape[1] :]  # [1, seq]
-            greedy_tokens = greedy_tokens[
-                :, contxt_id.shape[1] : input_ids.shape[1]
-            ]  # [1, seq]
+            greedy_tokens = greedy_tokens[:, contxt_id.shape[1] : input_ids.shape[1]]  # [1, seq]
             max_equal = (greedy_tokens == cont_toks).all()
             res.append((float(loss.item()), bool(max_equal)))
             pbar.update(1)
@@ -393,9 +326,7 @@ class AuroraCap(lmms):
     def load_video(self, video_path, max_frames_num):
         vr = VideoReader(video_path, ctx=cpu(0))
         total_frame_num = len(vr)
-        uniform_sampled_frames = np.linspace(
-            0, total_frame_num - 1, max_frames_num, dtype=int
-        )
+        uniform_sampled_frames = np.linspace(0, total_frame_num - 1, max_frames_num, dtype=int)
         frame_idx = uniform_sampled_frames.tolist()
         spare_frames = vr.get_batch(frame_idx).asnumpy()
         return spare_frames  # (frames, height, width, channels)
@@ -446,24 +377,16 @@ class AuroraCap(lmms):
         # we group requests by their generation_kwargs,
         # so that we don't try to execute e.g. greedy sampling and temp=0.8 sampling
         # in the same batch.
-        re_ords = utils.Collator(
-            [reg.args for reg in requests], _collate, grouping=True
-        )
+        re_ords = utils.Collator([reg.args for reg in requests], _collate, grouping=True)
         chunks = re_ords.get_batched(n=self.batch_size, batch_fn=None)
-        num_iters = (
-            len(requests) // self.batch_size
-            if len(requests) % self.batch_size == 0
-            else len(requests) // self.batch_size + 1
-        )
+        num_iters = len(requests) // self.batch_size if len(requests) % self.batch_size == 0 else len(requests) // self.batch_size + 1
         pbar = tqdm(total=num_iters, disable=(self.rank != 0), desc="Model Responding")
 
         for chunk in chunks:
             contexts, all_gen_kwargs, doc_to_visual, doc_id, task, split = zip(*chunk)
             task = task[0]
             split = split[0]
-            visuals = [
-                doc_to_visual[0](self.task_dict[task][split][ids]) for ids in doc_id
-            ]  # the length of visuals is 1, equal to batchsize
+            visuals = [doc_to_visual[0](self.task_dict[task][split][ids]) for ids in doc_id]  # the length of visuals is 1, equal to batchsize
             visuals = self.flatten(visuals)
             # we assume all gen kwargs in the batch are the same
             # this is safe to assume because the `grouper` object ensures it.
@@ -478,65 +401,39 @@ class AuroraCap(lmms):
                 if isinstance(until, str):
                     until = [until]
                 elif not isinstance(until, list):
-                    raise ValueError(
-                        f"Expected `gen_kwargs['until']` to be of type Union[str,list] but got {type(until)}"
-                    )
+                    raise ValueError(f"Expected `gen_kwargs['until']` to be of type Union[str,list] but got {type(until)}")
 
-            if (
-                "image_aspect_ratio" in gen_kwargs.keys()
-                and "image_aspect_ratio" not in self._config.__dict__
-            ):
+            if "image_aspect_ratio" in gen_kwargs.keys() and "image_aspect_ratio" not in self._config.__dict__:
                 # here we should pop it out of gen_kwargs so that it doesn't get passed to the model for next step of generation
                 self._config.image_aspect_ratio = gen_kwargs.pop("image_aspect_ratio")
-                eval_logger.info(
-                    f"Setting image aspect ratio: {self._config.image_aspect_ratio}"
-                )
+                eval_logger.info(f"Setting image aspect ratio: {self._config.image_aspect_ratio}")
             # encode, pad, and truncate contexts for this batch
             if visuals:
                 if isinstance(visuals[0], dict):
                     video_path = visuals[0]["video_path"]
                     keyframe = visuals[0]["keyframe"]
                     video = self.extract_keyframes(video_path, keyframe)
-                    image_tensor = self.process_images(
-                        video, self._image_processor, self._config
-                    ).to(self._device)
+                    image_tensor = self.process_images(video, self._image_processor, self._config).to(self._device)
                 elif isinstance(visuals, list):
                     print(visuals[0])
                     if isinstance(visuals[0], Image.Image):
-                        image_tensor = self.process_images(
-                            visuals, self._image_processor, self._config
-                        )
+                        image_tensor = self.process_images(visuals, self._image_processor, self._config)
                     else:
                         if visuals[0].endswith("mp4"):
                             if self.video_decode_backend == "decord":
                                 video = self.load_video(visuals[0], self.max_frames_num)
                             elif self.video_decode_backend == "pyav":
-                                video = read_video_pyav(
-                                    visuals[0], num_frm=self.max_frames_num
-                                )
-                            image_tensor = self.process_images(
-                                video, self._image_processor, self._config
-                            ).to(self._device)
+                                video = read_video_pyav(visuals[0], num_frm=self.max_frames_num)
+                            image_tensor = self.process_images(video, self._image_processor, self._config).to(self._device)
                         elif visuals[0].endswith("mkv"):
-                            assert self.video_decode_backend == "pyav", (
-                                "we only tested this case, decord may not work"
-                            )
-                            video = read_video_pyav(
-                                visuals[0], num_frm=self.max_frames_num
-                            )
-                            image_tensor = self.process_images(
-                                video, self._image_processor, self._config
-                            ).to(self._device)
+                            assert self.video_decode_backend == "pyav", "we only tested this case, decord may not work"
+                            video = read_video_pyav(visuals[0], num_frm=self.max_frames_num)
+                            image_tensor = self.process_images(video, self._image_processor, self._config).to(self._device)
 
                 if type(image_tensor) is list:
-                    image_tensor = [
-                        _image.to(dtype=torch.float16, device=self.device)
-                        for _image in image_tensor
-                    ]
+                    image_tensor = [_image.to(dtype=torch.float16, device=self.device) for _image in image_tensor]
                 else:
-                    image_tensor = image_tensor.to(
-                        dtype=torch.float16, device=self.device
-                    )
+                    image_tensor = image_tensor.to(dtype=torch.float16, device=self.device)
 
             else:
                 image_tensor = None
@@ -544,11 +441,7 @@ class AuroraCap(lmms):
             question_input = []
 
             for visual, context in zip(visuals, contexts):
-                if (
-                    image_tensor is not None
-                    and len(image_tensor) != 0
-                    and DEFAULT_IMAGE_TOKEN not in context
-                ):
+                if image_tensor is not None and len(image_tensor) != 0 and DEFAULT_IMAGE_TOKEN not in context:
                     """
                     Three senarios:
                     1. No image, and there for, no image token should be added.
@@ -559,11 +452,7 @@ class AuroraCap(lmms):
                         image_tokens = [DEFAULT_IMAGE_TOKEN] * len(video)
                     elif isinstance(visuals, list):
                         if isinstance(visuals[0], Image.Image):
-                            image_tokens = (
-                                [DEFAULT_IMAGE_TOKEN] * len(visual)
-                                if isinstance(visual, list)
-                                else [DEFAULT_IMAGE_TOKEN]
-                            )
+                            image_tokens = [DEFAULT_IMAGE_TOKEN] * len(visual) if isinstance(visual, list) else [DEFAULT_IMAGE_TOKEN]
                         else:
                             if visual.endswith("mp4") or visual.endswith("mkv"):
                                 image_tokens = [DEFAULT_IMAGE_TOKEN] * len(video)
@@ -593,19 +482,13 @@ class AuroraCap(lmms):
 
             # preconfigure gen_kwargs with defaults
             if isinstance(visuals[0], dict):
-                gen_kwargs["image_sizes"] = [
-                    video[idx].size for idx in range(len(video))
-                ]
+                gen_kwargs["image_sizes"] = [video[idx].size for idx in range(len(video))]
             elif isinstance(visuals, list):
                 if isinstance(visuals[0], Image.Image):
-                    gen_kwargs["image_sizes"] = [
-                        visuals[idx].size for idx in range(len(visuals))
-                    ]
+                    gen_kwargs["image_sizes"] = [visuals[idx].size for idx in range(len(visuals))]
                 else:
                     if visuals[0].endswith("mp4"):
-                        gen_kwargs["image_sizes"] = [
-                            video[idx].size for idx in range(len(video))
-                        ]
+                        gen_kwargs["image_sizes"] = [video[idx].size for idx in range(len(video))]
 
             if "max_new_tokens" not in gen_kwargs:
                 gen_kwargs["max_new_tokens"] = 1024
@@ -616,20 +499,9 @@ class AuroraCap(lmms):
             if "num_beams" not in gen_kwargs:
                 gen_kwargs["num_beams"] = 1
 
-            input_ids_list = [
-                tokenizer_image_token(
-                    prompt, self.tokenizer, IMAGE_TOKEN_INDEX, return_tensors="pt"
-                )
-                for prompt in question_input
-            ]
-            pad_token_ids = (
-                self.tokenizer.pad_token_id
-                if self.tokenizer.pad_token_id is not None
-                else self.tokenizer.eos_token_id
-            )
-            input_ids = self.pad_sequence(
-                input_ids_list, batch_first=True, padding_value=pad_token_ids
-            ).to(self.device)
+            input_ids_list = [tokenizer_image_token(prompt, self.tokenizer, IMAGE_TOKEN_INDEX, return_tensors="pt") for prompt in question_input]
+            pad_token_ids = self.tokenizer.pad_token_id if self.tokenizer.pad_token_id is not None else self.tokenizer.eos_token_id
+            input_ids = self.pad_sequence(input_ids_list, batch_first=True, padding_value=pad_token_ids).to(self.device)
             attention_masks = input_ids.ne(pad_token_ids).to(self.device)
             # These steps are not in LLaVA's original code, but are necessary for generation to work
             try:
@@ -655,9 +527,7 @@ class AuroraCap(lmms):
                     num_beams=gen_kwargs["num_beams"],
                     max_new_tokens=gen_kwargs["max_new_tokens"],
                 )
-                text_outputs = self.tokenizer.batch_decode(
-                    cont, skip_special_tokens=True
-                )
+                text_outputs = self.tokenizer.batch_decode(cont, skip_special_tokens=True)
             except Exception as e:
                 eval_logger.error(f"Error {e} in generating")
                 cont = ""
@@ -666,9 +536,7 @@ class AuroraCap(lmms):
             print(text_outputs)
 
             res.extend(text_outputs)
-            self.cache_hook.add_partial(
-                "generate_until", (context, gen_kwargs), text_outputs
-            )
+            self.cache_hook.add_partial("generate_until", (context, gen_kwargs), text_outputs)
             pbar.update(1)
             # reorder this group of results back to original unsorted form
         res = re_ords.get_original(res)

--- a/lmms_eval/models/simple/internvideo2.py
+++ b/lmms_eval/models/simple/internvideo2.py
@@ -52,39 +52,23 @@ def get_index(max_frame, num_segments, fps, first_idx=0, bound=None):
     start_idx = max(first_idx, round(start * fps))
     end_idx = min(round(end * fps), max_frame)
     seg_size = float(end_idx - start_idx) / num_segments
-    frame_indices = np.array(
-        [
-            int(start_idx + (seg_size / 2) + np.round(seg_size * idx))
-            for idx in range(num_segments)
-        ]
-    )
+    frame_indices = np.array([int(start_idx + (seg_size / 2) + np.round(seg_size * idx)) for idx in range(num_segments)])
     return frame_indices
 
 
 def load_image(image_path, resolution=224, hd_num=6):
     image = Image.open(image_path).convert("RGB")
     image_tensor = T.PILToTensor()(image).unsqueeze(0)
-    image_tensor = HD_transform_no_padding(
-        image_tensor.float(), image_size=resolution, hd_num=hd_num
-    )
+    image_tensor = HD_transform_no_padding(image_tensor.float(), image_size=resolution, hd_num=hd_num)
     T_, C, H, W = image_tensor.shape
 
     mean = (0.485, 0.456, 0.406)
     std = (0.229, 0.224, 0.225)
 
-    transform = T.Compose(
-        [T.Lambda(lambda x: x.float().div(255.0)), T.Normalize(mean, std)]
-    )
+    transform = T.Compose([T.Lambda(lambda x: x.float().div(255.0)), T.Normalize(mean, std)])
     image_tensor = transform(image_tensor)
 
-    sub_img = (
-        image_tensor.reshape(
-            1, T_, 3, H // resolution, resolution, W // resolution, resolution
-        )
-        .permute(0, 3, 5, 1, 2, 4, 6)
-        .reshape(-1, T_, 3, resolution, resolution)
-        .contiguous()
-    )
+    sub_img = image_tensor.reshape(1, T_, 3, H // resolution, resolution, W // resolution, resolution).permute(0, 3, 5, 1, 2, 4, 6).reshape(-1, T_, 3, resolution, resolution).contiguous()
 
     glb_img = (
         F.interpolate(
@@ -122,33 +106,20 @@ def load_video(
     mean = (0.485, 0.456, 0.406)
     std = (0.229, 0.224, 0.225)
 
-    transform = T.Compose(
-        [T.Lambda(lambda x: x.float().div(255.0)), T.Normalize(mean, std)]
-    )
+    transform = T.Compose([T.Lambda(lambda x: x.float().div(255.0)), T.Normalize(mean, std)])
 
     frames = vr.get_batch(frame_indices)
     frames = frames.permute(0, 3, 1, 2)
 
     if padding:
-        frames = HD_transform_padding(
-            frames.float(), image_size=resolution, hd_num=hd_num
-        )
+        frames = HD_transform_padding(frames.float(), image_size=resolution, hd_num=hd_num)
     else:
-        frames = HD_transform_no_padding(
-            frames.float(), image_size=resolution, hd_num=hd_num
-        )
+        frames = HD_transform_no_padding(frames.float(), image_size=resolution, hd_num=hd_num)
 
     frames = transform(frames)
     T_, C, H, W = frames.shape
 
-    sub_img = (
-        frames.reshape(
-            1, T_, 3, H // resolution, resolution, W // resolution, resolution
-        )
-        .permute(0, 3, 5, 1, 2, 4, 6)
-        .reshape(-1, T_, 3, resolution, resolution)
-        .contiguous()
-    )
+    sub_img = frames.reshape(1, T_, 3, H // resolution, resolution, W // resolution, resolution).permute(0, 3, 5, 1, 2, 4, 6).reshape(-1, T_, 3, resolution, resolution).contiguous()
 
     glb_img = (
         F.interpolate(
@@ -167,9 +138,7 @@ def load_video(
         fps = float(vr.get_avg_fps())
         sec = ", ".join([str(round(f / fps, 1)) for f in frame_indices])
         # " " should be added in the start and end
-        msg = (
-            f"The video contains {len(frame_indices)} frames sampled at {sec} seconds."
-        )
+        msg = f"The video contains {len(frame_indices)} frames sampled at {sec} seconds."
         return frames, msg
     else:
         return frames
@@ -209,9 +178,7 @@ def HD_transform_padding(frames, image_size=224, hd_num=6):
     new_w = int(scale * image_size)
     new_h = int(new_w / ratio)
 
-    resized_frames = F.interpolate(
-        frames, size=(new_h, new_w), mode="bicubic", align_corners=False
-    )
+    resized_frames = F.interpolate(frames, size=(new_h, new_w), mode="bicubic", align_corners=False)
     padded_frames = _padding_224(resized_frames)
 
     if trans:
@@ -243,22 +210,14 @@ def HD_transform_no_padding(frames, image_size=224, hd_num=6, fix_ratio=(2, 1)):
     aspect_ratio = orig_width / orig_height
 
     # calculate the existing video aspect ratio
-    target_ratios = set(
-        (i, j)
-        for n in range(min_num, max_num + 1)
-        for i in range(1, n + 1)
-        for j in range(1, n + 1)
-        if i * j <= max_num and i * j >= min_num
-    )
+    target_ratios = set((i, j) for n in range(min_num, max_num + 1) for i in range(1, n + 1) for j in range(1, n + 1) if i * j <= max_num and i * j >= min_num)
     target_ratios = sorted(target_ratios, key=lambda x: x[0] * x[1])
 
     # find the closest aspect ratio to the target
     if fix_ratio:
         target_aspect_ratio = fix_ratio
     else:
-        target_aspect_ratio = find_closest_aspect_ratio(
-            aspect_ratio, target_ratios, orig_width, orig_height, image_size
-        )
+        target_aspect_ratio = find_closest_aspect_ratio(aspect_ratio, target_ratios, orig_width, orig_height, image_size)
 
     # calculate the target width and height
     target_width = image_size * target_aspect_ratio[0]
@@ -266,9 +225,7 @@ def HD_transform_no_padding(frames, image_size=224, hd_num=6, fix_ratio=(2, 1)):
     blocks = target_aspect_ratio[0] * target_aspect_ratio[1]
 
     # resize the frames
-    resized_frame = F.interpolate(
-        frames, size=(target_height, target_width), mode="bicubic", align_corners=False
-    )
+    resized_frame = F.interpolate(frames, size=(target_height, target_width), mode="bicubic", align_corners=False)
     return resized_frame
 
 
@@ -289,22 +246,12 @@ class InternVideo2(lmms):
         self.path = pretrained
         self.instruction = "Carefully watch the video and pay attention to the cause and sequence of events, the detail and movement of objects, and the action and pose of persons.\n"
 
-        self._tokenizer = AutoTokenizer.from_pretrained(
-            self.path, trust_remote_code=True, use_fast=False
-        )
-        self._model = (
-            AutoModel.from_pretrained(
-                self.path, torch_dtype=torch.bfloat16, trust_remote_code=True
-            )
-            .eval()
-            .to(self._device)
-        )
+        self._tokenizer = AutoTokenizer.from_pretrained(self.path, trust_remote_code=True, use_fast=False)
+        self._model = AutoModel.from_pretrained(self.path, torch_dtype=torch.bfloat16, trust_remote_code=True).eval().to(self._device)
         batch_size = int(batch_size)
         self.num_segments = int(num_segments)
         self.hd_num = int(hd_num)
-        assert batch_size == 1, (
-            f"Batch size should be 1 for InternVideo2, but got {batch_size}."
-        )
+        assert batch_size == 1, f"Batch size should be 1 for InternVideo2, but got {batch_size}."
         self.batch_size_per_gpu = batch_size
         accelerator_kwargs = InitProcessGroupKwargs(timeout=timedelta(weeks=52))
         accelerator = Accelerator(kwargs_handlers=[accelerator_kwargs])
@@ -331,36 +278,22 @@ class InternVideo2(lmms):
             if accelerator.distributed_type == DistributedType.DEEPSPEED:
                 kwargs = {
                     "train_micro_batch_size_per_gpu": self.batch_size_per_gpu,
-                    "train_batch_size": self.batch_size_per_gpu
-                    * accelerator.num_processes,
+                    "train_batch_size": self.batch_size_per_gpu * accelerator.num_processes,
                 }
-                AcceleratorState().deepspeed_plugin.deepspeed_config_process(
-                    must_match=True, **kwargs
-                )
-                eval_logger.info(
-                    "Detected that you are using DistributedType.DEEPSPEED. Make sure you run `accelerate config` and set zero stage to 0"
-                )
+                AcceleratorState().deepspeed_plugin.deepspeed_config_process(must_match=True, **kwargs)
+                eval_logger.info("Detected that you are using DistributedType.DEEPSPEED. Make sure you run `accelerate config` and set zero stage to 0")
 
-            if (
-                accelerator.distributed_type == DistributedType.FSDP
-                or accelerator.distributed_type == DistributedType.DEEPSPEED
-            ):
+            if accelerator.distributed_type == DistributedType.FSDP or accelerator.distributed_type == DistributedType.DEEPSPEED:
                 self._model = accelerator.prepare(self.model)
             else:
-                self._model = accelerator.prepare_model(
-                    self.model, evaluation_mode=True
-                )
+                self._model = accelerator.prepare_model(self.model, evaluation_mode=True)
             self.accelerator = accelerator
             if self.accelerator.is_local_main_process:
-                eval_logger.info(
-                    f"Using {accelerator.num_processes} devices with data parallelism"
-                )
+                eval_logger.info(f"Using {accelerator.num_processes} devices with data parallelism")
             self._rank = self.accelerator.local_process_index
             self._world_size = self.accelerator.num_processes
         elif accelerator.num_processes == 1 and device_map == "auto":
-            eval_logger.info(
-                f"Using {accelerator.num_processes} devices with tensor parallelism"
-            )
+            eval_logger.info(f"Using {accelerator.num_processes} devices with tensor parallelism")
             self._rank = 0
             self._world_size = 1
         else:
@@ -413,13 +346,9 @@ class InternVideo2(lmms):
 
     def generate_until(self, requests) -> List[str]:
         res = []
-        pbar = tqdm(
-            total=len(requests), disable=(self.rank != 0), desc="Model Responding"
-        )
+        pbar = tqdm(total=len(requests), disable=(self.rank != 0), desc="Model Responding")
 
-        for contexts, gen_kwargs, doc_to_visual, doc_id, task, split in [
-            reg.args for reg in requests
-        ]:
+        for contexts, gen_kwargs, doc_to_visual, doc_id, task, split in [reg.args for reg in requests]:
             if "until" in gen_kwargs:
                 gen_kwargs.pop("until")
             for k, v in DEFAULT_GEN_KWARGS.items():
@@ -438,9 +367,7 @@ class InternVideo2(lmms):
             visuals = self.flatten(visuals)
             if self.modality == "image":
                 image_path = visuals[0]
-                pixel_values = load_image(
-                    image_path, resolution=224, hd_num=self.hd_num
-                )
+                pixel_values = load_image(image_path, resolution=224, hd_num=self.hd_num)
                 pixel_values = pixel_values.to(torch.bfloat16).to(self._device)
                 question = contexts
                 response, history = self.model.chat(
@@ -455,9 +382,7 @@ class InternVideo2(lmms):
                     **gen_kwargs,
                 )
             elif self.modality == "video":
-                assert len(visuals) == 1, (
-                    f"Only one video is supported, but got {len(visuals)} videos. [META-INFO]{visuals}"
-                )
+                assert len(visuals) == 1, f"Only one video is supported, but got {len(visuals)} videos. [META-INFO]{visuals}"
                 video_path = visuals[0]
                 if "mvbench" in task:
                     answer_prompt = "Best Option:("
@@ -494,6 +419,4 @@ class InternVideo2(lmms):
         assert False, "Not implemented yet."
 
     def generate_until_multi_round(self, requests) -> List[str]:
-        raise NotImplementedError(
-            "TODO: Implement multi-round generation for InternVideo2"
-        )
+        raise NotImplementedError("TODO: Implement multi-round generation for InternVideo2")

--- a/lmms_eval/models/simple/internvl.py
+++ b/lmms_eval/models/simple/internvl.py
@@ -39,13 +39,9 @@ try:
     from internvl.model.internvl_chat.modeling_intern_vit import InternVisionModel
     from internvl.train.dataset import build_transform, dynamic_preprocess
 except ImportError:
-    eval_logger.debug(
-        "InternVL is not installed. Please install InternVL to use this model."
-    )
+    eval_logger.debug("InternVL is not installed. Please install InternVL to use this model.")
     if not eval_logger.internvl_warning_logged:
-        eval_logger.debug(
-            "InternVL is not installed. Please install InternVL to use this model."
-        )
+        eval_logger.debug("InternVL is not installed. Please install InternVL to use this model.")
         eval_logger.internvl_warning_logged = True
 
 import re
@@ -177,9 +173,7 @@ class InternVLChat(lmms):
             local_dir_use_symlinks=False,
         )
         config = InternVLChatConfig.from_pretrained(cache_dir)
-        tokenizer = AutoTokenizer.from_pretrained(
-            cache_dir, trust_remote_code=True, use_fast=False
-        )
+        tokenizer = AutoTokenizer.from_pretrained(cache_dir, trust_remote_code=True, use_fast=False)
         model = InternVLChatModel.from_pretrained(
             cache_dir,
             low_cpu_mem_usage=True,
@@ -215,36 +209,22 @@ class InternVLChat(lmms):
             if accelerator.distributed_type == DistributedType.DEEPSPEED:
                 kwargs = {
                     "train_micro_batch_size_per_gpu": self.batch_size_per_gpu,
-                    "train_batch_size": self.batch_size_per_gpu
-                    * accelerator.num_processes,
+                    "train_batch_size": self.batch_size_per_gpu * accelerator.num_processes,
                 }
-                AcceleratorState().deepspeed_plugin.deepspeed_config_process(
-                    must_match=True, **kwargs
-                )
-                eval_logger.info(
-                    "Detected that you are using DistributedType.DEEPSPEED. Make sure you run `accelerate config` and set zero stage to 0"
-                )
+                AcceleratorState().deepspeed_plugin.deepspeed_config_process(must_match=True, **kwargs)
+                eval_logger.info("Detected that you are using DistributedType.DEEPSPEED. Make sure you run `accelerate config` and set zero stage to 0")
 
-            if (
-                accelerator.distributed_type == DistributedType.FSDP
-                or accelerator.distributed_type == DistributedType.DEEPSPEED
-            ):
+            if accelerator.distributed_type == DistributedType.FSDP or accelerator.distributed_type == DistributedType.DEEPSPEED:
                 self._model = accelerator.prepare(self.model)
             else:
-                self._model = accelerator.prepare_model(
-                    self.model, evaluation_mode=True
-                )
+                self._model = accelerator.prepare_model(self.model, evaluation_mode=True)
             self.accelerator = accelerator
             if self.accelerator.is_local_main_process:
-                eval_logger.info(
-                    f"Using {accelerator.num_processes} devices with data parallelism"
-                )
+                eval_logger.info(f"Using {accelerator.num_processes} devices with data parallelism")
             self._rank = self.accelerator.local_process_index
             self._world_size = self.accelerator.num_processes
         elif accelerator.num_processes == 1 and device_map == "auto":
-            eval_logger.info(
-                f"Using {accelerator.num_processes} devices with tensor parallelism"
-            )
+            eval_logger.info(f"Using {accelerator.num_processes} devices with tensor parallelism")
             self._rank = 0
             self._world_size = 1
         else:
@@ -301,10 +281,7 @@ class InternVLChat(lmms):
             int(c / (scale_factor * scale_factor)),
         )
         if self.ps_version == "v1":
-            warnings.warn(
-                "In ps_version 'v1', the height and width have not been swapped back, "
-                "which results in a transposed image."
-            )
+            warnings.warn("In ps_version 'v1', the height and width have not been swapped back, " "which results in a transposed image.")
         else:
             x = x.permute(0, 2, 1, 3).contiguous()
         return x
@@ -317,13 +294,9 @@ class InternVLChat(lmms):
 
     def extract_feature(self, pixel_values):
         if self.select_layer == -1:
-            vit_embeds = self.vision_model(
-                pixel_values=pixel_values, output_hidden_states=False, return_dict=True
-            ).last_hidden_state
+            vit_embeds = self.vision_model(pixel_values=pixel_values, output_hidden_states=False, return_dict=True).last_hidden_state
         else:
-            vit_embeds = self.vision_model(
-                pixel_values=pixel_values, output_hidden_states=True, return_dict=True
-            ).hidden_states[self.select_layer]
+            vit_embeds = self.vision_model(pixel_values=pixel_values, output_hidden_states=True, return_dict=True).hidden_states[self.select_layer]
         vit_embeds = vit_embeds[:, 1:, :]
 
         if self.training and self.neftune_alpha is not None:
@@ -352,9 +325,7 @@ class InternVLChat(lmms):
         img_context_token_id = tokenizer.convert_tokens_to_ids(IMG_CONTEXT_TOKEN)
         self.img_context_token_id = img_context_token_id
         if tokenizer.convert_tokens_to_ids("<|im_end|>") != 0:
-            eos_token_id = tokenizer.convert_tokens_to_ids(
-                "<|im_end|>"
-            )  # 92542, InternLM2
+            eos_token_id = tokenizer.convert_tokens_to_ids("<|im_end|>")  # 92542, InternLM2
         else:
             eos_token_id = tokenizer.eos_token_id
 
@@ -368,12 +339,7 @@ class InternVLChat(lmms):
             image_bs = pixel_values.shape[0]
             # print(f"dynamic ViT batch size: {image_bs}, image_counts: {image_counts}")
             for idx, image_count in enumerate(image_counts):
-                image_tokens += (
-                    f"<image {idx + 1}> (图{idx + 1}):"
-                    + IMG_START_TOKEN
-                    + IMG_CONTEXT_TOKEN * self.num_image_token * image_count
-                    + IMG_END_TOKEN
-                )
+                image_tokens += f"<image {idx + 1}> (图{idx + 1}):" + IMG_START_TOKEN + IMG_CONTEXT_TOKEN * self.num_image_token * image_count + IMG_END_TOKEN
             question = image_tokens + "\n" + question
         else:
             for old_question, old_answer in history:
@@ -393,9 +359,7 @@ class InternVLChat(lmms):
             attention_mask=attention_mask,
             **generation_config,
         )
-        response = tokenizer.batch_decode(generation_output, skip_special_tokens=True)[
-            0
-        ]
+        response = tokenizer.batch_decode(generation_output, skip_special_tokens=True)[0]
         response = response.split("<|im_end|>")[0].strip()  # for InternLM2
         history.append((question, response))
         if return_history:
@@ -434,9 +398,7 @@ class InternVLChat(lmms):
     def world_size(self):
         return self._world_size
 
-    def tok_encode(
-        self, string: str, left_truncate_len=None, add_special_tokens=None
-    ) -> List[int]:
+    def tok_encode(self, string: str, left_truncate_len=None, add_special_tokens=None) -> List[int]:
         """ """
         add_special_tokens = False if add_special_tokens is None else add_special_tokens
         encoding = self.tokenizer.encode(string, add_special_tokens=add_special_tokens)
@@ -452,12 +414,7 @@ class InternVLChat(lmms):
             return self.tokenizer.decode([tokens])
 
     def post_processing(self, response):
-        response = (
-            response.replace("\n", "")
-            .replace("不是", "No")
-            .replace("是", "Yes")
-            .replace("否", "No")
-        )
+        response = response.replace("\n", "").replace("不是", "No").replace("是", "Yes").replace("否", "No")
         response = response.lower().replace("true", "yes").replace("false", "no")
         pattern = re.compile(r"[\u4e00-\u9fa5]")
         response = re.sub(pattern, "", response)
@@ -547,30 +504,18 @@ class InternVLChat(lmms):
         # we group requests by their generation_kwargs,
         # so that we don't try to execute e.g. greedy sampling and temp=0.8 sampling
         # in the same batch.
-        re_ords = utils.Collator(
-            [reg.args for reg in requests], _collate, grouping=True
-        )
+        re_ords = utils.Collator([reg.args for reg in requests], _collate, grouping=True)
         chunks = re_ords.get_batched(n=self.batch_size, batch_fn=None)
-        num_iters = (
-            len(requests) // self.batch_size
-            if len(requests) % self.batch_size == 0
-            else len(requests) // self.batch_size + 1
-        )
+        num_iters = len(requests) // self.batch_size if len(requests) % self.batch_size == 0 else len(requests) // self.batch_size + 1
         pbar = tqdm(total=num_iters, disable=(self.rank != 0), desc="Model Responding")
         for chunk in chunks:
             contexts, all_gen_kwargs, doc_to_visual, doc_id, task, split = zip(*chunk)
             task = task[0]
             split = split[0]
-            batched_visuals = [
-                doc_to_visual[0](self.task_dict[task][split][ids]) for ids in doc_id
-            ]  # [B, N]
+            batched_visuals = [doc_to_visual[0](self.task_dict[task][split][ids]) for ids in doc_id]  # [B, N]
             flattened_visuals = self.flatten(batched_visuals)
             try:
-                pixel_values = (
-                    self.load_image(flattened_visuals, self.image_size)
-                    .to(self._device)
-                    .to(torch.bfloat16)
-                )
+                pixel_values = self.load_image(flattened_visuals, self.image_size).to(self._device).to(torch.bfloat16)
             except IndexError:
                 pixel_values = None
             gen_kwargs = all_gen_kwargs[0]
@@ -602,9 +547,7 @@ class InternVLChat(lmms):
             # TODO(choiszt) try batch_chat for multiple inputs
             response = self.post_processing(response)
             res.append(response)
-            self.cache_hook.add_partial(
-                "generate_until", (question, gen_kwargs), response
-            )
+            self.cache_hook.add_partial("generate_until", (question, gen_kwargs), response)
             pbar.update(1)
         res = re_ords.get_original(res)
         return res

--- a/lmms_eval/models/simple/internvl2.py
+++ b/lmms_eval/models/simple/internvl2.py
@@ -56,26 +56,16 @@ def find_closest_aspect_ratio(aspect_ratio, target_ratios, width, height, image_
     return best_ratio
 
 
-def dynamic_preprocess(
-    image, min_num=1, max_num=6, image_size=448, use_thumbnail=False
-):
+def dynamic_preprocess(image, min_num=1, max_num=6, image_size=448, use_thumbnail=False):
     orig_width, orig_height = image.size
     aspect_ratio = orig_width / orig_height
 
     # calculate the existing image aspect ratio
-    target_ratios = set(
-        (i, j)
-        for n in range(min_num, max_num + 1)
-        for i in range(1, n + 1)
-        for j in range(1, n + 1)
-        if i * j <= max_num and i * j >= min_num
-    )
+    target_ratios = set((i, j) for n in range(min_num, max_num + 1) for i in range(1, n + 1) for j in range(1, n + 1) if i * j <= max_num and i * j >= min_num)
     target_ratios = sorted(target_ratios, key=lambda x: x[0] * x[1])
 
     # find the closest aspect ratio to the target
-    target_aspect_ratio = find_closest_aspect_ratio(
-        aspect_ratio, target_ratios, orig_width, orig_height, image_size
-    )
+    target_aspect_ratio = find_closest_aspect_ratio(aspect_ratio, target_ratios, orig_width, orig_height, image_size)
 
     # calculate the target width and height
     target_width = image_size * target_aspect_ratio[0]
@@ -104,9 +94,7 @@ def dynamic_preprocess(
 
 def load_image(image, input_size=448, max_num=6):
     transform = build_transform(input_size=input_size)
-    images = dynamic_preprocess(
-        image, image_size=input_size, use_thumbnail=True, max_num=max_num
-    )
+    images = dynamic_preprocess(image, image_size=input_size, use_thumbnail=True, max_num=max_num)
     pixel_values = [transform(image) for image in images]
     pixel_values = torch.stack(pixel_values)
     return pixel_values
@@ -120,12 +108,7 @@ def get_index(bound, fps, max_frame, first_idx=0, num_segments=32):
     start_idx = max(first_idx, round(start * fps))
     end_idx = min(round(end * fps), max_frame)
     seg_size = float(end_idx - start_idx) / num_segments
-    frame_indices = np.array(
-        [
-            int(start_idx + (seg_size / 2) + np.round(seg_size * idx))
-            for idx in range(num_segments)
-        ]
-    )
+    frame_indices = np.array([int(start_idx + (seg_size / 2) + np.round(seg_size * idx)) for idx in range(num_segments)])
     return frame_indices
 
 
@@ -136,14 +119,10 @@ def load_video(video_path, bound=None, input_size=448, max_num=1, num_segments=3
 
     pixel_values_list, num_patches_list = [], []
     transform = build_transform(input_size=input_size)
-    frame_indices = get_index(
-        bound, fps, max_frame, first_idx=0, num_segments=num_segments
-    )
+    frame_indices = get_index(bound, fps, max_frame, first_idx=0, num_segments=num_segments)
     for frame_index in frame_indices:
         img = Image.fromarray(vr[frame_index].asnumpy()).convert("RGB")
-        img = dynamic_preprocess(
-            img, image_size=input_size, use_thumbnail=True, max_num=max_num
-        )
+        img = dynamic_preprocess(img, image_size=input_size, use_thumbnail=True, max_num=max_num)
         pixel_values = [transform(tile) for tile in img]
         pixel_values = torch.stack(pixel_values)
         num_patches_list.append(pixel_values.shape[0])
@@ -220,9 +199,7 @@ class InternVL2(lmms):
         self.num_frame = num_frame
 
         batch_size = int(batch_size)
-        assert batch_size == 1, (
-            f"Batch size should be 1 for InternVL2, but got {batch_size}."
-        )
+        assert batch_size == 1, f"Batch size should be 1 for InternVL2, but got {batch_size}."
         self.batch_size_per_gpu = batch_size
 
         accelerator_kwargs = InitProcessGroupKwargs(timeout=timedelta(weeks=52))
@@ -246,9 +223,7 @@ class InternVL2(lmms):
             trust_remote_code=True,
             device_map=self.device_map,
         ).eval()
-        self._tokenizer = AutoTokenizer.from_pretrained(
-            self.path, trust_remote_code=True, device_map=self.device_map
-        )
+        self._tokenizer = AutoTokenizer.from_pretrained(self.path, trust_remote_code=True, device_map=self.device_map)
 
         if accelerator.num_processes > 1:
             assert accelerator.distributed_type in [
@@ -262,36 +237,22 @@ class InternVL2(lmms):
             if accelerator.distributed_type == DistributedType.DEEPSPEED:
                 kwargs = {
                     "train_micro_batch_size_per_gpu": self.batch_size_per_gpu,
-                    "train_batch_size": self.batch_size_per_gpu
-                    * accelerator.num_processes,
+                    "train_batch_size": self.batch_size_per_gpu * accelerator.num_processes,
                 }
-                AcceleratorState().deepspeed_plugin.deepspeed_config_process(
-                    must_match=True, **kwargs
-                )
-                eval_logger.info(
-                    "Detected that you are using DistributedType.DEEPSPEED. Make sure you run `accelerate config` and set zero stage to 0"
-                )
+                AcceleratorState().deepspeed_plugin.deepspeed_config_process(must_match=True, **kwargs)
+                eval_logger.info("Detected that you are using DistributedType.DEEPSPEED. Make sure you run `accelerate config` and set zero stage to 0")
 
-            if (
-                accelerator.distributed_type == DistributedType.FSDP
-                or accelerator.distributed_type == DistributedType.DEEPSPEED
-            ):
+            if accelerator.distributed_type == DistributedType.FSDP or accelerator.distributed_type == DistributedType.DEEPSPEED:
                 self._model = accelerator.prepare(self.model)
             else:
-                self._model = accelerator.prepare_model(
-                    self.model, evaluation_mode=True
-                )
+                self._model = accelerator.prepare_model(self.model, evaluation_mode=True)
             self.accelerator = accelerator
             if self.accelerator.is_local_main_process:
-                eval_logger.info(
-                    f"Using {accelerator.num_processes} devices with data parallelism"
-                )
+                eval_logger.info(f"Using {accelerator.num_processes} devices with data parallelism")
             self._rank = self.accelerator.local_process_index
             self._world_size = self.accelerator.num_processes
         elif accelerator.num_processes == 1 and device_map == "auto":
-            eval_logger.info(
-                f"Using {accelerator.num_processes} devices with tensor parallelism"
-            )
+            eval_logger.info(f"Using {accelerator.num_processes} devices with tensor parallelism")
             self._rank = 0
             self._world_size = 1
         else:
@@ -344,13 +305,9 @@ class InternVL2(lmms):
 
     def generate_until(self, requests) -> List[str]:
         res = []
-        pbar = tqdm(
-            total=len(requests), disable=(self.rank != 0), desc="Model Responding"
-        )
+        pbar = tqdm(total=len(requests), disable=(self.rank != 0), desc="Model Responding")
 
-        for contexts, gen_kwargs, doc_to_visual, doc_id, task, split in [
-            reg.args for reg in requests
-        ]:
+        for contexts, gen_kwargs, doc_to_visual, doc_id, task, split in [reg.args for reg in requests]:
             if "until" in gen_kwargs:
                 gen_kwargs.pop("until")
             for k, v in DEFAULT_GEN_KWARGS.items():
@@ -369,10 +326,7 @@ class InternVL2(lmms):
             visuals = self.flatten(visuals)
             if self.modality == "image":
                 if visuals:
-                    visuals = [
-                        load_image(visual).to(torch.bfloat16).to(self._device)
-                        for visual in visuals
-                    ]
+                    visuals = [load_image(visual).to(torch.bfloat16).to(self._device) for visual in visuals]
                     pixel_values = torch.cat(visuals, dim=0)
                     num_patches_list = [visual.size(0) for visual in visuals]
                     image_tokens = ["<image>"] * len(visuals)
@@ -391,17 +345,11 @@ class InternVL2(lmms):
                     return_history=True,
                 )
             elif self.modality == "video":
-                assert len(visuals) == 1, (
-                    f"Only one video is supported, but got {len(visuals)} videos."
-                )
+                assert len(visuals) == 1, f"Only one video is supported, but got {len(visuals)} videos."
                 video_path = visuals[0]
-                pixel_values, num_patches_list = load_video(
-                    video_path, num_segments=self.num_frame
-                )
+                pixel_values, num_patches_list = load_video(video_path, num_segments=self.num_frame)
                 pixel_values = pixel_values.to(torch.bfloat16).to(self._device)
-                video_prefix = "".join(
-                    [f"Frame{i + 1}: <image>\n" for i in range(len(num_patches_list))]
-                )
+                video_prefix = "".join([f"Frame{i + 1}: <image>\n" for i in range(len(num_patches_list))])
                 question = video_prefix + contexts
                 response, history = self.model.chat(
                     self.tokenizer,
@@ -421,6 +369,4 @@ class InternVL2(lmms):
         assert False, "Not implemented yet."
 
     def generate_until_multi_round(self, requests) -> List[str]:
-        raise NotImplementedError(
-            "TODO: Implement multi-round generation for InternVL2"
-        )
+        raise NotImplementedError("TODO: Implement multi-round generation for InternVL2")

--- a/lmms_eval/models/simple/llava_onevision.py
+++ b/lmms_eval/models/simple/llava_onevision.py
@@ -51,9 +51,7 @@ try:
     )
     from llava.model.builder import load_pretrained_model
 except ImportError as e:
-    eval_logger.debug(
-        f"LLaVA is not installed. Please install LLaVA to use this model.\nError: {e}"
-    )
+    eval_logger.debug(f"LLaVA is not installed. Please install LLaVA to use this model.\nError: {e}")
 
 
 # Determine best attention implementation
@@ -80,16 +78,12 @@ class Llava_OneVision(lmms):
         device_map: Optional[str] = "cuda:0",
         conv_template: Optional[str] = "qwen_1_5",
         use_cache: Optional[bool] = True,
-        truncate_context: Optional[
-            bool
-        ] = False,  # whether to truncate the context in generation, set it False for LLaVA-1.6
+        truncate_context: Optional[bool] = False,  # whether to truncate the context in generation, set it False for LLaVA-1.6
         customized_config: Optional[str] = None,  # ends in json
         max_frames_num: Optional[int] = 32,
         mm_spatial_pool_stride: Optional[int] = 2,
         mm_spatial_pool_mode: Optional[str] = "bilinear",
-        token_strategy: Optional[
-            str
-        ] = "single",  # could be "single" or "multiple", "multiple" denotes adding multiple <image> tokens for each frame
+        token_strategy: Optional[str] = "single",  # could be "single" or "multiple", "multiple" denotes adding multiple <image> tokens for each frame
         video_decode_backend: str = "decord",
         **kwargs,
     ) -> None:
@@ -118,11 +112,7 @@ class Llava_OneVision(lmms):
             llava_model_args["attn_implementation"] = attn_implementation
         if "use_flash_attention_2" in kwargs:
             llava_model_args["use_flash_attention_2"] = kwargs["use_flash_attention_2"]
-        model_name = (
-            model_name
-            if model_name is not None
-            else get_model_name_from_path(pretrained)
-        )
+        model_name = model_name if model_name is not None else get_model_name_from_path(pretrained)
 
         self.pretrained = pretrained
         self.token_strategy = token_strategy
@@ -139,26 +129,22 @@ class Llava_OneVision(lmms):
         llava_model_args["overwrite_config"] = overwrite_config
         try:
             # Try to load the model with the multimodal argument
-            self._tokenizer, self._model, self._image_processor, self._max_length = (
-                load_pretrained_model(
-                    pretrained,
-                    None,
-                    model_name,
-                    device_map=self.device_map,
-                    **llava_model_args,
-                )
+            self._tokenizer, self._model, self._image_processor, self._max_length = load_pretrained_model(
+                pretrained,
+                None,
+                model_name,
+                device_map=self.device_map,
+                **llava_model_args,
             )
         except TypeError:
             # for older versions of LLaVA that don't have multimodal argument
             llava_model_args.pop("multimodal", None)
-            self._tokenizer, self._model, self._image_processor, self._max_length = (
-                load_pretrained_model(
-                    pretrained,
-                    None,
-                    model_name,
-                    device_map=self.device_map,
-                    **llava_model_args,
-                )
+            self._tokenizer, self._model, self._image_processor, self._max_length = load_pretrained_model(
+                pretrained,
+                None,
+                model_name,
+                device_map=self.device_map,
+                **llava_model_args,
             )
 
         self._config = self._model.config
@@ -168,9 +154,7 @@ class Llava_OneVision(lmms):
         self.conv_template = conv_template
         self.use_cache = use_cache
         self.truncate_context = truncate_context
-        assert self.batch_size_per_gpu == 1, (
-            "Llava currently does not support batched generation. See https://github.com/haotian-liu/LLaVA/issues/754. HF Llava also has this issue."
-        )
+        assert self.batch_size_per_gpu == 1, "Llava currently does not support batched generation. See https://github.com/haotian-liu/LLaVA/issues/754. HF Llava also has this issue."
 
         if accelerator.num_processes > 1:
             assert accelerator.distributed_type in [
@@ -184,37 +168,23 @@ class Llava_OneVision(lmms):
             if accelerator.distributed_type == DistributedType.DEEPSPEED:
                 kwargs = {
                     "train_micro_batch_size_per_gpu": self.batch_size_per_gpu,
-                    "train_batch_size": self.batch_size_per_gpu
-                    * accelerator.num_processes,
+                    "train_batch_size": self.batch_size_per_gpu * accelerator.num_processes,
                 }
-                AcceleratorState().deepspeed_plugin.deepspeed_config_process(
-                    must_match=True, **kwargs
-                )
-                eval_logger.info(
-                    "Detected that you are using DistributedType.DEEPSPEED. Make sure you run `accelerate config` and set zero stage to 0"
-                )
+                AcceleratorState().deepspeed_plugin.deepspeed_config_process(must_match=True, **kwargs)
+                eval_logger.info("Detected that you are using DistributedType.DEEPSPEED. Make sure you run `accelerate config` and set zero stage to 0")
 
-            if (
-                accelerator.distributed_type == DistributedType.FSDP
-                or accelerator.distributed_type == DistributedType.DEEPSPEED
-            ):
+            if accelerator.distributed_type == DistributedType.FSDP or accelerator.distributed_type == DistributedType.DEEPSPEED:
                 self._model = accelerator.prepare(self.model)
             else:
-                self._model = accelerator.prepare_model(
-                    self.model, evaluation_mode=True
-                )
+                self._model = accelerator.prepare_model(self.model, evaluation_mode=True)
             self.accelerator = accelerator
             if self.accelerator.is_local_main_process:
-                eval_logger.info(
-                    f"Using {accelerator.num_processes} devices with data parallelism"
-                )
+                eval_logger.info(f"Using {accelerator.num_processes} devices with data parallelism")
             self._rank = self.accelerator.local_process_index
             self._world_size = self.accelerator.num_processes
 
         elif accelerator.num_processes == 1 and device_map == "auto":
-            eval_logger.info(
-                f"Using {accelerator.num_processes} devices with tensor parallelism"
-            )
+            eval_logger.info(f"Using {accelerator.num_processes} devices with tensor parallelism")
             self._rank = 0
             self._world_size = 1
 
@@ -253,9 +223,7 @@ class Llava_OneVision(lmms):
     def pad_sequence(self, input_ids, batch_first, padding_value):
         if self.tokenizer.padding_side == "left":
             input_ids = [torch.flip(_input_ids, [0]) for _input_ids in input_ids]
-        input_ids = torch.nn.utils.rnn.pad_sequence(
-            input_ids, batch_first=batch_first, padding_value=padding_value
-        )
+        input_ids = torch.nn.utils.rnn.pad_sequence(input_ids, batch_first=batch_first, padding_value=padding_value)
         if self.tokenizer.padding_side == "left":
             input_ids = torch.flip(input_ids, [1])
         return input_ids
@@ -276,9 +244,7 @@ class Llava_OneVision(lmms):
     def world_size(self):
         return self._world_size
 
-    def tok_encode(
-        self, string: str, left_truncate_len=None, add_special_tokens=None
-    ) -> List[int]:
+    def tok_encode(self, string: str, left_truncate_len=None, add_special_tokens=None) -> List[int]:
         """ """
         add_special_tokens = False if add_special_tokens is None else add_special_tokens
         encoding = self.tokenizer.encode(string, add_special_tokens=add_special_tokens)
@@ -295,25 +261,16 @@ class Llava_OneVision(lmms):
 
     def loglikelihood(self, requests: List[Instance]) -> List[Tuple[float, bool]]:
         res = []
-        pbar = tqdm(
-            total=len(requests), disable=(self.rank != 0), desc="Model Responding"
-        )
+        pbar = tqdm(total=len(requests), disable=(self.rank != 0), desc="Model Responding")
 
         origin_image_aspect_ratio = getattr(self._config, "image_aspect_ratio", None)
 
-        for contexts, doc_to_target, doc_to_visual, doc_id, task, split in [
-            reg.args for reg in requests
-        ]:
+        for contexts, doc_to_target, doc_to_visual, doc_id, task, split in [reg.args for reg in requests]:
             visual = doc_to_visual(self.task_dict[task][split][doc_id])
 
-            if (
-                origin_image_aspect_ratio is not None
-                and self._config.image_aspect_ratio != origin_image_aspect_ratio
-            ):
+            if origin_image_aspect_ratio is not None and self._config.image_aspect_ratio != origin_image_aspect_ratio:
                 self._config.image_aspect_ratio = origin_image_aspect_ratio
-                eval_logger.info(
-                    f"Resetting image aspect ratio to {origin_image_aspect_ratio}"
-                )
+                eval_logger.info(f"Resetting image aspect ratio to {origin_image_aspect_ratio}")
 
             if visual is None or visual == []:
                 visual = None
@@ -322,53 +279,29 @@ class Llava_OneVision(lmms):
             else:
                 if len(visual) > 1 or "image_aspect_ratio" not in self._config.__dict__:
                     self._config.image_aspect_ratio = "pad"
-                    eval_logger.info(
-                        f"In Multi-Image setting, image aspect ratio: {self._config.image_aspect_ratio}"
-                    )
+                    eval_logger.info(f"In Multi-Image setting, image aspect ratio: {self._config.image_aspect_ratio}")
 
-                if (
-                    "task_type" in self.metadata
-                    and self.metadata["task_type"] == "video"
-                    and "sample_frames" in self.metadata
-                ):
-                    assert type(visual) == list, (
-                        "sample_frames must be specified for video task"
-                    )
-                    sample_indices = np.linspace(
-                        0, len(visual) - 1, self.metadata["sample_frames"], dtype=int
-                    )
+                if "task_type" in self.metadata and self.metadata["task_type"] == "video" and "sample_frames" in self.metadata:
+                    assert type(visual) == list, "sample_frames must be specified for video task"
+                    sample_indices = np.linspace(0, len(visual) - 1, self.metadata["sample_frames"], dtype=int)
                     visual = [visual[i] for i in sample_indices]
                     assert len(visual) == self.metadata["sample_frames"]
 
-                    image_tensor = process_images(
-                        visual, self._image_processor, self._config
-                    )
+                    image_tensor = process_images(visual, self._image_processor, self._config)
                     if type(image_tensor) is list:
-                        image_tensor = [
-                            _image.to(dtype=torch.float16, device=self.device)
-                            for _image in image_tensor
-                        ]
+                        image_tensor = [_image.to(dtype=torch.float16, device=self.device) for _image in image_tensor]
                     else:
-                        image_tensor = image_tensor.to(
-                            dtype=torch.float16, device=self.device
-                        )
+                        image_tensor = image_tensor.to(dtype=torch.float16, device=self.device)
 
                     task_type = "video"
 
                 # elif type(visual[0]) == PIL.Image.Image:
                 elif isinstance(visual[0], PIL.Image.Image):
-                    image_tensor = process_images(
-                        visual, self._image_processor, self._config
-                    )
+                    image_tensor = process_images(visual, self._image_processor, self._config)
                     if type(image_tensor) is list:
-                        image_tensor = [
-                            _image.to(dtype=torch.float16, device=self.device)
-                            for _image in image_tensor
-                        ]
+                        image_tensor = [_image.to(dtype=torch.float16, device=self.device) for _image in image_tensor]
                     else:
-                        image_tensor = image_tensor.to(
-                            dtype=torch.float16, device=self.device
-                        )
+                        image_tensor = image_tensor.to(dtype=torch.float16, device=self.device)
 
                     task_type = "image"
 
@@ -378,16 +311,8 @@ class Llava_OneVision(lmms):
                         if self.video_decode_backend == "decord":
                             frames = self.load_video(visual, self.max_frames_num)
                         elif self.video_decode_backend == "pyav":
-                            frames = read_video_pyav(
-                                visual[0], num_frm=self.max_frames_num
-                            )
-                        frames = (
-                            self._image_processor.preprocess(
-                                frames, return_tensors="pt"
-                            )["pixel_values"]
-                            .half()
-                            .to(self._device)
-                        )
+                            frames = read_video_pyav(visual[0], num_frm=self.max_frames_num)
+                        frames = self._image_processor.preprocess(frames, return_tensors="pt")["pixel_values"].half().to(self._device)
                         image_tensor.append(frames)
                     except Exception as e:
                         eval_logger.error(f"Error {e} in loading video")
@@ -395,16 +320,10 @@ class Llava_OneVision(lmms):
 
                     task_type = "video"
 
-            if (
-                image_tensor is not None
-                and len(image_tensor) != 0
-                and DEFAULT_IMAGE_TOKEN not in contexts
-            ):
+            if image_tensor is not None and len(image_tensor) != 0 and DEFAULT_IMAGE_TOKEN not in contexts:
                 placeholder_count = len(visual) if isinstance(visual, list) else 1
                 if task_type == "video":
-                    placeholder_count = (
-                        len(frames) if self.token_strategy == "multiple" else 1
-                    )
+                    placeholder_count = len(frames) if self.token_strategy == "multiple" else 1
                 image_tokens = [DEFAULT_IMAGE_TOKEN] * placeholder_count
                 image_tokens = " ".join(image_tokens)
                 prompts_input = image_tokens + "\n" + contexts
@@ -420,13 +339,7 @@ class Llava_OneVision(lmms):
             conv.append_message(conv.roles[1], None)
             prompt = conv.get_prompt()
 
-            input_ids = (
-                tokenizer_image_token(
-                    prompt, self.tokenizer, IMAGE_TOKEN_INDEX, return_tensors="pt"
-                )
-                .unsqueeze(0)
-                .to(self.device)
-            )
+            input_ids = tokenizer_image_token(prompt, self.tokenizer, IMAGE_TOKEN_INDEX, return_tensors="pt").unsqueeze(0).to(self.device)
 
             if type(doc_to_target) == str:
                 continuation = doc_to_target
@@ -435,24 +348,14 @@ class Llava_OneVision(lmms):
 
             conv.messages[-1][1] = continuation
             full_prompt = conv.get_prompt()
-            full_input_ids = (
-                tokenizer_image_token(
-                    full_prompt, self.tokenizer, IMAGE_TOKEN_INDEX, return_tensors="pt"
-                )
-                .unsqueeze(0)
-                .to(self.device)
-            )
+            full_input_ids = tokenizer_image_token(full_prompt, self.tokenizer, IMAGE_TOKEN_INDEX, return_tensors="pt").unsqueeze(0).to(self.device)
 
             labels = full_input_ids.clone()
             labels[0, : input_ids.shape[1]] = -100
 
             kwargs = {}
             if task_type == "image":
-                kwargs["image_sizes"] = (
-                    [[v.size[0], v.size[1]] for v in visual]
-                    if isinstance(visual, list)
-                    else [[visual.size[0], visual.size[1]]]
-                )
+                kwargs["image_sizes"] = [[v.size[0], v.size[1]] for v in visual] if isinstance(visual, list) else [[visual.size[0], visual.size[1]]]
             elif task_type == "video":
                 kwargs["modalities"] = ["video"]
                 self._config.mm_spatial_pool_stride = self.mm_spatial_pool_stride
@@ -471,9 +374,7 @@ class Llava_OneVision(lmms):
             logits = outputs["logits"]
             greedy_tokens = logits.argmax(dim=-1)
             cont_toks = full_input_ids[:, input_ids.shape[1] :]
-            greedy_tokens = greedy_tokens[
-                :, input_ids.shape[1] : full_input_ids.shape[1]
-            ]
+            greedy_tokens = greedy_tokens[:, input_ids.shape[1] : full_input_ids.shape[1]]
             max_equal = (greedy_tokens == cont_toks).all()
 
             res.append((float(loss.item()), bool(max_equal)))
@@ -498,9 +399,7 @@ class Llava_OneVision(lmms):
         else:
             vr = VideoReader(video_path[0], ctx=cpu(0))
         total_frame_num = len(vr)
-        uniform_sampled_frames = np.linspace(
-            0, total_frame_num - 1, max_frames_num, dtype=int
-        )
+        uniform_sampled_frames = np.linspace(0, total_frame_num - 1, max_frames_num, dtype=int)
         frame_idx = uniform_sampled_frames.tolist()
         spare_frames = vr.get_batch(frame_idx).asnumpy()
         return spare_frames  # (frames, height, width, channels)
@@ -522,15 +421,9 @@ class Llava_OneVision(lmms):
         # so that we don't try to execute e.g. greedy sampling and temp=0.8 sampling
         # in the same batch.
         metadata = requests[0].metadata
-        re_ords = utils.Collator(
-            [reg.args for reg in requests], _collate, grouping=True
-        )
+        re_ords = utils.Collator([reg.args for reg in requests], _collate, grouping=True)
         chunks = re_ords.get_batched(n=self.batch_size, batch_fn=None)
-        num_iters = (
-            len(requests) // self.batch_size
-            if len(requests) % self.batch_size == 0
-            else len(requests) // self.batch_size + 1
-        )
+        num_iters = len(requests) // self.batch_size if len(requests) % self.batch_size == 0 else len(requests) // self.batch_size + 1
         pbar = tqdm(total=num_iters, disable=(self.rank != 0), desc="Model Responding")
 
         origin_image_aspect_ratio = getattr(self._config, "image_aspect_ratio", None)
@@ -546,10 +439,7 @@ class Llava_OneVision(lmms):
             ) = zip(*chunk)
             task = batched_task[0]
             split = batched_split[0]
-            batched_visuals = [
-                batched_doc_to_visual[0](self.task_dict[task][split][ids])
-                for ids in batched_doc_id
-            ]  # [B, N]
+            batched_visuals = [batched_doc_to_visual[0](self.task_dict[task][split][ids]) for ids in batched_doc_id]  # [B, N]
             assert len(batched_visuals) == 1
 
             # we assume all gen kwargs in the batch are the same
@@ -561,14 +451,9 @@ class Llava_OneVision(lmms):
             question_input = []
             # import ipdb; ipdb.set_trace()
             for visual, context in zip(batched_visuals, batched_contexts):
-                if (
-                    origin_image_aspect_ratio is not None
-                    and self._config.image_aspect_ratio != origin_image_aspect_ratio
-                ):
+                if origin_image_aspect_ratio is not None and self._config.image_aspect_ratio != origin_image_aspect_ratio:
                     self._config.image_aspect_ratio = origin_image_aspect_ratio
-                    eval_logger.info(
-                        f"Resetting image aspect ratio to {origin_image_aspect_ratio}"
-                    )
+                    eval_logger.info(f"Resetting image aspect ratio to {origin_image_aspect_ratio}")
 
                 if visual is None or visual == []:  # for text-only tasks.
                     visual = None
@@ -576,67 +461,34 @@ class Llava_OneVision(lmms):
                     placeholder_count = 0
                     image_tensor = None
                 else:
-                    if (
-                        len(visual) > 1
-                        or "image_aspect_ratio" not in self._config.__dict__
-                    ):  # for multi image case, we treat per image aspect ratio as "pad" by default.
-                        self._config.image_aspect_ratio = getattr(
-                            gen_kwargs, "image_aspect_ratio", "pad"
-                        )
-                        eval_logger.info(
-                            f"In Multi-Image setting, image aspect ratio: {self._config.image_aspect_ratio}"
-                        )
+                    if len(visual) > 1 or "image_aspect_ratio" not in self._config.__dict__:  # for multi image case, we treat per image aspect ratio as "pad" by default.
+                        self._config.image_aspect_ratio = getattr(gen_kwargs, "image_aspect_ratio", "pad")
+                        eval_logger.info(f"In Multi-Image setting, image aspect ratio: {self._config.image_aspect_ratio}")
 
-                    if (
-                        "task_type" in metadata
-                        and metadata["task_type"] == "video"
-                        and "sample_frames" in metadata
-                    ):  # overwrite logic for video task with multiple static image frames
-                        assert type(visual) == list, (
-                            "sample_frames must be specified for video task"
-                        )
-                        sample_indices = np.linspace(
-                            0, len(visual) - 1, metadata["sample_frames"], dtype=int
-                        )
+                    if "task_type" in metadata and metadata["task_type"] == "video" and "sample_frames" in metadata:  # overwrite logic for video task with multiple static image frames
+                        assert type(visual) == list, "sample_frames must be specified for video task"
+                        sample_indices = np.linspace(0, len(visual) - 1, metadata["sample_frames"], dtype=int)
                         visual = [visual[i] for i in sample_indices]
                         assert len(visual) == metadata["sample_frames"]
 
-                        image_tensor = process_images(
-                            visual, self._image_processor, self._config
-                        )
+                        image_tensor = process_images(visual, self._image_processor, self._config)
                         if type(image_tensor) is list:
-                            image_tensor = [
-                                _image.to(dtype=torch.float16, device=self.device)
-                                for _image in image_tensor
-                            ]
+                            image_tensor = [_image.to(dtype=torch.float16, device=self.device) for _image in image_tensor]
                         else:
-                            image_tensor = image_tensor.to(
-                                dtype=torch.float16, device=self.device
-                            )
+                            image_tensor = image_tensor.to(dtype=torch.float16, device=self.device)
 
                         task_type = "video"
                         placeholder_count = 1
 
-                    elif (
-                        type(visual[0]) == PIL.Image.Image
-                    ):  # For image, multi-image tasks
-                        image_tensor = process_images(
-                            visual, self._image_processor, self._config
-                        )
+                    elif type(visual[0]) == PIL.Image.Image:  # For image, multi-image tasks
+                        image_tensor = process_images(visual, self._image_processor, self._config)
                         if type(image_tensor) is list:
-                            image_tensor = [
-                                _image.to(dtype=torch.float16, device=self.device)
-                                for _image in image_tensor
-                            ]
+                            image_tensor = [_image.to(dtype=torch.float16, device=self.device) for _image in image_tensor]
                         else:
-                            image_tensor = image_tensor.to(
-                                dtype=torch.float16, device=self.device
-                            )
+                            image_tensor = image_tensor.to(dtype=torch.float16, device=self.device)
 
                         task_type = "image"
-                        placeholder_count = (
-                            len(visual) if isinstance(visual, list) else 1
-                        )
+                        placeholder_count = len(visual) if isinstance(visual, list) else 1
 
                     elif type(visual[0]) == str:  # For video task
                         image_tensor = []
@@ -644,31 +496,17 @@ class Llava_OneVision(lmms):
                             if self.video_decode_backend == "decord":
                                 frames = self.load_video(visual, self.max_frames_num)
                             elif self.video_decode_backend == "pyav":
-                                frames = read_video_pyav(
-                                    visual[0], num_frm=self.max_frames_num
-                                )
-                            frames = (
-                                self._image_processor.preprocess(
-                                    frames, return_tensors="pt"
-                                )["pixel_values"]
-                                .half()
-                                .to(self._device)
-                            )
+                                frames = read_video_pyav(visual[0], num_frm=self.max_frames_num)
+                            frames = self._image_processor.preprocess(frames, return_tensors="pt")["pixel_values"].half().to(self._device)
                             image_tensor.append(frames)
                         except Exception as e:
                             eval_logger.error(f"Error {e} in loading video")
                             image_tensor = None
 
                         task_type = "video"
-                        placeholder_count = (
-                            len(frames) if self.token_strategy == "multiple" else 1
-                        )
+                        placeholder_count = len(frames) if self.token_strategy == "multiple" else 1
 
-                if (
-                    image_tensor is not None
-                    and len(image_tensor) != 0
-                    and DEFAULT_IMAGE_TOKEN not in context
-                ):
+                if image_tensor is not None and len(image_tensor) != 0 and DEFAULT_IMAGE_TOKEN not in context:
                     """
                     Three senarios:
                     1. No image, and there for, no image token should be added.
@@ -709,35 +547,17 @@ class Llava_OneVision(lmms):
                     prompt_question = conv.get_prompt()
                     question_input.append(prompt_question)
 
-            input_ids_list = [
-                tokenizer_image_token(
-                    prompt, self.tokenizer, IMAGE_TOKEN_INDEX, return_tensors="pt"
-                )
-                for prompt in question_input
-            ]
-            pad_token_ids = (
-                self.tokenizer.pad_token_id
-                if self.tokenizer.pad_token_id is not None
-                else self.tokenizer.eos_token_id
-            )
-            input_ids = self.pad_sequence(
-                input_ids_list, batch_first=True, padding_value=pad_token_ids
-            ).to(self.device)
+            input_ids_list = [tokenizer_image_token(prompt, self.tokenizer, IMAGE_TOKEN_INDEX, return_tensors="pt") for prompt in question_input]
+            pad_token_ids = self.tokenizer.pad_token_id if self.tokenizer.pad_token_id is not None else self.tokenizer.eos_token_id
+            input_ids = self.pad_sequence(input_ids_list, batch_first=True, padding_value=pad_token_ids).to(self.device)
             attention_masks = input_ids.ne(pad_token_ids).to(self.device)
 
             if task_type == "image":
-                gen_kwargs["image_sizes"] = [
-                    batched_visuals[0][idx].size
-                    for idx in range(len(batched_visuals[0]))
-                ]
+                gen_kwargs["image_sizes"] = [batched_visuals[0][idx].size for idx in range(len(batched_visuals[0]))]
             elif task_type == "video":
-                stop_str = (
-                    conv.sep if conv.sep_style != SeparatorStyle.TWO else conv.sep2
-                )
+                stop_str = conv.sep if conv.sep_style != SeparatorStyle.TWO else conv.sep2
                 keywords = [stop_str]
-                stopping_criteria = KeywordsStoppingCriteria(
-                    keywords, self.tokenizer, input_ids
-                )
+                stopping_criteria = KeywordsStoppingCriteria(keywords, self.tokenizer, input_ids)
                 gen_kwargs["modalities"] = ["video"]
                 gen_kwargs["stopping_criteria"] = [stopping_criteria]
                 self._config.mm_spatial_pool_stride = self.mm_spatial_pool_stride
@@ -769,17 +589,13 @@ class Llava_OneVision(lmms):
                     )
                     # cont = self.model.generate(qwen_input_ids, pad_token_id=pad_token_ids, images=image_tensor, use_cache=self.use_cache, **gen_kwargs)
 
-                text_outputs = self.tokenizer.batch_decode(
-                    cont, skip_special_tokens=True
-                )
+                text_outputs = self.tokenizer.batch_decode(cont, skip_special_tokens=True)
             except Exception as e:
                 raise e
 
             text_outputs = [response.strip() for response in text_outputs]
             res.extend(text_outputs)
-            self.cache_hook.add_partial(
-                "generate_until", (context, gen_kwargs), text_outputs
-            )
+            self.cache_hook.add_partial("generate_until", (context, gen_kwargs), text_outputs)
             pbar.update(1)
             # reorder this group of results back to original unsorted form
         res = re_ords.get_original(res)
@@ -804,15 +620,9 @@ class Llava_OneVision(lmms):
         # so that we don't try to execute e.g. greedy sampling and temp=0.8 sampling
         # in the same batch.
         metadata = requests[0].metadata
-        re_ords = utils.Collator(
-            [reg.args for reg in requests], _collate, grouping=True
-        )
+        re_ords = utils.Collator([reg.args for reg in requests], _collate, grouping=True)
         chunks = re_ords.get_batched(n=self.batch_size, batch_fn=None)
-        num_iters = (
-            len(requests) // self.batch_size
-            if len(requests) % self.batch_size == 0
-            else len(requests) // self.batch_size + 1
-        )
+        num_iters = len(requests) // self.batch_size if len(requests) % self.batch_size == 0 else len(requests) // self.batch_size + 1
         pbar = tqdm(total=num_iters, disable=(self.rank != 0), desc="Model Responding")
 
         origin_image_aspect_ratio = getattr(self._config, "image_aspect_ratio", None)
@@ -829,10 +639,7 @@ class Llava_OneVision(lmms):
             ) = zip(*chunk)
             task = batched_task[0]
             split = batched_split[0]
-            batched_visuals = [
-                batched_doc_to_visual[0](self.task_dict[task][split][ids])
-                for ids in batched_doc_id
-            ]  # [B, N]
+            batched_visuals = [batched_doc_to_visual[0](self.task_dict[task][split][ids]) for ids in batched_doc_id]  # [B, N]
             assert len(batched_visuals) == 1
 
             # we assume all gen kwargs in the batch are the same
@@ -848,9 +655,7 @@ class Llava_OneVision(lmms):
             while True:
                 question_input = []
 
-                if (
-                    round_idx != 0
-                ):  # get current round visual and context from doc_to_text function
+                if round_idx != 0:  # get current round visual and context from doc_to_text function
                     (
                         batched_visuals,
                         batched_contexts,
@@ -862,39 +667,23 @@ class Llava_OneVision(lmms):
                             *[
                                 batched_doc_to_text[0](
                                     self.task_dict[task][split][ids],
-                                    previous_output=[
-                                        round_res[ids_idx]
-                                        for round_res in batched_round_res
-                                    ],
+                                    previous_output=[round_res[ids_idx] for round_res in batched_round_res],
                                     round_idx=round_idx,
-                                    previous_round_info=batched_previous_round_info[
-                                        ids_idx
-                                    ]
-                                    if batched_previous_round_info is not None
-                                    else None,
+                                    previous_round_info=batched_previous_round_info[ids_idx] if batched_previous_round_info is not None else None,
                                 )
                                 for ids_idx, ids in enumerate(batched_doc_id)
                             ]
                         )
                     )
                     # import ipdb; ipdb.set_trace()
-                    batched_round_res = list(
-                        zip(*batched_round_res)
-                    )  # [(r1_1, r1_2), (r2_1, r2_2), ...]
-                    if batched_terminal_singal[
-                        0
-                    ]:  # terminal signal from doc_to_text function
+                    batched_round_res = list(zip(*batched_round_res))  # [(r1_1, r1_2), (r2_1, r2_2), ...]
+                    if batched_terminal_singal[0]:  # terminal signal from doc_to_text function
                         break
 
                 for visual, context in zip(batched_visuals, batched_contexts):
-                    if (
-                        origin_image_aspect_ratio is not None
-                        and self._config.image_aspect_ratio != origin_image_aspect_ratio
-                    ):
+                    if origin_image_aspect_ratio is not None and self._config.image_aspect_ratio != origin_image_aspect_ratio:
                         self._config.image_aspect_ratio = origin_image_aspect_ratio
-                        eval_logger.info(
-                            f"Resetting image aspect ratio to {origin_image_aspect_ratio}"
-                        )
+                        eval_logger.info(f"Resetting image aspect ratio to {origin_image_aspect_ratio}")
 
                     if visual is None or visual == []:  # for text-only tasks.
                         visual = None
@@ -902,101 +691,52 @@ class Llava_OneVision(lmms):
                         placeholder_count = 0
                         image_tensor = None
                     else:
-                        if (
-                            len(visual) > 1
-                            or "image_aspect_ratio" not in self._config.__dict__
-                        ):  # for multi image case, we treat per image aspect ratio as "pad" by default.
-                            self._config.image_aspect_ratio = getattr(
-                                gen_kwargs, "image_aspect_ratio", "pad"
-                            )
-                            eval_logger.info(
-                                f"In Multi-Image setting, image aspect ratio: {self._config.image_aspect_ratio}"
-                            )
+                        if len(visual) > 1 or "image_aspect_ratio" not in self._config.__dict__:  # for multi image case, we treat per image aspect ratio as "pad" by default.
+                            self._config.image_aspect_ratio = getattr(gen_kwargs, "image_aspect_ratio", "pad")
+                            eval_logger.info(f"In Multi-Image setting, image aspect ratio: {self._config.image_aspect_ratio}")
 
-                        if (
-                            "task_type" in metadata
-                            and metadata["task_type"] == "video"
-                            and "sample_frames" in metadata
-                        ):  # overwrite logic for video task with multiple static image frames
-                            assert type(visual) == list, (
-                                "sample_frames must be specified for video task"
-                            )
-                            sample_indices = np.linspace(
-                                0, len(visual) - 1, metadata["sample_frames"], dtype=int
-                            )
+                        if "task_type" in metadata and metadata["task_type"] == "video" and "sample_frames" in metadata:  # overwrite logic for video task with multiple static image frames
+                            assert type(visual) == list, "sample_frames must be specified for video task"
+                            sample_indices = np.linspace(0, len(visual) - 1, metadata["sample_frames"], dtype=int)
                             visual = [visual[i] for i in sample_indices]
                             assert len(visual) == metadata["sample_frames"]
 
-                            image_tensor = process_images(
-                                visual, self._image_processor, self._config
-                            )
+                            image_tensor = process_images(visual, self._image_processor, self._config)
                             if type(image_tensor) is list:
-                                image_tensor = [
-                                    _image.to(dtype=torch.float16, device=self.device)
-                                    for _image in image_tensor
-                                ]
+                                image_tensor = [_image.to(dtype=torch.float16, device=self.device) for _image in image_tensor]
                             else:
-                                image_tensor = image_tensor.to(
-                                    dtype=torch.float16, device=self.device
-                                )
+                                image_tensor = image_tensor.to(dtype=torch.float16, device=self.device)
 
                             task_type = "video"
                             placeholder_count = 1
 
-                        elif (
-                            type(visual[0]) == PIL.Image.Image
-                        ):  # For image, multi-image tasks
-                            image_tensor = process_images(
-                                visual, self._image_processor, self._config
-                            )
+                        elif type(visual[0]) == PIL.Image.Image:  # For image, multi-image tasks
+                            image_tensor = process_images(visual, self._image_processor, self._config)
                             if type(image_tensor) is list:
-                                image_tensor = [
-                                    _image.to(dtype=torch.float16, device=self.device)
-                                    for _image in image_tensor
-                                ]
+                                image_tensor = [_image.to(dtype=torch.float16, device=self.device) for _image in image_tensor]
                             else:
-                                image_tensor = image_tensor.to(
-                                    dtype=torch.float16, device=self.device
-                                )
+                                image_tensor = image_tensor.to(dtype=torch.float16, device=self.device)
 
                             task_type = "image"
-                            placeholder_count = (
-                                len(visual) if isinstance(visual, list) else 1
-                            )
+                            placeholder_count = len(visual) if isinstance(visual, list) else 1
 
                         elif type(visual[0]) == str:  # For video task
                             image_tensor = []
                             try:
                                 if self.video_decode_backend == "decord":
-                                    frames = self.load_video(
-                                        visual, self.max_frames_num
-                                    )
+                                    frames = self.load_video(visual, self.max_frames_num)
                                 elif self.video_decode_backend == "pyav":
-                                    frames = read_video_pyav(
-                                        visual[0], num_frm=self.max_frames_num
-                                    )
-                                frames = (
-                                    self._image_processor.preprocess(
-                                        frames, return_tensors="pt"
-                                    )["pixel_values"]
-                                    .half()
-                                    .to(self._device)
-                                )
+                                    frames = read_video_pyav(visual[0], num_frm=self.max_frames_num)
+                                frames = self._image_processor.preprocess(frames, return_tensors="pt")["pixel_values"].half().to(self._device)
                                 image_tensor.append(frames)
                             except Exception as e:
                                 eval_logger.error(f"Error {e} in loading video")
                                 image_tensor = None
 
                             task_type = "video"
-                            placeholder_count = (
-                                len(frames) if self.token_strategy == "multiple" else 1
-                            )
+                            placeholder_count = len(frames) if self.token_strategy == "multiple" else 1
 
-                    if (
-                        image_tensor is not None
-                        and len(image_tensor) != 0
-                        and DEFAULT_IMAGE_TOKEN not in context
-                    ):
+                    if image_tensor is not None and len(image_tensor) != 0 and DEFAULT_IMAGE_TOKEN not in context:
                         """
                         Three senarios:
                         1. No image, and there for, no image token should be added.
@@ -1045,43 +785,23 @@ class Llava_OneVision(lmms):
                 # Only set temperature and top_p if do_sample is True
                 if gen_kwargs.get("do_sample", False):
                     if "temperature" not in gen_kwargs:
-                        gen_kwargs["temperature"] = (
-                            1.0  # Default temperature for sampling
-                        )
+                        gen_kwargs["temperature"] = 1.0  # Default temperature for sampling
                     if "top_p" not in gen_kwargs:
                         gen_kwargs["top_p"] = 1.0  # Default top_p for sampling
                 if "num_beams" not in gen_kwargs:
                     gen_kwargs["num_beams"] = 1
 
-                input_ids_list = [
-                    tokenizer_image_token(
-                        prompt, self.tokenizer, IMAGE_TOKEN_INDEX, return_tensors="pt"
-                    )
-                    for prompt in question_input
-                ]
-                pad_token_ids = (
-                    self.tokenizer.pad_token_id
-                    if self.tokenizer.pad_token_id is not None
-                    else self.tokenizer.eos_token_id
-                )
-                input_ids = self.pad_sequence(
-                    input_ids_list, batch_first=True, padding_value=pad_token_ids
-                ).to(self.device)
+                input_ids_list = [tokenizer_image_token(prompt, self.tokenizer, IMAGE_TOKEN_INDEX, return_tensors="pt") for prompt in question_input]
+                pad_token_ids = self.tokenizer.pad_token_id if self.tokenizer.pad_token_id is not None else self.tokenizer.eos_token_id
+                input_ids = self.pad_sequence(input_ids_list, batch_first=True, padding_value=pad_token_ids).to(self.device)
                 attention_masks = input_ids.ne(pad_token_ids).to(self.device)
 
                 if task_type == "image":
-                    gen_kwargs["image_sizes"] = [
-                        batched_visuals[0][idx].size
-                        for idx in range(len(batched_visuals[0]))
-                    ]
+                    gen_kwargs["image_sizes"] = [batched_visuals[0][idx].size for idx in range(len(batched_visuals[0]))]
                 elif task_type == "video":
-                    stop_str = (
-                        conv.sep if conv.sep_style != SeparatorStyle.TWO else conv.sep2
-                    )
+                    stop_str = conv.sep if conv.sep_style != SeparatorStyle.TWO else conv.sep2
                     keywords = [stop_str]
-                    stopping_criteria = KeywordsStoppingCriteria(
-                        keywords, self.tokenizer, input_ids
-                    )
+                    stopping_criteria = KeywordsStoppingCriteria(keywords, self.tokenizer, input_ids)
                     gen_kwargs["modalities"] = ["video"]
                     gen_kwargs["stopping_criteria"] = [stopping_criteria]
                     self._config.mm_spatial_pool_stride = self.mm_spatial_pool_stride
@@ -1107,9 +827,7 @@ class Llava_OneVision(lmms):
                         )
                         # cont = self.model.generate(qwen_input_ids, pad_token_id=pad_token_ids, images=image_tensor, use_cache=self.use_cache, **gen_kwargs)
 
-                    text_outputs = self.tokenizer.batch_decode(
-                        cont, skip_special_tokens=True
-                    )
+                    text_outputs = self.tokenizer.batch_decode(cont, skip_special_tokens=True)
                 except Exception as e:
                     raise e
 
@@ -1119,9 +837,7 @@ class Llava_OneVision(lmms):
                 round_idx += 1
 
             res.extend(list(zip(*batched_round_res)))
-            self.cache_hook.add_partial(
-                "generate_until_multi_round", (context, gen_kwargs), batched_round_res
-            )
+            self.cache_hook.add_partial("generate_until_multi_round", (context, gen_kwargs), batched_round_res)
             pbar.update(1)
             # reorder this group of results back to original unsorted form
         res = re_ords.get_original(res)

--- a/lmms_eval/models/simple/llava_vid.py
+++ b/lmms_eval/models/simple/llava_vid.py
@@ -117,9 +117,7 @@ class LlavaVid(lmms):
         if accelerator.num_processes > 1:
             self._device = torch.device(f"cuda:{accelerator.local_process_index}")
             self.device_map = f"cuda:{accelerator.local_process_index}"
-        elif accelerator.num_processes == 1 and (
-            device_map == "auto" or device_map == "balanced_low_0"
-        ):
+        elif accelerator.num_processes == 1 and (device_map == "auto" or device_map == "balanced_low_0"):
             self._device = torch.device(device)
             self.device_map = device_map
         else:
@@ -160,15 +158,9 @@ class LlavaVid(lmms):
 
                 if "224" in cfg_pretrained.mm_vision_tower:
                     # suppose the length of text tokens is around 1000, from bo's report
-                    least_token_number = (
-                        self.max_frames_num * (16 // self.mm_spatial_pool_stride) ** 2
-                        + 1000
-                    )
+                    least_token_number = self.max_frames_num * (16 // self.mm_spatial_pool_stride) ** 2 + 1000
                 else:
-                    least_token_number = (
-                        self.max_frames_num * (24 // self.mm_spatial_pool_stride) ** 2
-                        + 1000
-                    )
+                    least_token_number = self.max_frames_num * (24 // self.mm_spatial_pool_stride) ** 2 + 1000
 
                 scaling_factor = math.ceil(least_token_number / 4096)
                 if scaling_factor >= 2:
@@ -179,31 +171,25 @@ class LlavaVid(lmms):
                         "type": "linear",
                     }
                     overwrite_config["max_sequence_length"] = 4096 * scaling_factor
-                    overwrite_config["tokenizer_model_max_length"] = (
-                        4096 * scaling_factor
-                    )
+                    overwrite_config["tokenizer_model_max_length"] = 4096 * scaling_factor
 
-            self._tokenizer, self._model, self._image_processor, self._max_length = (
-                load_pretrained_model(
-                    pretrained,
-                    None,
-                    self.model_name,
-                    device_map=self.device_map,
-                    torch_dtype=self.torch_dtype,
-                    overwrite_config=overwrite_config,
-                    attn_implementation=attn_implementation,
-                )
+            self._tokenizer, self._model, self._image_processor, self._max_length = load_pretrained_model(
+                pretrained,
+                None,
+                self.model_name,
+                device_map=self.device_map,
+                torch_dtype=self.torch_dtype,
+                overwrite_config=overwrite_config,
+                attn_implementation=attn_implementation,
             )
         else:
-            self._tokenizer, self._model, self._image_processor, self._max_length = (
-                load_pretrained_model(
-                    pretrained,
-                    None,
-                    self.model_name,
-                    device_map=self.device_map,
-                    torch_dtype=self.torch_dtype,
-                    attn_implementation=attn_implementation,
-                )
+            self._tokenizer, self._model, self._image_processor, self._max_length = load_pretrained_model(
+                pretrained,
+                None,
+                self.model_name,
+                device_map=self.device_map,
+                torch_dtype=self.torch_dtype,
+                attn_implementation=attn_implementation,
             )
 
         self._config = self._model.config
@@ -236,35 +222,21 @@ class LlavaVid(lmms):
             if accelerator.distributed_type == DistributedType.DEEPSPEED:
                 kwargs = {
                     "train_micro_batch_size_per_gpu": self.batch_size_per_gpu,
-                    "train_batch_size": self.batch_size_per_gpu
-                    * accelerator.num_processes,
+                    "train_batch_size": self.batch_size_per_gpu * accelerator.num_processes,
                 }
-                AcceleratorState().deepspeed_plugin.deepspeed_config_process(
-                    must_match=True, **kwargs
-                )
-                eval_logger.info(
-                    "Detected that you are using DistributedType.DEEPSPEED. Make sure you run `accelerate config` and set zero stage to 0"
-                )
-            if (
-                accelerator.distributed_type == DistributedType.FSDP
-                or accelerator.distributed_type == DistributedType.DEEPSPEED
-            ):
+                AcceleratorState().deepspeed_plugin.deepspeed_config_process(must_match=True, **kwargs)
+                eval_logger.info("Detected that you are using DistributedType.DEEPSPEED. Make sure you run `accelerate config` and set zero stage to 0")
+            if accelerator.distributed_type == DistributedType.FSDP or accelerator.distributed_type == DistributedType.DEEPSPEED:
                 self._model = accelerator.prepare(self.model)
             else:
-                self._model = accelerator.prepare_model(
-                    self.model, evaluation_mode=True
-                )
+                self._model = accelerator.prepare_model(self.model, evaluation_mode=True)
             self.accelerator = accelerator
             if self.accelerator.is_local_main_process:
-                eval_logger.info(
-                    f"Using {accelerator.num_processes} devices with data parallelism"
-                )
+                eval_logger.info(f"Using {accelerator.num_processes} devices with data parallelism")
             self._rank = self.accelerator.local_process_index
             self._world_size = self.accelerator.num_processes
         elif accelerator.num_processes == 1 and device_map == "auto":
-            eval_logger.info(
-                f"Using {accelerator.num_processes} devices with tensor parallelism"
-            )
+            eval_logger.info(f"Using {accelerator.num_processes} devices with tensor parallelism")
             self._rank = 0
             self._world_size = 1
         else:
@@ -302,9 +274,7 @@ class LlavaVid(lmms):
     def pad_sequence(self, input_ids, batch_first, padding_value):
         if self.tokenizer.padding_side == "left":
             input_ids = [torch.flip(_input_ids, [0]) for _input_ids in input_ids]
-        input_ids = torch.nn.utils.rnn.pad_sequence(
-            input_ids, batch_first=batch_first, padding_value=padding_value
-        )
+        input_ids = torch.nn.utils.rnn.pad_sequence(input_ids, batch_first=batch_first, padding_value=padding_value)
         if self.tokenizer.padding_side == "left":
             input_ids = torch.flip(input_ids, [1])
         return input_ids
@@ -325,9 +295,7 @@ class LlavaVid(lmms):
     def world_size(self):
         return self._world_size
 
-    def tok_encode(
-        self, string: str, left_truncate_len=None, add_special_tokens=None
-    ) -> List[int]:
+    def tok_encode(self, string: str, left_truncate_len=None, add_special_tokens=None) -> List[int]:
         """ """
         add_special_tokens = False if add_special_tokens is None else add_special_tokens
         encoding = self.tokenizer.encode(string, add_special_tokens=add_special_tokens)
@@ -337,11 +305,7 @@ class LlavaVid(lmms):
         return encoding
 
     def load_image(self, image_path):
-        frame_files = [
-            os.path.join(image_path, f)
-            for f in os.listdir(image_path)
-            if os.path.isfile(os.path.join(image_path, f))
-        ]
+        frame_files = [os.path.join(image_path, f) for f in os.listdir(image_path) if os.path.isfile(os.path.join(image_path, f))]
         frame_files.sort()  # Ensure the frames are sorted if they are named sequentially
 
         # TODO: Hard CODE: Determine the indices for uniformly sampling 10 frames
@@ -349,9 +313,7 @@ class LlavaVid(lmms):
 
         total_frames = len(frame_files)
 
-        sampled_indices = np.linspace(
-            0, total_frames - 1, num_frames_to_sample, dtype=int
-        )
+        sampled_indices = np.linspace(0, total_frames - 1, num_frames_to_sample, dtype=int)
 
         # Read and store the sampled frames
         video = []
@@ -378,9 +340,7 @@ class LlavaVid(lmms):
         frame_time = [i / fps for i in frame_idx]
         if len(frame_idx) > max_frames_num or force_sample:
             sample_fps = max_frames_num
-            uniform_sampled_frames = np.linspace(
-                0, total_frame_num - 1, sample_fps, dtype=int
-            )
+            uniform_sampled_frames = np.linspace(0, total_frame_num - 1, sample_fps, dtype=int)
             frame_idx = uniform_sampled_frames.tolist()
             frame_time = [i / vr.get_avg_fps() for i in frame_idx]
         frame_time = ",".join([f"{i:.2f}s" for i in frame_time])
@@ -394,13 +354,9 @@ class LlavaVid(lmms):
 
     def loglikelihood(self, requests: List[Instance]) -> List[Tuple[float, bool]]:
         res = []
-        pbar = tqdm(
-            total=len(requests), disable=(self.rank != 0), desc="Model Responding"
-        )
+        pbar = tqdm(total=len(requests), disable=(self.rank != 0), desc="Model Responding")
 
-        for contexts, doc_to_target, doc_to_visual, doc_id, task, split in [
-            reg.args for reg in requests
-        ]:
+        for contexts, doc_to_target, doc_to_visual, doc_id, task, split in [reg.args for reg in requests]:
             # encode, pad, and truncate contexts for this batch
             if type(doc_to_target) == str:
                 continuation = doc_to_target
@@ -416,9 +372,7 @@ class LlavaVid(lmms):
                     self.fps,
                     force_sample=self.force_sample,
                 )
-                video = self._image_processor.preprocess(video, return_tensors="pt")[
-                    "pixel_values"
-                ].to(self._device)
+                video = self._image_processor.preprocess(video, return_tensors="pt")["pixel_values"].to(self._device)
                 if self.torch_dtype == "bfloat16":
                     video = video.bfloat16()
                 else:
@@ -427,13 +381,7 @@ class LlavaVid(lmms):
 
             qs = contexts
             if self.model.config.mm_use_im_start_end:
-                qs = (
-                    DEFAULT_IM_START_TOKEN
-                    + DEFAULT_IMAGE_TOKEN
-                    + DEFAULT_IM_END_TOKEN
-                    + "\n"
-                    + qs
-                )
+                qs = DEFAULT_IM_START_TOKEN + DEFAULT_IMAGE_TOKEN + DEFAULT_IM_END_TOKEN + "\n" + qs
             else:
                 qs = DEFAULT_IMAGE_TOKEN + "\n" + qs
 
@@ -442,29 +390,15 @@ class LlavaVid(lmms):
             conv.append_message(conv.roles[1], None)
             prompt = conv.get_prompt()
 
-            contxt_id = (
-                tokenizer_image_token(
-                    prompt, self.tokenizer, IMAGE_TOKEN_INDEX, return_tensors="pt"
-                )
-                .unsqueeze(0)
-                .to(self.device)
-            )
+            contxt_id = tokenizer_image_token(prompt, self.tokenizer, IMAGE_TOKEN_INDEX, return_tensors="pt").unsqueeze(0).to(self.device)
 
             conv = conv_templates[self.conv_template].copy()
             conv.append_message(conv.roles[0], qs)
             conv.append_message(conv.roles[1], continuation)
             prompt = conv.get_prompt()
 
-            input_ids = (
-                tokenizer_image_token(
-                    prompt, self.tokenizer, IMAGE_TOKEN_INDEX, return_tensors="pt"
-                )
-                .unsqueeze(0)
-                .to(self._device)
-            )
-            attention_masks = (
-                input_ids.ne(self.tokenizer.pad_token_id).long().to(self._device)
-            )
+            input_ids = tokenizer_image_token(prompt, self.tokenizer, IMAGE_TOKEN_INDEX, return_tensors="pt").unsqueeze(0).to(self._device)
+            attention_masks = input_ids.ne(self.tokenizer.pad_token_id).long().to(self._device)
 
             labels = input_ids.clone()
             # Context part no need to calculate for loss
@@ -483,9 +417,7 @@ class LlavaVid(lmms):
             logits = outputs["logits"]
             greedy_tokens = logits.argmax(dim=-1)
             cont_toks = input_ids[:, contxt_id.shape[1] :]  # [1, seq]
-            greedy_tokens = greedy_tokens[
-                :, contxt_id.shape[1] : input_ids.shape[1]
-            ]  # [1, seq]
+            greedy_tokens = greedy_tokens[:, contxt_id.shape[1] : input_ids.shape[1]]  # [1, seq]
             max_equal = (greedy_tokens == cont_toks).all()
             res.append((float(loss.item()), bool(max_equal)))
             pbar.update(1)
@@ -501,13 +433,9 @@ class LlavaVid(lmms):
 
     def generate_until(self, requests) -> List[str]:
         res = []
-        pbar = tqdm(
-            total=len(requests), disable=(self.rank != 0), desc="Model Responding"
-        )
+        pbar = tqdm(total=len(requests), disable=(self.rank != 0), desc="Model Responding")
 
-        for contexts, gen_kwargs, doc_to_visual, doc_id, task, split in [
-            reg.args for reg in requests
-        ]:
+        for contexts, gen_kwargs, doc_to_visual, doc_id, task, split in [reg.args for reg in requests]:
             # if self.task_dict[task][split][doc_id]["duration"] != "short":
             # # if doc_id != 112:
             #     # import pdb;pdb.set_trace()
@@ -551,9 +479,7 @@ class LlavaVid(lmms):
                         # Reference: https://github.com/jayleicn/TVQA/blob/dfb0e5fe4582efca574dfddfeafd1008db3b33ef/data/README.md?plain=1#L50C34-L50C60
                         fps = 3
                         video_time = len(visuals) / fps
-                        sampled_indices = np.linspace(
-                            0, len(visuals) - 1, self.max_frames_num, dtype=int
-                        )
+                        sampled_indices = np.linspace(0, len(visuals) - 1, self.max_frames_num, dtype=int)
                         frame_idx = sampled_indices.tolist()
                         frame_time = [i / fps for i in frame_idx]
                         frame_time = ",".join([f"{i:.2f}s" for i in frame_time])
@@ -563,9 +489,7 @@ class LlavaVid(lmms):
                             axis=0,
                         )
 
-                video = self._image_processor.preprocess(video, return_tensors="pt")[
-                    "pixel_values"
-                ].to(self._device)
+                video = self._image_processor.preprocess(video, return_tensors="pt")["pixel_values"].to(self._device)
                 if self.torch_dtype == "bfloat16":
                     video = video.bfloat16()
                 else:
@@ -586,13 +510,7 @@ class LlavaVid(lmms):
                 time_instruciton = f"The video lasts for {video_time:.2f} seconds, and {len(video)} frames are uniformly sampled from it. These frames are located at {frame_time}.Please answer the following questions related to this video."
                 qs = f"{time_instruciton}\n{qs}"
             if self.model.config.mm_use_im_start_end:
-                qs = (
-                    DEFAULT_IM_START_TOKEN
-                    + DEFAULT_IMAGE_TOKEN
-                    + DEFAULT_IM_END_TOKEN
-                    + "\n"
-                    + qs
-                )
+                qs = DEFAULT_IM_START_TOKEN + DEFAULT_IMAGE_TOKEN + DEFAULT_IM_END_TOKEN + "\n" + qs
             else:
                 qs = DEFAULT_IMAGE_TOKEN * len(videos) + "\n" + qs
 
@@ -606,18 +524,8 @@ class LlavaVid(lmms):
             conv.append_message(conv.roles[1], None)
             prompt = conv.get_prompt()
 
-            input_ids = (
-                tokenizer_image_token(
-                    prompt, self.tokenizer, IMAGE_TOKEN_INDEX, return_tensors="pt"
-                )
-                .unsqueeze(0)
-                .to(self._device)
-            )
-            pad_token_ids = (
-                self.tokenizer.pad_token_id
-                if self.tokenizer.pad_token_id is not None
-                else self.tokenizer.eos_token_id
-            )
+            input_ids = tokenizer_image_token(prompt, self.tokenizer, IMAGE_TOKEN_INDEX, return_tensors="pt").unsqueeze(0).to(self._device)
+            pad_token_ids = self.tokenizer.pad_token_id if self.tokenizer.pad_token_id is not None else self.tokenizer.eos_token_id
             if "llama_3" in self.conv_template:
                 pad_token_ids = 0  # lmms-lab/llama3-llava-8b is trained on this pad token id. You may need to customize this for other models.
             attention_masks = input_ids.ne(pad_token_ids).long().to(self._device)
@@ -625,9 +533,7 @@ class LlavaVid(lmms):
             stop_str = conv.sep if conv.sep_style != SeparatorStyle.TWO else conv.sep2
             keywords = [stop_str]
 
-            stopping_criteria = KeywordsStoppingCriteria(
-                keywords, self.tokenizer, input_ids
-            )
+            stopping_criteria = KeywordsStoppingCriteria(keywords, self.tokenizer, input_ids)
 
             cur_prompt = qs
 
@@ -658,9 +564,7 @@ class LlavaVid(lmms):
                 # output_ids_2 = self.model.generate(inputs=input_ids, images=videos, attention_mask=attention_masks, modalities="video", do_sample=False, max_new_tokens=50,stopping_criteria=[stopping_criteria])
                 # output_ids = self.model.generate(inputs=input_ids, images=videos, attention_mask=attention_masks, modalities="video", do_sample=True, temperature=0.2, max_new_tokens=50,use_cache=True)
 
-            outputs = self.tokenizer.batch_decode(output_ids, skip_special_tokens=True)[
-                0
-            ].strip()
+            outputs = self.tokenizer.batch_decode(output_ids, skip_special_tokens=True)[0].strip()
             eval_logger.debug(f"Question: {cur_prompt}")
             eval_logger.debug(f"Answer: {outputs}")
             # import pdb;pdb.set_trace()

--- a/lmms_eval/models/simple/longva.py
+++ b/lmms_eval/models/simple/longva.py
@@ -47,10 +47,7 @@ try:
     from longva.model.builder import load_pretrained_model
 
 except Exception as e:
-    eval_logger.debug(
-        "longva is not installed. Please install longva to use this model.\nError: %s"
-        % e
-    )
+    eval_logger.debug("longva is not installed. Please install longva to use this model.\nError: %s" % e)
 
 # inference implementation for attention, can be "sdpa", "eager", "flash_attention_2". Seems FA2 is not effective during inference: https://discuss.huggingface.co/t/flash-attention-has-no-effect-on-inference/73453/5
 # if is_flash_attn_2_available:
@@ -75,16 +72,12 @@ class LongVA(lmms):
         device_map: Optional[str] = "cuda:0",
         conv_template: Optional[str] = "vicuna_v1",
         use_cache: Optional[bool] = True,
-        truncate_context: Optional[
-            bool
-        ] = False,  # whether to truncate the context in generation, set it False for LLaVA-1.6
+        truncate_context: Optional[bool] = False,  # whether to truncate the context in generation, set it False for LLaVA-1.6
         customized_config: Optional[str] = None,  # ends in json
         max_frames_num: Optional[int] = 32,
         mm_spatial_pool_stride: Optional[int] = 2,
         mm_spatial_pool_mode: Optional[str] = "average",
-        token_strategy: Optional[
-            str
-        ] = "single",  # could be "single" or "multiple", "multiple" denotes adding multiple <image> tokens for each frame
+        token_strategy: Optional[str] = "single",  # could be "single" or "multiple", "multiple" denotes adding multiple <image> tokens for each frame
         video_decode_backend: str = "pyav",
         **kwargs,
     ) -> None:
@@ -114,11 +107,7 @@ class LongVA(lmms):
             llava_model_args["attn_implementation"] = attn_implementation
         if "use_flash_attention_2" in kwargs:
             llava_model_args["use_flash_attention_2"] = kwargs["use_flash_attention_2"]
-        model_name = (
-            model_name
-            if model_name is not None
-            else get_model_name_from_path(pretrained)
-        )
+        model_name = model_name if model_name is not None else get_model_name_from_path(pretrained)
 
         self.pretrained = pretrained
         self.token_strategy = token_strategy
@@ -135,26 +124,22 @@ class LongVA(lmms):
         llava_model_args["overwrite_config"] = overwrite_config
         try:
             # Try to load the model with the multimodal argument
-            self._tokenizer, self._model, self._image_processor, self._max_length = (
-                load_pretrained_model(
-                    pretrained,
-                    None,
-                    model_name,
-                    device_map=self.device_map,
-                    **llava_model_args,
-                )
+            self._tokenizer, self._model, self._image_processor, self._max_length = load_pretrained_model(
+                pretrained,
+                None,
+                model_name,
+                device_map=self.device_map,
+                **llava_model_args,
             )
         except TypeError:
             # for older versions of LLaVA that don't have multimodal argument
             llava_model_args.pop("multimodal", None)
-            self._tokenizer, self._model, self._image_processor, self._max_length = (
-                load_pretrained_model(
-                    pretrained,
-                    None,
-                    model_name,
-                    device_map=self.device_map,
-                    **llava_model_args,
-                )
+            self._tokenizer, self._model, self._image_processor, self._max_length = load_pretrained_model(
+                pretrained,
+                None,
+                model_name,
+                device_map=self.device_map,
+                **llava_model_args,
             )
 
         self._config = self._model.config
@@ -165,9 +150,7 @@ class LongVA(lmms):
         self.conv_template = conv_template
         self.use_cache = use_cache
         self.truncate_context = truncate_context
-        assert self.batch_size_per_gpu == 1, (
-            "Llava currently does not support batched generation. See https://github.com/haotian-liu/LLaVA/issues/754. HF Llava also has this issue."
-        )
+        assert self.batch_size_per_gpu == 1, "Llava currently does not support batched generation. See https://github.com/haotian-liu/LLaVA/issues/754. HF Llava also has this issue."
 
         if accelerator.num_processes > 1:
             assert accelerator.distributed_type in [
@@ -181,37 +164,23 @@ class LongVA(lmms):
             if accelerator.distributed_type == DistributedType.DEEPSPEED:
                 kwargs = {
                     "train_micro_batch_size_per_gpu": self.batch_size_per_gpu,
-                    "train_batch_size": self.batch_size_per_gpu
-                    * accelerator.num_processes,
+                    "train_batch_size": self.batch_size_per_gpu * accelerator.num_processes,
                 }
-                AcceleratorState().deepspeed_plugin.deepspeed_config_process(
-                    must_match=True, **kwargs
-                )
-                eval_logger.info(
-                    "Detected that you are using DistributedType.DEEPSPEED. Make sure you run `accelerate config` and set zero stage to 0"
-                )
+                AcceleratorState().deepspeed_plugin.deepspeed_config_process(must_match=True, **kwargs)
+                eval_logger.info("Detected that you are using DistributedType.DEEPSPEED. Make sure you run `accelerate config` and set zero stage to 0")
 
-            if (
-                accelerator.distributed_type == DistributedType.FSDP
-                or accelerator.distributed_type == DistributedType.DEEPSPEED
-            ):
+            if accelerator.distributed_type == DistributedType.FSDP or accelerator.distributed_type == DistributedType.DEEPSPEED:
                 self._model = accelerator.prepare(self.model)
             else:
-                self._model = accelerator.prepare_model(
-                    self.model, evaluation_mode=True
-                )
+                self._model = accelerator.prepare_model(self.model, evaluation_mode=True)
             self.accelerator = accelerator
             if self.accelerator.is_local_main_process:
-                eval_logger.info(
-                    f"Using {accelerator.num_processes} devices with data parallelism"
-                )
+                eval_logger.info(f"Using {accelerator.num_processes} devices with data parallelism")
             self._rank = self.accelerator.local_process_index
             self._world_size = self.accelerator.num_processes
 
         elif accelerator.num_processes == 1 and device_map == "auto":
-            eval_logger.info(
-                f"Using {accelerator.num_processes} devices with tensor parallelism"
-            )
+            eval_logger.info(f"Using {accelerator.num_processes} devices with tensor parallelism")
             self._rank = 0
             self._world_size = 1
 
@@ -250,9 +219,7 @@ class LongVA(lmms):
     def pad_sequence(self, input_ids, batch_first, padding_value):
         if self.tokenizer.padding_side == "left":
             input_ids = [torch.flip(_input_ids, [0]) for _input_ids in input_ids]
-        input_ids = torch.nn.utils.rnn.pad_sequence(
-            input_ids, batch_first=batch_first, padding_value=padding_value
-        )
+        input_ids = torch.nn.utils.rnn.pad_sequence(input_ids, batch_first=batch_first, padding_value=padding_value)
         if self.tokenizer.padding_side == "left":
             input_ids = torch.flip(input_ids, [1])
         return input_ids
@@ -273,9 +240,7 @@ class LongVA(lmms):
     def world_size(self):
         return self._world_size
 
-    def tok_encode(
-        self, string: str, left_truncate_len=None, add_special_tokens=None
-    ) -> List[int]:
+    def tok_encode(self, string: str, left_truncate_len=None, add_special_tokens=None) -> List[int]:
         """ """
         add_special_tokens = False if add_special_tokens is None else add_special_tokens
         encoding = self.tokenizer.encode(string, add_special_tokens=add_special_tokens)
@@ -293,13 +258,9 @@ class LongVA(lmms):
     def loglikelihood(self, requests: List[Instance]) -> List[Tuple[float, bool]]:
         # TODO
         res = []
-        pbar = tqdm(
-            total=len(requests), disable=(self.rank != 0), desc="Model Responding"
-        )
+        pbar = tqdm(total=len(requests), disable=(self.rank != 0), desc="Model Responding")
 
-        for contexts, doc_to_target, doc_to_visual, doc_id, task, split in [
-            reg.args for reg in requests
-        ]:
+        for contexts, doc_to_target, doc_to_visual, doc_id, task, split in [reg.args for reg in requests]:
             # encode, pad, and truncate contexts for this batch
             if type(doc_to_target) == str:
                 continuation = doc_to_target
@@ -311,10 +272,7 @@ class LongVA(lmms):
             if visuals:
                 image = process_images(visuals, self._image_processor, self._config)
                 if type(image) is list:
-                    image = [
-                        _image.to(dtype=torch.float16, device=self.device)
-                        for _image in image
-                    ]
+                    image = [_image.to(dtype=torch.float16, device=self.device) for _image in image]
                 else:
                     image = image.to(dtype=torch.float16, device=self.device)
             else:
@@ -322,11 +280,7 @@ class LongVA(lmms):
 
             prompts_input = contexts[0] if isinstance(contexts, list) else contexts
 
-            if (
-                image is not None
-                and len(image) != 0
-                and DEFAULT_IMAGE_TOKEN not in prompts_input
-            ):
+            if image is not None and len(image) != 0 and DEFAULT_IMAGE_TOKEN not in prompts_input:
                 """
                 Three senarios:
                 1. No image, and there for, no image token should be added.
@@ -335,11 +289,7 @@ class LongVA(lmms):
                 """
                 image_tokens = [DEFAULT_IMAGE_TOKEN] * len(visuals)
                 image_tokens = " ".join(image_tokens)
-                prompts_input = (
-                    image_tokens
-                    + "\n"
-                    + (contexts[0] if isinstance(contexts, list) else contexts)
-                )
+                prompts_input = image_tokens + "\n" + (contexts[0] if isinstance(contexts, list) else contexts)
 
             # This is much safer for llama3, as we now have some object type in it
             if "llama_3" in self.conv_template:
@@ -350,29 +300,13 @@ class LongVA(lmms):
             conv.append_message(conv.roles[0], prompts_input)
             conv.append_message(conv.roles[1], None)
             prompt = conv.get_prompt()
-            pad_token_id = (
-                self.tokenizer.pad_token_id
-                if self.tokenizer.pad_token_id is not None
-                else self.tokenizer.eos_token_id
-            )
-            contxt_id = (
-                tokenizer_image_token(
-                    prompt, self.tokenizer, IMAGE_TOKEN_INDEX, return_tensors="pt"
-                )
-                .unsqueeze(0)
-                .to(self.device)
-            )
+            pad_token_id = self.tokenizer.pad_token_id if self.tokenizer.pad_token_id is not None else self.tokenizer.eos_token_id
+            contxt_id = tokenizer_image_token(prompt, self.tokenizer, IMAGE_TOKEN_INDEX, return_tensors="pt").unsqueeze(0).to(self.device)
             # Add the answer of the second role
             conv.messages[1][1] = continuation
 
             prompt = conv.get_prompt()
-            input_ids = (
-                tokenizer_image_token(
-                    prompt, self.tokenizer, IMAGE_TOKEN_INDEX, return_tensors="pt"
-                )
-                .unsqueeze(0)
-                .to(self.device)
-            )
+            input_ids = tokenizer_image_token(prompt, self.tokenizer, IMAGE_TOKEN_INDEX, return_tensors="pt").unsqueeze(0).to(self.device)
             labels = input_ids.clone()
             # Context part no need to calculate for loss
             labels[0, : contxt_id.shape[1]] = -100
@@ -389,9 +323,7 @@ class LongVA(lmms):
             logits = outputs["logits"]
             greedy_tokens = logits.argmax(dim=-1)
             cont_toks = input_ids[:, contxt_id.shape[1] :]  # [1, seq]
-            greedy_tokens = greedy_tokens[
-                :, contxt_id.shape[1] : input_ids.shape[1]
-            ]  # [1, seq]
+            greedy_tokens = greedy_tokens[:, contxt_id.shape[1] : input_ids.shape[1]]  # [1, seq]
             max_equal = (greedy_tokens == cont_toks).all()
             res.append((float(loss.item()), bool(max_equal)))
             pbar.update(1)
@@ -412,9 +344,7 @@ class LongVA(lmms):
         else:
             vr = VideoReader(video_path[0], ctx=cpu(0))
         total_frame_num = len(vr)
-        uniform_sampled_frames = np.linspace(
-            0, total_frame_num - 1, max_frames_num, dtype=int
-        )
+        uniform_sampled_frames = np.linspace(0, total_frame_num - 1, max_frames_num, dtype=int)
         frame_idx = uniform_sampled_frames.tolist()
         spare_frames = vr.get_batch(frame_idx).asnumpy()
         return spare_frames  # (frames, height, width, channels)
@@ -435,15 +365,9 @@ class LongVA(lmms):
         # we group requests by their generation_kwargs,
         # so that we don't try to execute e.g. greedy sampling and temp=0.8 sampling
         # in the same batch.
-        re_ords = utils.Collator(
-            [reg.args for reg in requests], _collate, grouping=True
-        )
+        re_ords = utils.Collator([reg.args for reg in requests], _collate, grouping=True)
         chunks = re_ords.get_batched(n=self.batch_size, batch_fn=None)
-        num_iters = (
-            len(requests) // self.batch_size
-            if len(requests) % self.batch_size == 0
-            else len(requests) // self.batch_size + 1
-        )
+        num_iters = len(requests) // self.batch_size if len(requests) % self.batch_size == 0 else len(requests) // self.batch_size + 1
         pbar = tqdm(total=num_iters, disable=(self.rank != 0), desc="Model Responding")
         for chunk in chunks:
             (
@@ -456,10 +380,7 @@ class LongVA(lmms):
             ) = zip(*chunk)
             task = batched_task[0]
             split = batched_split[0]
-            batched_visuals = [
-                batched_doc_to_visual[0](self.task_dict[task][split][ids])
-                for ids in batched_doc_id
-            ]  # [B, N]
+            batched_visuals = [batched_doc_to_visual[0](self.task_dict[task][split][ids]) for ids in batched_doc_id]  # [B, N]
             flattened_visuals = self.flatten(batched_visuals)  # [B*N]
             assert len(batched_visuals) == 1
 
@@ -472,32 +393,18 @@ class LongVA(lmms):
             question_input = []
 
             for visual, context in zip(batched_visuals, batched_contexts):
-                if (
-                    "image_aspect_ratio" in gen_kwargs.keys()
-                    and "image_aspect_ratio" not in self._config.__dict__
-                ):
+                if "image_aspect_ratio" in gen_kwargs.keys() and "image_aspect_ratio" not in self._config.__dict__:
                     # here we should pop it out of gen_kwargs so that it doesn't get passed to the model for next step of generation
-                    self._config.image_aspect_ratio = gen_kwargs.pop(
-                        "image_aspect_ratio"
-                    )
-                    eval_logger.info(
-                        f"Setting image aspect ratio: {self._config.image_aspect_ratio}"
-                    )
+                    self._config.image_aspect_ratio = gen_kwargs.pop("image_aspect_ratio")
+                    eval_logger.info(f"Setting image aspect ratio: {self._config.image_aspect_ratio}")
 
                 # encode, pad, and truncate contexts for this batch
                 if type(visual[0]) == PIL.Image.Image:  # For image task
-                    image_tensor = process_images(
-                        visual, self._image_processor, self._config
-                    )
+                    image_tensor = process_images(visual, self._image_processor, self._config)
                     if type(image_tensor) is list:
-                        image_tensor = [
-                            _image.to(dtype=torch.float16, device=self.device)
-                            for _image in image_tensor
-                        ]
+                        image_tensor = [_image.to(dtype=torch.float16, device=self.device) for _image in image_tensor]
                     else:
-                        image_tensor = image_tensor.to(
-                            dtype=torch.float16, device=self.device
-                        )
+                        image_tensor = image_tensor.to(dtype=torch.float16, device=self.device)
 
                     task_type = "image"
 
@@ -507,16 +414,8 @@ class LongVA(lmms):
                         if self.video_decode_backend == "decord":
                             frames = self.load_video(visual, self.max_frames_num)
                         elif self.video_decode_backend == "pyav":
-                            frames = read_video_pyav(
-                                visual[0], num_frm=self.max_frames_num
-                            )
-                        frames = (
-                            self._image_processor.preprocess(
-                                frames, return_tensors="pt"
-                            )["pixel_values"]
-                            .half()
-                            .to(self._device)
-                        )
+                            frames = read_video_pyav(visual[0], num_frm=self.max_frames_num)
+                        frames = self._image_processor.preprocess(frames, return_tensors="pt")["pixel_values"].half().to(self._device)
                         image_tensor.append(frames)
                     except Exception as e:
                         eval_logger.error(f"Error {e} in loading video")
@@ -524,11 +423,7 @@ class LongVA(lmms):
 
                     task_type = "video"
 
-                if (
-                    image_tensor is not None
-                    and len(image_tensor) != 0
-                    and DEFAULT_IMAGE_TOKEN not in context
-                ):
+                if image_tensor is not None and len(image_tensor) != 0 and DEFAULT_IMAGE_TOKEN not in context:
                     """
                     Three senarios:
                     1. No image, and there for, no image token should be added.
@@ -537,17 +432,9 @@ class LongVA(lmms):
                     4. For video tasks, we could add a <image> token or multiple <image> tokens for each frame in the context. This depends on the training strategy and should balance in test to decide which is better
                     """
                     if task_type == "image":
-                        image_tokens = (
-                            [DEFAULT_IMAGE_TOKEN] * len(visual)
-                            if isinstance(visual, list)
-                            else [DEFAULT_IMAGE_TOKEN]
-                        )
+                        image_tokens = [DEFAULT_IMAGE_TOKEN] * len(visual) if isinstance(visual, list) else [DEFAULT_IMAGE_TOKEN]
                     elif task_type == "video":
-                        image_tokens = (
-                            [DEFAULT_IMAGE_TOKEN] * len(frames)
-                            if self.token_strategy == "multiple"
-                            else [DEFAULT_IMAGE_TOKEN]
-                        )
+                        image_tokens = [DEFAULT_IMAGE_TOKEN] * len(frames) if self.token_strategy == "multiple" else [DEFAULT_IMAGE_TOKEN]
 
                     image_tokens = " ".join(image_tokens)
                     question = image_tokens + "\n" + context
@@ -576,34 +463,17 @@ class LongVA(lmms):
             if "num_beams" not in gen_kwargs:
                 gen_kwargs["num_beams"] = 1
 
-            input_ids_list = [
-                tokenizer_image_token(
-                    prompt, self.tokenizer, IMAGE_TOKEN_INDEX, return_tensors="pt"
-                )
-                for prompt in question_input
-            ]
-            pad_token_ids = (
-                self.tokenizer.pad_token_id
-                if self.tokenizer.pad_token_id is not None
-                else self.tokenizer.eos_token_id
-            )
-            input_ids = self.pad_sequence(
-                input_ids_list, batch_first=True, padding_value=pad_token_ids
-            ).to(self.device)
+            input_ids_list = [tokenizer_image_token(prompt, self.tokenizer, IMAGE_TOKEN_INDEX, return_tensors="pt") for prompt in question_input]
+            pad_token_ids = self.tokenizer.pad_token_id if self.tokenizer.pad_token_id is not None else self.tokenizer.eos_token_id
+            input_ids = self.pad_sequence(input_ids_list, batch_first=True, padding_value=pad_token_ids).to(self.device)
             attention_masks = input_ids.ne(pad_token_ids).to(self.device)
 
             if task_type == "image":
-                gen_kwargs["image_sizes"] = [
-                    flattened_visuals[idx].size for idx in range(len(flattened_visuals))
-                ]
+                gen_kwargs["image_sizes"] = [flattened_visuals[idx].size for idx in range(len(flattened_visuals))]
             elif task_type == "video":
-                stop_str = (
-                    conv.sep if conv.sep_style != SeparatorStyle.TWO else conv.sep2
-                )
+                stop_str = conv.sep if conv.sep_style != SeparatorStyle.TWO else conv.sep2
                 keywords = [stop_str]
-                stopping_criteria = KeywordsStoppingCriteria(
-                    keywords, self.tokenizer, input_ids
-                )
+                stopping_criteria = KeywordsStoppingCriteria(keywords, self.tokenizer, input_ids)
                 gen_kwargs["modalities"] = ["video"]
                 gen_kwargs["stopping_criteria"] = [stopping_criteria]
                 self._config.mm_spatial_pool_stride = self.mm_spatial_pool_stride
@@ -624,17 +494,13 @@ class LongVA(lmms):
                         **gen_kwargs,
                     )
 
-                text_outputs = self.tokenizer.batch_decode(
-                    cont, skip_special_tokens=True
-                )
+                text_outputs = self.tokenizer.batch_decode(cont, skip_special_tokens=True)
             except Exception as e:
                 raise e
 
             text_outputs = [response.strip() for response in text_outputs]
             res.extend(text_outputs)
-            self.cache_hook.add_partial(
-                "generate_until", (context, gen_kwargs), text_outputs
-            )
+            self.cache_hook.add_partial("generate_until", (context, gen_kwargs), text_outputs)
             pbar.update(1)
             # reorder this group of results back to original unsorted form
         res = re_ords.get_original(res)

--- a/lmms_eval/models/simple/vila.py
+++ b/lmms_eval/models/simple/vila.py
@@ -38,9 +38,7 @@ try:
     )
     from llava.model.builder import load_pretrained_model
 except ImportError as e:
-    raise ImportError(
-        f"VILA is not installed. Please install VILA to use this model. Error: {e}"
-    )
+    raise ImportError(f"VILA is not installed. Please install VILA to use this model. Error: {e}")
 
 
 @register_model("vila")
@@ -86,13 +84,11 @@ class VILA(lmms):
         self.max_frames_num = max_frames_num
         # self._config = AutoConfig.from_pretrained(self.pretrained)
 
-        self._tokenizer, self._model, self._image_processor, self._max_length = (
-            load_pretrained_model(
-                pretrained,
-                self.model_name,
-                device_map=self.device_map,
-                attn_implementation=attn_implementation,
-            )
+        self._tokenizer, self._model, self._image_processor, self._max_length = load_pretrained_model(
+            pretrained,
+            self.model_name,
+            device_map=self.device_map,
+            attn_implementation=attn_implementation,
         )
 
         self.model.image_processor = self._image_processor
@@ -125,35 +121,21 @@ class VILA(lmms):
             if accelerator.distributed_type == DistributedType.DEEPSPEED:
                 kwargs = {
                     "train_micro_batch_size_per_gpu": self.batch_size_per_gpu,
-                    "train_batch_size": self.batch_size_per_gpu
-                    * accelerator.num_processes,
+                    "train_batch_size": self.batch_size_per_gpu * accelerator.num_processes,
                 }
-                AcceleratorState().deepspeed_plugin.deepspeed_config_process(
-                    must_match=True, **kwargs
-                )
-                eval_logger.info(
-                    "Detected that you are using DistributedType.DEEPSPEED. Make sure you run `accelerate config` and set zero stage to 0"
-                )
-            if (
-                accelerator.distributed_type == DistributedType.FSDP
-                or accelerator.distributed_type == DistributedType.DEEPSPEED
-            ):
+                AcceleratorState().deepspeed_plugin.deepspeed_config_process(must_match=True, **kwargs)
+                eval_logger.info("Detected that you are using DistributedType.DEEPSPEED. Make sure you run `accelerate config` and set zero stage to 0")
+            if accelerator.distributed_type == DistributedType.FSDP or accelerator.distributed_type == DistributedType.DEEPSPEED:
                 self._model = accelerator.prepare(self.model)
             else:
-                self._model = accelerator.prepare_model(
-                    self.model, evaluation_mode=True
-                )
+                self._model = accelerator.prepare_model(self.model, evaluation_mode=True)
             self.accelerator = accelerator
             if self.accelerator.is_local_main_process:
-                eval_logger.info(
-                    f"Using {accelerator.num_processes} devices with data parallelism"
-                )
+                eval_logger.info(f"Using {accelerator.num_processes} devices with data parallelism")
             self._rank = self.accelerator.local_process_index
             self._world_size = self.accelerator.num_processes
         elif accelerator.num_processes == 1 and device_map == "auto":
-            eval_logger.info(
-                f"Using {accelerator.num_processes} devices with tensor parallelism"
-            )
+            eval_logger.info(f"Using {accelerator.num_processes} devices with tensor parallelism")
             self._rank = 0
             self._world_size = 1
         else:
@@ -191,9 +173,7 @@ class VILA(lmms):
     def pad_sequence(self, input_ids, batch_first, padding_value):
         if self.tokenizer.padding_side == "left":
             input_ids = [torch.flip(_input_ids, [0]) for _input_ids in input_ids]
-        input_ids = torch.nn.utils.rnn.pad_sequence(
-            input_ids, batch_first=batch_first, padding_value=padding_value
-        )
+        input_ids = torch.nn.utils.rnn.pad_sequence(input_ids, batch_first=batch_first, padding_value=padding_value)
         if self.tokenizer.padding_side == "left":
             input_ids = torch.flip(input_ids, [1])
         return input_ids
@@ -214,9 +194,7 @@ class VILA(lmms):
     def world_size(self):
         return self._world_size
 
-    def tok_encode(
-        self, string: str, left_truncate_len=None, add_special_tokens=None
-    ) -> List[int]:
+    def tok_encode(self, string: str, left_truncate_len=None, add_special_tokens=None) -> List[int]:
         """ """
         add_special_tokens = False if add_special_tokens is None else add_special_tokens
         encoding = self.tokenizer.encode(string, add_special_tokens=add_special_tokens)
@@ -242,13 +220,9 @@ class VILA(lmms):
 
     def loglikelihood(self, requests: List[Instance]) -> List[Tuple[float, bool]]:
         res = []
-        pbar = tqdm(
-            total=len(requests), disable=(self.rank != 0), desc="Model Responding"
-        )
+        pbar = tqdm(total=len(requests), disable=(self.rank != 0), desc="Model Responding")
 
-        for contexts, doc_to_target, doc_to_visual, doc_id, task, split in [
-            reg.args for reg in requests
-        ]:
+        for contexts, doc_to_target, doc_to_visual, doc_id, task, split in [reg.args for reg in requests]:
             # encode, pad, and truncate contexts for this batch
             if type(doc_to_target) == str:
                 continuation = doc_to_target
@@ -259,24 +233,12 @@ class VILA(lmms):
             videos = []
             for visual in visuals:
                 video = self.load_video(visual, self.max_frames_num)
-                video = (
-                    self._image_processor.preprocess(video, return_tensors="pt")[
-                        "pixel_values"
-                    ]
-                    .half()
-                    .to(self._device)
-                )
+                video = self._image_processor.preprocess(video, return_tensors="pt")["pixel_values"].half().to(self._device)
                 videos.append(video)
 
             qs = contexts
             if self.model.config.mm_use_im_start_end:
-                qs = (
-                    DEFAULT_IM_START_TOKEN
-                    + DEFAULT_IMAGE_TOKEN
-                    + DEFAULT_IM_END_TOKEN
-                    + "\n"
-                    + qs
-                )
+                qs = DEFAULT_IM_START_TOKEN + DEFAULT_IMAGE_TOKEN + DEFAULT_IM_END_TOKEN + "\n" + qs
             else:
                 qs = DEFAULT_IMAGE_TOKEN + "\n" + qs
 
@@ -285,29 +247,15 @@ class VILA(lmms):
             conv.append_message(conv.roles[1], None)
             prompt = conv.get_prompt()
 
-            contxt_id = (
-                tokenizer_image_token(
-                    prompt, self.tokenizer, IMAGE_TOKEN_INDEX, return_tensors="pt"
-                )
-                .unsqueeze(0)
-                .to(self.device)
-            )
+            contxt_id = tokenizer_image_token(prompt, self.tokenizer, IMAGE_TOKEN_INDEX, return_tensors="pt").unsqueeze(0).to(self.device)
 
             conv = conv_templates[self.conv_template].copy()
             conv.append_message(conv.roles[0], qs)
             conv.append_message(conv.roles[1], continuation)
             prompt = conv.get_prompt()
 
-            input_ids = (
-                tokenizer_image_token(
-                    prompt, self.tokenizer, IMAGE_TOKEN_INDEX, return_tensors="pt"
-                )
-                .unsqueeze(0)
-                .to(self._device)
-            )
-            attention_masks = (
-                input_ids.ne(self.tokenizer.pad_token_id).long().to(self._device)
-            )
+            input_ids = tokenizer_image_token(prompt, self.tokenizer, IMAGE_TOKEN_INDEX, return_tensors="pt").unsqueeze(0).to(self._device)
+            attention_masks = input_ids.ne(self.tokenizer.pad_token_id).long().to(self._device)
 
             labels = input_ids.clone()
             # Context part no need to calculate for loss
@@ -326,9 +274,7 @@ class VILA(lmms):
             logits = outputs["logits"]
             greedy_tokens = logits.argmax(dim=-1)
             cont_toks = input_ids[:, contxt_id.shape[1] :]  # [1, seq]
-            greedy_tokens = greedy_tokens[
-                :, contxt_id.shape[1] : input_ids.shape[1]
-            ]  # [1, seq]
+            greedy_tokens = greedy_tokens[:, contxt_id.shape[1] : input_ids.shape[1]]  # [1, seq]
             max_equal = (greedy_tokens == cont_toks).all()
             res.append((float(loss.item()), bool(max_equal)))
             pbar.update(1)
@@ -344,13 +290,9 @@ class VILA(lmms):
 
     def generate_until(self, requests) -> List[str]:
         res = []
-        pbar = tqdm(
-            total=len(requests), disable=(self.rank != 0), desc="Model Responding"
-        )
+        pbar = tqdm(total=len(requests), disable=(self.rank != 0), desc="Model Responding")
 
-        for contexts, gen_kwargs, doc_to_visual, doc_id, task, split in [
-            reg.args for reg in requests
-        ]:
+        for contexts, gen_kwargs, doc_to_visual, doc_id, task, split in [reg.args for reg in requests]:
             # encode, pad, and truncate contexts for this batch
             visuals = [doc_to_visual(self.task_dict[task][split][doc_id])]
             visuals = self.flatten(visuals)
@@ -359,13 +301,7 @@ class VILA(lmms):
             videos = []
             if self.max_frames_num == 0:
                 images = [Image.new("RGB", (448, 448), (0, 0, 0))] * num_video_frames
-                video = (
-                    process_images(
-                        images, self.model.image_processor, self.model.config
-                    )
-                    .half()
-                    .to(self._device)
-                )
+                video = process_images(images, self.model.image_processor, self.model.config).half().to(self._device)
                 videos.append(video)
             else:
                 for visual in visuals:
@@ -373,24 +309,12 @@ class VILA(lmms):
                         images = self.load_video(visual, num_video_frames)
                     elif self.video_decode_backend == "pyav":
                         images = read_video_pyav(visual, num_frm=num_video_frames)
-                    video = (
-                        process_images(
-                            images, self.model.image_processor, self.model.config
-                        )
-                        .half()
-                        .to(self._device)
-                    )
+                    video = process_images(images, self.model.image_processor, self.model.config).half().to(self._device)
                     videos.append(video)
 
             qs = f"<video>\n {contexts}"
             if self.model.config.mm_use_im_start_end:
-                qs = (
-                    DEFAULT_IM_START_TOKEN
-                    + DEFAULT_IMAGE_TOKEN
-                    + DEFAULT_IM_END_TOKEN
-                    + "\n"
-                    + qs
-                )
+                qs = DEFAULT_IM_START_TOKEN + DEFAULT_IMAGE_TOKEN + DEFAULT_IM_END_TOKEN + "\n" + qs
             else:
                 qs = (DEFAULT_IMAGE_TOKEN + "\n") * len(images) + qs
 
@@ -405,18 +329,8 @@ class VILA(lmms):
             conv.append_message(conv.roles[1], None)
             prompt = conv.get_prompt()
 
-            input_ids = (
-                tokenizer_image_token(
-                    prompt, self.tokenizer, IMAGE_TOKEN_INDEX, return_tensors="pt"
-                )
-                .unsqueeze(0)
-                .to(self._device)
-            )
-            pad_token_ids = (
-                self.tokenizer.pad_token_id
-                if self.tokenizer.pad_token_id is not None
-                else self.tokenizer.eos_token_id
-            )
+            input_ids = tokenizer_image_token(prompt, self.tokenizer, IMAGE_TOKEN_INDEX, return_tensors="pt").unsqueeze(0).to(self._device)
+            pad_token_ids = self.tokenizer.pad_token_id if self.tokenizer.pad_token_id is not None else self.tokenizer.eos_token_id
             # if "llama_3" in self.conv_template:
             #     pad_token_ids = 0  # lmms-lab/llama3-llava-8b is trained on this pad token id. You may need to customize this for other models.
             attention_masks = input_ids.ne(pad_token_ids).long().to(self._device)
@@ -429,9 +343,7 @@ class VILA(lmms):
             stop_str = conv.sep if conv.sep_style != SeparatorStyle.TWO else conv.sep2
             keywords = [stop_str]
 
-            stopping_criteria = KeywordsStoppingCriteria(
-                keywords, self.tokenizer, input_ids
-            )
+            stopping_criteria = KeywordsStoppingCriteria(keywords, self.tokenizer, input_ids)
 
             cur_prompt = contexts
 
@@ -460,9 +372,7 @@ class VILA(lmms):
                 # output_ids_2 = self.model.generate(inputs=input_ids, images=videos, attention_mask=attention_masks, modalities="video", do_sample=False, max_new_tokens=50,stopping_criteria=[stopping_criteria])
                 # output_ids = self.model.generate(inputs=input_ids, images=videos, attention_mask=attention_masks, modalities="video", do_sample=True, temperature=0.2, max_new_tokens=50,use_cache=True)
 
-            outputs = self.tokenizer.batch_decode(output_ids, skip_special_tokens=True)[
-                0
-            ].strip()
+            outputs = self.tokenizer.batch_decode(output_ids, skip_special_tokens=True)[0].strip()
             print("Question: ", cur_prompt)
             print("Answer: ", outputs)
             res.append(outputs)


### PR DESCRIPTION
## Summary

Replaces hardcoded `.cuda()` calls with `.to(self._device)` to support proper device placement when using multi-GPU setups or non-default CUDA devices.

## Problem

Many model implementations use hardcoded `.cuda()` calls which always place tensors on `cuda:0`, regardless of the `device` parameter passed to the model. This causes issues when:
- Running on specific GPUs (e.g., `--device cuda:1`)
- Using multi-GPU distributed evaluation
- The default GPU is occupied or unavailable

## Changes

Fixed device placement in 9 major model implementations:
- `llava_onevision.py` - 3 occurrences
- `llava_vid.py` - 4 occurrences
- `vila.py` - 6 occurrences
- `longva.py` - 1 occurrence
- `internvl.py` - 4 occurrences
- `internvl2.py` - 2 occurrences
- `internvideo2.py` - 4 occurrences (including helper function fix)
- `internvideo2_5.py` - 3 occurrences + model loading order fix
- `auroracap.py` - 3 occurrences

All `.cuda()` calls replaced with `.to(self._device)` to respect the device configuration.

## Related Issues

Fixes #952, #845

## Testing

- Verified all modified files have valid Python syntax
- No new lint errors introduced (existing pre-existing warnings remain)
- Device placement now respects `self._device` which is properly set based on accelerator configuration

## Note

24 `.cuda()` calls remain in less commonly used models (cambrian, egogpt, videochat, vita, etc.) - these can be addressed in a follow-up PR if needed.