### PR TITLE
fix(qwen-vl): initialize fps for qwen3_vl and qwen2_5_vl chat path

### DIFF
--- a/lmms_eval/models/chat/qwen2_5_vl.py
+++ b/lmms_eval/models/chat/qwen2_5_vl.py
@@ -66,9 +66,8 @@ class Qwen2_5_VL(Qwen2_5_VLSimple):
                 "max_pixels": self.max_pixels,
                 "min_pixels": self.min_pixels,
             }
-            fps = getattr(self, "fps", None)
-            if fps is not None:
-                video_kwargs["fps"] = fps
+            if self.fps is not None:
+                video_kwargs["fps"] = self.fps
             else:
                 # Probe videos to get frame count and set nframes = min(max_num_frames, total_frames)
                 # This avoids the error when video has fewer frames than max_num_frames

--- a/lmms_eval/models/chat/qwen3_vl.py
+++ b/lmms_eval/models/chat/qwen3_vl.py
@@ -61,9 +61,8 @@ class Qwen3_VL(Qwen3_VLSimple):
                 "max_pixels": self.max_pixels,
                 "min_pixels": self.min_pixels,
             }
-            fps = getattr(self, "fps", None)
-            if fps is not None:
-                video_kwargs["fps"] = fps
+            if self.fps is not None:
+                video_kwargs["fps"] = self.fps
                 # limit the number of frames in case fps is set
                 video_kwargs["max_frames"] = self.max_num_frames
             else:


### PR DESCRIPTION
## Summary
- initialize `fps` in the shared simple Qwen VL base classes
- guard chat video kwargs construction with `getattr(self, "fps", None)`
- fix the crash reported in #1238 when default model resolution picks the chat implementation

## Validation
- `python3 -m py_compile lmms_eval/models/simple/qwen3_vl.py lmms_eval/models/simple/qwen2_5_vl.py lmms_eval/models/chat/qwen3_vl.py lmms_eval/models/chat/qwen2_5_vl.py`

Closes #1238