### PR TITLE
add dependency for reasoning tasks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ dependencies = [
     "sentence_transformers",
     "python-dotenv",
     "qwen-vl-utils>=0.0.14",
+    "math-verify",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Add `math-verify` to pyproject.toml.

`math-verify` is necessary for reasoing tasks, i.e. `mmmu_val_reasoing`. Ref: https://github.com/EvolvingLMMs-Lab/lmms-eval/issues/1043

@Luodian