### PR TITLE
refactor(models/chat): improve async_openai code structure and readability

### DIFF
--- a/lmms_eval/models/chat/async_openai.py
+++ b/lmms_eval/models/chat/async_openai.py
@@ -461,7 +461,7 @@ class AsyncOpenAIChat(lmms):
                 for call in message.tool_calls:
                     eval_logger.debug(f"Calling {call.function.name}...")
                     result = await self.mcp_client.run_tool(call.function.name, eval(call.function.arguments))
-                    all_response += f"<tool_call>{call.function.name} {call.function.arguments}</tool_call></tool_response>"
+                    all_response += f"<tool_call>{call.function.name} {call.function.arguments}</tool_call><tool_response>"
                     tool_messages.append({"role": "tool", "name": call.function.name, "content": []})
                     for content in result.content:
                         tool_message = self.mcp_client.convert_result_to_openai_format(content)
@@ -471,7 +471,7 @@ class AsyncOpenAIChat(lmms):
                             elif content["type"] == "text":
                                 all_response += content["text"]
                         tool_messages[-1]["content"].extend(tool_message)
-                    all_response += f"</{call.function.name}>"
+                    all_response += "</tool_response>"
 
             response = await self.client.chat.completions.create(
                 model=self.model_version,


### PR DESCRIPTION
## Summary

- Extract `prepare_messages()` method to separate message formatting logic, allowing subclasses to override
- Refactor complex `generate_until()` concurrency control from 130 lines into focused helper methods
- Add comprehensive docstrings to all new methods and classes
- Create new `async_openai_qwen3_vl.py` model that inherits from `AsyncOpenAIChat` and overrides only `prepare_messages()`
- Register `async_openai_qwen3_vl` in model registry

## Changes

### Code Structure Improvements
- `_AdaptiveConcurrencyTracker`: Dataclass for tracking adaptive concurrency statistics
- `_get_initial_concurrency()`: Calculate initial concurrency level
- `_compute_dispatch_order()`: Compute request dispatch order with prefix-aware sorting
- `_process_with_retry()`: Handle single request execution with retry logic
- `_should_update_concurrency()`: Determine when to update concurrency
- `_update_concurrency()`: Update concurrency based on tracked statistics
- `_run_scheduling_loop()`: Main async scheduling loop

### Simplified `generate_until()`
The `run()` inner function is now only 8 lines, making the overall flow much clearer:
```python
async def run():
    pbar = tqdm(...)
    current_concurrency = self._get_initial_concurrency()
    dispatch_order = self._compute_dispatch_order(requests)
    res = await self._run_scheduling_loop(requests, dispatch_order, pbar, current_concurrency)
    pbar.close()
    return res
```

### New Model: `async_openai_qwen3_vl`
- Inherits from `AsyncOpenAIChat` with minimal code duplication
- Overrides only `prepare_messages()` to use `to_qwen3_vl_openai_messages()`
- Maintains all async concurrency control and retry logic from parent class

## Files Changed

- `lmms_eval/models/chat/async_openai.py`: Refactored with new helper methods (+244, -127)
- `lmms_eval/models/chat/async_openai_qwen3_vl.py`: New file (+35 lines)
- `lmms_eval/models/__init__.py`: Registered new model (+1 line)
- `.gitignore`: Ignore scripts directory

## Testing

Verified with `--limit 5` test runs on both `async_openai` and `async_openai_qwen3_vl` models.