### PR TITLE
refactor: unify model caching on ResponseCache

### DIFF
--- a/lmms_eval/api/instance.py
+++ b/lmms_eval/api/instance.py
@@ -71,7 +71,7 @@ class Instance:
     request_type: Literal["loglikelihood", "generate_until", "generate_until_multi_round", "generate_until_agentic"]
     arguments: tuple
     idx: int
-    metadata: Tuple[str, int, int] = field(default_factory=lambda: (None, None, None))  # TODO: better typehints here
+    metadata: Dict[str, Union[str, int]] = field(default_factory=dict)
     resps: list = field(default_factory=list)
     filtered_resps: dict = field(default_factory=dict)
     raw_filtered_resps: dict = field(default_factory=dict)

--- a/lmms_eval/models/chat/bagel_lmms_engine.py
+++ b/lmms_eval/models/chat/bagel_lmms_engine.py
@@ -62,8 +62,6 @@ class BagelLmmsEngine(lmms):
         text_temperature: float = 0.3,
         seed: int = 0,
         image_ratio: str = "1:1",
-        continual_mode: bool = True,
-        response_persistent_folder: Optional[str] = None,
         device: Optional[str] = "cuda",
         device_map: Optional[str] = None,
         **kwargs,
@@ -74,7 +72,6 @@ class BagelLmmsEngine(lmms):
         self.load_in_4bit = load_in_4bit
         self.load_in_8bit = load_in_8bit
         self.show_thinking = show_thinking
-        self.continual_mode = continual_mode
 
         # Generation hyperparameters
         self.cfg_text_scale = cfg_text_scale
@@ -106,7 +103,7 @@ class BagelLmmsEngine(lmms):
             self.image_shapes = (1024, 1024)
 
         if output_image_dir is None:
-            self.output_image_dir = os.path.join(self.response_persistent_folder, "bagel_generated_images")
+            self.output_image_dir = "./logs/bagel_generated_images"
         else:
             self.output_image_dir = output_image_dir
 

--- a/lmms_eval/models/simple/qwen_vl_api.py
+++ b/lmms_eval/models/simple/qwen_vl_api.py
@@ -1,4 +1,3 @@
-import json
 import os
 import tempfile
 import time
@@ -29,32 +28,13 @@ class Qwen_VL_API(lmms):
         image_token: str = "<image>",  # Use to separate interleaved image and text
         system_prompt: str = "",  # Whether you want some special system prompt here
         tmp_folder: str = "./tmp",  # Due to qwen's api restriction,
-        continual_mode: bool = False,
-        response_persistent_folder: str = None,
         **kwargs,
     ) -> None:
         super().__init__()
-        self.continual_mode = continual_mode
-
         self.model_version = model_version
         self.image_token = image_token
         self.system_prompt = system_prompt
         self.tmp_folder = tmp_folder
-        if self.continual_mode:
-            if response_persistent_folder is None:
-                raise ValueError("Continual mode requires a persistent path for the response. Please provide a valid path.")
-
-            os.makedirs(response_persistent_folder, exist_ok=True)
-            self.response_persistent_folder = response_persistent_folder
-            self.response_persistent_file = os.path.join(self.response_persistent_folder, f"{self.model_version}_response.json")
-
-            if os.path.exists(self.response_persistent_file):
-                with open(self.response_persistent_file, "r") as f:
-                    self.response_cache = json.load(f)
-                self.cache_mode = "resume"
-            else:
-                self.response_cache = {}
-                self.cache_mode = "start"
 
     @property
     def rank(self):
@@ -74,14 +54,6 @@ class Qwen_VL_API(lmms):
         pbar = tqdm(total=len(requests), disable=(self.rank != 0), desc="Model Responding")
 
         for contexts, gen_kwargs, doc_to_visual, doc_id, task, split in [reg.args for reg in requests]:
-            if self.continual_mode is True and self.cache_mode == "resume":
-                doc_uuid = f"{task}___{split}___{doc_id}"
-                if doc_uuid in self.response_cache:
-                    response_text = self.response_cache[doc_uuid]
-                    if response_text:
-                        res.append(response_text)
-                        pbar.update(1)
-                        continue
             # encode, pad, and truncate contexts for this batch
             visuals = [doc_to_visual(self.task_dict[task][split][doc_id])]
             visuals = self.flatten(visuals)
@@ -136,12 +108,6 @@ class Qwen_VL_API(lmms):
                     eval_logger.error(f"Error {e} happens when parsing input.")
                     eval_logger.error(f"{response_data}")
                     res.append("")
-
-                if self.continual_mode is True:  # Cache the response
-                    doc_uuid = f"{task}___{split}___{doc_id}"
-                    self.response_cache[doc_uuid] = res[-1]
-                    with open(self.response_persistent_file, "w") as f:
-                        json.dump(self.response_cache, f)
 
             finally:
                 for temp_file in temp_files:

--- a/lmms_eval/models/simple/srt_api.py
+++ b/lmms_eval/models/simple/srt_api.py
@@ -1,6 +1,4 @@
 import asyncio
-import json
-import os
 import time
 from multiprocessing import cpu_count
 from typing import List, Tuple
