### PR TITLE
feat: add WenetSpeech test_net split for evaluation

### DIFF
--- a/lmms_eval/tasks/wenet_speech/wenet_speech.yaml
+++ b/lmms_eval/tasks/wenet_speech/wenet_speech.yaml
@@ -2,3 +2,4 @@ group: wenet_speech
 task:
   - wenet_speech_dev
   - wenet_speech_test_meeting
+  - wenet_speech_test_net

--- a/lmms_eval/tasks/wenet_speech/wenet_speech_test_net.yaml
+++ b/lmms_eval/tasks/wenet_speech/wenet_speech_test_net.yaml
@@ -1,0 +1,16 @@
+task: "wenet_speech_test_net"
+test_split: test_net
+include: _default_template_yaml
+lmms_eval_specific_kwargs:
+  default:
+    pre_prompt: ""
+    post_prompt: ""
+    audio_column: "audio"
+    source_text_column: "text" 
+
+process_results: !function utils.wenet_speech_process_results
+
+metric_list:
+  - metric: mer
+    aggregation: mean
+    higher_is_better: false  # Lower MER is better


### PR DESCRIPTION
## Summary

Adds the `test_net` split to the WenetSpeech evaluation task, completing coverage of all available splits.

## Changes

- Added `wenet_speech_test_net.yaml` task configuration
- Updated `wenet_speech.yaml` group to include the new split

## WenetSpeech Splits

The WenetSpeech dataset has three splits:
- `dev` - Development set (already supported)
- `test_meeting` - Meeting domain test set (already supported)
- `test_net` - Internet domain test set (now added)

## Usage

```bash
# Evaluate on test_net split only
python -m lmms_eval --tasks wenet_speech_test_net ...

# Evaluate on all WenetSpeech splits
python -m lmms_eval --tasks wenet_speech ...
```