### PR TITLE
fix(charxiv): lazy-init OpenAI client and make model version configur…

### DIFF
--- a/lmms_eval/tasks/charxiv/reasoning_utils.py
+++ b/lmms_eval/tasks/charxiv/reasoning_utils.py
@@ -9,7 +9,7 @@ from lmms_eval.tasks.charxiv.constant import (
 )
 
 
-def get_reasoning_result_gpt(client, prompt, max_retries=10):
+def get_reasoning_result_gpt(client, prompt, model="gpt-4o-2024-05-13", max_retries=10):
     curr_retries = 0
     max_tokens = 256
     while curr_retries < max_retries:
@@ -22,7 +22,7 @@ def get_reasoning_result_gpt(client, prompt, max_retries=10):
                             "content": prompt,
                         }
                     ],
-                    model="gpt-4o-2024-05-13",
+                    model=model,
                     response_format={"type": "json_object"},
                     n=1,
                     max_tokens=max_tokens,

--- a/lmms_eval/tasks/charxiv/utils.py
+++ b/lmms_eval/tasks/charxiv/utils.py
@@ -22,7 +22,17 @@ OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "YOUR_OPENAI_API_KEY")
 OPENAI_BASE_URL = os.getenv("OPENAI_BASE_URL", "YOUR_OPENAI_BASE_URL")
 MODEL_VERSION = os.getenv("MODEL_VERSION", "YOUR_MODEL_VERSION")
 
-client = OpenAI(api_key=OPENAI_API_KEY, base_url=OPENAI_BASE_URL)
+# Lazy-initialize the OpenAI client to avoid creating an SSLContext at import time.
+# An SSLContext cannot be pickled, which breaks dataset.map() multiprocessing even
+# with num_proc=1 on newer versions of the `datasets` library.
+_client = None
+
+
+def _get_client():
+    global _client
+    if _client is None:
+        _client = OpenAI(api_key=OPENAI_API_KEY, base_url=OPENAI_BASE_URL)
+    return _client
 
 
 def charxiv_reasoning_doc_to_text_cot(doc, lmms_eval_specific_kwargs=None):
@@ -53,7 +63,9 @@ def charxiv_descriptive_process_docs(dataset: Dataset) -> Dataset:
         example["descriptive_a"] = example[f"descriptive_a{q_number}"]
         return {"qid": qid, **example}
 
-    dataset = dataset.map(_process_row, with_indices=True, num_proc=1)
+    # Use num_proc=None (single-process, no pickling) to avoid SSLContext
+    # serialization errors from the lazy OpenAI client in module globals.
+    dataset = dataset.map(_process_row, with_indices=True)
     return dataset
 
 
@@ -99,7 +111,7 @@ def charxiv_descriptive_aggregate_results(results):
     queries = build_descriptive_grading_queries(groups)
     combined_queries = []
     for query in tqdm(queries):
-        result = get_descriptive_result_gpt(client, query["grading_query"], len(query["resp_keys"]), model=MODEL_VERSION)
+        result = get_descriptive_result_gpt(_get_client(), query["grading_query"], len(query["resp_keys"]), model=MODEL_VERSION)
         # query contains resp_keys, grading_query, extract_answer and score
         combined_queries.append({**query, **result})
     queries = combined_queries
@@ -131,7 +143,7 @@ def charxiv_reasoning_aggregate_results(results):
         resps[result["resp_key"]] = result["resp_value"]
     queries = build_reasoning_grading_queries(data, resps)
     for figure_id, query in tqdm(queries.items()):
-        ext, scr = get_reasoning_result_gpt(client, query["grading_query"])
+        ext, scr = get_reasoning_result_gpt(_get_client(), query["grading_query"], model=MODEL_VERSION)
         queries[figure_id]["extracted_answer"] = ext
         queries[figure_id]["score"] = scr
         queries[figure_id].pop("grading_query")


### PR DESCRIPTION
## Summary
<!-- Max 3 bullets. -->
  - Lazy-initialize OpenAI client to avoid SSLContext pickling errors in datasets.map() multiprocessing                                             
  - Make model version configurable via MODEL_VERSION env var for both descriptive and reasoning grading

## In scope
<!-- Explicitly list what this PR changes. -->
  - lmms_eval/tasks/charxiv/utils.py: replace module-level client with _get_client() lazy initializer; remove num_proc=1 from dataset.map()         
  - lmms_eval/tasks/charxiv/reasoning_utils.py: add model parameter to get_reasoning_result_gpt()

## Out of scope
<!-- Explicitly list what this PR does NOT change. -->
  - No changes to grading logic, prompts, or evaluation metrics
  - No changes to other tasks or model integrations

## Validation
<!--
Max 3 bullets.
Use this format:
`<command>` | sample size: `N=<...>` | key metrics: `<...>` | result: `pass/fail`
If you ran tests/benchmarks with metrics, include concrete numbers.
-->
- 

## Risk / Compatibility
<!-- 1-2 bullets. Note breaking changes, behavior changes, or migration impact. -->
  - Low risk: lazy init is functionally equivalent; default model value preserves existing behavior
  - MODEL_VERSION env var now takes effect for reasoning grading (previously ignored)

## Type of Change
- [x] Bug fix (non-breaking change)
- [ ] New feature
- [ ] New benchmark/task
- [ ] New model integration
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
