### PR TITLE
[Benchmark Backfill] Integrate OmniDocBench into lmms-eval

### DIFF
--- a/docs/current_tasks.md
+++ b/docs/current_tasks.md
@@ -404,6 +404,7 @@ python -m lmms_eval --tasks list_with_num
   - Infographic VQA Test (infovqa_test)
 - [OCRBench](https://github.com/Yuliang-Liu/MultimodalOCR) (ocrbench)
 - [OCRBench v2](https://github.com/Yuliang-Liu/MultimodalOCR) (ocrbench_v2)
+- [OmniDocBench](https://github.com/opendatalab/OmniDocBench) (omnidocbench)
 - [PRISMM-Bench](https://arxiv.org/abs/2510.16505) (prismm_bench)
   - PRISMM-Bench Identification (prismm_bench_identification)
   - PRISMM-Bench Identification Whole Page Context (prismm_bench_identification_whole_page)

--- a/lmms_eval/tasks/omnidocbench/omnidocbench.yaml
+++ b/lmms_eval/tasks/omnidocbench/omnidocbench.yaml
@@ -1,0 +1,27 @@
+dataset_path: ouyanglinke/OmniDocBench_tsv
+dataset_kwargs:
+  token: True
+task: omnidocbench
+test_split: train
+output_type: generate_until
+doc_to_visual: !function utils.omnidocbench_doc_to_visual
+doc_to_text: !function utils.omnidocbench_doc_to_text
+doc_to_target: !function utils.omnidocbench_doc_to_target
+generation_kwargs:
+  max_new_tokens: 64
+  temperature: 0
+  do_sample: false
+process_results: !function utils.omnidocbench_process_results
+metric_list:
+  - metric: omnidocbench_exact_match
+    aggregation: mean
+    higher_is_better: true
+lmms_eval_specific_kwargs:
+  default:
+    pre_prompt: ""
+    post_prompt: "\nAnswer with a single word, phrase, or option letter."
+  qwen_vl:
+    pre_prompt: ""
+    post_prompt: " Answer:"
+metadata:
+  - version: 0.0

--- a/lmms_eval/tasks/omnidocbench/utils.py
+++ b/lmms_eval/tasks/omnidocbench/utils.py
@@ -1,0 +1,116 @@
+import io
+import re
+from typing import Any
+
+from PIL import Image
+
+
+def _normalize_text(text: Any) -> str:
+    if text is None:
+        return ""
+    return " ".join(str(text).strip().lower().split())
+
+
+def _extract_question(doc: dict) -> str:
+    for key in ["question", "query", "prompt", "instruction", "text"]:
+        value = doc.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return ""
+
+
+def _extract_answers(doc: dict) -> list[str]:
+    answers = doc.get("answers", doc.get("answer", doc.get("target")))
+    if answers is None:
+        return []
+    if isinstance(answers, list):
+        return [str(item) for item in answers if str(item).strip()]
+    return [str(answers)]
+
+
+def _extract_options(doc: dict) -> list[str]:
+    options = doc.get("options", doc.get("choices"))
+    if isinstance(options, list):
+        values = []
+        for item in options:
+            if isinstance(item, dict):
+                values.append(str(item.get("text", item.get("option", ""))))
+            else:
+                values.append(str(item))
+        return [value for value in values if value.strip()]
+    return []
+
+
+def _extract_option_letter(prediction: str) -> str:
+    match = re.search(r"\b([A-Z])\b", prediction.strip().upper())
+    if match:
+        return match.group(1)
+    return ""
+
+
+def _to_rgb(image_obj: Any):
+    if isinstance(image_obj, Image.Image):
+        return image_obj.convert("RGB")
+    if isinstance(image_obj, bytes):
+        return Image.open(io.BytesIO(image_obj)).convert("RGB")
+    return None
+
+
+def omnidocbench_doc_to_visual(doc):
+    visuals = []
+
+    for key in ["image", "page_image", "document_image"]:
+        if key in doc:
+            img = _to_rgb(doc[key])
+            if img is not None:
+                visuals.append(img)
+
+    for key in ["images", "page_images", "document_images", "pages"]:
+        value = doc.get(key)
+        if isinstance(value, list):
+            for item in value:
+                img = _to_rgb(item)
+                if img is not None:
+                    visuals.append(img)
+
+    return visuals
+
+
+def omnidocbench_doc_to_text(doc, lmms_eval_specific_kwargs=None):
+    kwargs = lmms_eval_specific_kwargs or {}
+    pre_prompt = kwargs.get("pre_prompt", "")
+    post_prompt = kwargs.get("post_prompt", "")
+
+    question = _extract_question(doc)
+    options = _extract_options(doc)
+    if not options:
+        return f"{pre_prompt}{question}{post_prompt}"
+
+    option_labels = [chr(ord("A") + idx) for idx in range(len(options))]
+    option_lines = "\n".join(f"{label}. {choice}" for label, choice in zip(option_labels, options))
+    return f"{pre_prompt}{question}\n{option_lines}{post_prompt}"
+
+
+def omnidocbench_doc_to_target(doc):
+    answers = _extract_answers(doc)
+    return answers[0] if answers else ""
+
+
+def omnidocbench_process_results(doc, results):
+    prediction = _normalize_text(results[0])
+    answers = _extract_answers(doc)
+    if not answers:
+        return {"omnidocbench_exact_match": 0.0}
+
+    answer_set = {_normalize_text(answer) for answer in answers}
+    score = float(prediction in answer_set)
+
+    options = _extract_options(doc)
+    if options:
+        pred_letter = _extract_option_letter(str(results[0]))
+        if pred_letter:
+            for answer in answers:
+                if pred_letter == answer.strip().upper()[:1]:
+                    score = max(score, 1.0)
+
+    return {"omnidocbench_exact_match": score}


### PR DESCRIPTION
## Summary
- Add `omnidocbench` benchmark task integration with YAML config and utility functions.
- Update document-understanding benchmark list in `docs/current_tasks.md`.
- Use a loadable OmniDocBench TSV mirror dataset path for reliable task execution.

## Validation
- `uv run python -m lmms_eval --model openai --model_args model_version=bytedance-seed/seed-1.6-flash,api_key=$OPENROUTER_API_KEY,base_url=https://openrouter.ai/api/v1 --tasks omnidocbench --batch_size 1 --limit 1`