### PR TITLE
feat: add ARC-AGI-1, ARC-AGI-2, and BrowseComp benchmark tasks

### DIFF
--- a/lmms_eval/tasks/arc_agi_1/README.md
+++ b/lmms_eval/tasks/arc_agi_1/README.md
@@ -1,0 +1,12 @@
+# ARC-AGI-1 (Image)
+
+ARC-AGI-1 visual reasoning benchmark using community-rendered image dataset.
+
+- Original: https://github.com/fchollet/ARC-AGI
+- Dataset: https://huggingface.co/datasets/mertaylin/arc-agi-images
+- Note: Uses community image conversion (not official ARC Prize packaging)
+
+## Usage
+```bash
+python -m lmms_eval --tasks arc_agi_1 --model <model_name> --batch_size 1
+```

--- a/lmms_eval/tasks/arc_agi_1/_default_template_yaml
+++ b/lmms_eval/tasks/arc_agi_1/_default_template_yaml
@@ -1,0 +1,23 @@
+dataset_path: mertaylin/arc-agi-images
+dataset_kwargs:
+  token: false
+output_type: generate_until
+doc_to_visual: !function utils.arc_agi_1_doc_to_visual
+doc_to_text: !function utils.arc_agi_1_doc_to_text
+doc_to_target: !function utils.arc_agi_1_doc_to_target
+generation_kwargs:
+  max_new_tokens: 1024
+  temperature: 0
+  top_p: 1.0
+  do_sample: false
+process_results: !function utils.arc_agi_1_process_results
+metric_list:
+  - metric: arc_agi_1_acc
+    aggregation: mean
+    higher_is_better: true
+lmms_eval_specific_kwargs:
+  default:
+    pre_prompt: ""
+    post_prompt: ""
+metadata:
+  version: 0.0

--- a/lmms_eval/tasks/arc_agi_1/arc_agi_1.yaml
+++ b/lmms_eval/tasks/arc_agi_1/arc_agi_1.yaml
@@ -1,0 +1,3 @@
+include: _default_template_yaml
+task: arc_agi_1
+test_split: eval

