### PR TITLE
Fix missing VideoReader imports in FALCONBench and LongVideoBench

### DIFF
--- a/lmms_eval/tasks/FALCONBench/utils.py
+++ b/lmms_eval/tasks/FALCONBench/utils.py
@@ -25,7 +25,7 @@ from pathlib import Path
 import requests
 import torch
 import yaml
-from decord import cpu
+from decord import VideoReader, cpu
 from loguru import logger as eval_logger
 from PIL import Image
 

--- a/lmms_eval/tasks/longvideobench/utils.py
+++ b/lmms_eval/tasks/longvideobench/utils.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import torch
 import yaml
-from decord import cpu
+from decord import VideoReader, cpu
 from loguru import logger as eval_logger
 from PIL import Image
 


### PR DESCRIPTION
## Summary

This PR fixes missing `VideoReader` imports in two task utilities that call `VideoReader(...)` during video loading:

- `lmms_eval/tasks/FALCONBench/utils.py`
- `lmms_eval/tasks/longvideobench/utils.py`

Both files used `VideoReader(...)` but only imported `cpu` from `decord`. This can raise a `NameError` when the corresponding code path is executed.

## Changes

- add `VideoReader` to the `decord` import in `FALCONBench`
- add `VideoReader` to the `decord` import in `LongVideoBench`

## Notes

- this is a minimal fix with no intended behavioral change beyond preventing the missing-import error
- no task logic or sampling behavior was modified
