### PR TITLE
[Fix] Add revision field to LLaVA-OneVision-1.5 model

### DIFF
--- a/lmms_eval/models/simple/llava_onevision1_5.py
+++ b/lmms_eval/models/simple/llava_onevision1_5.py
@@ -50,6 +50,13 @@ class Llava_OneVision1_5(lmms):
         **kwargs,
     ) -> None:
         super().__init__()
+
+        # Extract revision from kwargs
+        # Allows for specifying a particular model revision from Hugging Face Hub
+        # when the official repo havent updated to be compatible with the latest transformers.
+        # e.g. revision='6b3d97091777ae511438186d60270089515adc0d' to be used with transformers==4.57.6
+        revision = kwargs.pop("revision", None)
+
         if kwargs:
             eval_logger.warning(f"Ignoring unexpected kwargs: {list(kwargs.keys())}")
 
@@ -80,6 +87,10 @@ class Llava_OneVision1_5(lmms):
             "device_map": self.device_map,
             "trust_remote_code": True,
         }
+
+        # Add revision if specified
+        if revision is not None:
+            model_kwargs["revision"] = revision
 
         # Add attention implementation if specified
         if attn_implementation is not None:


### PR DESCRIPTION
  ## Summary                                                                                                           
                                                                                                                    
  Add support for specifying a Hugging Face Hub model revision in the LLaVA-OneVision-1.5 model wrapper.

  This allows users to pin a specific commit/revision of the model repository, which is useful when the official
  repo hasn't been updated to be compatible with a particular version of transformers. For example, a specific
  revision can be targeted to work with transformers==4.57.6.

  ## Usage

```bash
# tested with
# dependenies versions
# NVIDIA-SMI 550.90.07 | Driver Version: 550.90.07 | CUDA Version: 13.1
# "torch==2.7.1",
# "torchvision==0.22.1",
# "transformers==4.57.6"
# installation
# uv venv -p 3.11
# source .venv/bin/activate
# uv pip install . spacy
# uv pip install flash-attn --no-build-isolation
revision="6b3d97091777ae511438186d60270089515adc0d"  # compatible revision for transformers==4.57.6

CUDA_VISIBLE_DEVICES=5,6,7 accelerate launch \
    --num_processes=3 \
    --num_machines=1 \
    --mixed_precision=no \
    --dynamo_backend=no \
    --main_process_port=12346 \
    -m lmms_eval \
    --model llava_onevision1_5 \
    --model_args=pretrained=lmms-lab/LLaVA-OneVision-1.5-8B-Instruct,attn_implementation=flash_attention_2,max_pixels=3240000,revision=${revision} \
    --tasks 3dsrbench_circular \
    --batch_size 1 \
    --log_samples \
    --verbosity DEBUG \
    --output_path ./logs/

```

 ##  Changes

  - Extract revision from kwargs in the Llava_OneVision1_5 constructor
  - Pass revision to the model loading kwargs when specified
  
  ## Tests
I tested the model on `3dsr_circular` after implementing the change.
<img width="820" height="254" alt="image" src="https://github.com/user-attachments/assets/bca5f361-56b5-44c8-9af8-418e5534f501" />
