### PR TITLE
Add fps attribute to Llava_OneVision1_5 class

### DIFF
--- a/lmms_eval/models/chat/llava_onevision1_5.py
+++ b/lmms_eval/models/chat/llava_onevision1_5.py
@@ -22,6 +22,7 @@ process_vision_info, _ = optional_import("qwen_vl_utils", "process_vision_info")
 @register_model("llava_onevision1_5_chat")
 class Llava_OneVision1_5(LlavaOneVisionSimple):
     is_simple = False
+    fps = None
 
     def generate_until(self, requests: List[Instance]) -> List[GenerationResult]:
         assert process_vision_info is not None, "qwen_vl_utils is required. Please install it via `pip install qwen-vl-utils`"


### PR DESCRIPTION
## Summary
- Set default `fps=None` for the LLaVA-OneVision model configuration.
- Avoid unintended frame sampling when FPS is not explicitly specified.
- Align default behavior with upstream expectation for video inputs.

## In scope
- Modify default configuration of `LLaVA-OneVision` to set `fps=None`.
- Ensure the model does not apply implicit FPS-based frame sampling when loading videos.

## Out of scope
- No changes to model architecture or inference pipeline.
- No changes to dataset preprocessing or video decoding logic.

## Validation
- `accelerate launch --num_processes=8 --main_process_port 12399 -m lmms_eval \
    --model=llava_onevision1_5 \
    --model_args=pretrained=lmms-lab/LLaVA-OneVision-1.5-8B-Instruct,attn_implementation=flash_attention_2,max_pixels=3240000 \
    --tasks=mmmu_val,mmmu_pro_standard,mmbench_en_test,mmerealworld,mmerealworld_cn,ai2d,ai2d_no_mask,vstar_bench,chartqa,charxiv,docvqa_test,mathvista_testmini,mmstar,scienceqa \
    --batch_size=1` 

## Risk / Compatibility
- Behavior change if downstream code relied on implicit FPS defaults.
- Backward compatible for users who explicitly set `fps`.

## Type of Change
- [ ] Bug fix (non-breaking change)
- [x] New feature
- [ ] New benchmark/task
- [x] New model integration
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring (no functional changes)