### PR TITLE
fix: replace 113 bare excepts with except Exception

### DIFF
--- a/lmms_eval/models/simple/egogpt.py
+++ b/lmms_eval/models/simple/egogpt.py
@@ -226,7 +226,7 @@ class EgoGPT(lmms):
     def tok_decode(self, tokens):
         try:
             return self.tokenizer.decode(tokens)
-        except:
+        except Exception:
             return self.tokenizer.decode([tokens])
 
     def loglikelihood(self, requests: List[Instance]) -> List[Tuple[float, bool]]:

--- a/lmms_eval/models/simple/internvl.py
+++ b/lmms_eval/models/simple/internvl.py
@@ -394,7 +394,7 @@ class InternVLChat(lmms):
     def tok_decode(self, tokens):
         try:
             return self.tokenizer.decode(tokens)
-        except:
+        except Exception:
             return self.tokenizer.decode([tokens])
 
     def post_processing(self, response):

--- a/lmms_eval/models/simple/llava.py
+++ b/lmms_eval/models/simple/llava.py
@@ -205,7 +205,7 @@ class Llava(lmms):
     def tok_decode(self, tokens):
         try:
             return self.tokenizer.decode(tokens)
-        except:
+        except Exception:
             return self.tokenizer.decode([tokens])
 
     def loglikelihood(self, requests: List[Instance]) -> List[Tuple[float, bool]]:

--- a/lmms_eval/models/simple/llava_onevision.py
+++ b/lmms_eval/models/simple/llava_onevision.py
@@ -253,7 +253,7 @@ class Llava_OneVision(lmms):
     def tok_decode(self, tokens):
         try:
             return self.tokenizer.decode(tokens)
-        except:
+        except Exception:
             return self.tokenizer.decode([tokens])
 
     def loglikelihood(self, requests: List[Instance]) -> List[Tuple[float, bool]]:

--- a/lmms_eval/models/simple/llava_onevision_moviechat.py
+++ b/lmms_eval/models/simple/llava_onevision_moviechat.py
@@ -266,7 +266,7 @@ class Llava_OneVision_MovieChat(lmms):
     def tok_decode(self, tokens):
         try:
             return self.tokenizer.decode(tokens)
-        except:
+        except Exception:
             return self.tokenizer.decode([tokens])
 
     def loglikelihood(self, requests: List[Instance]) -> List[Tuple[float, bool]]:

--- a/lmms_eval/models/simple/longva.py
+++ b/lmms_eval/models/simple/longva.py
@@ -247,7 +247,7 @@ class LongVA(lmms):
     def tok_decode(self, tokens):
         try:
             return self.tokenizer.decode(tokens)
-        except:
+        except Exception:
             return self.tokenizer.decode([tokens])
 
     def loglikelihood(self, requests: List[Instance]) -> List[Tuple[float, bool]]:

--- a/lmms_eval/models/simple/mantis.py
+++ b/lmms_eval/models/simple/mantis.py
@@ -205,7 +205,7 @@ class Mantis(lmms):
     def tok_decode(self, tokens):
         try:
             return self.tokenizer.decode(tokens)
-        except:
+        except Exception:
             return self.tokenizer.decode([tokens])
 
     def loglikelihood(self, requests: List[Instance]) -> List[Tuple[float, bool]]:

--- a/lmms_eval/models/simple/moviechat.py
+++ b/lmms_eval/models/simple/moviechat.py
@@ -235,7 +235,7 @@ class MovieChat(lmms):
     def tok_decode(self, tokens):
         try:
             return self.tokenizer.decode(tokens)
-        except:
+        except Exception:
             return self.tokenizer.decode([tokens])
 
     def loglikelihood(self, requests: List[Instance]) -> List[Tuple[float, bool]]:

--- a/lmms_eval/models/simple/ola.py
+++ b/lmms_eval/models/simple/ola.py
@@ -65,7 +65,7 @@ try:
     from ola.model.language_model.ola_qwen import OlaConfigQwen
 
     AutoConfig.register("ola_qwen", OlaConfigQwen)
-except:
+except Exception:
     eval_logger.debug("")
 from moviepy.video.io.VideoFileClip import VideoFileClip
 

--- a/lmms_eval/models/simple/oryx.py
+++ b/lmms_eval/models/simple/oryx.py
@@ -42,7 +42,7 @@ try:
     from oryx.model.language_model.oryx_qwen import OryxQwenConfig
 
     AutoConfig.register("oryx_qwen", OryxQwenConfig)
-except:
+except Exception:
     eval_logger.debug("")
 
 

--- a/lmms_eval/models/simple/qwen_vl.py
+++ b/lmms_eval/models/simple/qwen_vl.py
@@ -254,7 +254,7 @@ class Qwen_VL(lmms):
             if "image_sizes" not in gen_kwargs:
                 try:
                     gen_kwargs["image_sizes"] = [visuals[0].size]
-                except:
+                except Exception:
                     gen_kwargs["image_sizes"] = None
             if "max_new_tokens" not in gen_kwargs:
                 gen_kwargs["max_new_tokens"] = 1024
@@ -299,7 +299,7 @@ class Qwen_VL(lmms):
                 for visual_path in visual_paths:
                     try:
                         os.remove(visual_path)
-                    except:
+                    except Exception:
                         pass
                 pbar.update(1)
             # reorder this group of results back to original unsorted form

