### PR TITLE
[Benchmark Backfill] Integrate MMLongBench into lmms-eval

### DIFF
--- a/docs/current_tasks.md
+++ b/docs/current_tasks.md
@@ -210,6 +210,7 @@ python -m lmms_eval --tasks list_with_num
   - llava_interleave_bench_out_domain
   - llava_interleave_bench_multi_view
 - [MIRB](https://github.com/ys-zong/MIRB) (mirb)
+- [MMLongBench](https://zhaowei-wang-nlp.github.io/MMLongBench-page/) (mmlongbench)
 - [MMMU](https://mmmu-benchmark.github.io/) (mmmu)
   - MMMU Validation (mmmu_val)
   - MMMU Test (mmmu_test)

--- a/lmms_eval/tasks/mmlongbench/mmlongbench.yaml
+++ b/lmms_eval/tasks/mmlongbench/mmlongbench.yaml
@@ -1,0 +1,24 @@
+dataset_path: json
+dataset_kwargs:
+  data_files: https://huggingface.co/datasets/ZhaoweiWang/MMLongBench/resolve/main/mmlb_data_example/NIAH/counting-image_test_K128_dep3.jsonl
+task: mmlongbench
+test_split: train
+output_type: generate_until
+doc_to_visual: !function utils.mmlongbench_doc_to_visual
+doc_to_text: !function utils.mmlongbench_doc_to_text
+doc_to_target: answer
+generation_kwargs:
+  max_new_tokens: 128
+  temperature: 0
+  do_sample: false
+process_results: !function utils.mmlongbench_process_results
+metric_list:
+  - metric: mmlongbench_acc
+    aggregation: !function utils.mmlongbench_aggregate_results
+    higher_is_better: true
+lmms_eval_specific_kwargs:
+  default:
+    pre_prompt: ""
+    post_prompt: "Answer:"
+metadata:
+  - version: 0.0

--- a/lmms_eval/tasks/mmlongbench/utils.py
+++ b/lmms_eval/tasks/mmlongbench/utils.py
@@ -1,0 +1,272 @@
+import ast
+import os
+import re
+import string
+from pathlib import Path
+from typing import Any
+
+from loguru import logger as eval_logger
+
+IMAGE_ROOT_ENV_VAR = "MMLONGBENCH_IMAGE_ROOT"
+
+
+def _normalize_text(text: Any) -> str:
+    normalized = "" if text is None else str(text)
+    normalized = normalized.lower()
+    normalized = normalized.translate(str.maketrans("", "", string.punctuation))
+    return " ".join(normalized.split())
+
+
+def _extract_answer_text(prediction: Any) -> str:
+    text = "" if prediction is None else str(prediction).strip()
+    if not text:
+        return ""
+
+    match = re.search(r"answer\s*:\s*(.*)", text, flags=re.IGNORECASE | re.DOTALL)
+    if match:
+        extracted = match.group(1).strip()
+        if extracted:
+            return extracted
+    return text
+
+
+def _looks_like_visual_haystack(doc: dict) -> bool:
+    ctxs = doc.get("ctxs")
+    return isinstance(ctxs, list) and len(ctxs) > 0 and isinstance(ctxs[0], str)
+
+
+def _resolve_image_path(relative_path: str) -> str | None:
+    direct_path = Path(relative_path)
+    if direct_path.exists():
+        return str(direct_path)
+
+    image_root = os.getenv(IMAGE_ROOT_ENV_VAR, "").strip()
+    if image_root:
+        rooted_path = Path(image_root).expanduser() / relative_path
+        if rooted_path.exists():
+            return str(rooted_path)
+
+    return None
+
+
+def _collect_visual_paths(doc: dict) -> list[str]:
+    if _looks_like_visual_haystack(doc):
+        candidates = list(doc.get("ctxs", []))
+    else:
+        candidates = list(doc.get("image_list", []))
+        for optional_key in ("needle_image_list", "choices_image"):
+            optional_values = doc.get(optional_key)
+            if isinstance(optional_values, list):
+                candidates.extend(optional_values)
+
+    deduplicated = []
+    seen = set()
+    for candidate in candidates:
+        if not isinstance(candidate, str):
+            continue
+        resolved_path = _resolve_image_path(candidate)
+        if resolved_path is None or resolved_path in seen:
+            continue
+        seen.add(resolved_path)
+        deduplicated.append(resolved_path)
+    return deduplicated
+
+
+def _ctx_item_to_prompt_text(item: Any) -> str:
+    if isinstance(item, dict):
+        if item.get("type") == "image":
+            return "<image>"
+        text_value = item.get("text", "")
+        return str(text_value).strip()
+    if isinstance(item, str):
+        return "<image>"
+    return ""
+
+
+def _build_context_block(doc: dict) -> str:
+    ctxs = doc.get("ctxs", [])
+    if not isinstance(ctxs, list):
+        return ""
+
+    prompt_chunks = []
+    for item in ctxs:
+        chunk = _ctx_item_to_prompt_text(item)
+        if chunk:
+            prompt_chunks.append(chunk)
+    return "\n\n".join(prompt_chunks)
+
+
+def _build_question_block(doc: dict) -> str:
+    question = str(doc.get("question", "")).strip()
+    choice_images = doc.get("choices_image")
+    if not isinstance(choice_images, list) or not choice_images:
+        return question
+
+    option_lines = [f"{chr(ord('A') + idx)}. <image>" for idx in range(len(choice_images))]
+    return "\n".join([question] + option_lines)
+
+
+def _build_instruction(doc: dict) -> str:
+    if _looks_like_visual_haystack(doc):
+        return "You are given a set of images. Answer the question with Yes or No."
+
+    if isinstance(doc.get("choices_image"), list) and doc.get("choices_image"):
+        return "You are given interleaved text and images. Answer with the option letter only."
+
+    answer = doc.get("answer")
+    if isinstance(answer, list):
+        return "You are given interleaved text and images. Answer with a list of integers in brackets, like [1, 2, 3]."
+
+    return "You are given interleaved text and images. Answer the question concisely."
+
+
+def _to_int_list(value: Any) -> list[int]:
+    if isinstance(value, list):
+        return [int(item) for item in value if isinstance(item, int)]
+    return []
+
+
+def _extract_predicted_int_list(prediction: str) -> list[int]:
+    bracketed_candidates = re.findall(r"\[[^\]]*\]", prediction)
+    for candidate in reversed(bracketed_candidates):
+        try:
+            parsed = ast.literal_eval(candidate)
+        except (ValueError, SyntaxError):
+            continue
+        if isinstance(parsed, list):
+            values = []
+            for item in parsed:
+                try:
+                    values.append(int(item))
+                except (TypeError, ValueError):
+                    continue
+            if values:
+                return values
+
+    return [int(item) for item in re.findall(r"-?\d+", prediction)]
+
+
+def _extract_binary_label(prediction: str) -> str:
+    matches = re.findall(r"\b(yes|no)\b", prediction.lower())
+    return matches[-1] if matches else ""
+
+
+def _extract_choice_index(prediction: str) -> int:
+    normalized = prediction.strip().upper()
+
+    explicit_match = re.search(r"ANSWER\s*[:\-]?\s*\(?([A-J])\)?", normalized)
+    if explicit_match:
+        return ord(explicit_match.group(1)) - ord("A")
+
+    letter_match = re.search(r"\b([A-J])\b(?!.*\b[A-J]\b)", normalized)
+    if letter_match:
+        return ord(letter_match.group(1)) - ord("A")
+
+    digit_match = re.search(r"\b(\d+)\b(?!.*\b\d+\b)", normalized)
+    if digit_match:
+        return int(digit_match.group(1))
+
+    return -1
+
+
+def _substring_exact_match(prediction: str, answers: list[str]) -> float:
+    normalized_prediction = _normalize_text(prediction)
+    if not normalized_prediction:
+        return 0.0
+
+    for answer in answers:
+        normalized_answer = _normalize_text(answer)
+        if normalized_answer and normalized_answer in normalized_prediction:
+            return 1.0
+    return 0.0
+
+
+def _infer_category(doc: dict) -> str:
+    category = doc.get("category")
+    if isinstance(category, str) and category:
+        return category
+    if _looks_like_visual_haystack(doc):
+        return "visual-haystack"
+    return "unknown"
+
+
+def _score_prediction(doc: dict, parsed_prediction: str) -> float:
+    answer = doc.get("answer")
+
+    if _looks_like_visual_haystack(doc):
+        return float(_extract_binary_label(parsed_prediction) == _extract_binary_label(str(answer)))
+
+    if isinstance(answer, list):
+        gold_list = _to_int_list(answer)
+        pred_list = _extract_predicted_int_list(parsed_prediction)
+        return float(sum(gold_list) == sum(pred_list))
+
+    if isinstance(answer, int):
+        return float(_extract_choice_index(parsed_prediction) == answer)
+
+    if isinstance(answer, str):
+        return _substring_exact_match(parsed_prediction, [answer])
+
+    return 0.0
+
+
+def mmlongbench_doc_to_visual(doc):
+    return _collect_visual_paths(doc)
+
+
+def mmlongbench_doc_to_text(doc, lmms_eval_specific_kwargs=None):
+    kwargs = lmms_eval_specific_kwargs or {}
+    pre_prompt = kwargs.get("pre_prompt", "")
+    post_prompt = kwargs.get("post_prompt", "Answer:")
+
+    instruction = _build_instruction(doc)
+    context = _build_context_block(doc)
+    question_block = _build_question_block(doc)
+
+    prompt_parts = []
+    prefix_block = f"{pre_prompt}{instruction}".strip()
+    if prefix_block:
+        prompt_parts.append(prefix_block)
+    if context:
+        prompt_parts.append(context)
+    prompt_parts.append(f"Question: {question_block}")
+    if post_prompt:
+        prompt_parts.append(post_prompt)
+
+    return "\n\n".join(prompt_parts).strip()
+
+
+def mmlongbench_process_results(doc, results):
+    prediction = _extract_answer_text(results[0] if results else "")
+    score = _score_prediction(doc, prediction)
+    return {
+        "mmlongbench_acc": {
+            "score": score,
+            "category": _infer_category(doc),
+        }
+    }
+
+
+def mmlongbench_aggregate_results(results):
+    if not results:
+        return 0.0
+
+    total_score = 0.0
+    per_category: dict[str, dict[str, float]] = {}
+
+    for result in results:
+        score = float(result.get("score", 0.0))
+        category = str(result.get("category", "unknown"))
+        total_score += score
+
+        if category not in per_category:
+            per_category[category] = {"score": 0.0, "count": 0.0}
+        per_category[category]["score"] += score
+        per_category[category]["count"] += 1
+
+    for category, stats in sorted(per_category.items()):
+        count = stats["count"]
+        category_score = stats["score"] / count if count > 0 else 0.0
+        eval_logger.info("MMLongBench category={} samples={} acc={:.4f}", category, int(count), category_score)
+
+    return total_score / len(results)


### PR DESCRIPTION
## Summary
- Add a new `mmlongbench` task under `lmms_eval/tasks/mmlongbench` with task YAML + utility functions for prompt construction, visual resolution, and category-aware scoring.
- Use the official MMLongBench NIAH K128 example JSONL as the default dataset source to provide a stable backfill path in lmms-eval.
- Update `docs/current_tasks.md` to include MMLongBench in the supported task catalog.

## Validation
- `uv run pre-commit run --files docs/current_tasks.md lmms_eval/tasks/mmlongbench/mmlongbench.yaml lmms_eval/tasks/mmlongbench/utils.py` (passed)
- `HF_TOKEN='' uv run python -m lmms_eval --tasks list` and verified `mmlongbench` appears in the task list.
- `HF_TOKEN='' uv run python -m lmms_eval --model dummy_video_reader --model_args response=A,fail_on_missing=false --tasks mmlongbench --limit 8 --batch_size 1 --verbosity INFO` (smoke eval succeeded)

## Tracking
- Closes #1133
- Linear: LMM-284

<!-- smoke-validation:start -->
## Smoke Validation (limit=8)

Status: PASS (LMM-284 / mmlongbench)

### Output Table
| Metric | Value |
|---|---:|
| mmlongbench_acc | 0.0 |

### Sample Output

**Sample 1** (doc_id: 0)
- **Input**: You are given interleaved text and images. Answer with a list of integers in brackets, like [1, 2, 3]. ↵  ↵ Tesa Green soaks in the satisfaction of a 100-mile victory at the finish line. Photo: Kristi Mayo/Mile 90 Photography ↵  ↵ Morris won his second Hawk Hundred at 2:16 a.m., followed by a trickl…
- **Model Output**: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
- **Reference**: [1]
- **Scores**: `mmlongbench_acc` = 0.0 (category: count-image)
- **Tokens**: output=128, reasoning=0

**Sample 2** (doc_id: 1)
- **Input**: You are given interleaved text and images. Answer with a list of integers in brackets, like [1, 2, 3]. ↵  ↵ Tesa Green soaks in the satisfaction of a 100-mile victory at the finish line. Photo: Kristi Mayo/Mile 90 Photography ↵  ↵ Morris won his second Hawk Hundred at 2:16 a.m., followed by a trickl…
- **Model Output**: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
- **Reference**: [1]
- **Scores**: `mmlongbench_acc` = 0.0 (category: count-image)
- **Tokens**: output=128, reasoning=0

### Test Params
`uv run python -m lmms_eval --model openai_compatible --model_args "model_version=google/gemini-2.0-flash-001" --tasks mmlongbench --batch_size 1 --limit 8.0 --log_samples`
<!-- smoke-validation:end -->