--- a/lmms_eval/tasks/arc_agi_1/utils.py
+++ b/lmms_eval/tasks/arc_agi_1/utils.py
@@ -1,0 +1,161 @@
+import json
+import re
+from typing import Any
+
+from loguru import logger as eval_logger
+from PIL import Image
+
+CODE_FENCE_PATTERN = re.compile(r"```(?:json)?\s*(.*?)```", re.IGNORECASE | re.DOTALL)
+GRID_PATTERN = re.compile(r"\[\s*\[.*?\]\s*\]", re.DOTALL)
+
+
+def _extract_first_image(image_value):
+    if isinstance(image_value, (list, tuple)):
+        if len(image_value) == 0:
+            return None
+        image_value = image_value[0]
+
+    if isinstance(image_value, Image.Image):
+        return image_value.convert("RGB")
+
+    if hasattr(image_value, "convert"):
+        try:
+            return image_value.convert("RGB")
+        except Exception as err:
+            eval_logger.warning("Failed to convert ARC-AGI image to RGB: {}", err)
+
+    return None
+
+
+def _extract_first_value(value: Any, default: Any = None) -> Any:
+    if isinstance(value, (list, tuple)):
+        if len(value) == 0:
+            return default
+        value = value[0]
+    if value is None:
+        return default
+    return value
+
+
+def _is_grid_of_ints(value):
+    if not isinstance(value, list):
+        return False
+    for row in value:
+        if not isinstance(row, list):
+            return False
+        for cell in row:
+            if isinstance(cell, bool) or not isinstance(cell, int):
+                return False
+    return True
+
+
+def _try_parse_grid(candidate):
+    if not isinstance(candidate, str):
+        return None
+
+    candidate = candidate.strip()
+    if not candidate:
+        return None
+
+    try:
+        parsed = json.loads(candidate)
+    except json.JSONDecodeError:
+        return None
+
+    if _is_grid_of_ints(parsed):
+        return parsed
+    return None
+
+
+def _get_raw_solution_grid(doc):
+    raw_solution = doc.get("raw_solution")
+    target = _extract_first_value(raw_solution, default=[])
+    if _is_grid_of_ints(target):
+        return target
+    eval_logger.warning("Invalid ARC-AGI raw_solution format for id={}", doc.get("id", "unknown"))
+    return None
+
+
+def arc_agi_1_doc_to_visual(doc):
+    stacked_train_image = _extract_first_image(doc.get("stacked_train_image"))
+    test_input_image = _extract_first_image(doc.get("test_images"))
+
+    if stacked_train_image is None:
+        eval_logger.warning("Missing stacked_train_image for id={}", doc.get("id", "unknown"))
+    if test_input_image is None:
+        eval_logger.warning("Missing test_images for id={}", doc.get("id", "unknown"))
+
+    if stacked_train_image is None or test_input_image is None:
+        raise ValueError(f"ARC-AGI-1 visual inputs are incomplete for id={doc.get('id', 'unknown')}")
+
+    return [stacked_train_image, test_input_image]
+
+
+def arc_agi_1_doc_to_text(doc, lmms_eval_specific_kwargs=None):
+    if lmms_eval_specific_kwargs is None:
+        lmms_eval_specific_kwargs = {}
+
+    pre_prompt = lmms_eval_specific_kwargs.get("pre_prompt", "")
+    post_prompt = lmms_eval_specific_kwargs.get("post_prompt", "")
+
+    test_input_text = _extract_first_value(doc.get("test_inputs"), default="")
+
+    prompt = (
+        "You are given demonstration input-output pairs as images. "
+        "Based on the pattern, predict the output grid for the test input.\n"
+        "The first image contains all demonstration input/output pairs.\n"
+        "The second image contains the test input grid.\n\n"
+        f"Text representation of the test input grid:\n{test_input_text}\n\n"
+        "Output only the predicted output grid as a JSON array of arrays of integers.\n"
+        "Example: [[1,2],[3,4]]"
+    )
+
+    return f"{pre_prompt}{prompt}{post_prompt}"
+
+
+def arc_agi_1_doc_to_target(doc):
+    target = _extract_first_value(doc.get("raw_solution"), default=[])
+    return json.dumps(target)
+
+
+def _parse_grid_from_response(text: str) -> list[list[int]] | None:
+    if not isinstance(text, str):
+        return None
+
+    text = text.strip()
+    if not text:
+        return None
+
+    parsed_grid = _try_parse_grid(text)
+    if parsed_grid is not None:
+        return parsed_grid
+
+    for block in CODE_FENCE_PATTERN.findall(text):
+        parsed_grid = _try_parse_grid(block)
+        if parsed_grid is not None:
+            return parsed_grid
+
+    for match in GRID_PATTERN.findall(text):
+        parsed_grid = _try_parse_grid(match)
+        if parsed_grid is not None:
+            return parsed_grid
+
+    return None
+
+
+def arc_agi_1_process_results(doc, results):
+    response_text = results[0] if results else ""
+    if not isinstance(response_text, str):
+        response_text = str(response_text)
+
+    parsed_grid = _parse_grid_from_response(response_text)
+    target_grid = _get_raw_solution_grid(doc)
+
+    if parsed_grid is None:
+        eval_logger.debug("Failed to parse model output as ARC grid for id={}", doc.get("id", "unknown"))
+        return {"arc_agi_1_acc": 0.0}
+
+    if target_grid is None:
+        return {"arc_agi_1_acc": 0.0}
+
+    return {"arc_agi_1_acc": 1.0 if parsed_grid == target_grid else 0.0}

--- a/lmms_eval/tasks/arc_agi_2/README.md
+++ b/lmms_eval/tasks/arc_agi_2/README.md
@@ -1,0 +1,12 @@
+# ARC-AGI-2 (Image)
+
+ARC-AGI-2 visual reasoning benchmark using community-rendered image dataset.
+
+- Original: https://github.com/arcprize/ARC-AGI-2
+- Dataset: https://huggingface.co/datasets/vincentkoc/arc-agi-2
+- Note: Uses community image conversion (not official ARC Prize packaging)
+
+## Usage
+```bash
+python -m lmms_eval --tasks arc_agi_2 --model <model_name> --batch_size 1
+```