--- a/lmms_eval/models/simple/qwen_vl_api.py
+++ b/lmms_eval/models/simple/qwen_vl_api.py
@@ -15,7 +15,7 @@ from loguru import logger as eval_logger
 
 try:
     import dashscope
-except:
+except Exception:
     eval_logger.debug("Can not import Dashscope")
 
 API_KEY = os.getenv("DASHSCOPE_API_KEY", "YOUR_API_KEY")

--- a/lmms_eval/models/simple/ross.py
+++ b/lmms_eval/models/simple/ross.py
@@ -205,7 +205,7 @@ class Ross(lmms):
     def tok_decode(self, tokens):
         try:
             return self.tokenizer.decode(tokens)
-        except:
+        except Exception:
             return self.tokenizer.decode([tokens])
 
     def loglikelihood(self, requests: List[Instance]) -> List[Tuple[float, bool]]:

--- a/lmms_eval/models/simple/slime.py
+++ b/lmms_eval/models/simple/slime.py
@@ -205,7 +205,7 @@ class Slime(lmms):
     def tok_decode(self, tokens):
         try:
             return self.tokenizer.decode(tokens)
-        except:
+        except Exception:
             return self.tokenizer.decode([tokens])
 
     def loglikelihood(self, requests: List[Instance]) -> List[Tuple[float, bool]]:

--- a/lmms_eval/models/simple/tinyllava.py
+++ b/lmms_eval/models/simple/tinyllava.py
@@ -180,7 +180,7 @@ class TinyLlava(lmms):
     def tok_decode(self, tokens):
         try:
             return self.tokenizer.decode(tokens)
-        except:
+        except Exception:
             return self.tokenizer.decode([tokens])
 
     def flatten(self, input):

--- a/lmms_eval/models/simple/video_chatgpt.py
+++ b/lmms_eval/models/simple/video_chatgpt.py
@@ -59,7 +59,7 @@ class VideoChatGPT(lmms):
             self.device_map = f"cuda:{accelerator.local_process_index}"
         try:
             self.model, self.vision_tower, self.tokenizer, self.image_processor, self.video_token_len = initialize_model(model_path, projection_path, device=self.device)
-        except:
+        except Exception:
             eval_logger.info("Does not find the model from the path you provide, try downloading from the hf repo.")
             model_path = snapshot_download(repo_id=model_path)
             projection_path = os.path.join(snapshot_download(repo_id=projection_path), "video_chatgpt-7B.bin")

--- a/lmms_eval/models/simple/videochat_flash.py
+++ b/lmms_eval/models/simple/videochat_flash.py
@@ -174,7 +174,7 @@ class VideoChat_Flash(lmms):
     def tok_decode(self, tokens):
         try:
             return self.tokenizer.decode(tokens)
-        except:
+        except Exception:
             return self.tokenizer.decode([tokens])
 
     def loglikelihood(self, requests: List[Instance]) -> List[Tuple[float, bool]]:

--- a/lmms_eval/models/simple/vita.py
+++ b/lmms_eval/models/simple/vita.py
@@ -201,7 +201,7 @@ class VITA(lmms):
     def tok_decode(self, tokens):
         try:
             return self.tokenizer.decode(tokens)
-        except:
+        except Exception:
             return self.tokenizer.decode([tokens])
 
     def loglikelihood(self, requests: List[Instance]) -> List[Tuple[float, bool]]:

--- a/lmms_eval/models/simple/vora.py
+++ b/lmms_eval/models/simple/vora.py
@@ -248,7 +248,7 @@ class VoRA(lmms):
                 for visual_path in visual_paths:
                     try:
                         os.remove(visual_path)
-                    except:
+                    except Exception:
                         pass
                 pbar.update(1)
             # reorder this group of results back to original unsorted form

--- a/lmms_eval/tasks/FALCONBench/utils.py
+++ b/lmms_eval/tasks/FALCONBench/utils.py
@@ -305,7 +305,7 @@ def evaluate_FALCONbench_gpteval(results):
         eval_score = result["score"]
         try:
             eval_score = int(eval_score)
-        except:
+        except Exception:
             eval_score = 0.0
         score += eval_score
 
@@ -314,7 +314,7 @@ def evaluate_FALCONbench_gpteval(results):
             eval_acc = str(eval_acc)
             if eval_acc == "yes":
                 acc += 1
-        except:
+        except Exception:
             acc += 0
     return {"score": score / len(results), "acc": acc / len(results)}
 

--- a/lmms_eval/tasks/gedit_bench/viescore/utils.py
+++ b/lmms_eval/tasks/gedit_bench/viescore/utils.py
@@ -227,12 +227,12 @@ def mllm_output_to_dict(input_string, give_up_parsing=False):
             new_data = json.loads(json_str)
             if not isinstance(new_data["score"], list):
                 new_data["score"] = [new_data["score"]]
-        except:
+        except Exception:
             print("Now fixing: ", json_str)
             try:
                 new_data = json.loads(fix_json(json_str))
                 return new_data
-            except:
+            except Exception:
                 print("Error: Cannot fix", json_str)
                 return False
         return new_data

--- a/lmms_eval/tasks/hallusion_bench/evaluate_hb.py
+++ b/lmms_eval/tasks/hallusion_bench/evaluate_hb.py
@@ -105,7 +105,7 @@ def hb_aggregation_result_intern(results, metric):
             key = "_".join([r["category"], r["subcategory"], str(r["set_id"]), str(r["question_id"])])
             try:
                 qlist[key].append(r["answer"] == r["gt_answer"])
