### PR TITLE
fix: include task resources in pip package + version-aware response cache

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,6 +150,7 @@ all = [
 ]
 
 [tool.setuptools.package-data]
+"lmms_eval" = ["**/*.yaml", "**/*.yml", "**/*.json", "**/*.txt"]
 "lmms_eval.tui.web.dist" = ["**/*"]
 "lmms_eval.tui.web.dist.assets" = ["**/*"]
 


### PR DESCRIPTION
## Summary

Two fixes for the v0.7.0 release:

### 1. Include task YAML/JSON resource files in pip package

Fixes #1215 — `lmms-eval --tasks list` returns empty list after `pip install lmms-eval`.

**Root cause**: `[tool.setuptools.package-data]` in `pyproject.toml` did not include task config files (YAML, JSON, etc.), so the built wheel shipped zero task definitions.

**Fix**: Add a single package-data glob to include `*.yaml`, `*.yml`, `*.json`, and `*.txt` files from the `lmms_eval` package tree.

**Verification**: Built the wheel locally and confirmed:
- **1530 YAML** task configs now included (was 0)
- **13 JSON** rule/prompt/data files now included (was 0)
- All existing TUI web dist assets remain unaffected

### 2. Track lmms-eval version in response cache

The response cache previously had no awareness of which lmms-eval version generated a cached entry. After upgrading, stale cached responses could silently be reused even if evaluation logic changed.

**Changes**:
- `get_lmms_eval_cache_version()` in `utils.py` — returns PyPI version for pip installs, git commit hash for source/editable installs
- `eval_version` field added to cache key payload (schema v2 → v3) — version changes automatically produce cache misses
- `eval_version` stored in SQLite meta table for auditability
- `eval_version` written to every JSONL audit log record
- Startup warning when the cache was created by a different version

**Behavior**:
- PyPI users: cache auto-invalidates on version upgrade (e.g., `0.7.0` → `0.7.1`)
- Dev users: cache auto-invalidates on every new commit
- Old entries are NOT deleted, they simply stop matching — users can manually clean up

### 3. Remove unused `.claude-plugin/marketplace.json`

Dead config file referencing a non-functional plugin distribution manifest. The repo already has `AGENTS.md` for agent guidance.