--- a/lmms_eval/tasks/arc_agi_2/_default_template_yaml
+++ b/lmms_eval/tasks/arc_agi_2/_default_template_yaml
@@ -1,0 +1,23 @@
+dataset_path: vincentkoc/arc-agi-2
+dataset_kwargs:
+  token: false
+output_type: generate_until
+doc_to_visual: !function utils.arc_agi_2_doc_to_visual
+doc_to_text: !function utils.arc_agi_2_doc_to_text
+doc_to_target: !function utils.arc_agi_2_doc_to_target
+generation_kwargs:
+  max_new_tokens: 1024
+  temperature: 0
+  top_p: 1.0
+  do_sample: false
+process_results: !function utils.arc_agi_2_process_results
+metric_list:
+  - metric: arc_agi_2_acc
+    aggregation: mean
+    higher_is_better: true
+lmms_eval_specific_kwargs:
+  default:
+    pre_prompt: ""
+    post_prompt: ""
+metadata:
+  version: 0.0

--- a/lmms_eval/tasks/arc_agi_2/arc_agi_2.yaml
+++ b/lmms_eval/tasks/arc_agi_2/arc_agi_2.yaml
@@ -1,0 +1,3 @@
+include: _default_template_yaml
+task: arc_agi_2
+test_split: evaluation

