### PR TITLE
fix: harden MMSI-Bench parity handling

### DIFF
--- a/test/eval/test_mmsi_bench_utils.py
+++ b/test/eval/test_mmsi_bench_utils.py
@@ -1,0 +1,33 @@
+import unittest
+
+from lmms_eval.tasks.mmsi_bench import utils
+
+
+class TestMMSIBenchUtils(unittest.TestCase):
+    def test_doc_to_text_handles_none_kwargs(self):
+        doc = {"question": "Which option is correct?"}
+
+        rendered = utils.msr_doc_to_text(doc, None)
+
+        self.assertEqual(rendered, "Which option is correct?")
+
+    def test_extract_single_choice_is_case_insensitive(self):
+        score = utils.extract_single_choice_with_word_boundary("the answer is b", "b")
+
+        self.assertEqual(score, 1.0)
+
+    def test_process_results_normalizes_legacy_category_names(self):
+        doc = {
+            "id": "sample-1",
+            "answer": "A",
+            "question_type": "Positional Relationship (Cam.-Obj.)",
+        }
+
+        processed = utils.msr_process_results(doc, ["A"])
+
+        self.assertIn("Positional Relationship (Cam.–Obj.)", processed)
+        self.assertNotIn("Positional Relationship (Cam.-Obj.)", processed)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- harden `mmsi_bench` prompt rendering by handling missing/non-dict `lmms_eval_specific_kwargs` safely.
- normalize legacy positional category labels (for example `Obj.-Obj.`) to canonical MMSI-Bench labels so metric aggregation remains stable across dataset variants.
- make answer extraction case-insensitive for MCQ letters and add focused regression tests for these edge cases.

## Validation
- `uv run python -m unittest discover -s test/eval -p "test_mmsi_bench_utils.py"`
- `uv run python -m py_compile lmms_eval/tasks/mmsi_bench/utils.py test/eval/test_mmsi_bench_utils.py`
- `uv run python -m lmms_eval --model dummy_video_reader --model_args response=A,fail_on_missing=false --tasks mmsi_bench --limit 8 --batch_size 1`
- `uv run python -c "from lmms_eval.tasks import TaskManager; tm = TaskManager(); print('mmsi_bench' in tm.all_tasks)"` -> `True`

## Tracking
- Closes #1143
- Linear: LMM-294

<!-- smoke-validation:start -->
## Smoke Validation (limit=8)

Status: PASS (LMM-294 / mmsi_bench)

### Output Table
| Metric | Value |
|---|---:|
| Attribute (Meas.) | 0.0 |
| Motion (Cam.) | 0.3333333333333333 |
| Positional Relationship (Cam.–Obj.) | 1.0 |
| average | 0.5 |

### Sample Output

**Sample 1** (doc_id: 0)
- **Input**: The images are taken continuously from a first-person perspective. In which direction are you moving? ↵ Options: A: Left while moving backward, B: Forward to the left, C: Forward to the right, D: Right while moving backward ↵ Answer with the option's letter from the given choices directly. Enclose t…
- **Model Output**: C
- **Reference**: C
- **Scores**: `Motion (Cam.)` = 1.0 (question_id: 0, l2_category: Motion (Cam.)) · `average` = 1.0 (question_id: 0, l2_category: Motion (Cam.))
- **Tokens**: output=695, reasoning=694

**Sample 2** (doc_id: 1)
- **Input**: The images are taken continuously from a first-person perspective. In which direction is the camera rotating? ↵ Options: A: Back, B: Left, C: Right, D: Forward ↵ Answer with the option's letter from the given choices directly. Enclose the option's letter within ``.
- **Model Output**: To determine the direction of the camera rotation, we analyze the continuous first-person perspective. Observing the scene, the camera's view shifts such that the objects in the tray appear to move relative to the fixed perspective. By examining the movement of the objects and the background, we can infer the rotation direction. The camera is rotating to the right. ↵  ↵ C
- **Reference**: B
- **Scores**: `Motion (Cam.)` = 0.0 (question_id: 1, l2_category: Motion (Cam.)) · `average` = 0.0 (question_id: 1, l2_category: Motion (Cam.))
- **Tokens**: output=777, reasoning=706

### Test Params
`uv run python -m lmms_eval --model openai_compatible --model_args "model_version=bytedance-seed/seed-1.6-flash" --tasks mmsi_bench --batch_size 1 --limit 8.0 --log_samples`
<!-- smoke-validation:end -->