### PR TITLE
fix simple qwen3_vl inference when batch_size > 1

### DIFF
--- a/lmms_eval/models/simple/qwen3_vl.py
+++ b/lmms_eval/models/simple/qwen3_vl.py
@@ -203,9 +203,7 @@ class Qwen3_VL(lmms):
         chunks = re_ords.get_batched(n=self.batch_size, batch_fn=None)
         for chunk in chunks:
             contexts, all_gen_kwargs, doc_to_visual, doc_id, task, split = zip(*chunk)
-            task = task[0]
-            split = split[0]
-            visual_list = [doc_to_visual[0](self.task_dict[task][split][ids]) for ids in doc_id]
+            visual_list = [doc_to_visual[0](self.task_dict[t][s][i]) for t, s, i in zip(task, split, doc_id)]
             gen_kwargs = all_gen_kwargs[0]
 
             # Set default until or update values from gen_kwargs if present


### PR DESCRIPTION
#### Description

This PR fixes an issue with simple/qwen3_vl inference when batch_size > 1.

The same issue also affects other Qwen models when using the --force_simple version.

This likely resolves #592.

#### Root Cause

The current logic in [simple/qwen3_vl.py#L204](https://github.com/EvolvingLMMs-Lab/lmms-eval/blob/main/lmms_eval/models/simple/qwen3_vl.py#L204) forces:
```
task = task[0]
split = split[0]
```

even when batch_size > 1.

When multiple samples are processed in a batch, collapsing task and split to a single element leads to misalignment between dataset indices and batch elements, ultimately causing out-of-bounds indexing errors inside datasets.

Example error:
```
File "/usr/local/lib/python3.11/dist-packages/datasets/formatting/formatting.py", line 612, in query_table
    _check_valid_index_key(key, size)
File "/usr/local/lib/python3.11/dist-packages/datasets/formatting/formatting.py", line 552, in _check_valid_index_key
    raise IndexError(f"Invalid key: {key} is out of bounds for size {size}")
IndexError: Invalid key: 3745 is out of bounds for size 2801

2026-02-17 10:57:52 | ERROR | __main__:cli_evaluate:534 -
Error during evaluation: Invalid key: 3745 is out of bounds for size 2801.
Please set `--verbosity=DEBUG` to get more information.
```
After This Fix

This previously failing example now runs successfully.
```
MAX_PIXELS=$((2048 * 32 * 32))
MIN_PIXELS=$((256 * 32 * 32))

accelerate launch --num_processes 1 --main_process_port 12380 -m lmms_eval \
    --model "qwen3_vl" \
    --model_args "pretrained=Qwen/Qwen3-VL-2B-Instruct,attn_implementation=flash_attention_2,max_pixels=${MAX_PIXELS},min_pixels=${MIN_PIXELS}" \
    --tasks "infovqa_val,docvqa_val" \
    --batch_size 2 \
    --force_simple 
```
```
qwen3_vl (pretrained=Qwen/Qwen3-VL-2B-Instruct,attn_implementation=flash_attention_2,max_pixels=2097152,min_pixels=262144), gen_kwargs: (), limit: None, offset: 0, num_fewshot: None, batch_size: 2
|   Tasks   |Version|Filter|n-shot|Metric|   |Value |   |Stderr|Stderr_CLT|
|-----------|-------|------|-----:|------|---|-----:|---|-----:|---------:|
|docvqa_val |Yaml   |none  |     0|anls  |↑  |0.9179|±  |0.0035|    0.0035|
|infovqa_val|Yaml   |none  |     0|anls  |↑  |0.7013|±  |0.0082|    0.0082|
```