--- a/lmms_eval/tasks/arc_agi_2/utils.py
+++ b/lmms_eval/tasks/arc_agi_2/utils.py
@@ -1,0 +1,267 @@
+import json
+import re
+from typing import Any
+
+from loguru import logger as eval_logger
+from PIL import Image
+
+_CODE_FENCE_PATTERN = re.compile(r"```(?:json)?\s*([\s\S]*?)```", re.IGNORECASE)
+_DOUBLE_BRACKET_PATTERN = re.compile(r"\[\s*\[.*?\]\s*\]", re.DOTALL)
+
+
+def _to_rgb_image(image_obj: Any) -> Image.Image | None:
+    if isinstance(image_obj, Image.Image):
+        return image_obj.convert("RGB")
+    if hasattr(image_obj, "convert"):
+        try:
+            return image_obj.convert("RGB")
+        except Exception:
+            return None
+    return None
+
+
+def arc_agi_2_doc_to_visual(doc: dict) -> list[Image.Image]:
+    visuals = []
+    train_inputs = doc.get("train_input_image_color") or []
+    train_outputs = doc.get("train_output_image_color") or []
+
+    if len(train_inputs) != len(train_outputs):
+        eval_logger.warning(
+            "ARC-AGI-2 train pair mismatch for task {}: {} inputs vs {} outputs",
+            doc.get("id", doc.get("task_id", "unknown")),
+            len(train_inputs),
+            len(train_outputs),
+        )
+
+    pair_count = min(len(train_inputs), len(train_outputs))
+    for idx in range(pair_count):
+        train_input = _to_rgb_image(train_inputs[idx])
+        train_output = _to_rgb_image(train_outputs[idx])
+
+        if train_input is not None:
+            visuals.append(train_input)
+        else:
+            eval_logger.warning(
+                "ARC-AGI-2 missing/invalid train input image at pair {} for task {}",
+                idx,
+                doc.get("id", doc.get("task_id", "unknown")),
+            )
+
+        if train_output is not None:
+            visuals.append(train_output)
+        else:
+            eval_logger.warning(
+                "ARC-AGI-2 missing/invalid train output image at pair {} for task {}",
+                idx,
+                doc.get("id", doc.get("task_id", "unknown")),
+            )
+
+    test_inputs = doc.get("test_input_image_color") or []
+    if test_inputs:
+        test_image = _to_rgb_image(test_inputs[0])
+        if test_image is not None:
+            visuals.append(test_image)
+        else:
+            eval_logger.warning(
+                "ARC-AGI-2 missing/invalid test input image for task {}",
+                doc.get("id", doc.get("task_id", "unknown")),
+            )
+    else:
+        eval_logger.warning(
+            "ARC-AGI-2 has no test input image for task {}",
+            doc.get("id", doc.get("task_id", "unknown")),
+        )
+
+    return visuals
+
+
+def arc_agi_2_doc_to_text(doc: dict, lmms_eval_specific_kwargs=None) -> str:
+    lmms_eval_specific_kwargs = lmms_eval_specific_kwargs or {}
+    pre_prompt = lmms_eval_specific_kwargs.get("pre_prompt", "")
+    post_prompt = lmms_eval_specific_kwargs.get("post_prompt", "")
+
+    train_inputs = doc.get("train_input_image_color") or []
+    train_outputs = doc.get("train_output_image_color") or []
+    pair_count = min(len(train_inputs), len(train_outputs))
+
+    image_refs = []
+    for idx in range(pair_count):
+        image_refs.append(f"Image {2 * idx + 1} is demo input {idx + 1}.")
+        image_refs.append(f"Image {2 * idx + 2} is demo output {idx + 1}.")
+    image_refs.append(f"Image {2 * pair_count + 1} is the final test input.")
+
+    test_input_texts = doc.get("test_input_texts") or [""]
+    test_input_text = test_input_texts[0] if test_input_texts else ""
+
+    prompt = (
+        "You are solving an ARC visual reasoning task. "
+        "Each task contains demo input/output grid pairs where the output is generated from the input by a hidden rule.\n\n"
+        "Image references:\n"
+        f"{' '.join(image_refs)}\n\n"
+        "Based on the pattern in the demo pairs, predict the output grid for the final test input image.\n"
+        "The test input is also provided in text grid form for clarity:\n"
+        f"{test_input_text}\n\n"
+        "Return the final predicted grid as a JSON array of arrays, for example [[1,2],[3,4]].\n"
+        "Return only the JSON array with no additional text."
+    )
+
+    parts = []
+    if pre_prompt:
+        parts.append(pre_prompt)
+    parts.append(prompt)
+    if post_prompt:
+        parts.append(post_prompt)
+    return "\n\n".join(parts)
+
+
+def arc_agi_2_doc_to_target(doc: dict) -> str:
+    test_targets = doc.get("test_targets") or []
+    if not test_targets:
+        return "[]"
+    return test_targets[0]
+
+
+def _try_parse_grid_candidate(candidate: str) -> list[list[int]] | None:
+    candidate = candidate.strip()
+    if not candidate:
+        return None
+
+    try:
+        parsed = json.loads(candidate)
+    except json.JSONDecodeError:
+        return None
+
+    if isinstance(parsed, dict) and isinstance(parsed.get("text"), str):
+        return _parse_grid_from_response(parsed["text"])
+
+    return _normalize_grid(parsed)
+
+
+def _extract_bracket_candidates(text: str) -> list[str]:
+    candidates = []
+    depth = 0
+    start = None
+    in_string = False
+    escaped = False
+
+    for idx, char in enumerate(text):
+        if in_string:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == '"':
+                in_string = False
+            continue
+
+        if char == '"':
+            in_string = True
+            continue
+
+        if char == "[":
+            if depth == 0:
+                start = idx
+            depth += 1
+            continue
+
+        if char == "]" and depth > 0:
+            depth -= 1
+            if depth == 0 and start is not None:
+                candidates.append(text[start : idx + 1])
+                start = None
+
+    return candidates
+
+
+def _parse_grid_from_response(text: str) -> list[list[int]] | None:
+    if text is None:
+        return None
+
+    if not isinstance(text, str):
+        text = str(text)
+    text = text.strip()
+    if not text:
+        return None
+
+    parsed = _try_parse_grid_candidate(text)
+    if parsed is not None:
+        return parsed
+
+    for fenced_content in _CODE_FENCE_PATTERN.findall(text):
+        parsed = _try_parse_grid_candidate(fenced_content)
+        if parsed is not None:
+            return parsed
+
+    for bracket_match in _DOUBLE_BRACKET_PATTERN.findall(text):
+        parsed = _try_parse_grid_candidate(bracket_match)
+        if parsed is not None:
+            return parsed
+
+    for candidate in _extract_bracket_candidates(text):
+        parsed = _try_parse_grid_candidate(candidate)
+        if parsed is not None:
+            return parsed
+
+    return None
+
+
+def _normalize_grid(grid: Any) -> list[list[int]] | None:
+    if isinstance(grid, str):
+        try:
+            grid = json.loads(grid)
+        except json.JSONDecodeError:
+            return None
+
+    if not isinstance(grid, list):
+        return None
+
+    normalized_grid = []
+    for row in grid:
+        if not isinstance(row, list):
+            return None
+
+        normalized_row = []
+        for value in row:
+            if isinstance(value, bool):
+                return None
+            if isinstance(value, int):
+                normalized_row.append(value)
+                continue
+            if isinstance(value, float) and value.is_integer():
+                normalized_row.append(int(value))
+                continue
+            if isinstance(value, str):
+                stripped = value.strip()
+                if re.fullmatch(r"-?\d+", stripped) is None:
+                    return None
+                normalized_row.append(int(stripped))
+                continue
+            return None
+        normalized_grid.append(normalized_row)
+
+    return normalized_grid
+
+
+def arc_agi_2_process_results(doc: dict, results: list[str]) -> dict[str, float]:
+    response_text = results[0] if results else ""
+    predicted_grid = _parse_grid_from_response(response_text)
+
+    raw_test_outputs = doc.get("test_outputs") or []
+    ground_truth_raw = raw_test_outputs[0] if raw_test_outputs else None
+    ground_truth_grid = _normalize_grid(ground_truth_raw)
+    if ground_truth_grid is None and isinstance(ground_truth_raw, str):
+        ground_truth_grid = _parse_grid_from_response(ground_truth_raw)
+
+    if predicted_grid is None:
+        eval_logger.debug(
+            "ARC-AGI-2 failed to parse prediction for task {}",
+            doc.get("id", doc.get("task_id", "unknown")),
+        )
+    if ground_truth_grid is None:
+        eval_logger.warning(
+            "ARC-AGI-2 failed to parse ground truth for task {}",
+            doc.get("id", doc.get("task_id", "unknown")),
+        )
+
+    score = 1.0 if predicted_grid is not None and predicted_grid == ground_truth_grid else 0.0
+    return {"arc_agi_2_acc": score}

