### PR TITLE
fix(vllm): fail fast on single-process data parallel

### DIFF
--- a/examples/models/vllm_qwen35.sh
+++ b/examples/models/vllm_qwen35.sh
@@ -4,6 +4,7 @@ MODEL="Qwen/Qwen3.5-397B-A17B"
 TASKS="mmmu_val,mme"
 
 TENSOR_PARALLEL_SIZE=8
+# Global DP replica count across the full launch, not a per-GPU local value.
 DATA_PARALLEL_SIZE=1
 GPU_MEMORY_UTILIZATION=0.85
 BATCH_SIZE=16

--- a/examples/models/vllm_qwen3vl.sh
+++ b/examples/models/vllm_qwen3vl.sh
@@ -29,7 +29,7 @@ MODEL="Qwen/Qwen3-VL-30B-A3B-Instruct"
 # Adjust based on your GPU configuration.
 # If DATA_PARALLEL_SIZE > 1, this script automatically switches to torchrun.
 TENSOR_PARALLEL_SIZE=4  # Number of GPUs for tensor parallelism
-DATA_PARALLEL_SIZE=1    # Number of model replicas for data parallelism
+DATA_PARALLEL_SIZE=1    # Global number of data-parallel replicas, not a per-GPU local value
 
 # Memory and Performance Settings
 GPU_MEMORY_UTILIZATION=0.85  # Fraction of GPU memory to use (0.0 - 1.0)

--- a/lmms_eval/models/simple/vllm.py
+++ b/lmms_eval/models/simple/vllm.py
@@ -51,6 +51,9 @@ class VLLM(lmms):
             Default: "Qwen/Qwen2.5-VL-3B-Instruct"
         tensor_parallel_size (int): Number of GPUs to use for tensor parallelism.
             Default: 1
+        data_parallel_size (int): Global number of data-parallel replicas across the
+            distributed launch. This is a world-size value, not a per-node or per-GPU
+            local count. Default: 1
         gpu_memory_utilization (float): Fraction of GPU memory to use for model weights.
             Should be between 0.0 and 1.0. Default: 0.8
         batch_size (int): Number of requests to process in parallel per GPU.
@@ -212,9 +215,16 @@ class VLLM(lmms):
             self.accelerator = accelerator
             self._rank = self.accelerator.local_process_index
             self._world_size = self.accelerator.num_processes
+        expected_world_size = self.tensor_parallel_size * self.data_parallel_size
+        if self.data_parallel_size > 1 and accelerator.num_processes == 1:
+            raise ValueError(
+                "vLLM data parallel requires torchrun/accelerate multi-process launch. "
+                f"Expected world_size = tensor_parallel_size * data_parallel_size = {expected_world_size}, "
+                "but got single-process execution. Re-launch lmms_eval with torchrun or another "
+                "distributed launcher instead of passing data_parallel_size to a single process."
+            )
         if accelerator.num_processes > 1:
             kwargs["distributed_executor_backend"] = "external_launcher"
-            expected_world_size = self.tensor_parallel_size * self.data_parallel_size
             if expected_world_size > 1 and accelerator.num_processes != expected_world_size:
                 raise ValueError("For external_launcher mode, accelerate world size must equal " f"tensor_parallel_size * data_parallel_size ({expected_world_size}), " f"but got {accelerator.num_processes}.")
         self.client = LLM(


### PR DESCRIPTION
## Summary
- fail fast when `data_parallel_size > 1` is requested from a single lmms-eval process
- keep the error message explicit about using `torchrun` or another multi-process launcher and the required `world_size = tensor_parallel_size * data_parallel_size`
- add repo-level agent notes documenting the current TP+DP development logic and example behavior

## Testing
- pre-commit run --files AGENTS.md lmms_eval/models/simple/vllm.py
- uv run python -m compileall lmms_eval/models/simple/vllm.py