### PR TITLE
docs: add LMM-280 benchmark backfill intake tracker

### DIFF
--- a/docs/roadmap/03_benchmark_backfill_intake_tracker.md
+++ b/docs/roadmap/03_benchmark_backfill_intake_tracker.md
@@ -1,0 +1,80 @@
+# Benchmark Backfill Intake Tracker (LMM-280)
+
+> Canonical tracker for benchmark backfill intake under Linear parent issue LMM-280.
+> Source of truth: Linear issue states and linked GitHub issue/PR attachments.
+> Snapshot date: 2026-02-22 (UTC).
+
+## Scope
+
+- Parent tracker: [LMM-280](https://linear.app/lmms-lab/issue/LMM-280/benchmark-backfill-intake-officeqa-and-newly-missing-multimodal)
+- Synced GitHub parent issue: [#1129](https://github.com/EvolvingLMMs-Lab/lmms-eval/issues/1129)
+- Child implementation issues covered: `LMM-281` through `LMM-299`
+
+## Status summary
+
+| Bucket | Count | Details |
+|--------|-------|---------|
+| Done | 4 | 3 merged PRs, 1 open PR |
+| In Review | 1 | 1 open PR |
+| In Progress | 13 | 13 open PRs |
+| Backlog | 1 | no PR yet |
+| Total | 19 | 18 child issues already have linked PRs |
+
+## Done
+
+| Benchmark | Linear issue | GitHub issue | PR |
+|-----------|--------------|--------------|----|
+| OfficeQA | [LMM-281](https://linear.app/lmms-lab/issue/LMM-281/benchmark-backfill-integrate-officeqa-into-lmms-eval) (Done) | [#1130](https://github.com/EvolvingLMMs-Lab/lmms-eval/issues/1130) | [#1150 (merged)](https://github.com/EvolvingLMMs-Lab/lmms-eval/pull/1150) |
+| OmniDocBench | [LMM-282](https://linear.app/lmms-lab/issue/LMM-282/benchmark-backfill-integrate-omnidocbench-into-lmms-eval) (Done) | [#1131](https://github.com/EvolvingLMMs-Lab/lmms-eval/issues/1131) | [#1152 (merged)](https://github.com/EvolvingLMMs-Lab/lmms-eval/pull/1152) |
+| DUDE | [LMM-283](https://linear.app/lmms-lab/issue/LMM-283/benchmark-backfill-integrate-dude-into-lmms-eval) (Done) | [#1132](https://github.com/EvolvingLMMs-Lab/lmms-eval/issues/1132) | [#1151 (merged)](https://github.com/EvolvingLMMs-Lab/lmms-eval/pull/1151) |
+| FSC-147 | [LMM-292](https://linear.app/lmms-lab/issue/LMM-292/benchmark-backfill-integrate-fsc-147-into-lmms-eval) (Done) | [#1141](https://github.com/EvolvingLMMs-Lab/lmms-eval/issues/1141) | [#1163 (open)](https://github.com/EvolvingLMMs-Lab/lmms-eval/pull/1163) |
+
+## In Review and In Progress
+
+| Benchmark | Linear issue | GitHub issue | PR |
+|-----------|--------------|--------------|----|
+| MMLongBench | [LMM-284](https://linear.app/lmms-lab/issue/LMM-284/benchmark-backfill-integrate-mmlongbench-into-lmms-eval) (In Progress) | [#1133](https://github.com/EvolvingLMMs-Lab/lmms-eval/issues/1133) | [#1169 (open)](https://github.com/EvolvingLMMs-Lab/lmms-eval/pull/1169) |
+| MMLongBench-Doc | [LMM-285](https://linear.app/lmms-lab/issue/LMM-285/benchmark-backfill-integrate-mmlongbench-doc-into-lmms-eval) (In Progress) | [#1134](https://github.com/EvolvingLMMs-Lab/lmms-eval/issues/1134) | [#1164 (open)](https://github.com/EvolvingLMMs-Lab/lmms-eval/pull/1164) |
+| MathKangaroo | [LMM-286](https://linear.app/lmms-lab/issue/LMM-286/benchmark-backfill-integrate-mathkangaroo-into-lmms-eval) (In Progress) | [#1135](https://github.com/EvolvingLMMs-Lab/lmms-eval/issues/1135) | [#1158 (open)](https://github.com/EvolvingLMMs-Lab/lmms-eval/pull/1158) |
+| MathCanvas | [LMM-287](https://linear.app/lmms-lab/issue/LMM-287/benchmark-backfill-integrate-mathcanvas-into-lmms-eval) (In Progress) | [#1136](https://github.com/EvolvingLMMs-Lab/lmms-eval/issues/1136) | [#1161 (open)](https://github.com/EvolvingLMMs-Lab/lmms-eval/pull/1161) |
+| VisuLogic | [LMM-288](https://linear.app/lmms-lab/issue/LMM-288/benchmark-backfill-integrate-visulogic-into-lmms-eval) (In Progress) | [#1137](https://github.com/EvolvingLMMs-Lab/lmms-eval/issues/1137) | [#1159 (open)](https://github.com/EvolvingLMMs-Lab/lmms-eval/pull/1159) |
+| TVBench | [LMM-289](https://linear.app/lmms-lab/issue/LMM-289/benchmark-backfill-integrate-tvbench-into-lmms-eval) (In Progress) | [#1138](https://github.com/EvolvingLMMs-Lab/lmms-eval/issues/1138) | [#1160 (open)](https://github.com/EvolvingLMMs-Lab/lmms-eval/pull/1160) |
+| EgoTempo | [LMM-290](https://linear.app/lmms-lab/issue/LMM-290/benchmark-backfill-integrate-egotempo-into-lmms-eval) (In Progress) | [#1139](https://github.com/EvolvingLMMs-Lab/lmms-eval/issues/1139) | [#1155 (open)](https://github.com/EvolvingLMMs-Lab/lmms-eval/pull/1155) |
+| CountBench | [LMM-291](https://linear.app/lmms-lab/issue/LMM-291/benchmark-backfill-integrate-countbench-into-lmms-eval) (In Progress) | [#1140](https://github.com/EvolvingLMMs-Lab/lmms-eval/issues/1140) | [#1156 (open)](https://github.com/EvolvingLMMs-Lab/lmms-eval/pull/1156) |
+| Point-Bench | [LMM-293](https://linear.app/lmms-lab/issue/LMM-293/benchmark-backfill-integrate-point-bench-into-lmms-eval) (In Progress) | [#1142](https://github.com/EvolvingLMMs-Lab/lmms-eval/issues/1142) | [#1157 (open)](https://github.com/EvolvingLMMs-Lab/lmms-eval/pull/1157) |
+| MMSIBench | [LMM-294](https://linear.app/lmms-lab/issue/LMM-294/benchmark-backfill-integrate-mmsibench-into-lmms-eval) (In Review) | [#1143](https://github.com/EvolvingLMMs-Lab/lmms-eval/issues/1143) | [#1162 (open)](https://github.com/EvolvingLMMs-Lab/lmms-eval/pull/1162) |
+| ViVerBench | [LMM-295](https://linear.app/lmms-lab/issue/LMM-295/benchmark-backfill-integrate-viverbench-into-lmms-eval) (In Progress) | [#1144](https://github.com/EvolvingLMMs-Lab/lmms-eval/issues/1144) | [#1166 (open)](https://github.com/EvolvingLMMs-Lab/lmms-eval/pull/1166) |
+| MTVQA | [LMM-296](https://linear.app/lmms-lab/issue/LMM-296/benchmark-backfill-integrate-mtvqa-into-lmms-eval) (In Progress) | [#1145](https://github.com/EvolvingLMMs-Lab/lmms-eval/issues/1145) | [#1167 (open)](https://github.com/EvolvingLMMs-Lab/lmms-eval/pull/1167) |
+| WorldVQA | [LMM-297](https://linear.app/lmms-lab/issue/LMM-297/benchmark-backfill-integrate-worldvqa-into-lmms-eval) (In Progress) | [#1146](https://github.com/EvolvingLMMs-Lab/lmms-eval/issues/1146) | [#1168 (open)](https://github.com/EvolvingLMMs-Lab/lmms-eval/pull/1168) |
+| OSWorld-Verified parity | [LMM-298](https://linear.app/lmms-lab/issue/LMM-298/benchmark-backfill-integrate-osworld-verified-parity-into-lmms-eval) (In Progress) | [#1147](https://github.com/EvolvingLMMs-Lab/lmms-eval/issues/1147) | [#1165 (open)](https://github.com/EvolvingLMMs-Lab/lmms-eval/pull/1165) |
+
+## Backlog
+
+| Benchmark | Linear issue | GitHub issue | PR |
+|-----------|--------------|--------------|----|
+| Additional benchmark gap triage | [LMM-299](https://linear.app/lmms-lab/issue/LMM-299/benchmark-backfill-triage-additional-candidate-benchmark-gaps-from) (Backlog) | [#1148](https://github.com/EvolvingLMMs-Lab/lmms-eval/issues/1148) | - |
+
+## Guidance: converting intake into implementation issues
+
+1. Intake capture in parent tracker
+   - Add benchmark candidate, modality, and source evidence to `LMM-280` (or the active intake parent).
+   - Confirm the benchmark is not already listed in `docs/current_tasks.md` and not present under `lmms_eval/tasks/`.
+2. Spawn a child implementation issue
+   - Use title format: `[Benchmark Backfill] Integrate <Benchmark> into lmms-eval`.
+   - Set parent to intake tracker and include definition of done:
+     - task config and utils added;
+     - task appears in `python -m lmms_eval --tasks list`;
+     - smoke run succeeds with `--limit 8`.
+3. Create linked execution artifacts
+   - Create or sync a GitHub issue from the Linear child issue.
+   - Open a working branch using `feat/lmm-<id>-<benchmark-slug>` naming.
+4. Track delivery state with PR linkage
+   - Attach the implementation PR to the same Linear child issue.
+   - Use Linear states as the primary status signal: `Backlog` -> `In Progress` -> `In Review` -> `Done`.
+5. Close loop in tracker
+   - After PR merge to `dev-v0d7`, set child issue to `Done`.
+   - Update this tracker document in the same PR (or immediate follow-up) to keep status and links synchronized.
+
+## Maintenance rule
+
+- Do not update this tracker from memory or branch activity; always refresh using current `linear issue view ... --json` and `gh pr view ...` data.


### PR DESCRIPTION
## Summary
- add a canonical tracker document at `docs/roadmap/03_benchmark_backfill_intake_tracker.md` for parent issue LMM-280
- summarize current child issue intake status using Linear as source of truth (done, in review, in progress, backlog) with linked GitHub issue and PR references
- include an operational guide for converting future intake items into implementation issues and keeping tracker status synchronized

## Validation
- `pre-commit run --all-files`
- `pre-commit run --files docs/roadmap/03_benchmark_backfill_intake_tracker.md`

## Source of truth
- Linear issue: LMM-280 and children LMM-281..LMM-299 via `linear issue view --json`
- GitHub PR state cross-check via `gh pr view --json`