### PR TITLE
feat(omnidocbench): add normalized Levenshtein distance metric

### DIFF
--- a/lmms_eval/tasks/omnidocbench/omnidocbench.yaml
+++ b/lmms_eval/tasks/omnidocbench/omnidocbench.yaml
@@ -20,6 +20,9 @@ metric_list:
   - metric: omnidocbench_exact_match
     aggregation: mean
     higher_is_better: true
+  - metric: omnidocbench_nld_score
+    aggregation: mean
+    higher_is_better: true
 lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""

--- a/lmms_eval/tasks/omnidocbench/utils.py
+++ b/lmms_eval/tasks/omnidocbench/utils.py
@@ -2,6 +2,7 @@ import io
 import re
 from typing import Any
 
+import Levenshtein
 from PIL import Image
 
 
@@ -96,14 +97,29 @@ def omnidocbench_doc_to_target(doc):
     return answers[0] if answers else ""
 
 
+def _normalized_levenshtein_score(pred: str, ref: str) -> float:
+    """Compute (1 - normalized_levenshtein_distance) * 100.
+
+    Following the Kimi K2.5 technical report metric.
+    """
+    if not pred and not ref:
+        return 100.0
+    max_len = max(len(pred), len(ref))
+    if max_len == 0:
+        return 100.0
+    dist = Levenshtein.distance(pred, ref)
+    return (1.0 - dist / max_len) * 100.0
+
+
 def omnidocbench_process_results(doc, results):
     prediction = _normalize_text(results[0])
     answers = _extract_answers(doc)
     if not answers:
-        return {"omnidocbench_exact_match": 0.0}
+        return {"omnidocbench_exact_match": 0.0, "omnidocbench_nld_score": 0.0}
 
+    # Exact match
     answer_set = {_normalize_text(answer) for answer in answers}
-    score = float(prediction in answer_set)
+    em_score = float(prediction in answer_set)
 
     options = _extract_options(doc)
     if options:
@@ -111,6 +127,9 @@ def omnidocbench_process_results(doc, results):
         if pred_letter:
             for answer in answers:
                 if pred_letter == answer.strip().upper()[:1]:
-                    score = max(score, 1.0)
+                    em_score = max(em_score, 1.0)
 
-    return {"omnidocbench_exact_match": score}
+    # Normalized Levenshtein score: (1 - NLD) * 100, take best across answers
+    nld_score = max(_normalized_levenshtein_score(prediction, _normalize_text(answer)) for answer in answers)
+
+    return {"omnidocbench_exact_match": em_score, "omnidocbench_nld_score": nld_score}


### PR DESCRIPTION
Add omnidocbench_nld_score metric computed as (1 - NLD) * 100, following the Kimi K2.5 technical report scoring method. The existing exact_match metric is preserved alongside the new one.

## Summary
<!-- Max 3 bullets. -->
  - Add omnidocbench_nld_score metric: (1 - normalized_levenshtein_distance) * 100, using the Levenshtein library
  - When multiple reference answers exist, take the best (max) score across all answers
  - Register the new metric in omnidocbench.yaml with aggregation: mean  

## In scope
<!-- Explicitly list what this PR changes. -->
  - lmms_eval/tasks/omnidocbench/utils.py: add _normalized_levenshtein_score() helper, update omnidocbench_process_results to return both
  omnidocbench_exact_match and omnidocbench_nld_score
  - lmms_eval/tasks/omnidocbench/omnidocbench.yaml: register omnidocbench_nld_score in metric_list

## Out of scope
<!-- Explicitly list what this PR does NOT change. -->
  - No changes to other tasks (charxiv, ocrbench, ocrbench_v2, etc.)
  - No changes to the existing omnidocbench_exact_match scoring logic
  - No new dependencies added (Levenshtein is already declared in pyproject.toml under [project.optional-dependencies].metrics)

## Validation
<!--
Max 3 bullets.
Use this format:
`<command>` | sample size: `N=<...>` | key metrics: `<...>` | result: `pass/fail`
If you ran tests/benchmarks with metrics, include concrete numbers.
-->
  - python -m lmms_eval --model vllm --model_args model=Qwen/Qwen3-VL-8B-Instruct,tensor_parallel_size=2,data_parallel_size=4 --tasks omnidocbench 
  --limit 4 --batch_size 4 | sample size: N=4 | key metrics: omnidocbench_exact_match, omnidocbench_nld_score both reported | result: pass

## Risk / Compatibility
<!-- 1-2 bullets. Note breaking changes, behavior changes, or migration impact. -->
  - Non-breaking: existing omnidocbench_exact_match metric is unchanged; the new metric is purely additive
  - Results from prior runs remain valid and comparable

## Type of Change
- [ ] Bug fix (non-breaking change)
- [x] New feature
- [ ] New benchmark/task
- [ ] New model integration
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
