### PR TITLE
docs: document TreeBench name mapping for spatialtreebench

### DIFF
--- a/lmms_eval/tasks/spatialtreebench/README.md
+++ b/lmms_eval/tasks/spatialtreebench/README.md
@@ -1,0 +1,35 @@
+# SpatialTreeBench (`spatialtreebench`)
+
+SpatialTreeBench is a hierarchical benchmark for evaluating spatial capabilities in multimodal models, from low-level perception to higher-level simulation and agentic behavior.
+
+## Name Mapping in lmms-eval
+
+Model cards and reports may use different benchmark names. In lmms-eval, the following name variants all refer to this existing task:
+
+- `TreeBench`
+- `SpatialTreeBench`
+- `Spatial-TreeBench`
+
+Canonical lmms-eval task name: `spatialtreebench`
+
+Task config: `lmms_eval/tasks/spatialtreebench/spatialtreebench.yaml`
+
+Dataset configured in YAML: `LongfeiLi/SpatialTree-Bench`
+
+## References
+
+- Paper: [SpatialTree: How Spatial Abilities Branch Out in MLLMs](https://arxiv.org/abs/2512.20617)
+- Project page: [spatialtree.github.io](https://spatialtree.github.io/)
+- Dataset: [LongfeiLi/SpatialTree-Bench](https://huggingface.co/datasets/LongfeiLi/SpatialTree-Bench)
+
+## Usage
+
+```bash
+python -m lmms_eval \
+  --model <model_name> \
+  --model_args <key=value,...> \
+  --tasks spatialtreebench \
+  --batch_size 1
+```
+
+Use `--tasks spatialtreebench` even when source materials mention `TreeBench` or `Spatial-TreeBench`.


### PR DESCRIPTION
## Summary
- Add `lmms_eval/tasks/spatialtreebench/README.md` documenting the benchmark and canonical lmms-eval task name.
- Record that `TreeBench`, `SpatialTreeBench`, and `Spatial-TreeBench` all map to `spatialtreebench` in lmms-eval.
- Include paper/dataset references and a runnable usage example for `--tasks spatialtreebench`.

## Validation
- `pre-commit run --files lmms_eval/tasks/spatialtreebench/README.md`
- `lsp_diagnostics` is not available for `.md` files in this environment.

Refs: LMM-308, #1180