### PR TITLE
SAM3 & SA-Co/Gold integration

### DIFF
--- a/lmms_eval/models/__init__.py
+++ b/lmms_eval/models/__init__.py
@@ -79,6 +79,7 @@ AVAILABLE_SIMPLE_MODELS = {
     "qwen3_vl": "Qwen3_VL",
     "reka": "Reka",
     "ross": "Ross",
+    "sam3": "SAM3",
     "slime": "Slime",
     "srt_api": "SRT_API",
     "tinyllava": "TinyLlava",

--- a/lmms_eval/models/simple/sam3.py
+++ b/lmms_eval/models/simple/sam3.py
@@ -1,0 +1,296 @@
+import json
+
+import numpy as np
+import torch
+from PIL import Image
+from loguru import logger as eval_logger
+from tqdm import tqdm
+from typing import Dict, List, Optional, Tuple, Union
+
+from lmms_eval.api.instance import Instance
+from lmms_eval.api.model import lmms
+from lmms_eval.api.registry import register_model
+
+try:
+    from transformers import Sam3Model, Sam3Processor
+
+    HAS_SAM3 = True
+except ImportError:
+    HAS_SAM3 = False
+    eval_logger.warning("SAM3 not found. Please install transformers with SAM3 support.")
+
+try:
+    from pycocotools import mask as mask_utils
+
+    HAS_PYCOCOTOOLS = True
+except ImportError:
+    HAS_PYCOCOTOOLS = False
+    eval_logger.warning("pycocotools not found. Install with: pip install pycocotools")
+
+try:
+    from accelerate import Accelerator, DistributedType
+
+    HAS_ACCELERATOR = True
+except ImportError:
+    HAS_ACCELERATOR = False
+    eval_logger.warning("Accelerate not found. Multi-GPU evaluation will not work.")
+
+
+def mask_to_coco_rle(binary_mask: np.ndarray) -> Dict:
+    """Convert a binary mask (H, W) to COCO RLE format via pycocotools.
+
+    Returns ``{"counts": "<rle_string>", "size": [H, W]}``.
+    This is the universal COCO RLE representation used by pycocotools,
+    COCO evaluation tools, and SAM3 evaluation scripts.
+    """
+    mask_fortran = np.asfortranarray(binary_mask.astype(np.uint8))
+    rle = mask_utils.encode(mask_fortran)
+    # pycocotools returns bytes for counts — convert to str for JSON
+    rle["counts"] = rle["counts"].decode("utf-8")
+    return rle
+
+
+@register_model("sam3")
+class SAM3(lmms):
+    """SAM3 (Segment Anything Model 3) for text-prompted instance segmentation.
+
+    SAM3 is *not* a text-generation model.  It takes an image and a short text
+    prompt and returns segmentation masks, bounding boxes and confidence scores.
+
+    In order to fit into the lmms-eval ``generate_until`` interface the model
+    serialises its structured outputs as a JSON string containing **both**
+    masks and bounding boxes for every request::
+
+        {
+            "masks": [                         # COCO RLE encoded masks
+                {"counts": "...", "size": [H, W]},
+                ...
+            ],
+            "boxes": [                         # normalised xyxy bounding boxes
+                {"x_min": 0.1, "y_min": 0.2, "x_max": 0.3, "y_max": 0.4},
+                ...
+            ],
+            "scores": [0.95, 0.87, ...]        # confidence scores
+        }
+
+    Downstream task ``process_results`` functions pick whichever fields they
+    need (masks for segmentation tasks, boxes for detection tasks).
+
+    Example
+    -------
+    ::
+
+        python -m lmms_eval \\
+            --model sam3 \\
+            --model_args pretrained=facebook/sam3 \\
+            --tasks saco_gold_attributes_seg \\
+            --output_path ./results
+    """
+
+    is_simple = True
+
+    def __init__(
+        self,
+        pretrained: str = "facebook/sam3",
+        device: Optional[str] = "cuda",
+        batch_size: Optional[Union[int, str]] = 1,
+        threshold: float = 0.5,
+        mask_threshold: float = 0.5,
+        **kwargs,
+    ) -> None:
+        super().__init__()
+
+        if not HAS_SAM3:
+            raise ImportError(
+                "SAM3 is required but not installed.  "
+                "Please install / upgrade transformers with SAM3 support."
+            )
+        if not HAS_PYCOCOTOOLS:
+            raise ImportError(
+                "pycocotools is required for COCO RLE mask encoding.  "
+                "Install with: pip install pycocotools"
+            )
+
+        self.pretrained = pretrained
+        self.threshold = threshold
+        self.mask_threshold = mask_threshold
+
+        eval_logger.info(f"Loading SAM3 model: {pretrained}")
+        eval_logger.info(f"threshold={threshold}, mask_threshold={mask_threshold}")
+
+        if kwargs:
+            eval_logger.info(f"Additional kwargs: {kwargs}")
+
+        # ---- Distributed / device setup ---------------------------------- #
+        accelerator = Accelerator() if HAS_ACCELERATOR else None
+
+        if accelerator is not None and accelerator.num_processes > 1:
+            self._device = torch.device(f"cuda:{accelerator.local_process_index}")
+            self.device_map = f"cuda:{accelerator.local_process_index}"
+            self._rank = accelerator.local_process_index
+            self._world_size = accelerator.num_processes
+            eval_logger.info(f"Distributed mode: rank {self._rank}/{self._world_size}")
+        else:
+            if torch.cuda.is_available() and device is not None:
+                self._device = torch.device(device)
+            else:
+                self._device = torch.device("cpu")
+            self.device_map = str(self._device)
+            self._rank = 0
+            self._world_size = 1
+
+        self._accelerator = accelerator
+
+        # ---- Load model & processor -------------------------------------- #
+        self._model = Sam3Model.from_pretrained(pretrained).to(self._device).eval()
+        self._processor = Sam3Processor.from_pretrained(pretrained)
+
+        eval_logger.info("SAM3 model and processor loaded successfully")
+
+        self.batch_size_per_gpu = int(batch_size)
+
+    # -- Properties expected by the base class / framework ----------------- #
+
+    @property
+    def model(self):
+        return self._model
+
+    @property
+    def processor(self):
+        return self._processor
+
+    @property
+    def batch_size(self):
+        return self.batch_size_per_gpu
+
+    @property
+    def device(self):
+        return self._device
+
+    @property
+    def rank(self):
+        return self._rank
+
+    @property
+    def world_size(self):
+        return self._world_size
+
+    # -- Helpers ----------------------------------------------------------- #
+
+    @staticmethod
+    def _to_pil(image) -> Image.Image:
+        """Coerce *image* to an RGB PIL Image."""
+        if isinstance(image, str):
+            return Image.open(image).convert("RGB")
+        if isinstance(image, np.ndarray):
+            return Image.fromarray(image).convert("RGB")
+        if isinstance(image, Image.Image):
+            return image.convert("RGB")
+        raise ValueError(f"Unsupported image type: {type(image)}")
+
+    @staticmethod
+    def _format_results(results: Dict, img_width: int, img_height: int) -> str:
+        """Serialise SAM3 post-processed outputs to a JSON string.
+
+        Returns a JSON object with ``masks`` (COCO RLE), ``boxes`` (normalised
+        xyxy) and ``scores``.  Downstream task utils pick the fields they need.
+        """
+        # -- Masks → COCO RLE ---------------------------------------------- #
+        raw_masks = results.get("masks", [])
+        rle_masks = []
+        for mask in raw_masks:
+            mask_np = mask.cpu().numpy().astype(np.uint8)
+            rle_masks.append(mask_to_coco_rle(mask_np))
+
+        # -- Boxes → normalised xyxy --------------------------------------- #
+        raw_boxes = results.get("boxes", [])
+        norm_boxes = []
+        for box in raw_boxes:
+            box_cpu = box.cpu() if torch.is_tensor(box) else box
+            norm_boxes.append(
+                {
+                    "x_min": float(box_cpu[0] / img_width),
+                    "y_min": float(box_cpu[1] / img_height),
+                    "x_max": float(box_cpu[2] / img_width),
+                    "y_max": float(box_cpu[3] / img_height),
+                }
+            )
+
+        # -- Scores -------------------------------------------------------- #
+        raw_scores = results.get("scores", [])
+        scores = [float(s) for s in raw_scores]
+
+        return json.dumps({"masks": rle_masks, "boxes": norm_boxes, "scores": scores})
+
+    # -- Core interface methods -------------------------------------------- #
+
+    def loglikelihood(self, requests: List[Instance]) -> List[Tuple[float, bool]]:
+        """Not applicable for SAM3 — returns dummy values."""
+        eval_logger.warning("loglikelihood is not applicable for SAM3")
+        return [(0.0, True) for _ in requests]
+
+    def generate_until(self, requests: List[Instance]) -> List[str]:
+        """Run SAM3 inference and return results as JSON strings.
+
+        Each request yields a JSON object containing COCO-RLE masks, normalised
+        bounding boxes and confidence scores.  The downstream task
+        ``process_results`` function picks whichever fields it needs.
+        """
+        res: List[str] = []
+        empty_result = json.dumps({"masks": [], "boxes": [], "scores": []})
+
+        pbar = tqdm(
+            total=len(requests),
+            disable=(self.rank != 0),
+            desc="SAM3 Inference",
+        )
+
+        for req in requests:
+            try:
+                # Unpack instance arguments (simple model format)
+                doc_id = req.args[3]
+                task = req.args[4]
+                split = req.args[5]
+                doc_data = self.task_dict[task][split][doc_id]
+
+                image = doc_data["image"]
+                expression = doc_data["expression"]
+
+                image_pil = self._to_pil(image)
+
+                # Prepare inputs
+                inputs = self._processor(
+                    images=image_pil,
+                    text=expression,
+                    return_tensors="pt",
+                ).to(self.device)
+
+                # Forward pass
+                with torch.no_grad():
+                    outputs = self._model(**inputs)
+
+                # Post-process
+                results = self._processor.post_process_instance_segmentation(
+                    outputs,
+                    threshold=self.threshold,
+                    mask_threshold=self.mask_threshold,
+                    target_sizes=inputs.get("original_sizes").tolist(),
+                )[0]
+
+                img_w, img_h = image_pil.size
+                res.append(self._format_results(results, img_w, img_h))
+
+            except Exception as e:
+                eval_logger.error(f"Error processing request: {e}")
+                res.append(empty_result)
+
+            pbar.update(1)
+
+        pbar.close()
+        return res
+
+    def generate_until_multi_round(self, requests: List[Instance]) -> List[str]:
+        """Not applicable for SAM3."""
+        raise NotImplementedError(
+            "Multi-round generation is not supported for SAM3."
+        )

--- a/lmms_eval/tasks/saco/_default_template_saco_gold_yaml
+++ b/lmms_eval/tasks/saco/_default_template_saco_gold_yaml
@@ -1,0 +1,51 @@
+dataset_path: yasserDahou/saco-gold
+dataset_kwargs:
+  token: True
+group: "saco_gold"
+output_type: generate_until
+doc_to_visual: !function utils.saco_doc_to_visual
+doc_to_text: !function utils.saco_doc_to_text
+doc_to_target: !function utils.saco_doc_to_target
+process_results: !function utils.saco_process_results
+generation_kwargs:
+  max_new_tokens: 2048
+  temperature: 0.0
+  do_sample: false
+metric_list:
+  # ===== Classification signals (summed → used to compute MCC) =====
+  - metric: IL_TP
+    aggregation: !function utils.IL_TP
+    higher_is_better: true
+
+  - metric: IL_TN
+    aggregation: !function utils.IL_TN
+    higher_is_better: true
+
+  - metric: IL_FP
+    aggregation: !function utils.IL_FP
+    higher_is_better: false
+
+  - metric: IL_FN
+    aggregation: !function utils.IL_FN
+    higher_is_better: false
+
+  # ===== Count accuracy =====
+  - metric: count_accuracy
+    aggregation: !function utils.count_accuracy
+    higher_is_better: true
+
+  # ===== Macro F1 (avg of per-sample F1 across 10 IoU thresholds) =====
+  - metric: sample_f1
+    aggregation: !function utils.sample_f1
+    higher_is_better: true
+
+  # ===== Localization counts (TP/FP/FN at 10 thresholds, packed) =====
+  - metric: loc_counts
+    aggregation: !function utils.loc_counts
+    higher_is_better: true
+
+metadata:
+  version: 4.0
+  description: >
+    SaCO-gold segmentation benchmark with SAM3-style cgF1 metrics.
+    Run compute_metrics.py on the results JSON to derive MCC, pmF1, cgF1.

--- a/lmms_eval/tasks/saco/compute_metrics.py
+++ b/lmms_eval/tasks/saco/compute_metrics.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Compute final SaCO / PBench metrics (MCC, pmF1, cgF1) from lmms-eval results JSON.
+
+Usage::
+
+    python -m lmms_eval.tasks.saco.compute_metrics results/facebook__sam3/*_results.json
+
+The script reads the aggregated TP/TN/FP/FN sums and per-threshold
+localization counts already present in the JSON, computes the derived
+dataset-level metrics, prints a summary table, and writes the metrics
+back into the JSON.
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+from lmms_eval.tasks.saco.utils import compute_saco_final_metrics
+
+
+def _print_table(summary: dict, json_path: str) -> None:
+    """Print a formatted results table similar to run_falcon_eval.py."""
+    if not summary:
+        print("  No saco_gold / pbench tasks found in results.")
+        return
+
+    # Determine benchmark name from task keys
+    task_names = sorted(summary.keys())
+    is_pbench = any(t.startswith("pbench") for t in task_names)
+    is_saco = any(t.startswith("saco_gold") for t in task_names)
+    bench_name = "PBench" if is_pbench else "SaCO-Gold" if is_saco else "Segmentation"
+
+    # Strip common prefix for cleaner display
+    if is_pbench:
+        display = {t: t.replace("pbench_", "") for t in task_names}
+    elif is_saco:
+        display = {t: t.replace("saco_gold_", "") for t in task_names}
+    else:
+        display = {t: t for t in task_names}
+
+    # Header
+    w_split = max(max(len(v) for v in display.values()), 12)
+    hdr = (
+        f"{'Split':<{w_split}}"
+        f"  {'IL_MCC':>8}"
+        f"  {'pmF1':>8}"
+        f"  {'cgF1':>8}"
+        f"  {'macro_F1':>8}"
+        f"  {'cnt_acc':>8}"
+    )
+    sep = "-" * len(hdr)
+
+    print(f"\n{'=' * len(hdr)}")
+    print(f"{bench_name} RESULTS — {json_path}")
+    print(f"{'=' * len(hdr)}")
+    print(hdr)
+    print(sep)
+
+    # Per-split rows
+    totals = {"IL_MCC": 0, "pmF1": 0, "cgF1": 0, "macro_F1": 0, "cnt_acc": 0}
+    n = 0
+    for t in task_names:
+        m = summary[t]
+        label = display[t]
+
+        # count_accuracy comes from the original JSON (not computed here)
+        cnt_acc = m.get("count_accuracy", 0.0)
+
+        print(
+            f"{label:<{w_split}}"
+            f"  {m['IL_MCC']:>8.4f}"
+            f"  {m['pmF1'] * 100:>7.1f}%"
+            f"  {m['cgF1']:>7.2f}"
+            f"  {m['macro_F1'] * 100:>7.1f}%"
+            f"  {cnt_acc * 100:>7.1f}%"
+        )
+        totals["IL_MCC"] += m["IL_MCC"]
+        totals["pmF1"] += m["pmF1"]
+        totals["cgF1"] += m["cgF1"]
+        totals["macro_F1"] += m["macro_F1"]
+        totals["cnt_acc"] += cnt_acc
+        n += 1
+
+    if n > 1:
+        print(sep)
+        print(
+            f"{'AVERAGE':<{w_split}}"
+            f"  {totals['IL_MCC'] / n:>8.4f}"
+            f"  {totals['pmF1'] / n * 100:>7.1f}%"
+            f"  {totals['cgF1'] / n:>7.2f}"
+            f"  {totals['macro_F1'] / n * 100:>7.1f}%"
+            f"  {totals['cnt_acc'] / n * 100:>7.1f}%"
+        )
+    print(f"{'=' * len(hdr)}\n")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Compute SaCO / PBench final metrics (MCC, pmF1, cgF1) from lmms-eval results JSON."
+    )
+    parser.add_argument(
+        "results_json",
+        type=str,
+        nargs="+",
+        help="Path(s) to lmms-eval *_results.json file(s).",
+    )
+    parser.add_argument(
+        "--no-save",
+        action="store_true",
+        help="Do not write derived metrics back into the JSON.",
+    )
+    args = parser.parse_args()
+
+    for path in args.results_json:
+        if not Path(path).exists():
+            print(f"ERROR: File not found: {path}", file=sys.stderr)
+            continue
+
+        summary = compute_saco_final_metrics(path, save=not args.no_save)
+        _print_table(summary, path)
+
+        if not args.no_save:
+            print(f"  Derived metrics written back to {path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/lmms_eval/tasks/saco/saco_gold.yaml
+++ b/lmms_eval/tasks/saco/saco_gold.yaml
@@ -1,0 +1,9 @@
+group: saco_gold
+task:
+  - saco_gold_attributes
+  - saco_gold_crowded
+  - saco_gold_food
+  - saco_gold_metaclip
+  - saco_gold_sa1b
+  - saco_gold_sport
+  - saco_gold_wiki_common

--- a/lmms_eval/tasks/saco/saco_gold_attributes.yaml
+++ b/lmms_eval/tasks/saco/saco_gold_attributes.yaml
@@ -1,0 +1,3 @@
+task: "saco_gold_attributes"
+test_split: attributes
+include: _default_template_saco_gold_yaml

--- a/lmms_eval/tasks/saco/saco_gold_crowded.yaml
+++ b/lmms_eval/tasks/saco/saco_gold_crowded.yaml
@@ -1,0 +1,3 @@
+task: "saco_gold_crowded"
+test_split: crowded
+include: _default_template_saco_gold_yaml

--- a/lmms_eval/tasks/saco/saco_gold_food.yaml
+++ b/lmms_eval/tasks/saco/saco_gold_food.yaml
@@ -1,0 +1,3 @@
+task: "saco_gold_food"
+test_split: food
+include: _default_template_saco_gold_yaml

--- a/lmms_eval/tasks/saco/saco_gold_metaclip.yaml
+++ b/lmms_eval/tasks/saco/saco_gold_metaclip.yaml
@@ -1,0 +1,3 @@
+task: "saco_gold_metaclip"
+test_split: metaclip
+include: _default_template_saco_gold_yaml

--- a/lmms_eval/tasks/saco/saco_gold_sa1b.yaml
+++ b/lmms_eval/tasks/saco/saco_gold_sa1b.yaml
@@ -1,0 +1,3 @@
+task: "saco_gold_sa1b"
+test_split: sa1b
+include: _default_template_saco_gold_yaml

--- a/lmms_eval/tasks/saco/saco_gold_sport.yaml
+++ b/lmms_eval/tasks/saco/saco_gold_sport.yaml
@@ -1,0 +1,3 @@
+task: "saco_gold_sport"
+test_split: sport
+include: _default_template_saco_gold_yaml

--- a/lmms_eval/tasks/saco/saco_gold_wiki_common.yaml
+++ b/lmms_eval/tasks/saco/saco_gold_wiki_common.yaml
@@ -1,0 +1,3 @@
+task: "saco_gold_wiki_common"
+test_split: wiki_common
+include: _default_template_saco_gold_yaml

--- a/lmms_eval/tasks/saco/utils.py
+++ b/lmms_eval/tasks/saco/utils.py
@@ -1,0 +1,507 @@
+"""SaCo benchmark evaluation utilities.
+
+Implements SAM3-style cgF1 evaluation for text-prompted instance segmentation
+with **oracle evaluation** over 3 independent annotators:
+
+* For each sample the model prediction is compared against each annotator's GT
+  independently.  The annotator that yields the best mean local-F1 (across 10
+  IoU thresholds) is selected — this is the official SAM3 oracle protocol.
+
+* **Classification** — Image-level MCC (is object present?)
+* **Localization**  — Positive micro-F1 averaged over 10 IoU thresholds [0.5:0.05:0.95]
+* **Combined**      — cgF1 = 100 * pmF1 * IL_MCC
+
+For more details, see: 
+Paper: https://arxiv.org/abs/2511.16719
+Official evaluation: https://github.com/facebookresearch/sam3/tree/main/scripts/eval/gold
+
+All masks are expected in **COCO RLE** format (``{"counts": "...", "size": [H, W]}``).
+
+Dataset schema (``yasserDahou/saco-gold``)::
+
+    id              int                          Global sequential ID
+    image           Image                        RGB image
+    expression      string                       Referring expression
+    human_1_masks   [{size: [H,W], counts: str}] Annotator 1 masks (COCO RLE)
+    human_2_masks   [{size: [H,W], counts: str}] Annotator 2 masks (COCO RLE)
+    human_3_masks   [{size: [H,W], counts: str}] Annotator 3 masks (COCO RLE)
+    count           int                          max(len(h1), len(h2), len(h3))
+
+After running evaluation with lmms-eval, call :func:`compute_saco_final_metrics`
+on the results JSON to compute dataset-level MCC, pmF1, and cgF1.
+"""
+
+import json
+import math
+
+import numpy as np
+from loguru import logger as eval_logger
+from pycocotools import mask as mask_utils
+from scipy.optimize import linear_sum_assignment
+from typing import Any, Dict, List, Tuple
+
+# Official SAM3 IoU thresholds (0.5:0.05:0.95)
+IOU_THRESHOLDS = [0.5, 0.55, 0.6, 0.65, 0.7, 0.75, 0.8, 0.85, 0.9, 0.95]
+
+
+# =========================================================================== #
+#  Mask helpers (COCO RLE)
+# =========================================================================== #
+
+def decode_coco_rle(rle: Dict) -> np.ndarray:
+    """Decode a single COCO RLE dict to a binary (H, W) numpy mask."""
+    rle_copy = rle.copy()
+    if isinstance(rle_copy.get("counts"), str):
+        rle_copy["counts"] = rle_copy["counts"].encode("utf-8")
+    return mask_utils.decode(rle_copy).astype(np.uint8)
+
+
+def compute_mask_iou(mask1: np.ndarray, mask2: np.ndarray) -> float:
+    """IoU between two binary masks."""
+    m1 = (mask1 > 0).astype(np.uint8)
+    m2 = (mask2 > 0).astype(np.uint8)
+    intersection = np.logical_and(m1, m2).sum()
+    union = np.logical_or(m1, m2).sum()
+    if union == 0:
+        return 0.0
+    return float(intersection / union)
+
+
+def mask_nms(masks: List[np.ndarray], iou_threshold: float = 0.9) -> List[np.ndarray]:
+    """Remove duplicate masks via greedy NMS (keep larger mask)."""
+    if len(masks) <= 1:
+        return masks
+
+    areas = [int(np.sum(m > 0)) for m in masks]
+    order = np.argsort(areas)[::-1]
+
+    keep, removed = [], set()
+    for i in order:
+        if i in removed:
+            continue
+        keep.append(i)
+        for j in order:
+            if j in removed or j == i or j in keep:
+                continue
+            if compute_mask_iou(masks[i], masks[j]) >= iou_threshold:
+                removed.add(j)
+
+    filtered = [masks[k] for k in sorted(keep)]
+    if len(masks) != len(filtered):
+        eval_logger.debug(
+            f"Mask NMS: {len(masks)} -> {len(filtered)} "
+            f"(removed {len(masks) - len(filtered)})"
+        )
+    return filtered
+
+
+# =========================================================================== #
+#  Parsing model output
+# =========================================================================== #
+
+def parse_predicted_masks(response_text: str) -> List[Dict]:
+    """Extract COCO-RLE mask dicts from the model JSON response.
+
+    Accepts::
+
+        {"masks": [...], "boxes": [...], "scores": [...]}
+
+    or a bare list of mask dicts.
+    """
+    try:
+        data = json.loads(response_text)
+        if isinstance(data, dict):
+            masks = data.get("masks", [])
+        elif isinstance(data, list):
+            masks = data
+        else:
+            return []
+        return [m for m in masks if isinstance(m, dict)]
+    except (json.JSONDecodeError, TypeError):
+        eval_logger.debug("Failed to parse model response as JSON")
+        return []
+
+
+# =========================================================================== #
+#  doc_to_* functions (referenced by task YAML)
+# =========================================================================== #
+
+def saco_doc_to_visual(doc):
+    """Return a list of PIL images for the document."""
+    return [doc["image"].convert("RGB")]
+
+
+def saco_doc_to_text(doc):
+    """Return the text prompt (expression)."""
+    return doc["expression"]
+
+
+def saco_doc_to_target(doc):
+    """Return ground-truth info needed by process_results.
+
+    Returns all three annotators' masks for oracle evaluation.
+    """
+    return {
+        "human_1_masks": doc.get("human_1_masks", []),
+        "human_2_masks": doc.get("human_2_masks", []),
+        "human_3_masks": doc.get("human_3_masks", []),
+        "count": doc.get("count", 0),
+        "expression": doc["expression"],
+    }
+
+
+# =========================================================================== #
+#  Per-annotator evaluation helper
+# =========================================================================== #
+
+def _evaluate_against_one_gt(
+    predicted_masks: List[np.ndarray],
+    gt_masks_rle: List[Dict],
+) -> Dict[str, Any]:
+    """Evaluate predicted (decoded, NMS'd) masks against one annotator's GT.
+
+    Returns a dict with:
+        IL_TP/TN/FP/FN  — classification signals
+        sample_f1        — mean local F1 across 10 thresholds (-1 for negatives
+                           when no GT and no preds → sentinel for macro avg)
+        loc_counts       — {"tp": [10], "fp": [10], "fn": [10]}
+        has_local_f1s    — True when local_F1s were computed (used by oracle)
+        _mean_f1         — mean of local F1 (used by oracle selection)
+    """
+    target_count = len(gt_masks_rle)
+    predicted_count = len(predicted_masks)
+    n_thresh = len(IOU_THRESHOLDS)
+
+    is_positive = target_count > 0
+    has_prediction = predicted_count > 0
+
+    IL_TP = 1.0 if (is_positive and has_prediction) else 0.0
+    IL_TN = 1.0 if (not is_positive and not has_prediction) else 0.0
+    IL_FP = 1.0 if (not is_positive and has_prediction) else 0.0
+    IL_FN = 1.0 if (is_positive and not has_prediction) else 0.0
+
+    zero_counts = {"tp": [0.0] * n_thresh, "fp": [0.0] * n_thresh, "fn": [0.0] * n_thresh}
+
+    base = {
+        "IL_TP": IL_TP, "IL_TN": IL_TN, "IL_FP": IL_FP, "IL_FN": IL_FN,
+        "count_accuracy": 1.0 if predicted_count == target_count else 0.0,
+    }
+
+    # --- True negative: no GT, no predictions → correct rejection ---------- #
+    if not is_positive and not has_prediction:
+        base["sample_f1"] = -1.0  # sentinel: excluded from positive macro avg
+        base["loc_counts"] = zero_counts
+        base["has_local_f1s"] = False
+        base["_mean_f1"] = -1.0
+        base["_is_true_negative"] = True
+        return base
+
+    # --- False positive: no GT but has predictions ------------------------- #
+    if not is_positive and has_prediction:
+        base["sample_f1"] = -1.0
+        base["loc_counts"] = {
+            "tp": [0.0] * n_thresh,
+            "fp": [0.0] * n_thresh,
+            "fn": [0.0] * n_thresh,
+        }
+        base["has_local_f1s"] = True
+        base["_mean_f1"] = 0.0
+        base["_is_true_negative"] = False
+        return base
+
+    # --- False negative: has GT but no predictions ------------------------- #
+    if is_positive and not has_prediction:
+        base["sample_f1"] = 0.0
+        base["loc_counts"] = {
+            "tp": [0.0] * n_thresh,
+            "fp": [0.0] * n_thresh,
+            "fn": [float(target_count)] * n_thresh,
+        }
+        base["has_local_f1s"] = True
+        base["_mean_f1"] = 0.0
+        base["_is_true_negative"] = False
+        return base
+
+    # --- True positive: both GT and predictions exist ---------------------- #
+    gt_masks = [decode_coco_rle(m) for m in gt_masks_rle]
+
+    n_pred, n_gt = predicted_count, len(gt_masks)
+    cost = np.zeros((n_pred, n_gt))
+    for i, pm in enumerate(predicted_masks):
+        for j, gm in enumerate(gt_masks):
+            cost[i, j] = -compute_mask_iou(pm, gm)
+
+    pred_idx, gt_idx = linear_sum_assignment(cost)
+    match_ious = -cost[pred_idx, gt_idx]
+
+    tps, fps, fns, local_f1s = [], [], [], []
+    for thresh in IOU_THRESHOLDS:
+        tp = int((match_ious >= thresh).sum())
+        fp = predicted_count - tp
+        fn = target_count - tp
+
+        prec = tp / (tp + fp + 1e-4)
+        rec = tp / (tp + fn + 1e-4)
+        f1 = 2 * prec * rec / (prec + rec + 1e-4)
+
+        tps.append(float(tp))
+        fps.append(float(fp))
+        fns.append(float(fn))
+        local_f1s.append(f1)
+
+    mean_f1 = float(np.mean(local_f1s))
+    base["sample_f1"] = mean_f1
+    base["loc_counts"] = {"tp": tps, "fp": fps, "fn": fns}
+    base["has_local_f1s"] = True
+    base["_mean_f1"] = mean_f1
+    base["_is_true_negative"] = False
+    return base
+
+
+# =========================================================================== #
+#  Oracle selection — pick the best annotator for one sample
+# =========================================================================== #
+
+def _select_best_annotator(candidates: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Return the candidate dict that yields the best oracle score."""
+    if len(candidates) == 1:
+        return candidates[0]
+
+    best = candidates[0]
+    for current in candidates[1:]:
+        best_has = best.get("has_local_f1s", False)
+        curr_has = current.get("has_local_f1s", False)
+
+        if best_has and curr_has:
+            # Both have F1 scores — compare mean F1
+            if current["_mean_f1"] > best["_mean_f1"]:
+                best = current
+        else:
+            # One or both lack F1 (true-negative case).
+            # Prefer true-negative (IL_TN=1) over other cases.
+            if current.get("_is_true_negative", False):
+                best = current
+
+    return best
+
+
+# =========================================================================== #
+#  process_results — per-sample metric computation with oracle
+#
+#  For each sample:
+#    1. Parse + decode + NMS the predicted masks (once).
+#    2. Evaluate against each of the 3 annotators independently.
+#    3. Oracle-select the annotator that yields the best mean local-F1.
+#    4. Return that annotator's metrics as the sample result.
+# =========================================================================== #
+
+def saco_process_results(doc, result):
+    """Compute SAM3-style per-sample metrics with 3-annotator oracle.
+
+    Returns a dict with:
+
+    * ``IL_TP/TN/FP/FN`` — classification signals (from best annotator)
+    * ``count_accuracy`` — 1 if predicted count == GT count (best annotator)
+    * ``sample_f1`` — average local F1 across 10 IoU thresholds (−1 for negatives)
+    * ``loc_counts`` — ``{"tp": [10], "fp": [10], "fn": [10]}`` for post-processing
+    """
+    response_text = result[0] if len(result) > 0 else ""
+
+    # --- Parse predicted masks (COCO RLE) --------------------------------- #
+    predicted_masks_rle = parse_predicted_masks(response_text)
+
+    # Decode predicted masks (shared across all annotator evaluations)
+    predicted_masks: List[np.ndarray] = []
+    if predicted_masks_rle:
+        predicted_masks = [decode_coco_rle(m) for m in predicted_masks_rle]
+
+    predicted_count = len(predicted_masks)
+    expression = doc["expression"]
+    eval_logger.debug(f"[{expression}] Pred={predicted_count}")
+
+    # --- Evaluate against each annotator ---------------------------------- #
+    annotator_keys = ["human_1_masks", "human_2_masks", "human_3_masks"]
+    candidates: List[Dict[str, Any]] = []
+
+    for key in annotator_keys:
+        gt_masks_rle = doc.get(key, [])
+        if gt_masks_rle is None:
+            gt_masks_rle = []
+        candidate = _evaluate_against_one_gt(predicted_masks, gt_masks_rle)
+        candidates.append(candidate)
+
+    # --- Oracle selection ------------------------------------------------- #
+    best = _select_best_annotator(candidates)
+
+    # Strip internal oracle fields before returning
+    metrics = {
+        "IL_TP": best["IL_TP"],
+        "IL_TN": best["IL_TN"],
+        "IL_FP": best["IL_FP"],
+        "IL_FN": best["IL_FN"],
+        "count_accuracy": best["count_accuracy"],
+        "sample_f1": best["sample_f1"],
+        "loc_counts": best["loc_counts"],
+    }
+    return metrics
+
+
+# =========================================================================== #
+#  Aggregation functions (referenced by task YAML metric_list)
+# =========================================================================== #
+
+def IL_TP(items):
+    return sum(items) if items else 0.0
+
+def IL_TN(items):
+    return sum(items) if items else 0.0
+
+def IL_FP(items):
+    return sum(items) if items else 0.0
+
+def IL_FN(items):
+    return sum(items) if items else 0.0
+
+def count_accuracy(items):
+    return float(np.mean(items)) if items else 0.0
+
+def sample_f1(items):
+    """Macro F1: average of per-sample F1 over positive samples only."""
+    valid = [x for x in items if x >= 0] if items else []
+    return float(np.mean(valid)) if valid else 0.0
+
+def loc_counts(items):
+    """Element-wise sum of per-sample TP/FP/FN arrays across 10 thresholds."""
+    if not items:
+        n = len(IOU_THRESHOLDS)
+        return {"tp": [0.0] * n, "fp": [0.0] * n, "fn": [0.0] * n}
+    tp = np.zeros(len(IOU_THRESHOLDS))
+    fp = np.zeros(len(IOU_THRESHOLDS))
+    fn = np.zeros(len(IOU_THRESHOLDS))
+    for d in items:
+        tp += np.array(d["tp"])
+        fp += np.array(d["fp"])
+        fn += np.array(d["fn"])
+    return {"tp": tp.tolist(), "fp": fp.tolist(), "fn": fn.tolist()}
+
+
+# =========================================================================== #
+#  Derived dataset-level metrics (MCC, pmF1, cgF1)
+# =========================================================================== #
+
+def compute_IL_MCC(tp: float, tn: float, fp: float, fn: float) -> float:
+    """Matthews Correlation Coefficient."""
+    num = tp * tn - fp * fn
+    den = math.sqrt((tp + fp) * (tp + fn) * (tn + fp) * (tn + fn))
+    return num / den if den != 0 else 0.0
+
+
+def compute_pmF1(tp: float, fp: float, fn: float) -> float:
+    """Positive micro-F1."""
+    den = 2 * tp + fp + fn
+    return (2 * tp) / den if den != 0 else 0.0
+
+
+def compute_cgF1(pmf1: float, mcc: float) -> float:
+    """Classification-gated F1 = 100 * pmF1 * IL_MCC."""
+    return 100.0 * pmf1 * mcc
+
+
+def compute_saco_final_metrics(results_path: str, save: bool = True) -> Dict:
+    """Compute dataset-level MCC, pmF1, and cgF1 from an lmms-eval results JSON.
+
+    Reads the aggregated classification sums and per-threshold TP/FP/FN
+    from the JSON, computes the official SAM3 metrics, optionally writes
+    them back, and returns a summary dict.
+
+    Args:
+        results_path: Path to the ``*_results.json`` file produced by lmms-eval.
+        save: If True, enrich the JSON in-place with the derived metrics.
+
+    Returns:
+        ``{task_name: {"IL_MCC": …, "pmF1": …, "cgF1": …, …}}``
+    """
+    with open(results_path, "r") as f:
+        data = json.load(f)
+
+    summary: Dict = {}
+
+    for task_name, task_results in data.get("results", {}).items():
+        if not (task_name.startswith("saco_gold") or task_name.startswith("pbench")):
+            continue
+
+        # Skip group-level entries that have no actual metrics
+        if "IL_TP,none" not in task_results:
+            continue
+
+        # --- Classification ------------------------------------------------ #
+        il_tp = task_results.get("IL_TP,none", 0.0)
+        il_tn = task_results.get("IL_TN,none", 0.0)
+        il_fp = task_results.get("IL_FP,none", 0.0)
+        il_fn = task_results.get("IL_FN,none", 0.0)
+
+        mcc = compute_IL_MCC(il_tp, il_tn, il_fp, il_fn)
+
+        il_prec = il_tp / (il_tp + il_fp) if (il_tp + il_fp) > 0 else 0.0
+        il_rec = il_tp / (il_tp + il_fn) if (il_tp + il_fn) > 0 else 0.0
+        il_f1 = 2 * il_prec * il_rec / (il_prec + il_rec) if (il_prec + il_rec) > 0 else 0.0
+
+        # --- Localization (from aggregated loc_counts) --------------------- #
+        lc = task_results.get("loc_counts,none", {})
+        tp_arr = np.array(lc.get("tp", [0.0] * len(IOU_THRESHOLDS)))
+        fp_arr = np.array(lc.get("fp", [0.0] * len(IOU_THRESHOLDS)))
+        fn_arr = np.array(lc.get("fn", [0.0] * len(IOU_THRESHOLDS)))
+
+        pmf1_per_thresh = []
+        for i in range(len(IOU_THRESHOLDS)):
+            pmf1_per_thresh.append(compute_pmF1(tp_arr[i], fp_arr[i], fn_arr[i]))
+        pmf1_per_thresh = np.array(pmf1_per_thresh)
+        pmf1_avg = float(pmf1_per_thresh.mean())
+
+        # pmF1 at key thresholds
+        thresh_idx = {t: i for i, t in enumerate(IOU_THRESHOLDS)}
+        pmf1_50 = float(pmf1_per_thresh[thresh_idx[0.5]])
+        pmf1_75 = float(pmf1_per_thresh[thresh_idx[0.75]])
+
+        # --- Combined ------------------------------------------------------ #
+        cgf1_avg = compute_cgF1(pmf1_avg, mcc)
+        cgf1_50 = compute_cgF1(pmf1_50, mcc)
+        cgf1_75 = compute_cgF1(pmf1_75, mcc)
+
+        # --- Macro F1 (already aggregated) --------------------------------- #
+        macro_f1 = task_results.get("sample_f1,none", 0.0)
+
+        # --- Write back --------------------------------------------------- #
+        task_results["IL_MCC,none"] = mcc
+        task_results["IL_precision,none"] = il_prec
+        task_results["IL_recall,none"] = il_rec
+        task_results["IL_F1,none"] = il_f1
+        task_results["pmF1,none"] = pmf1_avg
+        task_results["pmF1_50,none"] = pmf1_50
+        task_results["pmF1_75,none"] = pmf1_75
+        task_results["cgF1,none"] = cgf1_avg
+        task_results["cgF1_50,none"] = cgf1_50
+        task_results["cgF1_75,none"] = cgf1_75
+
+        count_acc = task_results.get("count_accuracy,none", 0.0)
+
+        summary[task_name] = {
+            "IL_MCC": mcc,
+            "IL_precision": il_prec,
+            "IL_recall": il_rec,
+            "IL_F1": il_f1,
+            "pmF1": pmf1_avg,
+            "pmF1_50": pmf1_50,
+            "pmF1_75": pmf1_75,
+            "cgF1": cgf1_avg,
+            "cgF1_50": cgf1_50,
+            "cgF1_75": cgf1_75,
+            "macro_F1": macro_f1,
+            "count_accuracy": count_acc,
+        }
+
+    if save:
+        with open(results_path, "w") as f:
+            json.dump(data, f, indent=2)
+
+    return summary


### PR DESCRIPTION
I think open-vocab segmentation gonna be an important task over the coming months. SA-Co/Gold is the benchmark from the SAM3 paper: given an image and a text prompt, the model has to segment all matching objects (or predict nothing if the object isn't there). This PR adds SAM3 as a model and SA-Co/Gold as a benchmark so we can run this type of evaluation.

## Summary

- Adds [SAM3](https://huggingface.co/facebook/sam3) as a model (`lmms_eval/models/simple/sam3.py`), wraps `Sam3Model`/`Sam3Processor` from transformers, outputs COCO RLE masks.
- Adds [SA-Co/Gold](https://huggingface.co/datasets/facebook/SACo-Gold) benchmark with 7 splits (attributes, crowded, food, metaclip, sa1b, sport, wiki_common).
- Implements the cgF1 evaluation protocol from the [SAM3 paper](https://arxiv.org/abs/2511.16719), including oracle eval over 3 annotators per sample.

## Evaluation details

The dataset has 3 independent GT annotations per sample (`human_1_masks`, `human_2_masks`, `human_3_masks`). We compare predictions against all 3 and keep the best match per sample (oracle selection). This is how the official SAM3 eval works in [`cgf1_eval.py`](https://github.com/facebookresearch/sam3/blob/main/sam3/eval/cgf1_eval.py).

Per sample we do Hungarian matching on the IoU matrix, then count TP/FP/FN at 10 IoU thresholds [0.5:0.05:0.95]. Dataset-level metrics are computed from aggregated counts:
- **pmF1** (positive micro F1) — localization quality, only on positive samples
- **IL_MCC** (Matthews Correlation Coefficient) — classification (did the model correctly predict presence/absence)
- **cgF1** = pmF1 x IL_MCC

I cross-checked the eval logic against the official SAM3 code to make sure it matches. The main subtlety is that `pmF1` excludes FP counts from negative-GT samples (where GT has no masks but model predicted some), these count as classification errors only, not localization errors. This matches how the official code handles it.

**Dataset processing note**

The HF dataset was built from 7 source JSONs (167,522 samples after filtering out `is_instance_exhaustive=false`, 680 removed). Images resized to longest edge 1024px, stored as JPEG (~18GB total). Each sample has 3 annotator masks stored as COCO RLE lists, masks resized with nearest-neighbor to match the new image dimensions. The dataset is currently hosted here:

```python
from datasets import load_dataset
ds = load_dataset("yasserDahou/saco-gold", split="attributes")
```
Feel free to mirror it under the lmms org if needed.

## Usage

Single GPU:
```bash
python -m lmms_eval \
    --model sam3 \
    --model_args pretrained=facebook/sam3 \
    --tasks saco_gold \
    --batch_size 32 \
    --output_path ./results
```

Multi-GPU with accelerate:
```bash
accelerate launch --num_processes 8 -m lmms_eval \
    --model sam3 \
    --model_args pretrained=facebook/sam3 \
    --tasks saco_gold \
    --batch_size 32 \
    --output_path ./results
```

Compute final metrics (MCC, pmF1, cgF1) from the results JSON:
```bash
python -m lmms_eval.tasks.saco.compute_metrics results/*_results.json
```

## Files added/changed

- `lmms_eval/models/simple/sam3.py` — SAM3 model wrapper
- `lmms_eval/models/__init__.py` — registered `"sam3"` in `AVAILABLE_SIMPLE_MODELS`
- `lmms_eval/tasks/saco/` — benchmark config (7 split YAMLs + group YAML + default template)
- `lmms_eval/tasks/saco/utils.py` — evaluation logic (oracle, metric computation)
- `lmms_eval/tasks/saco/compute_metrics.py` — post-processsing script to get final table

## Results

Reproduced SAM3 on the `attributes` split, compared against official numbers from the SAM3 paper:

| Split      | Source      | IL_MCC | pmF1  | cgF1  |
|------------|-------------|--------|-------|-------|
| attributes | Official    | 0.76   | 72.0 | 54.9 |
| attributes | Reproduced  | 0.754   | 71.7 | 54.0 |

Minor difference comes from the data processing potentially (masks & image sizes)

Remark:  multi-gpu with accelerate needs #1089 to be merged first (fixes metric gather key ordering across ranks). single gpu works fine without it.
