### PR TITLE
refactor: flatten single-request JSONL log output from [[resp]] to [resp]

### DIFF
--- a/lmms_eval/tasks/videomathqa/cot_postprocess.py
+++ b/lmms_eval/tasks/videomathqa/cot_postprocess.py
@@ -58,7 +58,7 @@ def refine_samples_vllm(llm, sampling_params, tokenizer, sample_jsonl, output_js
     updated_samples = []
     for sample in tqdm(raw_samples, desc="Postprocessing samples with Qwen"):
         options = sample["doc"]["options"]
-        raw_pred = sample["resps"][0][0]
+        raw_pred = sample["resps"][0][0] if isinstance(sample["resps"][0], list) else sample["resps"][0]
         input_text = f"The options are: {options}\n\n The model response is: {raw_pred}"
         try:
             choice = extract_choice_vllm(llm, sampling_params, tokenizer, input_text, mcq)
@@ -73,7 +73,10 @@ def refine_samples_vllm(llm, sampling_params, tokenizer, sample_jsonl, output_js
             options.remove(answer)
             random.shuffle(options)
             choice = options[0]
-        sample["resps"][0][0] = choice
+        if isinstance(sample["resps"][0], list):
+            sample["resps"][0][0] = choice
+        else:
+            sample["resps"][0] = choice
         updated_samples.append(sample)
 
     with open(output_jsonl, "w") as f:

--- a/lmms_eval/tasks/videomathqa/cot_step_evaluation.py
+++ b/lmms_eval/tasks/videomathqa/cot_step_evaluation.py
@@ -94,7 +94,7 @@ def prepare_input(sample, matched):
     gt_answer = sample["answer"]
     gt_steps = sample["steps"]
     options = sample["options"]
-    prediction = matched["resps"][0][0]
+    prediction = matched["resps"][0][0] if isinstance(matched["resps"][0], list) else matched["resps"][0]
     input = {"qid": qid, "category": sample["category"], "question": question, "options": options, "gt_answer": gt_answer, "gt_steps": gt_steps, "prediction": prediction}
     return input
 


### PR DESCRIPTION
## Summary

Flatten the redundant outer list wrapper in `--log_samples` JSONL output for single-Instance-per-doc tasks (the common case for `generate_until`).

**Before**: `"resps": [["model output"]]`, `"filtered_resps": ["model output"]`
**After**: `"resps": ["model output"]`, `"filtered_resps": "model output"`

Multiple-choice / loglikelihood tasks (N Instances per doc) keep their nested structure unchanged.

## Why

The 2-level list exists to handle two dimensions:
- **Outer list**: multiple Instances per doc_id (only used in loglikelihood/MCQ tasks where each choice is a separate Instance)
- **Inner list**: multiple responses per Instance (only used when `repeats > 1` for stability metrics)

For `generate_until` (the dominant use case), both dimensions are always length 1, producing `[["single string"]]` - unnecessarily nested. This PR unwraps the outer layer at serialization time when it has length 1.

## Changes

| File | Change |
|------|--------|
| `lmms_eval/loggers/evaluation_tracker.py` | Flatten `resps` and `filtered_resps` outer list when length == 1 before JSONL write. Updated dedup logic accordingly. |
| `lmms_eval/tasks/videomathqa/cot_postprocess.py` | Backward-compatible access for both flattened and nested formats. |
| `lmms_eval/tasks/videomathqa/cot_step_evaluation.py` | Same backward-compatible access pattern. |

## Design decision

Flattening is done in `evaluation_tracker.py` (serialization layer) rather than `evaluator.py` (in-memory dict) to avoid breaking in-memory consumers (`wandb_logger.py`, `logging_utils.py`) that index into the 2-level structure for W&B table formatting.