--- a/lmms_eval/tasks/browsecomp/README.md
+++ b/lmms_eval/tasks/browsecomp/README.md
@@ -1,0 +1,23 @@
+# BrowseComp
+
+BrowseComp is a benchmark for evaluating the ability to find hard-to-locate information on the internet, published by OpenAI.
+
+- Paper: https://arxiv.org/abs/2504.12516
+- Dataset: https://openaipublic.blob.core.windows.net/simple-evals/browse_comp_test_set.csv
+- Reference implementation: https://github.com/openai/simple-evals
+
+## Notes
+
+- Data is XOR-encrypted to prevent training contamination; decryption happens at eval time.
+- LLM-as-Judge scoring is used when `use_lmms_judge: true` and API credentials are configured.
+- Fallback to exact string match when judge is unavailable.
+
+## Usage
+
+```bash
+# Basic evaluation (exact match fallback)
+python -m lmms_eval --tasks browsecomp --model <model_name>
+
+# With LLM judge (requires OPENAI_API_KEY)
+API_TYPE=openai OPENAI_API_KEY=<key> python -m lmms_eval --tasks browsecomp --model <model_name>
+```

--- a/lmms_eval/tasks/browsecomp/_default_template_yaml
+++ b/lmms_eval/tasks/browsecomp/_default_template_yaml
@@ -1,0 +1,26 @@
+dataset_path: csv
+dataset_kwargs:
+  data_files:
+    test: https://openaipublic.blob.core.windows.net/simple-evals/browse_comp_test_set.csv
+  token: false
+output_type: generate_until
+doc_to_visual: !function utils.browsecomp_doc_to_visual
+doc_to_text: !function utils.browsecomp_doc_to_text
+doc_to_target: !function utils.browsecomp_doc_to_target
+generation_kwargs:
+  max_new_tokens: 1024
+  temperature: 0
+  top_p: 1.0
+  do_sample: false
+process_results: !function utils.browsecomp_process_results
+metric_list:
+  - metric: browsecomp_acc
+    aggregation: !function utils.browsecomp_aggregate_results
+    higher_is_better: true
+lmms_eval_specific_kwargs:
+  default:
+    pre_prompt: ""
+    post_prompt: ""
+metadata:
+  version: 0.0
+  use_lmms_judge: true

