### PR TITLE
[Task] Add MMSearch-Plus

### DIFF
--- a/lmms_eval/tasks/mmsearch_plus/README.md
+++ b/lmms_eval/tasks/mmsearch_plus/README.md
@@ -1,0 +1,120 @@
+# MMSearch-Plus VQA Task
+
+This directory contains the implementation of the MMSearch-Plus VQA task for lmms-eval.
+
+## Overview
+
+MMSearch-Plus is a challenging benchmark designed to test multimodal browsing agents' ability to perform genuine visual reasoning. The dataset contains 311 carefully curated tasks that require extracting and using fine-grained visual cues through iterative image-text retrieval.
+
+**Paper**: [MMSearch-Plus: Benchmarking Provenance-Aware Search for Multimodal Browsing Agents](https://arxiv.org/abs/2508.21475)
+
+**Dataset**: [Cie1/MMSearch-Plus](https://huggingface.co/datasets/Cie1/MMSearch-Plus)
+
+**Project Page**: [https://mmsearch-plus.github.io/](https://mmsearch-plus.github.io/)
+
+## Dataset Structure
+
+Each sample in the dataset contains:
+- `question`: The question text (encrypted)
+- `answer`: List of valid answer strings (encrypted)
+- `num_images`: Number of images in the sample (1-5)
+- `img_1` through `img_5`: PIL Image objects
+- `arxiv_id`: ArXiv ID if the question is about a paper (optional, encrypted)
+- `video_url`: Video URL if the question is about a video (optional, encrypted)
+- `category`: Question category (e.g., "Academic Research", "Sports", "Film & TV")
+- `difficulty`: "easy" or "difficult"
+- `subtask`: Specific subtask type
+
+## Implementation
+
+This is a simple VQA implementation that:
+
+1. **Decrypts** the dataset fields using the provided canary string
+2. **Extracts** images from the sample based on `num_images`
+3. **Formats** the question as a text prompt
+4. **Evaluates** predictions using:
+   - **F1 Score**: Token-level overlap between prediction and ground truth
+   - **Exact Match**: Binary match after normalization
+
+## Files
+
+- `_mmsearch_plus.yaml`: Group configuration file
+- `_default_template_mmsearch_plus.yaml`: Default template with common settings
+- `mmsearch_plus_vqa.yaml`: VQA task configuration
+- `utils.py`: Helper functions for data loading and evaluation
+- `decrypt_utils.py`: Decryption utilities for the encrypted dataset
+- `README.md`: This file
+
+## Usage
+
+### Running Evaluation
+
+```bash
+python -m lmms_eval \
+    --model qwen2_5_vl \
+    --model_args pretrained=Qwen/Qwen2.5-VL-3B-Instruct \
+    --tasks mmsearch_plus_vqa \
+    --batch_size 1 \
+    --device cuda:0 \
+    --log_samples
+```
+
+```bash
+accelerate launch --num_processes=8 --main_process_port=12346 -m lmms_eval \
+    --model qwen3_vl \
+    --model_args=pretrained=Qwen/Qwen3-VL-32B-Instruct,max_pixels=12845056,attn_implementation=flash_attention_2,interleave_visuals=False \
+    --tasks "mmsearch_plus" \
+    --batch_size 1 \
+    --log_samples \
+    --output_path logs
+```
+
+### Available Tasks
+
+- `mmsearch_plus_vqa`: Simple VQA evaluation on the full dataset
+
+## Metrics
+
+- **f1_score**: Token-level F1 score (max across all valid answers)
+- **exact_match**: Exact match score after normalization (max across all valid answers)
+
+## Notes
+
+### Answer Normalization
+
+Both predictions and ground truth answers are normalized before comparison:
+1. Convert to lowercase
+2. Remove punctuation
+3. Remove extra whitespace
+
+### Multiple Valid Answers
+
+Each sample may have multiple valid answers. The evaluation computes the maximum score across all valid answers to be lenient with answer variations.
+
+## Limitations
+
+This is a **simplified VQA implementation** that:
+- Does not include the full browsing agent framework
+- Does not perform iterative search and retrieval
+- Evaluates based on direct question answering only
+
+For the full agentic evaluation, please refer to the official MMSearch-Plus repository.
+
+## Citation
+
+If you use MMSearch-Plus in your research, please cite:
+
+```bibtex
+@article{tao2025mmsearch,
+  title={MMSearch-Plus: A Simple Yet Challenging Benchmark for Multimodal Browsing Agents},
+  author={Tao, Xijia and Teng, Yihua and Su, Xinxing and Fu, Xinyu and Wu, Jihao and Tao, Chaofan and Liu, Ziru and Bai, Haoli and Liu, Rui and Kong, Lingpeng},
+  journal={arXiv preprint arXiv:2508.21475},
+  year={2025}
+}
+```
+
+## Contact
+
+For questions or issues related to this implementation, please open an issue in the lmms-eval repository.
+
+For questions about the MMSearch-Plus dataset or benchmark, please refer to the [project page](https://mmsearch-plus.github.io/).

--- a/lmms_eval/tasks/mmsearch_plus/_default_template_mmsearch_plus.yaml
+++ b/lmms_eval/tasks/mmsearch_plus/_default_template_mmsearch_plus.yaml
@@ -1,0 +1,20 @@
+dataset_path: Cie1/MMSearch-Plus
+dataset_kwargs:
+  token: False
+output_type: generate_until
+doc_to_visual: !function utils.mmsearch_plus_doc_to_visual
+doc_to_text: !function utils.mmsearch_plus_doc_to_text
+doc_to_target: answer
+generation_kwargs:
+  max_new_tokens: 128
+  temperature: 0
+  top_p: 1.0
+  num_beams: 1
+  do_sample: false
+process_results: !function utils.mmsearch_plus_process_results
+metadata:
+  version: 0.0
+lmms_eval_specific_kwargs:
+  default:
+    pre_prompt: ""
+    post_prompt: "\nAnswer the question using a single word or short phrase."

--- a/lmms_eval/tasks/mmsearch_plus/_mmsearch_plus.yaml
+++ b/lmms_eval/tasks/mmsearch_plus/_mmsearch_plus.yaml
@@ -1,0 +1,5 @@
+group: mmsearch_plus
+task:
+  - mmsearch_plus_vqa
+metadata:
+  version: 0.0

--- a/lmms_eval/tasks/mmsearch_plus/decrypt_utils.py
+++ b/lmms_eval/tasks/mmsearch_plus/decrypt_utils.py
@@ -1,0 +1,82 @@
+"""Decryption utilities for MMSearch-Plus dataset."""
+
+import base64
+import hashlib
+from typing import Any, Dict
+
+
+def derive_key(password: str, length: int) -> bytes:
+    """
+    Derive encryption key from password using SHA-256.
+    
+    Args:
+        password: Password/canary string
+        length: Desired key length
+        
+    Returns:
+        Derived key of specified length
+    """
+    hasher = hashlib.sha256()
+    hasher.update(password.encode())
+    key = hasher.digest()
+    return key * (length // len(key)) + key[: length % len(key)]
+
+
+def decrypt_text(ciphertext_b64: str, password: str) -> str:
+    """
+    Decrypt base64-encoded ciphertext using XOR cipher with derived key.
+    
+    Args:
+        ciphertext_b64: Base64-encoded encrypted string
+        password: Password/canary string
+        
+    Returns:
+        Decrypted string
+    """
+    if not ciphertext_b64:
+        return ciphertext_b64
+
+    try:
+        encrypted = base64.b64decode(ciphertext_b64)
+        key = derive_key(password, len(encrypted))
+        decrypted = bytes([a ^ b for a, b in zip(encrypted, key)])
+        return decrypted.decode("utf-8")
+    except Exception as e:
+        print(f"[Warning] Decryption failed: {e}")
+        return ciphertext_b64  # Return original if decryption fails
+
+
+def decrypt_sample(sample: Dict[str, Any], canary: str) -> Dict[str, Any]:
+    """
+    Decrypt text fields in a single sample using the provided canary password.
+    
+    Args:
+        sample: Dataset sample with encrypted fields
+        canary: Canary string (e.g., 'MMSearch-Plus')
+        
+    Returns:
+        Decrypted sample
+    """
+    decrypted_sample = sample.copy()
+
+    # Decrypt text fields
+    text_fields = ["question", "video_url", "arxiv_id"]
+
+    for field in text_fields:
+        if field in sample and sample[field]:
+            decrypted_sample[field] = decrypt_text(sample[field], canary)
+
+    # Handle answer field (list of strings)
+    if "answer" in sample and sample["answer"]:
+        decrypted_answers = []
+        for answer in sample["answer"]:
+            if answer:
+                decrypted_answers.append(decrypt_text(answer, canary))
+            else:
+                decrypted_answers.append(answer)
+        decrypted_sample["answer"] = decrypted_answers
+
+    # Images are NOT encrypted in the current version
+    # category, difficulty, and subtask are also NOT encrypted
+
+    return decrypted_sample

--- a/lmms_eval/tasks/mmsearch_plus/mmsearch_plus_vqa.yaml
+++ b/lmms_eval/tasks/mmsearch_plus/mmsearch_plus_vqa.yaml
@@ -1,0 +1,10 @@
+task: mmsearch_plus_vqa
+include: _default_template_mmsearch_plus.yaml
+test_split: train
+metric_list:
+  - metric: f1_score
+    aggregation: mean
+    higher_is_better: true
+  - metric: exact_match
+    aggregation: mean
+    higher_is_better: true

--- a/lmms_eval/tasks/mmsearch_plus/utils.py
+++ b/lmms_eval/tasks/mmsearch_plus/utils.py
@@ -1,0 +1,199 @@
+"""Utility functions for MMSearch-Plus VQA task."""
+
+import re
+from typing import Any, Dict, List
+
+from loguru import logger as eval_logger
+
+from lmms_eval.tasks.mmsearch_plus.decrypt_utils import decrypt_sample
+
+
+# Canary string for decryption (full dataset name)
+CANARY = "MMSearch-Plus"
+
+
+def mmsearch_plus_doc_to_visual(doc: Dict[str, Any]) -> List[Any]:
+    """
+    Extract images from document.
+    
+    Args:
+        doc: Document containing images
+        
+    Returns:
+        List of PIL Images
+    """
+    # Decrypt the document
+    doc = decrypt_sample(doc, CANARY)
+    
+    images = []
+    num_images = doc.get("num_images", 0)
+    
+    # Extract images based on num_images field
+    for i in range(1, num_images + 1):
+        img_key = f"img_{i}"
+        if img_key in doc and doc[img_key] is not None:
+            try:
+                images.append(doc[img_key].convert("RGB"))
+            except Exception as e:
+                eval_logger.warning(f"Failed to load image {img_key}: {e}")
+    
+    if not images:
+        eval_logger.warning(f"No images found in document")
+    
+    return images
+
+
+def mmsearch_plus_doc_to_text(
+    doc: Dict[str, Any], lmms_eval_specific_kwargs: Dict[str, Any] = None
+) -> str:
+    """
+    Convert document to text prompt.
+    
+    Args:
+        doc: Document containing question
+        lmms_eval_specific_kwargs: Model-specific kwargs
+        
+    Returns:
+        Formatted question prompt
+    """
+    # Decrypt the document
+    doc = decrypt_sample(doc, CANARY)
+    
+    if lmms_eval_specific_kwargs is None:
+        lmms_eval_specific_kwargs = {}
+    
+    pre_prompt = lmms_eval_specific_kwargs.get("pre_prompt", "")
+    post_prompt = lmms_eval_specific_kwargs.get(
+        "post_prompt",
+        "\nAnswer the question using a single word or short phrase.",
+    )
+    
+    question = doc.get("question", "")
+    return f"{pre_prompt}{question}{post_prompt}"
+
+
+def normalize_answer(answer: str) -> str:
+    """
+    Normalize answer for comparison.
+    
+    Args:
+        answer: Raw answer string
+        
+    Returns:
+        Normalized answer
+    """
+    # Convert to lowercase
+    answer = answer.lower().strip()
+    
+    # Remove punctuation
+    answer = re.sub(r"[^\w\s]", "", answer)
+    
+    # Remove extra whitespace
+    answer = " ".join(answer.split())
+    
+    return answer
+
+
+def compute_f1_score(prediction: str, ground_truth: str) -> float:
+    """
+    Compute token-level F1 score between prediction and ground truth.
+    
+    Args:
+        prediction: Predicted answer
+        ground_truth: Ground truth answer
+        
+    Returns:
+        F1 score (0-1)
+    """
+    pred_tokens = normalize_answer(prediction).split()
+    gt_tokens = normalize_answer(ground_truth).split()
+    
+    if not pred_tokens or not gt_tokens:
+        return 0.0
+    
+    # Calculate precision and recall
+    common = set(pred_tokens) & set(gt_tokens)
+    
+    if not common:
+        return 0.0
+    
+    precision = len(common) / len(pred_tokens)
+    recall = len(common) / len(gt_tokens)
+    
+    # Calculate F1
+    if precision + recall == 0:
+        return 0.0
+    
+    f1 = 2 * (precision * recall) / (precision + recall)
+    return f1
+
+
+def compute_exact_match(prediction: str, ground_truth: str) -> float:
+    """
+    Compute exact match score (1 or 0).
+    
+    Args:
+        prediction: Predicted answer
+        ground_truth: Ground truth answer
+        
+    Returns:
+        1.0 if exact match, 0.0 otherwise
+    """
+    pred_norm = normalize_answer(prediction)
+    gt_norm = normalize_answer(ground_truth)
+    
+    return 1.0 if pred_norm == gt_norm else 0.0
+
+
+def mmsearch_plus_process_results(
+    doc: Dict[str, Any], result: List[str]
+) -> Dict[str, Any]:
+    """
+    Process model results and compute metrics.
+    
+    Args:
+        doc: Document containing ground truth
+        result: Model predictions
+        
+    Returns:
+        Dictionary containing metrics
+    """
+    # Decrypt the document
+    doc = decrypt_sample(doc, CANARY)
+    
+    if not result or len(result) == 0:
+        eval_logger.warning("Empty result received")
+        return {
+            "f1_score": 0.0,
+            "exact_match": 0.0,
+        }
+    
+    prediction = result[0].strip()
+    
+    # Get ground truth answers
+    gt_answers = doc.get("answer", [])
+    if isinstance(gt_answers, str):
+        gt_answers = [gt_answers]
+    
+    if not gt_answers:
+        eval_logger.warning("No ground truth answers found")
+        return {
+            "f1_score": 0.0,
+            "exact_match": 0.0,
+        }
+    
+    # Compute max score across all valid answers
+    max_f1 = 0.0
+    max_em = 0.0
+    
+    for gt_answer in gt_answers:
+        f1 = compute_f1_score(prediction, gt_answer)
+        em = compute_exact_match(prediction, gt_answer)
+        
+        max_f1 = max(max_f1, f1)
+        max_em = max(max_em, em)
+    
+    return {
+        "f1_score": max_f1,
+        "exact_match": max_em,
+    }


### PR DESCRIPTION
**Added MMSearch-Plus:**
[https://huggingface.co/datasets/Cie1/MMSearch-Plus](https://huggingface.co/datasets/Cie1/MMSearch-Plus)

This is a **search-based VQA benchmark**. The current implementation supports **end-to-end VQA with direct answering** (no search or agentic pipeline involved). It is intended to evaluate the **world knowledge** of an MLLM on this benchmark.

**Sample evaluation result on Qwen3-VL-32B-Instruct:**
<img width="996" height="370" alt="Screenshot 2026-01-29 at 5 53 14 PM" src="https://github.com/user-attachments/assets/6377841a-a81a-49c2-9740-1a616c6694a7" />
- The 0% accuracy is expected as noted in our paper.
- To allow for better grading, users can run LLM as a judge after getting the logged samples.