-            except:
+            except Exception:
                 qlist[key] = [r["answer"] == r["gt_answer"]]
         out = []
         for q, v in qlist.items():
@@ -118,7 +118,7 @@ def hb_aggregation_result_intern(results, metric):
             key = "_".join([r["category"], r["subcategory"], str(r["set_id"]), str(r["figure_id"])])
             try:
                 qlist[key].append(r["answer"] == r["gt_answer"])
-            except:
+            except Exception:
                 qlist[key] = [r["answer"] == r["gt_answer"]]
         out = []
         for q, v in qlist.items():

--- a/lmms_eval/tasks/llava_interleave_bench/utils.py
+++ b/lmms_eval/tasks/llava_interleave_bench/utils.py
@@ -333,7 +333,7 @@ def overall_score(results):
 #                 result["gpt_eval_explanation"] = explanation
 #                 result["gpt_eval_rating"] = rating
 #                 result["gpt_eval_model_name"] = model_name
-#             except:
+#             except Exception:
 #                 eval_logger.error(f"Error on evaluating {result['sample_id']}. Results: {results}")
 #                 result["gpt_eval_explanation"] = ""
 #                 result["gpt_eval_rating"] = 0

--- a/lmms_eval/tasks/mathverse/utils.py
+++ b/lmms_eval/tasks/mathverse/utils.py
@@ -76,7 +76,7 @@ def mathverse_aggregate_results_submission(results, args, *, calculate_gain=Fals
     # Don't know why but this sometimes yields error so I hardcode it
     try:
         split_flag = results[0]["metadata"]["split"]
-    except:
+    except Exception:
         split_flag = "testmini"
     path = generate_submission_file(f"mathverse_{split_flag}_results.json", args)
     with open(path, "w") as f:

--- a/lmms_eval/tasks/mathvision/eval_utils.py
+++ b/lmms_eval/tasks/mathvision/eval_utils.py
@@ -123,7 +123,7 @@ def is_equal(asw: str, gt_asw: str) -> bool:
 
         else:
             return False
-    except:
+    except Exception:
         # If any error occurs during comparison, return False.
         return False
 
@@ -173,7 +173,7 @@ def extract_nums(s):
     for i in range(len(nums)):
         try:
             return_list.append(eval(nums[i].strip().lstrip(" 0")))
-        except:
+        except Exception:
             pass
     return return_list
 
@@ -236,7 +236,7 @@ def _fix_fracs(string):
                 # for numerator and denominator.
                 try:
                     assert len(substr) >= 2
-                except:
+                except Exception:
                     return string
 
                 a = substr[0]  # Potential numerator.
@@ -282,7 +282,7 @@ def _fix_a_slash_b(string):
         return new_string
 
     # Handle exceptions for non-integer fractions or other unexpected formats.
-    except:
+    except Exception:
         return string
 
 
@@ -398,7 +398,7 @@ def find_math_answer(s: str) -> str:
     try:
         pattern = re.compile("oxed{(.*)}", flags=re.S)
         ans = pattern.findall(s)[-1]
-    except:
+    except Exception:
         ans = s  # If the pattern is not found, consider the entire string as the answer.
 
     # If there's a closing bracket without an opening bracket before it, consider everything before it.

--- a/lmms_eval/tasks/mathvista/mathvista_evals.py
+++ b/lmms_eval/tasks/mathvista/mathvista_evals.py
@@ -283,7 +283,7 @@ class MathVistaEvaluator:
             else:
                 try:
                     extraction = str(extraction)
-                except:
+                except Exception:
                     extraction = ""
 
             # extract "A" from "(A) text"
@@ -305,19 +305,19 @@ class MathVistaEvaluator:
         elif answer_type == "integer":
             try:
                 extraction = str(int(float(extraction)))
-            except:
+            except Exception:
                 extraction = None
 
         elif answer_type == "float":
             try:
                 extraction = str(round(float(extraction), precision))
-            except:
+            except Exception:
                 extraction = None
 
         elif answer_type == "list":
             try:
                 extraction = str(extraction)
-            except:
+            except Exception:
                 extraction = None
 
         return extraction

--- a/lmms_eval/tasks/megabench/metrics/scoring/geo_proximity.py
+++ b/lmms_eval/tasks/megabench/metrics/scoring/geo_proximity.py
@@ -164,7 +164,7 @@ class GeoProximityLocationDict:
         """
         try:
             guess_coords = location_to_coords(**responses)
-        except:
+        except Exception:
             return 0
 
         if guess_coords is None:

--- a/lmms_eval/tasks/megabench/metrics/scoring/mse.py
+++ b/lmms_eval/tasks/megabench/metrics/scoring/mse.py
@@ -32,7 +32,7 @@ class NormalizedRMSE:
             rmse = np.clip(np.sqrt(mse_val), cls.MIN, cls.MAX)
             norm_rmse = 1 - (rmse - cls.MIN) / (cls.MAX - cls.MIN)
             return norm_rmse
-        except:
+        except Exception:
             # Usually Syntax, Type or Value errors, caused by wrong output formats
             return 0
 

--- a/lmms_eval/tasks/megabench/metrics/scoring/nbbox_iou.py
+++ b/lmms_eval/tasks/megabench/metrics/scoring/nbbox_iou.py
@@ -27,7 +27,7 @@ class NbboxIouTuple:
 
         try:
             iou_scores = calculate_iou(responses, targets)
-        except:
+        except Exception:
             return 0
 
         if not iou_scores:
@@ -63,7 +63,7 @@ class NbboxIouSingle:
             )
             if not iou_scores:
                 return 0
-        except:
+        except Exception:
             return 0
 
         # Take the mean IoU score for now.

--- a/lmms_eval/tasks/mmrefine/mmrefine_evals.py
+++ b/lmms_eval/tasks/mmrefine/mmrefine_evals.py
@@ -95,10 +95,10 @@ class MMRefineEvaluator:
                 eval_logger.error("Error in evaluating answer for problem")
             try:
                 solution_correctness = int(resp.strip())
-            except:
+            except Exception:
                 try:
                     solution_correctness = self.get_chat_response(PARSING_PROMPT.format(target="Output", model_response=resp), temperature=0, max_tokens=256, n=1)
-                except:
+                except Exception:
                     solution_correctness = 0
             return {
                 "solution_correctness": solution_correctness,
@@ -109,15 +109,15 @@ class MMRefineEvaluator:
                 resp = self.get_chat_response(full_prompt, temperature=0, max_tokens=1024, n=1)
                 try:
                     error_detection = int(self.get_chat_response(PARSING_PROMPT.format(target="Error Detection", model_response=resp), temperature=0, max_tokens=256, n=1).strip())
-                except:
+                except Exception:
                     error_detection = 0
                 try:
                     error_correction = int(self.get_chat_response(PARSING_PROMPT.format(target="Error Correction", model_response=resp), temperature=0, max_tokens=256, n=1).strip())
-                except:
+                except Exception:
                     error_correction = 0
                 try:
                     solution_correctness = int(self.get_chat_response(PARSING_PROMPT.format(target="Effectiveness and Correctness of the Feedback", model_response=resp), temperature=0, max_tokens=256, n=1).strip())
-                except:
+                except Exception:
                     solution_correctness = 0
             except Exception as e:
                 eval_logger.error(e)

--- a/lmms_eval/tasks/mmsearch/score/result_summary.py
+++ b/lmms_eval/tasks/mmsearch/score/result_summary.py
@@ -44,7 +44,7 @@ def get_result_summary(anno, result_list, summary_key):
                 area_dict=get_area_score(result_list, key),
                 subfield_dict=get_subfield_score(result_list, key, all_subfield),
             )
-        except:
+        except Exception:
             import pdb
 
             pdb.set_trace()

--- a/lmms_eval/tasks/moviechat/utils.py
+++ b/lmms_eval/tasks/moviechat/utils.py
@@ -247,7 +247,7 @@ def moviechat_aggregate_score(results, args):
         eval_score = result["score"]
         try:
             eval_score = int(eval_score)
-        except:
+        except Exception:
             eval_score = 0.0
 
         score += eval_score
@@ -263,7 +263,7 @@ def moviechat_aggregate_acc(results, args):
             eval_acc = str(eval_acc)
             if eval_acc == "yes":
                 acc += 1
-        except:
+        except Exception:
             acc += 0
 
     return acc / len(results)

--- a/lmms_eval/tasks/ocrbench_v2/IoUscore_metric.py
+++ b/lmms_eval/tasks/ocrbench_v2/IoUscore_metric.py
@@ -8,7 +8,7 @@ def calculate_iou(box1, box2):
     try:
         box1 = [int(coordinate) for coordinate in box1]
         box2 = [int(coordinate) for coordinate in box2]
-    except:
+    except Exception:
         return 0
 
     x1_inter = max(box1[0], box2[0])
@@ -37,7 +37,7 @@ def vqa_with_position_evaluation(predict, img_metas):
         try:
             predict_bbox_list = ast.literal_eval(predict["bbox"])
             score_bbox = calculate_iou(predict_bbox_list, gt_bbox)
-        except:
+        except Exception:
             score_bbox = 0
     return 0.5 * score_content + 0.5 * score_bbox
 

--- a/lmms_eval/tasks/ocrbench_v2/TEDS_metric.py
+++ b/lmms_eval/tasks/ocrbench_v2/TEDS_metric.py
@@ -253,7 +253,7 @@ def convert_str_to_dict(predict_str: str):
         try:
             for key, value in matches:
                 data[key.strip()] = value.strip()
-        except:
+        except Exception:
             return {}
 
     if not data:
@@ -261,7 +261,7 @@ def convert_str_to_dict(predict_str: str):
 
     try:
         result = {k.strip(): str(v).strip() for k, v in data.items()}
-    except:
+    except Exception:
         return {}
     return result
 
@@ -522,7 +522,7 @@ def get_anls(s1, s2):
     try:
         s1 = s1.lower()
         s2 = s2.lower()
-    except:
+    except Exception:
         pass
     if s1 == s2:
         return 1.0
@@ -649,7 +649,7 @@ def csv_eval(predictions, references, easy, pred_type="json"):
                 try:
                     num = float(c)
                     not_header = True
-                except:
+                except Exception:
                     continue
                 if not_header:
                     break
@@ -664,14 +664,14 @@ def csv_eval(predictions, references, easy, pred_type="json"):
             for i in range(1, len(values)):
                 try:
                     temp = [entity if entity[-1] != ":" else entity[:-1], ""]
-                except:
+                except Exception:
                     temp = [entity, ""]
                 if header is not None:
                     try:
                         this_header = header[i]
                         temp = [entity, this_header]
                         temp = [x if x[-1] != ":" else x[:-1] for x in temp]
-                    except:
+                    except Exception:
                         this_header = entity.strip()
                 value = values[i].strip()
                 value = re.sub(r"[^\d.-]", "", str(value))
@@ -756,7 +756,7 @@ def csv_eval(predictions, references, easy, pred_type="json"):
                     temp_gt_head = sorted(label[idx][:2])
                     pred[idx] = (temp_pred_head[0], temp_pred_head[1], pred[idx][2])
                     label[idx] = (temp_gt_head[0], temp_gt_head[1], label[idx][2])
-                except:
+                except Exception:
                     continue
             intersection = intersection_with_tolerance(pred, label, tol_word=tol_word, tol_num=tol_num)
             union = union_with_tolerance(pred, label, tol_word=tol_word, tol_num=tol_num)

--- a/lmms_eval/tasks/ocrbench_v2/spotting_eval/rrc_evaluation_funcs_1_1.py
+++ b/lmms_eval/tasks/ocrbench_v2/spotting_eval/rrc_evaluation_funcs_1_1.py
@@ -28,7 +28,7 @@ def load_zip_file_keys(file, fileNameRegExp=""):
     """
     try:
         archive = zipfile.ZipFile(file, mode="r", allowZip64=True)
-    except:
+    except Exception:
         raise Exception("Error loading the ZIP archive.")
 
     pairs = []
@@ -58,7 +58,7 @@ def load_zip_file(file, fileNameRegExp="", allEntries=False):
     """
     try:
         archive = zipfile.ZipFile(file, mode="r", allowZip64=True)
-    except:
+    except Exception:
         raise Exception("Error loading the ZIP archive")
 
     pairs = []
@@ -88,7 +88,7 @@ def decode_utf8(raw):
     """
     try:
         return raw.decode("utf-8-sig", errors="replace")
-    except:
+    except Exception:
         return None
 
 

--- a/lmms_eval/tasks/ocrbench_v2/spotting_eval/script.py
+++ b/lmms_eval/tasks/ocrbench_v2/spotting_eval/script.py
@@ -125,7 +125,7 @@ def evaluate_method(gtFilePath, submFilePath, evaluationParams):
     def get_intersection_over_union(pD, pG):
         try:
             return get_intersection(pD, pG) / get_union(pD, pG)
-        except:
+        except Exception:
             return 0
 
     def get_intersection(pD, pG):

--- a/lmms_eval/tasks/ocrbench_v2/utils.py
+++ b/lmms_eval/tasks/ocrbench_v2/utils.py
@@ -80,7 +80,7 @@ def is_nan_value(value):
 
         if pd.isna(value):
             return True
-    except:
+    except Exception:
         pass
     return False
 
@@ -203,7 +203,7 @@ def ocrbench_v2_process_results(doc, results):
                     gold_table_html = wrap_html_table(gt_ans[0])
                     try:
                         score = teds.evaluate(pred_table_html, gold_table_html)
-                    except:
+                    except Exception:
                         score = 0
 
             elif "markdown" in question.lower():
@@ -240,7 +240,7 @@ def ocrbench_v2_process_results(doc, results):
                 gold_table_html = wrap_html_table(gt_ans[0])
                 try:
                     score = teds.evaluate(pred_table_html, gold_table_html)
-                except:
+                except Exception:
                     score = 0
                     print("error")
 

--- a/lmms_eval/tasks/ocrbench_v2/vqa_metric.py
+++ b/lmms_eval/tasks/ocrbench_v2/vqa_metric.py
@@ -28,7 +28,7 @@ def vqa_evaluation(predict, answers):
                 answers[j] = str(answers[j])
             try:
                 answer = answers[j].lower().strip().replace("\n", " ")
-            except:
+            except Exception:
                 ipdb.set_trace()
             if isinstance(predict, (int, float)):
                 predict = str(predict)
@@ -71,7 +71,7 @@ def cn_vqa_evaluation(predict, answers):
                 answers[j] = str(answers[j])
             try:
                 answer = answers[j].lower().strip().replace("\n", " ").replace(" ", "")
-            except:
+            except Exception:
                 ipdb.set_trace()
             if isinstance(predict, (int, float)):
                 predict = str(predict)
@@ -114,7 +114,7 @@ def vqa_evaluation_case_sensitive(predict, answers):
                 answers[j] = str(answers[j])
             try:
                 answer = answers[j].strip().replace("\n", " ")
-            except:
+            except Exception:
                 ipdb.set_trace()
             predict = predict.strip().replace("\n", " ")
             if len(answer.split()) < 5:

--- a/lmms_eval/tasks/olympiadbench/cn_utils.py
+++ b/lmms_eval/tasks/olympiadbench/cn_utils.py
@@ -9,7 +9,7 @@ dir_name = os.path.dirname(os.path.abspath(__file__))
 
 try:
     olympiadbench_evaluator = OlympiadBenchEvaluator()
-except:
+except Exception:
     pass
 
 

--- a/lmms_eval/tasks/olympiadbench/olympiadbench_evals.py
+++ b/lmms_eval/tasks/olympiadbench/olympiadbench_evals.py
@@ -76,7 +76,7 @@ class OlympiadBenchEvaluator:
 
         try:
             expression1, expression2 = self.preprocess(expression1, expression2)
-        except:
+        except Exception:
             return False
         if expression1 == expression2:
             # print("Exactly equal")
@@ -139,7 +139,7 @@ class OlympiadBenchEvaluator:
                 if self.interval_equal(expression1, expression2):
                     # print("Interval equivalent")
                     return True
-            except:
+            except Exception:
                 return False
 
         # Then check for numerical equality
@@ -147,21 +147,21 @@ class OlympiadBenchEvaluator:
             if self.numerical_equal(expression1, expression2):
                 # print("Numerically equivalent")
                 return True
-        except:
+        except Exception:
             pass
         # Then check if expressions are mathematically equal
         try:
             if self.expression_equal(expression1, expression2) and not ("=" in expression1 and "=" in expression2):
                 # print("Expression equivalent")
                 return True
-        except:
+        except Exception:
             pass
         # Lastly, check for equation equality
         try:
             if self.equation_equal(expression1, expression2):
                 # print("Equation equivalent")
                 return True
-        except:
+        except Exception:
             pass
         return False
 
@@ -211,7 +211,7 @@ class OlympiadBenchEvaluator:
                         return True
                     else:
                         return False
-                except:
+                except Exception:
                     return False
             else:
                 try:
@@ -219,7 +219,7 @@ class OlympiadBenchEvaluator:
 
                     num_value = simplified_expr.evalf()
                     return abs(num_value) < 1e-3
-                except:
+                except Exception:
                     return False
 
     def equation_equal(self, expression1, expression2):

--- a/lmms_eval/tasks/olympiadbench_mimo/olympiadbench_evals.py
+++ b/lmms_eval/tasks/olympiadbench_mimo/olympiadbench_evals.py
@@ -78,7 +78,7 @@ class OlympiadBenchEvaluator:
 
         try:
             expression1, expression2 = self.preprocess(expression1, expression2)
-        except:
+        except Exception:
             return False
         if expression1 == expression2:
             # print("Exactly equal")
@@ -141,7 +141,7 @@ class OlympiadBenchEvaluator:
                 if self.interval_equal(expression1, expression2):
                     # print("Interval equivalent")
                     return True
-            except:
+            except Exception:
                 return False
 
         # Then check for numerical equality
@@ -149,21 +149,21 @@ class OlympiadBenchEvaluator:
             if self.numerical_equal(expression1, expression2):
                 # print("Numerically equivalent")
                 return True
-        except:
+        except Exception:
             pass
         # Then check if expressions are mathematically equal
         try:
             if self.expression_equal(expression1, expression2) and not ("=" in expression1 and "=" in expression2):
                 # print("Expression equivalent")
                 return True
-        except:
+        except Exception:
             pass
         # Lastly, check for equation equality
         try:
             if self.equation_equal(expression1, expression2):
                 # print("Equation equivalent")
                 return True
-        except:
+        except Exception:
             pass
         return False
 
@@ -213,7 +213,7 @@ class OlympiadBenchEvaluator:
                         return True
                     else:
                         return False
-                except:
+                except Exception:
                     return False
             else:
                 try:
@@ -221,7 +221,7 @@ class OlympiadBenchEvaluator:
 
                     num_value = simplified_expr.evalf()
                     return abs(num_value) < 1e-3
-                except:
+                except Exception:
                     return False
 
     def equation_equal(self, expression1, expression2):

--- a/lmms_eval/tasks/openai_math/utils.py
+++ b/lmms_eval/tasks/openai_math/utils.py
@@ -232,7 +232,7 @@ def process_docs_openai_math_cot_quality_check(dataset: datasets.Dataset) -> dat
             if getattr(doc, "few_shot", None) is not None:
                 out_doc["few_shot"] = True
             return out_doc
-        except:
+        except Exception:
             return {"problem": "Drop", "solution": "Drop", "answer": "Drop", "thinking_trajectory": ["Drop"]}
 
     processed_dataset = dataset.map(_process_doc)

--- a/lmms_eval/tasks/plm_videobench/rcap/rcap_utils.py
+++ b/lmms_eval/tasks/plm_videobench/rcap/rcap_utils.py
@@ -63,7 +63,7 @@ def plm_rcap_process_results(doc, results):
     try:
         judgement = json.loads(llm_response)
         success = 1
-    except:
+    except Exception:
         success = 0
         judgement = {"score": 0, "explanation": "N/A"}
 

--- a/lmms_eval/tasks/plm_videobench/rdcap/rdcap_utils.py
+++ b/lmms_eval/tasks/plm_videobench/rdcap/rdcap_utils.py
@@ -72,7 +72,7 @@ def plm_rdcap_process_results(doc, results):
             # Parse LLM judge outputs
             try:
                 judgement = json.loads(llm_response)
-            except:
+            except Exception:
                 judgement = {"score": 0, "explanation": "N/A"}
             score = judgement["score"] / 10
             scores.append(score)

--- a/lmms_eval/tasks/plm_videobench/rtloc/rtloc_utils.py
+++ b/lmms_eval/tasks/plm_videobench/rtloc/rtloc_utils.py
@@ -62,7 +62,7 @@ def plm_rtloc_process_results(doc, results):
         pred_window = re.findall(r"(\[[0-9]+(?:\.[0-9]+)?,\s*[0-9]+(?:\.[0-9]+)?\])", pred)[0]
         pred_segment = np.array([ast.literal_eval(pred_window)])
         parse_error = 0
-    except:
+    except Exception:
         pred_segment = np.array([[doc["end_frame"] + 10, doc["end_frame"] + 20]])
         parse_error = 1
 

--- a/lmms_eval/tasks/plm_videobench/sgqa/sgqa_utils.py
+++ b/lmms_eval/tasks/plm_videobench/sgqa/sgqa_utils.py
@@ -52,7 +52,7 @@ def plm_sgqa_process_results(doc, results):
 
     try:
         judgement = json.loads(llm_response)
-    except:
+    except Exception:
         if "yes" in llm_response or "Yes" in llm_response:
             judgement = {"pred": "yes", "reason": "parse_error"}
         else:

--- a/lmms_eval/tasks/scibench/utils.py
+++ b/lmms_eval/tasks/scibench/utils.py
@@ -16,7 +16,7 @@ def remove_boxed(s):
         if "=" in answer:
             answer = answer.split("=")[-1].lstrip(" ")
         return answer
-    except:
+    except Exception:
         return None
 
 
@@ -76,7 +76,7 @@ def cal_not(inputs):
         out = float(x) * 10 ** float(ab)
         # print(float(x)*10**float(ab))
         return str(out)
-    except:
+    except Exception:
         print("error")
     return inputs
 
@@ -102,7 +102,7 @@ def parse_not(inputs):
         else:
             return inputs
         return x, ab
-    except:
+    except Exception:
         return "", ""
 
 
@@ -113,13 +113,13 @@ def equiv_with_unit(model_output, answer, unit):
     try:
         ans = float(clean_number_string(answer))
         first = isclose(float(model_output.strip()), ans, rel_tol=0.05)
-    except:
+    except Exception:
         first = False
 
     try:
         model = model_output.strip().split()[0]
         second = isclose(float(model.strip()), ans, rel_tol=0.05)
-    except:
+    except Exception:
         second = False
 
     return first or second

--- a/lmms_eval/tasks/sparbench/utils.py
+++ b/lmms_eval/tasks/sparbench/utils.py
@@ -286,13 +286,13 @@ def sparbench_process_results(doc, results):
         for key, value in METRICS_FOR_NA.items():
             try:
                 doc[key] = eval(value)(to_float(process_na(doc["prediction"], doc["task"])), to_float(doc["answer"]))
-            except:
+            except Exception:
                 doc[key] = WORST_CASE_FOR_METRICS[key]
     elif doc["task"] in SPECIAL_QUESTION_TYPES:
         if doc["task"] == "view_change_infer":
             try:
                 doc["vci_metric"] = compute_vci_metric(doc["prediction"], doc["answer"])
-            except:
+            except Exception:
                 doc["vci_metric"] = 0
 
     else:

--- a/lmms_eval/tasks/stare/utils.py
+++ b/lmms_eval/tasks/stare/utils.py
@@ -103,7 +103,7 @@ def stare_doc_to_visual(doc):
     """
     try:
         [visual.convert("RGB") for visual in doc["images"]]
-    except:
+    except Exception:
         print("Not successful.")
         print(doc["qid"])
     return [visual.convert("RGB") for visual in doc["images"]]

--- a/lmms_eval/tasks/tempcompass/utils.py
+++ b/lmms_eval/tasks/tempcompass/utils.py
@@ -397,7 +397,7 @@ def get_llm_output_for_captioning(prompt):
     token_count = dict_result["usage"]
     try:
         llm_output = dict_result["choices"][0]["message"]["content"].strip()
-    except:
+    except Exception:
         if "error" in dict_result and dict_result["error"]["type"] == "invalid_request_error":
             llm_output = "invalid_request_error"
         else:
@@ -413,7 +413,7 @@ def get_eval_result_for_captioning(prompt, mc_answer, maxtry=10):
             eval_result = parse_llm_output_for_captioning(llm_output, gt_answer=mc_answer)
             eval_result["token_count"] = token_count
             return eval_result
-        except:
+        except Exception:
             if maxtry <= 0:
                 eval_result = {"chatgpt-reasoning": None, "chatgpt-answer": None, "rating": -1, "token_count": None}
                 return eval_result
@@ -465,7 +465,7 @@ def get_eval_result(prompt, maxtry=10, sys_prompt=None):
             llm_output = get_llm_output(prompt, sys_prompt)
             rating = llm_output_to_rating(llm_output)
             return llm_output, rating
-        except:
+        except Exception:
             if maxtry <= 0:
                 return llm_output, 0
             maxtry -= 1

--- a/lmms_eval/tasks/vdc/utils.py
+++ b/lmms_eval/tasks/vdc/utils.py
@@ -318,7 +318,7 @@ def vdc_aggregate_score(results, args):
         eval_score = result["score"]
         try:
             eval_score = float(eval_score)
-        except:
+        except Exception:
             eval_score = 0.0
 
         score += eval_score
@@ -332,7 +332,7 @@ def vdc_aggregate_acc(results, args):
         eval_acc = result["acc"]
         try:
             eval_acc = float(eval_acc)
-        except:
+        except Exception:
             eval_acc = 0.0
         acc += eval_acc
 

--- a/lmms_eval/tasks/video-tt/utils.py
+++ b/lmms_eval/tasks/video-tt/utils.py
@@ -95,7 +95,7 @@ def videott_doc_to_text_audio(doc, lmms_eval_specific_kwargs=None):
     try:
         with open(audio_path) as f:
             subtitle = f.read()
-    except:
+    except Exception:
         subtitle = ""
     question = doc["question"] + "\n" + doc["question_prompt"]
     post_prompt = lmms_eval_specific_kwargs["post_prompt"] if "post_prompt" in lmms_eval_specific_kwargs else "The best answer is:"

--- a/lmms_eval/tasks/video_detail_description/utils.py
+++ b/lmms_eval/tasks/video_detail_description/utils.py
@@ -210,7 +210,7 @@ def video_detail_description_aggregate_score(results, args):
         eval_score = result["score"]
         try:
             eval_score = int(eval_score)
-        except:
+        except Exception:
             eval_score = 0.0
 
         score += eval_score

--- a/lmms_eval/tasks/videomathqa/utils.py
+++ b/lmms_eval/tasks/videomathqa/utils.py
@@ -156,7 +156,7 @@ def videomathqa_doc_to_text_subtitle(doc, lmms_eval_specific_kwargs=None):
                     raw_text = subtitle_by_frame[idx][2]
                     try:
                         textlist.append(raw_text)
-                    except:
+                    except Exception:
                         continue
                 subtitle_text = "\n".join(textlist)
         else:
@@ -179,7 +179,7 @@ def videomathqa_doc_to_text_subtitle(doc, lmms_eval_specific_kwargs=None):
                     raw_text = subtitle_by_frame[idx][2]
                     try:
                         textlist.append(raw_text)
-                    except:
+                    except Exception:
                         continue
                 subtitle_text = "\n".join(textlist)
         subtitle = subtitle_text

--- a/lmms_eval/tasks/videomme/utils.py
+++ b/lmms_eval/tasks/videomme/utils.py
@@ -235,7 +235,7 @@ def videomme_doc_to_text_subtitle(doc, lmms_eval_specific_kwargs=None):
                     raw_text = re.findall(pattern, subtitle_by_frame[idx][2])
                     try:
                         textlist.append(raw_text[0])
-                    except:
+                    except Exception:
                         continue
                 subtitle_text = "\n".join(textlist)
         subtitle = subtitle_text

--- a/lmms_eval/tasks/visualwebbench/utils.py
+++ b/lmms_eval/tasks/visualwebbench/utils.py
@@ -80,7 +80,7 @@ def visualwebbench_process_results_accuracy(doc, results):
             cur_pred = ord(cur_pred) - ord("A")
         else:
             cur_pred = -1
-    except:
+    except Exception:
         cur_pred = -1
 
     is_correct = cur_pred == gold
@@ -166,7 +166,7 @@ def eval_action_prediction(preds, golds, **kwargs):
                 cur_pred = ord(cur_pred) - ord("A")
             else:
                 cur_pred = -1
-        except:
+        except Exception:
             cur_pred = -1
         results.append(cur_pred == gold)
 
@@ -182,7 +182,7 @@ def eval_element_ground(preds, golds, **kwargs):
                 cur_pred = ord(cur_pred) - ord("A")
             else:
                 cur_pred = -1
-        except:
+        except Exception:
             cur_pred = -1
         results.append(cur_pred == gold)
 
@@ -198,7 +198,7 @@ def eval_action_ground(preds, golds, **kwargs):
                 cur_pred = ord(cur_pred) - ord("A")
             else:
                 cur_pred = -1
-        except:
+        except Exception:
             cur_pred = -1
         results.append(cur_pred == gold)
 
@@ -214,7 +214,7 @@ def eval_webqa(preds, golds, **kwargs):
                 pred = " "
             cur_f1 = max([rouge.get_scores([pred], [gold], avg=True)["rouge-1"]["f"] for gold in gold_list])
             f1_scores.append(cur_f1)
-        except:
+        except Exception:
             pass
 
     return dict(f1=sum(f1_scores) / len(f1_scores) * 100)

--- a/lmms_eval/tasks/vitatecs/utils.py
+++ b/lmms_eval/tasks/vitatecs/utils.py
@@ -167,7 +167,7 @@ def get_eval_result(prompt, maxtry=10, sys_prompt=None):
             llm_output = get_llm_output(prompt, sys_prompt)
             rating = llm_output_to_rating(llm_output)
             return llm_output, rating
-        except:
+        except Exception:
             if maxtry <= 0:
                 return llm_output, 0
             maxtry -= 1

--- a/lmms_eval/tasks/voicebench/utils.py
+++ b/lmms_eval/tasks/voicebench/utils.py
@@ -49,10 +49,10 @@ def voicebench_doc_to_audio(doc):
                     elif str(type(audio_array).__name__) == "Tensor":
                         try:
                             audio_array = audio_array.cpu().numpy()
-                        except:
+                        except Exception:
                             try:
                                 audio_array = audio_array.detach().cpu().numpy()
-                            except:
+                            except Exception:
                                 audio_array = np.array(audio_array)
 
                     sampling_rate = 16000  # default


### PR DESCRIPTION
Replace 113 bare `except:` with `except Exception:` across 58 files. Bare `except:` catches `KeyboardInterrupt` and `SystemExit`, masking real errors and preventing clean process termination during long evaluation runs.