--- a/lmms_eval/tasks/browsecomp/browsecomp.yaml
+++ b/lmms_eval/tasks/browsecomp/browsecomp.yaml
@@ -1,0 +1,3 @@
+include: _default_template_yaml
+task: browsecomp
+test_split: test

--- a/lmms_eval/tasks/browsecomp/utils.py
+++ b/lmms_eval/tasks/browsecomp/utils.py
@@ -1,0 +1,245 @@
+import base64
+import hashlib
+import os
+import re
+from collections import defaultdict
+from pathlib import Path
+
+import yaml
+from loguru import logger as eval_logger
+
+_default_template_path = Path(__file__).parent / "_default_template_yaml"
+_browsecomp_config_path = Path(__file__).parent / "browsecomp.yaml"
+
+
+def _load_yaml_stripped(path: Path) -> dict:
+    with open(path, "r") as f:
+        raw_data = f.readlines()
+    safe_data = [line for line in raw_data if "!function" not in line]
+    return yaml.safe_load("".join(safe_data)) or {}
+
+
+_config = _load_yaml_stripped(_default_template_path)
+_config.update(_load_yaml_stripped(_browsecomp_config_path))
+
+_judge_server = None
+_judge_server_config = None
+if _config.get("metadata", {}).get("use_lmms_judge"):
+    try:
+        from lmms_eval.llm_judge import get_server
+        from lmms_eval.llm_judge.protocol import ServerConfig
+
+        API_TYPE = os.getenv("API_TYPE", "openai").lower()
+        DEPLOYMENT_NAME = os.getenv("DEPLOYMENT_NAME") or os.getenv("OPENAI_API_MODEL", "gpt-4o")
+
+        _judge_server_config = ServerConfig(model_name=DEPLOYMENT_NAME)
+        _judge_server = get_server(server_name=API_TYPE, config=_judge_server_config)
+        eval_logger.info("Using LMMS judge server for BrowseComp task.")
+    except Exception as err:
+        eval_logger.warning("Failed to initialize LMMS judge for BrowseComp: {}", err)
+        _judge_server = None
+        _judge_server_config = None
+
+
+BROWSECOMP_JUDGE_PROMPT = """Judge whether the following [response] to [question] is correct based on the [correct_answer].
+
+[question]: {question}
+[response]: {response}
+[correct_answer]: {correct_answer}
+
+Determine if the response's final answer matches the correct answer. Answer only "Correct" or "Incorrect".
+"""
+
+EXACT_ANSWER_PATTERN = re.compile(r"^\s*Exact\s*Answer\s*:\s*(.+?)\s*$", re.IGNORECASE | re.MULTILINE)
+FALLBACK_ANSWER_PATTERN = re.compile(r"^\s*(?:Final\s+)?Answer\s*:\s*(.+?)\s*$", re.IGNORECASE | re.MULTILINE)
+CONFIDENCE_PATTERN = re.compile(r"^\s*Confidence\s*:\s*([+-]?\d+(?:\.\d+)?)\s*%?\s*$", re.IGNORECASE | re.MULTILINE)
+
+
+def _derive_key(password: str, length: int) -> bytes:
+    hasher = hashlib.sha256()
+    hasher.update(password.encode())
+    key = hasher.digest()
+    return key * (length // len(key)) + key[: length % len(key)]
+
+
+def _decrypt(ciphertext_b64: str, password: str) -> str:
+    encrypted = base64.b64decode(ciphertext_b64)
+    key = _derive_key(password, len(encrypted))
+    return bytes(a ^ b for a, b in zip(encrypted, key)).decode()
+
+
+def _get_password(doc: dict) -> str:
+    canary = doc.get("canary", "")
+    if canary is None:
+        return ""
+
+    password = str(canary)
+    try:
+        decoded = base64.b64decode(password, validate=True).decode()
+        if decoded and decoded.isprintable():
+            return decoded
+    except Exception:
+        pass
+
+    return password
+
+
+def _safe_decrypt(ciphertext_b64: str, password: str) -> str:
+    try:
+        return _decrypt(ciphertext_b64, password)
+    except Exception as err:
+        eval_logger.warning("Failed to decrypt BrowseComp field: {}", err)
+        return ""
+
+
+def _extract_exact_answer(response: str) -> str:
+    if not response:
+        return ""
+
+    match = EXACT_ANSWER_PATTERN.search(response)
+    if match:
+        return match.group(1).strip()
+
+    fallback_match = FALLBACK_ANSWER_PATTERN.search(response)
+    if fallback_match:
+        return fallback_match.group(1).strip()
+
+    return response.strip()
+
+
+def _extract_confidence(response: str):
+    if not response:
+        return None
+
+    match = CONFIDENCE_PATTERN.search(response)
+    if not match:
+        return None
+
+    try:
+        score = float(match.group(1))
+    except ValueError:
+        return None
+
+    return max(0.0, min(100.0, score))
+
+
+def _normalize_for_exact_match(text: str) -> str:
+    return re.sub(r"\s+", " ", (text or "")).strip().lower()
+
+
+def _judge_is_correct(question: str, response: str, correct_answer: str):
+    if _judge_server is None or _judge_server_config is None:
+        return None
+
+    try:
+        from lmms_eval.llm_judge.protocol import Request
+
+        submit_prompt = BROWSECOMP_JUDGE_PROMPT.format(
+            question=question,
+            response=response,
+            correct_answer=correct_answer,
+        )
+        request = Request(messages=[{"role": "user", "content": submit_prompt}], config=_judge_server_config)
+        judge_response_obj = _judge_server.evaluate(request)
+        judge_result = str(judge_response_obj.content).strip().lower()
+
+        if "incorrect" in judge_result:
+            return False
+        if "correct" in judge_result:
+            return True
+    except Exception as err:
+        eval_logger.debug("BrowseComp LLM judge failed, fallback to exact match: {}", err)
+
+    return None
+
+
+def browsecomp_doc_to_visual(doc) -> list:
+    return []
+
+
+def browsecomp_doc_to_text(doc, lmms_eval_specific_kwargs=None) -> str:
+    if lmms_eval_specific_kwargs is None:
+        lmms_eval_specific_kwargs = {}
+
+    pre_prompt = lmms_eval_specific_kwargs.get("pre_prompt", "")
+    post_prompt = lmms_eval_specific_kwargs.get("post_prompt", "")
+
+    password = _get_password(doc)
+    question = _safe_decrypt(str(doc.get("problem", "")), password)
+
+    prompt = (
+        f"{question}\n\n"
+        "Your response should be in the following format:\n"
+        "Explanation: {your explanation for your final answer}\n"
+        "Exact Answer: {your succinct, final answer}\n"
+        "Confidence: {your confidence score between 0% and 100% for your answer}"
+    )
+
+    return f"{pre_prompt}{prompt}{post_prompt}"
+
+
+def browsecomp_doc_to_target(doc) -> str:
+    password = _get_password(doc)
+    return _safe_decrypt(str(doc.get("answer", "")), password)
+
+
+def browsecomp_process_results(doc, results) -> dict:
+    response = results[0] if results else ""
+    if not isinstance(response, str):
+        response = str(response)
+
+    password = _get_password(doc)
+    question = _safe_decrypt(str(doc.get("problem", "")), password)
+    ground_truth = _safe_decrypt(str(doc.get("answer", "")), password)
+
+    extracted_answer = _extract_exact_answer(response)
+    confidence_score = _extract_confidence(response)
+
+    response_for_judge = extracted_answer if extracted_answer else response.strip()
+    judge_decision = _judge_is_correct(
+        question=question,
+        response=response_for_judge,
+        correct_answer=ground_truth,
+    )
+
+    if judge_decision is None:
+        is_correct = _normalize_for_exact_match(extracted_answer) == _normalize_for_exact_match(ground_truth)
+    else:
+        is_correct = bool(judge_decision)
+
+    return {
+        "browsecomp_acc": {
+            "question_topic": doc.get("problem_topic", "unknown"),
+            "prediction": extracted_answer,
+            "target": ground_truth,
+            "confidence": confidence_score,
+            "correct": float(is_correct),
+        }
+    }
+
+
+def browsecomp_aggregate_results(results) -> float:
+    if not results:
+        eval_logger.warning("No BrowseComp samples were provided for aggregation.")
+        return 0.0
+
+    topic_correct = defaultdict(float)
+    topic_total = defaultdict(int)
+    total_correct = 0.0
+
+    for sample in results:
+        topic = str(sample.get("question_topic", "unknown"))
+        correct = float(sample.get("correct", 0.0))
+        topic_total[topic] += 1
+        topic_correct[topic] += correct
+        total_correct += correct
+
+    total_count = len(results)
+    overall_accuracy = total_correct / total_count if total_count > 0 else 0.0
+
+    eval_logger.info("BrowseComp overall accuracy: {:.4f} ({}/{})", overall_accuracy, int(total_correct), total_count)
+    for topic in sorted(topic_total):
+        accuracy = topic_correct[topic] / topic_total[topic]
+        eval_logger.info("BrowseComp topic [{}] accuracy: {:.4f} ({}/{})", topic, accuracy, int(topic_correct[topic]), topic_total[topic])
+
+    return float(overall_accuracy)


### PR DESCRIPTION
## Summary

- Add **ARC-AGI-1** image benchmark task using community dataset `mertaylin/arc-agi-images` (400 eval samples, exact grid match)
- Add **ARC-AGI-2** image benchmark task using community dataset `vincentkoc/arc-agi-2` (120 eval samples, interleaved demo images)
- Add **BrowseComp** text benchmark task from OpenAI (1,266 encrypted samples, LLM-as-judge with exact match fallback)

## Details

### ARC-AGI-1 (`lmms_eval/tasks/arc_agi_1/`)
- Dataset: `mertaylin/arc-agi-images` (eval split)
- Uses stacked demo composite image + test input image
- Metric: `arc_agi_1_acc` (exact grid match, JSON array-of-arrays parsing)

### ARC-AGI-2 (`lmms_eval/tasks/arc_agi_2/`)
- Dataset: `vincentkoc/arc-agi-2` (evaluation split)
- Interleaves train input/output images as few-shot demos
- Metric: `arc_agi_2_acc` (exact grid match with `_normalize_grid` type coercion)

### BrowseComp (`lmms_eval/tasks/browsecomp/`)
- Dataset: OpenAI Azure blob CSV (XOR-encrypted to prevent contamination)
- Decryption at eval time using SHA256-derived key
- LLM-as-Judge scoring via `lmms_eval/llm_judge` when API configured; falls back to exact match
- Custom aggregation with per-topic accuracy breakdown
- Metric: `browsecomp_acc`

## Verification
- All 3 tasks discoverable via `--tasks list` ✅
- Python syntax check passed ✅
- `pre-commit run` (black + isort) passed ✅

## Linear Issues
Resolves LMM-306, LMM-307, LMM-273