### PR TITLE
fix(tasks): remove hardcoded longvideobench cache path

### DIFF
--- a/lmms_eval/api/task.py
+++ b/lmms_eval/api/task.py
@@ -986,8 +986,7 @@ class ConfigurableTask(Task):
             if "video" in dataset_kwargs and dataset_kwargs["video"]:
                 hf_home = os.getenv("HF_HOME", "~/.cache/huggingface/")
                 hf_home = os.path.expanduser(hf_home)
-                cache_dir = dataset_kwargs["cache_dir"]
-                cache_dir = os.path.join(hf_home, cache_dir)
+                cache_dir = utils.resolve_cache_dir(dataset_kwargs["cache_dir"], base_dir=hf_home)
                 accelerator = Accelerator()
                 if accelerator.is_main_process:
                     force_download = dataset_kwargs.get("force_download", False)

--- a/lmms_eval/tasks/longvideobench/longvideobench_test_i.yaml
+++ b/lmms_eval/tasks/longvideobench/longvideobench_test_i.yaml
@@ -1,7 +1,7 @@
 dataset_path: longvideobench/LongVideoBench
 dataset_kwargs:
   token: True
-  cache_dir: /mnt/vast/cache/huggingface/datasets
+  cache_dir: datasets/longvideobench
   video: True
   force_download: False
   local_files_only: False
@@ -26,4 +26,3 @@ lmms_eval_specific_kwargs:
     pre_prompt: ""
     post_prompt: "Answer with the option's letter from the given choices directly.\n"
     insert_interleave_subtitles: True
-    

--- a/lmms_eval/tasks/longvideobench/longvideobench_test_v.yaml
+++ b/lmms_eval/tasks/longvideobench/longvideobench_test_v.yaml
@@ -1,7 +1,7 @@
 dataset_path: longvideobench/LongVideoBench
 dataset_kwargs:
   token: True
-  cache_dir: /mnt/vast/cache/huggingface/datasets
+  cache_dir: datasets/longvideobench
   video: True
   force_download: False
   local_files_only: False
@@ -25,4 +25,3 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: "Answer with the option's letter from the given choices directly.\n"
-  

--- a/lmms_eval/tasks/longvideobench/longvideobench_val_i.yaml
+++ b/lmms_eval/tasks/longvideobench/longvideobench_val_i.yaml
@@ -1,7 +1,7 @@
 dataset_path: longvideobench/LongVideoBench
 dataset_kwargs:
   token: True
-  cache_dir: /mnt/vast/cache/huggingface/datasets
+  cache_dir: datasets/longvideobench
   video: True
   force_download: False
   local_files_only: False
@@ -26,4 +26,3 @@ lmms_eval_specific_kwargs:
     pre_prompt: ""
     post_prompt: "Answer with the option's letter from the given choices directly.\n"
     insert_interleave_subtitles: True
-    

--- a/lmms_eval/tasks/longvideobench/longvideobench_val_v.yaml
+++ b/lmms_eval/tasks/longvideobench/longvideobench_val_v.yaml
@@ -1,7 +1,7 @@
 dataset_path: longvideobench/LongVideoBench
 dataset_kwargs:
   token: True
-  cache_dir: /mnt/vast/cache/huggingface/datasets
+  cache_dir: datasets/longvideobench
   video: True
   force_download: False
   local_files_only: False
@@ -25,4 +25,3 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: "Answer with the option's letter from the given choices directly.\n"
-  

--- a/lmms_eval/tasks/longvideobench/no_visual/longvideobench_no_visual.yaml
+++ b/lmms_eval/tasks/longvideobench/no_visual/longvideobench_no_visual.yaml
@@ -4,7 +4,7 @@
 dataset_path: longvideobench/LongVideoBench
 dataset_kwargs:
   token: True
-  cache_dir: /mnt/vast/cache/huggingface/datasets
+  cache_dir: datasets/longvideobench
   video: True
   force_download: False
   local_files_only: False

