### PR TITLE
[Model] Fixed the parameter name error in qwen2_audio

### DIFF
--- a/lmms_eval/models/simple/qwen2_audio.py
+++ b/lmms_eval/models/simple/qwen2_audio.py
@@ -233,7 +233,7 @@ class Qwen2_Audio(lmms):
             else:
                 text = ["<|audio_bos|><|AUDIO|><|audio_eos|>" + context for context in contexts]
 
-            inputs = self.processor(text=text, audios=audios, return_tensors="pt", padding=True, sampling_rate=self.processor.feature_extractor.sampling_rate)
+            inputs = self.processor(text=text, audio=audios, return_tensors="pt", padding=True, sampling_rate=self.processor.feature_extractor.sampling_rate)
 
             if self.device_map == "auto":
                 inputs = inputs.to("cuda")


### PR DESCRIPTION
## Description

Fixed a critical bug in the Qwen2-Audio model integration where audio data was not being passed to the processor, causing the model to generate identical responses for all samples.

## Type of Change

- Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Fixed incorrect parameter name in `qwen2_audio.py` line 236: changed `audios=audios` to `audio=audios`
- This aligns with the Qwen2AudioProcessor's expected parameter name and is consistent with other audio models (e.g., `qwen2_5_omni.py`)

## Root Cause

The processor was rejecting the `audios` parameter with warning:

Keyword argument [audios] is not a valid argument for this processor and will be ignored.

This caused all audio inputs to be ignored, resulting in the model receiving only text prompts and generating identical responses across different audio samples.

## Testing

- [x] Tested locally with: `python -m lmms_eval --model qwen2_audio --tasks song_describer_train --limit 5`
- [x] Verified that responses are now different for different audio samples (previously all identical)
