### PR TITLE
fix incomplete configs of mmmu_val*

### DIFF
--- a/lmms_eval/tasks/mmmu/mmmu_val.yaml
+++ b/lmms_eval/tasks/mmmu/mmmu_val.yaml
@@ -1,4 +1,6 @@
 dataset_path: lmms-lab/MMMU
+# Change dataset_name to evaluate on different subjects.
+dataset_name: Accounting
 task: "mmmu_val"
 test_split: validation
 output_type: generate_until

--- a/lmms_eval/tasks/mmmu/mmmu_val_pass64.yaml
+++ b/lmms_eval/tasks/mmmu/mmmu_val_pass64.yaml
@@ -1,4 +1,6 @@
 dataset_path: lmms-lab/MMMU
+# Change dataset_name to evaluate on different subjects.
+dataset_name: Accounting
 task: "mmmu_val_pass64"
 test_split: validation
 output_type: generate_until

--- a/lmms_eval/tasks/mmmu/mmmu_val_reasoning.yaml
+++ b/lmms_eval/tasks/mmmu/mmmu_val_reasoning.yaml
@@ -1,4 +1,6 @@
 dataset_path: lmms-lab/MMMU
+# Change dataset_name to evaluate on different subjects.
+dataset_name: Accounting
 task: "mmmu_val_reasoning"
 test_split: validation
 output_type: generate_until


### PR DESCRIPTION

add `dataset_name: Accounting` and comments to `mmmu_val*.yaml`

mmmu_val*.yaml lacks `dataset_name`, leading to `Value Error: Config name is missing`

@Luodian 