@@ -41,8 +39,6 @@ class SRT_API(lmms):
         mem_fraction_static: float = 0.83,
         tp: int = 8,
         chunked_prefill_size: int = 16384,
-        continual_mode: bool = False,
-        response_persistent_folder: str = None,
         num_processes: int = cpu_count() // 2,
         force_sample: bool = False,
         add_time_instruction: bool = False,
@@ -57,25 +53,9 @@ class SRT_API(lmms):
         self.max_frames_num = max_frames_num
         self.image_token = "<image>"
         self.timeout = timeout
-        self.continual_mode = continual_mode
         self.force_sample = force_sample
         self.add_time_instruction = add_time_instruction
         eval_logger.info(f"Force sample: {self.force_sample}")
-        if self.continual_mode:
-            if response_persistent_folder is None:
-                raise ValueError("Continual mode requires a persistent path for the response. Please provide a valid path.")
-
-            os.makedirs(response_persistent_folder, exist_ok=True)
-            self.response_persistent_folder = response_persistent_folder
-            self.response_persistent_file = os.path.join(self.response_persistent_folder, f"{self.model_version}_response.json")
-
-            if os.path.exists(self.response_persistent_file):
-                with open(self.response_persistent_file, "r") as f:
-                    self.response_cache = json.load(f)
-                self.cache_mode = "resume"
-            else:
-                self.response_cache = {}
-                self.cache_mode = "start"
 
         accelerator = Accelerator()
         self.model = model_version

--- a/test/cache/test_agentic_response_cache.py
+++ b/test/cache/test_agentic_response_cache.py
@@ -1,0 +1,98 @@
+import json
+import os
+import shutil
+import tempfile
+import unittest
+
+from lmms_eval.api.instance import Instance
+from lmms_eval.caching.response_cache import ResponseCache
+from lmms_eval.evaluator import _run_generate_until_agentic
+
+
+def _terminal_doc_to_text(_doc, previous_output, round_idx, previous_round_info):
+    return (
+        None,
+        None,
+        True,
+        previous_output,
+        {
+            "state": {"round": round_idx},
+            "tool_calls": 0,
+            "valid_tool_calls": 0,
+            "invalid_steps": 0,
+            "prev": previous_round_info,
+        },
+    )
+
+
+class _FakeSimpleLM:
+    is_simple = True
+
+    def __init__(self):
+        self.calls = 0
+        self.task_dict = {"agentic_task": {"test": [{"id": 0}]}}
+
+    def generate_until(self, requests):
+        self.calls += len(requests)
+        return [f"raw::{req.args[0]}" for req in requests]
+
+
+def _make_agentic_request(prompt: str) -> Instance:
+    return Instance(
+        request_type="generate_until_agentic",
+        arguments=(
+            prompt,
+            {"temperature": 0, "max_agentic_steps": 2},
+            lambda _doc: [],
+            _terminal_doc_to_text,
+            0,
+            "agentic_task",
+            "test",
+        ),
+        idx=0,
+        metadata={"task": "agentic_task", "doc_id": 0, "repeats": 1},
+    )
+
+
+class TestAgenticResponseCache(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.db_path = os.path.join(self.tmpdir, "rank0.db")
+        self.audit_path = os.path.join(self.tmpdir, "rank0.jsonl")
+        self.cache = ResponseCache(self.db_path, self.audit_path, model_fingerprint="agentic-test")
+
+    def tearDown(self):
+        self.cache.close()
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def test_agentic_path_uses_response_cache(self):
+        lm = _FakeSimpleLM()
+        req = _make_agentic_request("prompt_a")
+
+        out1 = _run_generate_until_agentic(lm, [req], response_cache=self.cache)
+        self.assertEqual(lm.calls, 1)
+
+        out2 = _run_generate_until_agentic(lm, [req], response_cache=self.cache)
+        self.assertEqual(lm.calls, 1)
+        self.assertEqual(out1, out2)
+
+    def test_agentic_same_doc_different_prompt_not_collide(self):
+        lm = _FakeSimpleLM()
+        req_a = _make_agentic_request("prompt_a")
+        req_b = _make_agentic_request("prompt_b")
+
+        _run_generate_until_agentic(lm, [req_a], response_cache=self.cache)
+        self.assertEqual(lm.calls, 1)
+
+        out_b = _run_generate_until_agentic(lm, [req_b], response_cache=self.cache)
+        self.assertEqual(lm.calls, 2)
+
+        payload_b = json.loads(out_b[0])
+        self.assertEqual(payload_b["last_model_output"], "raw::prompt_b")
+
+        _run_generate_until_agentic(lm, [req_b], response_cache=self.cache)
+        self.assertEqual(lm.calls, 2)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary
- remove provider-local JSON cache code paths from API/chat wrappers and rely on evaluator-level `ResponseCache`
- route `generate_until_agentic` through `ResponseCache` and normalize generated output handling
- harden cache keying by including request content hash for generation requests to prevent prompt collision on same doc/index
- add regression coverage for agentic cache reuse and same-doc different-prompt key separation

## Validation
- `uv run python -m unittest discover -s test/cache -p "test_*cache*.py"`
- `uv run python -m unittest discover -s test/models -p "test_model_registry_v2.py"`

Refs: LMM-276