### PR TITLE
Remove extra opening of chat_template file for vLLM.

### DIFF
--- a/lmms_eval/models/chat/vllm.py
+++ b/lmms_eval/models/chat/vllm.py
@@ -105,16 +105,11 @@ class VLLM(VLLMSimple):
 
             sampling_params = SamplingParams(**sampling_params)
             start_time = time.time()
-            if self.chat_template is not None:
-                with open(self.chat_template, "r") as f:
-                    chat_template = f.read()
-                response = self.client.chat(
-                    sampling_params=sampling_params,
-                    messages=batched_messages,
-                    chat_template=chat_template,
-                )
-            else:
-                response = self.client.chat(sampling_params=sampling_params, messages=batched_messages)
+            response = self.client.chat(
+                sampling_params=sampling_params,
+                messages=batched_messages,
+                chat_template=self.chat_template
+            )
             end_time = time.time()
 
             response_text = [o.outputs[0].text for o in response]


### PR DESCRIPTION
Before you open a pull-request, please check if a similar issue already exists or has been closed before.

### When you open a pull-request, please be sure to include the following

- [x] A descriptive title: [xxx] XXXX
- [x] A detailed description

### Descripition
The `__init__` function already reads in the chat template file: https://github.com/EvolvingLMMs-Lab/lmms-eval/blob/c39b6c452a773a5baa5d8997d5ddd2fa4f792000/lmms_eval/models/simple/vllm.py#L172-L182.


If you meet the lint warnings, you can use following scripts to reformat code.

```sh
pip install pre-commit
pre-commit install
pre-commit run --all-files
```

### Ask for review
Once you feel comfortable for your PR, feel free to @ one of the contributors to review

General: @Luodian @kcz358 @pufanyi
Audio: @pbcong @ngquangtrung57

Thank you for your contributions!
