### PR TITLE
fix(examples): use torchrun for vllm data parallel

### DIFF
--- a/examples/models/vllm_qwen35.sh
+++ b/examples/models/vllm_qwen35.sh
@@ -4,6 +4,7 @@ MODEL="Qwen/Qwen3.5-397B-A17B"
 TASKS="mmmu_val,mme"
 
 TENSOR_PARALLEL_SIZE=8
+DATA_PARALLEL_SIZE=1
 GPU_MEMORY_UTILIZATION=0.85
 BATCH_SIZE=16
 MAX_MODEL_LEN=262144
@@ -15,9 +16,17 @@ REASONING_PARSER="qwen3"
 OUTPUT_PATH="./logs/qwen35_vllm"
 LOG_SUFFIX="qwen35_vllm"
 
-CMD="uv run python -m lmms_eval \
+LAUNCHER="uv run python -m lmms_eval"
+MODEL_ARGS="model=${MODEL},tensor_parallel_size=${TENSOR_PARALLEL_SIZE},gpu_memory_utilization=${GPU_MEMORY_UTILIZATION},max_model_len=${MAX_MODEL_LEN},reasoning_parser=${REASONING_PARSER}"
+
+if [ "${DATA_PARALLEL_SIZE}" -gt 1 ]; then
+    LAUNCHER="uv run python -m torch.distributed.run --standalone --nproc_per_node=$((TENSOR_PARALLEL_SIZE * DATA_PARALLEL_SIZE)) -m lmms_eval"
+    MODEL_ARGS="${MODEL_ARGS},data_parallel_size=${DATA_PARALLEL_SIZE}"
+fi
+
+CMD="${LAUNCHER} \
     --model vllm \
-    --model_args model=${MODEL},tensor_parallel_size=${TENSOR_PARALLEL_SIZE},gpu_memory_utilization=${GPU_MEMORY_UTILIZATION},max_model_len=${MAX_MODEL_LEN},reasoning_parser=${REASONING_PARSER} \
+    --model_args ${MODEL_ARGS} \
     --tasks ${TASKS} \
     --batch_size ${BATCH_SIZE} \
     --log_samples --log_samples_suffix ${LOG_SUFFIX} \
@@ -27,4 +36,4 @@ echo "Running command:"
 echo "$CMD"
 echo ""
 
-eval $CMD
+eval "$CMD"

--- a/examples/models/vllm_qwen3vl.sh
+++ b/examples/models/vllm_qwen3vl.sh
@@ -26,9 +26,10 @@
 MODEL="Qwen/Qwen3-VL-30B-A3B-Instruct"
 
 # Parallelization Settings
-# Adjust based on your GPU configuration
+# Adjust based on your GPU configuration.
+# If DATA_PARALLEL_SIZE > 1, this script automatically switches to torchrun.
 TENSOR_PARALLEL_SIZE=4  # Number of GPUs for tensor parallelism
-DATA_PARALLEL_SIZE=1     # Number of GPUs for data parallelism
+DATA_PARALLEL_SIZE=1    # Number of model replicas for data parallelism
 
 # Memory and Performance Settings
 GPU_MEMORY_UTILIZATION=0.85  # Fraction of GPU memory to use (0.0 - 1.0)
@@ -68,10 +69,17 @@ echo "Batch Size: $BATCH_SIZE"
 echo "Output Path: $OUTPUT_PATH"
 echo "=========================================="
 
-# Build the command
-CMD="uv run python -m lmms_eval \
+LAUNCHER="uv run python -m lmms_eval"
+MODEL_ARGS="model=${MODEL},tensor_parallel_size=${TENSOR_PARALLEL_SIZE},gpu_memory_utilization=${GPU_MEMORY_UTILIZATION}"
+
+if [ "${DATA_PARALLEL_SIZE}" -gt 1 ]; then
+    LAUNCHER="uv run python -m torch.distributed.run --standalone --nproc_per_node=$((TENSOR_PARALLEL_SIZE * DATA_PARALLEL_SIZE)) -m lmms_eval"
+    MODEL_ARGS="${MODEL_ARGS},data_parallel_size=${DATA_PARALLEL_SIZE}"
+fi
+
+CMD="${LAUNCHER} \
     --model vllm \
-    --model_args model=${MODEL},tensor_parallel_size=${TENSOR_PARALLEL_SIZE},data_parallel_size=${DATA_PARALLEL_SIZE},gpu_memory_utilization=${GPU_MEMORY_UTILIZATION} \
+    --model_args ${MODEL_ARGS} \
     --tasks ${TASKS} \
     --batch_size ${BATCH_SIZE} \
     --output_path ${OUTPUT_PATH}"


### PR DESCRIPTION
## Summary

This PR narrows the change to the vLLM example scripts only.

Recent vLLM versions require explicit multi-process launching for offline data parallel inference. A single-process `python -m lmms_eval` invocation cannot simply turn on `data_parallel_size > 1` anymore. The examples should reflect that supported launch mode.

## What changed

The Qwen vLLM examples now switch to `torchrun --standalone --nproc_per_node=<tp*dp>` whenever `DATA_PARALLEL_SIZE > 1` is requested.

Specifically:

- `examples/models/vllm_qwen35.sh`
- `examples/models/vllm_qwen3vl.sh`

Both scripts still keep the simple single-process path for the default `DATA_PARALLEL_SIZE=1` case.

## Why this helps

Without this change, users can reasonably infer that setting `data_parallel_size` inside `model_args` is enough for offline vLLM evaluation. On current vLLM versions, that is misleading for data-parallel launches.

Updating the examples makes the supported path explicit while keeping the examples easy to run for the common single-process case.

## Validation

I validated the updated example scripts with:

- `bash -n examples/models/vllm_qwen35.sh examples/models/vllm_qwen3vl.sh`

