### PR TITLE
[Bug Fix] Cambrians model crashes on multi-image benchmarks

### DIFF
--- a/lmms_eval/models/simple/cambrians.py
+++ b/lmms_eval/models/simple/cambrians.py
@@ -350,11 +350,12 @@ class CambrianS(lmms):
                                     real_qs += DEFAULT_IMAGE_TOKEN + "\n"
                         qs = real_qs
                     elif isinstance(qs, str):
+                        num_images = len(visual_sizes)
                         if self.model_config.mm_use_im_start_end:
-                            qs = DEFAULT_IM_START_TOKEN + DEFAULT_IMAGE_TOKEN + DEFAULT_IM_END_TOKEN + "\n" + qs
+                            image_tokens = (DEFAULT_IM_START_TOKEN + DEFAULT_IMAGE_TOKEN + DEFAULT_IM_END_TOKEN + "\n") * num_images
+                            qs = image_tokens + qs
                         else:
-                            assert len(visual_tensors) == 1, "This should not happen."
-                            qs = DEFAULT_IMAGE_TOKEN * len(visual_tensors) + "\n" + qs
+                            qs = DEFAULT_IMAGE_TOKEN * num_images + "\n" + qs
                     else:
                         raise NotImplementedError
 


### PR DESCRIPTION
## Summary

  - Fix a `RuntimeError: Tensors must have same number of dimensions: got 3 and 4` crash
    when running the Cambrians model on multi-image benchmarks (e.g. MindCube)
  - The root cause was that only a single `<image>` token was inserted into the prompt
    regardless of the actual number of images, causing the downstream cambrian library
    to take its single-image code path while the image features tensor was shaped for
    multiple images
  - Now uses `len(visual_sizes)` to insert one `<image>` token per image so the cambrian
    library correctly routes to its multi-image concatenation path

  ## Test 
Verified to run on mindcube-tiny (a multi-image benchmark)
<img width="855" height="207" alt="image" src="https://github.com/user-attachments/assets/19ac10f0-cf84-473e-bc2b-40da2542d15b" />
