### PR TITLE
fix: resolve model registry conflict and saco_gold tag warning

### DIFF
--- a/lmms_eval/api/registry.py
+++ b/lmms_eval/api/registry.py
@@ -16,7 +16,8 @@ def register_model(*names):
         for name in names:
             assert issubclass(cls, lmms), f"Model '{name}' ({cls.__name__}) must extend lmms class"
 
-            assert name not in MODEL_REGISTRY, f"Model named '{name}' conflicts with existing model! Please register with a non-conflicting alias instead."
+            if name in MODEL_REGISTRY:
+                eval_logger.debug(f"Model '{name}' already registered ({MODEL_REGISTRY[name].__name__}); overwriting with {cls.__name__}.")
 
             MODEL_REGISTRY[name] = cls
         return cls

--- a/lmms_eval/tasks/saco/_default_template_saco_gold_yaml
+++ b/lmms_eval/tasks/saco/_default_template_saco_gold_yaml
@@ -1,7 +1,6 @@
 dataset_path: yasserDahou/saco-gold
 dataset_kwargs:
   token: True
-group: "saco_gold"
 output_type: generate_until
 doc_to_visual: !function utils.saco_doc_to_visual
 doc_to_text: !function utils.saco_doc_to_text


### PR DESCRIPTION
## Summary

- **Fix `openai` model registration crash**: `chat/openai.py` subclasses `simple/openai.py`, both decorated with `@register_model("openai")`. Importing the chat module triggers the simple module's decorator first, then the chat decorator hits a hard `assert` on duplicate names in the legacy `MODEL_REGISTRY`. Changed to a debug-level log + overwrite since `ModelRegistryV2` handles all actual routing.
- **Fix `saco_gold` tag/group warnings**: `_default_template_saco_gold_yaml` declared `group: "saco_gold"` which got auto-converted to a tag on each of the 7 subtasks, conflicting with the group already defined in `saco_gold.yaml`. Removed the redundant `group` line from the template.

## Changes

| File | Change |
|------|--------|
| `lmms_eval/api/registry.py` | Replace `assert` with debug log + overwrite in `register_model` decorator |
| `lmms_eval/tasks/saco/_default_template_saco_gold_yaml` | Remove duplicate `group: "saco_gold"` line |