### PR TITLE
fix: accept `model` as alias for `model_version` and warn on unknown kwargs in openai backends

### DIFF
--- a/lmms_eval/models/chat/async_openai.py
+++ b/lmms_eval/models/chat/async_openai.py
@@ -77,8 +77,7 @@ class AsyncOpenAIChat(lmms):
         if model is not None:
             model_version = model
         if kwargs:
-            eval_logger.warning(f"Unknown model_args ignored: {list(kwargs.keys())}. "
-                                f"Check the supported parameters for the 'async_openai' backend.")
+            eval_logger.warning(f"Unknown model_args ignored: {list(kwargs.keys())}. " f"Check the supported parameters for the 'async_openai' backend.")
         self.model_version = model_version
         self.timeout = timeout
         self.retry_backoff_s = max(0.0, float(1.0 if retry_backoff_s is None else retry_backoff_s))

--- a/lmms_eval/models/simple/openai.py
+++ b/lmms_eval/models/simple/openai.py
@@ -105,8 +105,7 @@ class OpenAICompatible(lmms):
         if model is not None:
             model_version = model
         if kwargs:
-            eval_logger.warning(f"Unknown model_args ignored: {list(kwargs.keys())}. "
-                                f"Check the supported parameters for the 'openai' backend.")
+            eval_logger.warning(f"Unknown model_args ignored: {list(kwargs.keys())}. " f"Check the supported parameters for the 'openai' backend.")
         self.model_version = model_version
         self.timeout = timeout
         self.retry_backoff_s = max(0.0, float(retry_backoff_s))


### PR DESCRIPTION
## Summary
- Accept both `model` and `model_version` in `--model_args` for the `openai` and `async_openai` backends
- Log a warning when unknown keyword arguments are silently ignored by `**kwargs`

## Problem

When users run:
```bash
python -m lmms_eval --model openai --model_args model=gpt-4o --tasks mme
```

The `model=gpt-4o` kwarg is silently captured by `**kwargs` and discarded, because the constructor parameter is named `model_version`. The model falls back to the default value `grok-2-latest` with no warning.

This is a common pitfall — the project's own README uses `model=gpt-4o` in its example (line 562), and other backends like `vllm` and `sglang` use `model` as the parameter name. The OpenAI API itself calls the field `model`.

## Fix

**1. `model` alias** — Add `model` as an explicit parameter that aliases to `model_version` in both:
- `lmms_eval/models/simple/openai.py` (`OpenAICompatible`)
- `lmms_eval/models/chat/async_openai.py` (`AsyncOpenAIChat`)

When `model` is provided, it populates `model_version`. If `model_version` is explicitly provided, it still works as before.

**2. Unknown kwargs warning** — When unexpected keyword arguments are passed via `--model_args`, log a warning instead of silently discarding them. This prevents future parameter-name mismatches from going unnoticed.

## Test
- [x] `--model_args model=gpt-4o` now correctly sets the model (previously fell back to `grok-2-latest`)
- [x] `--model_args model_version=gpt-4o` continues to work as before
- [x] Default behavior (no model arg) unchanged
- [x] `--model_args typo_param=foo` now produces a visible warning in logs