--- a/lmms_eval/tasks/longvideobench/random_choice/longvideobench_random_choice.yaml
+++ b/lmms_eval/tasks/longvideobench/random_choice/longvideobench_random_choice.yaml
@@ -4,7 +4,7 @@
 dataset_path: longvideobench/LongVideoBench
 dataset_kwargs:
   token: True
-  cache_dir: /mnt/vast/cache/huggingface/datasets
+  cache_dir: datasets/longvideobench
   video: True
   force_download: False
   local_files_only: False

--- a/lmms_eval/tasks/longvideobench/utils.py
+++ b/lmms_eval/tasks/longvideobench/utils.py
@@ -11,6 +11,7 @@ from decord import cpu
 from loguru import logger as eval_logger
 from PIL import Image
 
+from lmms_eval import utils as lmms_utils
 from lmms_eval.tasks._task_utils.file_utils import generate_submission_file
 
 
@@ -106,6 +107,25 @@ def insert_subtitles_into_frames(frame_timestamps, subtitles, starting_timestamp
     return "\n".join(interleaved_list)
 
 
+def _load_task_config(task_yaml_name):
+    with open(Path(__file__).parent / task_yaml_name, "r") as f:
+        raw_data = f.readlines()
+        safe_data = []
+        for line in raw_data:
+            # remove function definition since yaml load cannot handle it
+            if "!function" not in line:
+                safe_data.append(line)
+    return yaml.safe_load("".join(safe_data))
+
+
+def _resolve_dataset_dir(task_yaml_name, subdir_key, default_subdir):
+    task_config = _load_task_config(task_yaml_name)
+    dataset_kwargs = task_config["dataset_kwargs"]
+    hf_home = os.path.expanduser(os.getenv("HF_HOME", "~/.cache/huggingface/"))
+    cache_dir = lmms_utils.resolve_cache_dir(dataset_kwargs["cache_dir"], base_dir=hf_home)
+    return os.path.join(cache_dir, dataset_kwargs.get(subdir_key, default_subdir)), dataset_kwargs
+
+
 def longvideobench_doc_to_text(doc, lmms_eval_specific_kwargs):
     candidates = []
 
@@ -119,20 +139,11 @@ def longvideobench_doc_to_text(doc, lmms_eval_specific_kwargs):
     post_prompt = lmms_eval_specific_kwargs["post_prompt"]
 
     if lmms_eval_specific_kwargs.get("insert_interleave_subtitles", False):
-        with open(Path(__file__).parent / "longvideobench_val_i.yaml", "r") as f:
-            raw_data = f.readlines()
-            safe_data = []
-            for i, line in enumerate(raw_data):
-                # remove function definition since yaml load cannot handle it
-                if "!function" not in line:
-                    safe_data.append(line)
-        cache_name = yaml.safe_load("".join(safe_data))["dataset_kwargs"]["cache_dir"]
-        subtitle_subdir_name = yaml.safe_load("".join(safe_data))["dataset_kwargs"].get("subtitle_subdir", "subtitles")
-        cache_dir = os.path.join(base_cache_dir, cache_name, subtitle_subdir_name)
+        cache_dir, dataset_kwargs = _resolve_dataset_dir("longvideobench_val_i.yaml", "subtitle_subdir", "subtitles")
         with open(os.path.join(cache_dir, doc["subtitle_path"])) as f:
             subtitles = json.load(f)
 
-        max_num_frames = yaml.safe_load("".join(safe_data))["dataset_kwargs"].get("max_num_frames", 16)
+        max_num_frames = dataset_kwargs.get("max_num_frames", 16)
 
         frame_timestamps = compute_frame_timestamps(doc["duration"], max_num_frames)
         interleaved_prefix = insert_subtitles_into_frames(frame_timestamps, subtitles, doc["starting_timestamp_for_subtitles"], doc["duration"])
@@ -141,40 +152,18 @@ def longvideobench_doc_to_text(doc, lmms_eval_specific_kwargs):
         return f"{pre_prompt}{question}\n{post_prompt}"
 
 
-hf_home = os.getenv("HF_HOME", "~/.cache/huggingface/")
-base_cache_dir = os.path.expanduser(hf_home)
-
-
 def longvideobench_doc_to_visual_v(doc):
-    with open(Path(__file__).parent / "longvideobench_val_v.yaml", "r") as f:
-        raw_data = f.readlines()
-        safe_data = []
-        for i, line in enumerate(raw_data):
-            # remove function definition since yaml load cannot handle it
-            if "!function" not in line:
-                safe_data.append(line)
-    cache_name = yaml.safe_load("".join(safe_data))["dataset_kwargs"]["cache_dir"]
-    vid_subdir_name = yaml.safe_load("".join(safe_data))["dataset_kwargs"].get("video_subdir", "videos/")
-    cache_dir = os.path.join(base_cache_dir, cache_name, vid_subdir_name)
+    cache_dir, _ = _resolve_dataset_dir("longvideobench_val_v.yaml", "video_subdir", "videos/")
     video_path = doc["video_path"]
     video_path = os.path.join(cache_dir, video_path)
     return [video_path]
 
 
 def longvideobench_doc_to_visual_i(doc):
-    with open(Path(__file__).parent / "longvideobench_val_i.yaml", "r") as f:
-        raw_data = f.readlines()
-        safe_data = []
-        for i, line in enumerate(raw_data):
-            # remove function definition since yaml load cannot handle it
-            if "!function" not in line:
-                safe_data.append(line)
-    cache_name = yaml.safe_load("".join(safe_data))["dataset_kwargs"]["cache_dir"]
-    vid_subdir_name = yaml.safe_load("".join(safe_data))["dataset_kwargs"].get("video_subdir", "videos/")
-    cache_dir = os.path.join(base_cache_dir, cache_name, vid_subdir_name)
+    cache_dir, dataset_kwargs = _resolve_dataset_dir("longvideobench_val_i.yaml", "video_subdir", "videos/")
     video_path = doc["video_path"]
     video_path = os.path.join(cache_dir, video_path)
-    max_num_frames = yaml.safe_load("".join(safe_data))["dataset_kwargs"].get("max_num_frames", 16)
+    max_num_frames = dataset_kwargs.get("max_num_frames", 16)
     return load_video(video_path, doc["duration"], max_num_frames)
 
 

--- a/lmms_eval/utils.py
+++ b/lmms_eval/utils.py
@@ -129,6 +129,18 @@ def is_multimodal_content(value: Any) -> bool:
     return False
 
 
+def resolve_cache_dir(cache_dir: str, base_dir: Optional[str] = None) -> str:
+    """Resolve cache paths while allowing env vars and absolute paths.
+
+    Relative values are resolved against ``base_dir`` when provided.
+    Absolute values are preserved after ``$VAR``/``~`` expansion.
+    """
+    resolved = os.path.expanduser(os.path.expandvars(cache_dir))
+    if base_dir is not None and not os.path.isabs(resolved):
+        return os.path.join(base_dir, resolved)
+    return resolved
+
+
 def sanitize_list(sub):
     """
     Takes possible nested list and recursively converts all inner component to strings


### PR DESCRIPTION
## Summary
- replace the leaked LongVideoBench absolute cache path with a repo-safe relative cache namespace
- reuse the shared cache-dir resolver in the generic video loader and LongVideoBench task helpers
- keep shared-cache compatibility via `HF_HOME`, e.g. `datasets/longvideobench` resolves under the configured HF cache root

## Testing
- pre-commit run --all-files
- uv run python -m compileall lmms_eval/utils.py lmms_eval/api/task.py lmms_eval/tasks/longvideobench/utils.py