### PR TITLE
feat: add SimpleVQA benchmark task

### DIFF
--- a/lmms_eval/tasks/simplevqa/_default_template_simplevqa_yaml
+++ b/lmms_eval/tasks/simplevqa/_default_template_simplevqa_yaml
@@ -1,0 +1,27 @@
+dataset_path: m-a-p/SimpleVQA
+dataset_kwargs:
+  token: false
+output_type: generate_until
+doc_to_visual: !function utils.simplevqa_doc_to_visual
+doc_to_text: !function utils.simplevqa_doc_to_text
+doc_to_target: "answer"
+process_results: !function utils.simplevqa_process_results
+generation_kwargs:
+  max_new_tokens: 32
+  temperature: 0
+  top_p: 1.0
+  num_beams: 1
+  do_sample: false
+metric_list:
+  - metric: exact_match
+    aggregation: mean
+    higher_is_better: true
+lmms_eval_specific_kwargs:
+  default:
+    pre_prompt: ""
+    post_prompt: "\nAnswer the question using a short phrase."
+  qwen3_vl:
+    pre_prompt: "Question: "
+    post_prompt: "\nAnswer with a short phrase only."
+metadata:
+  - version: 0.0

--- a/lmms_eval/tasks/simplevqa/simplevqa.yaml
+++ b/lmms_eval/tasks/simplevqa/simplevqa.yaml
@@ -1,0 +1,3 @@
+task: simplevqa
+test_split: test
+include: _default_template_simplevqa_yaml

--- a/lmms_eval/tasks/simplevqa/utils.py
+++ b/lmms_eval/tasks/simplevqa/utils.py
@@ -1,0 +1,35 @@
+import base64
+import io
+
+from PIL import Image
+
+from lmms_eval.tasks._task_utils.vqa_eval_metric import EvalAIAnswerProcessor
+
+EVAL_AI_PROCESSOR = EvalAIAnswerProcessor()
+
+
+def simplevqa_doc_to_visual(doc):
+    image = doc["image"]
+    if isinstance(image, Image.Image):
+        return [image.convert("RGB")]
+
+    image_bytes = base64.b64decode(image)
+    decoded_image = Image.open(io.BytesIO(image_bytes)).convert("RGB")
+    return [decoded_image]
+
+
+def simplevqa_doc_to_text(doc, lmms_eval_specific_kwargs=None):
+    if lmms_eval_specific_kwargs is None:
+        lmms_eval_specific_kwargs = {}
+
+    pre_prompt = lmms_eval_specific_kwargs.get("pre_prompt", "")
+    post_prompt = lmms_eval_specific_kwargs.get("post_prompt", "")
+    question = doc["question"].strip()
+    return f"{pre_prompt}{question}{post_prompt}"
+
+
+def simplevqa_process_results(doc, result):
+    assert len(result) == 1, f"The result should be a list of length 1, but got {len(result)}."
+    prediction = EVAL_AI_PROCESSOR(result[0])
+    reference = EVAL_AI_PROCESSOR(doc["answer"])
+    return {"exact_match": float(prediction == reference)}


### PR DESCRIPTION
## Summary
- add new `simplevqa` task under `lmms_eval/tasks/simplevqa` with auto-discovered YAML config and utils
- decode base64-encoded dataset images from `m-a-p/SimpleVQA`, format prompts, and score with normalized exact match
- configure public dataset loading with `token: false` to avoid expired local HF token issues

## Validation
- `uv run pre-commit run --files lmms_eval/tasks/simplevqa/simplevqa.yaml lmms_eval/tasks/simplevqa/_default_template_simplevqa_yaml lmms_eval/tasks/simplevqa/utils.py`
  - passed (`black`, `isort`)
- `OPENAI_API_KEY="$OPENROUTER_API_KEY" OPENAI_API_BASE="https://openrouter.ai/api/v1" uv run python -m lmms_eval --model openai_compatible --model_args "model_version=bytedance-seed/seed-1.6-flash,max_retries=5,retry_backoff_s=2.0" --tasks simplevqa --batch_size 1 --limit 8 --log_samples --output_path ./logs/simplevqa_smoke_v2 --verbosity INFO`
  - score table: `simplevqa exact_match = 0.625 ± 0.183` (limit=8 smoke)
  - samples log: `logs/simplevqa_smoke_v2/bytedance-seed__seed-1.6-flash/20260222_225744_samples_simplevqa.jsonl`
  - result json: `logs/simplevqa_smoke_v2/bytedance-seed__seed-1.6-flash/20260222_225744_results.json`
  - verified JSONL entries have non-empty `filtered_resps` for all 8 samples

<!-- smoke-validation:start -->
## Smoke Validation (limit=8)

Status: PASS (LMM-299 / simplevqa)

### Output Table
| Metric | Value |
|---|---:|
| exact_match | 0.625 |

### Sample Output

**Sample 1** (doc_id: 0)
- **Input**: 图中所示穴位所属的经脉是什么？ ↵ Answer the question using a short phrase.
- **Model Output**: 足阳明胃经
- **Reference**: 足阳明胃经
- **Scores**: `exact_match` = 1.0
- **Tokens**: output=83, reasoning=79

**Sample 2** (doc_id: 1)
- **Input**: 图中这种中药药材叫什么？ ↵ Answer the question using a short phrase.
- **Model Output**: 黄柏
- **Reference**: 黄柏
- **Scores**: `exact_match` = 1.0
- **Tokens**: output=60, reasoning=59

### Test Params
`uv run python -m lmms_eval --model openai_compatible --model_args "model_version=bytedance-seed/seed-1.6-flash" --tasks simplevqa --batch_size 1 --limit 8 --log_samples`
<!-- smoke-validation:end -->
