### PR TITLE
fix(qwen2_5_vl): pass video metadata to processor for correct temporal encoding

### DIFF
--- a/lmms_eval/models/chat/qwen2_5_vl.py
+++ b/lmms_eval/models/chat/qwen2_5_vl.py
@@ -90,12 +90,23 @@ class Qwen2_5_VL(Qwen2_5_VLSimple):
                     video_kwargs["nframes"] = self.max_num_frames
             batched_messages = [chat_message.to_hf_messages(video_kwargs=video_kwargs) for chat_message in chat_messages]
             texts = self.processor.apply_chat_template(batched_messages, tokenize=False, add_generation_prompt=True)
-            image_inputs, video_inputs = process_vision_info(batched_messages)
+            image_inputs, video_inputs, video_kwargs_qwen = process_vision_info(
+                batched_messages,
+                return_video_kwargs=True,
+                return_video_metadata=True,
+            )
+
+            video_metadatas = None
+            if video_inputs is not None:
+                video_inputs, video_metadatas = zip(*video_inputs)
+                video_inputs, video_metadatas = list(video_inputs), list(video_metadatas)
+
             padding_side = "left" if self.batch_size > 1 else "right"
             inputs = self.processor(
                 text=texts,
                 images=image_inputs,
                 videos=video_inputs,
+                video_metadata=video_metadatas,
                 padding=True,
                 padding_side=padding_side,
                 return_tensors="pt",

--- a/scripts/test_qwen2_5_vl_video_metadata.sh
+++ b/scripts/test_qwen2_5_vl_video_metadata.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Test script for issue #1260: qwen2_5_vl video metadata fix
+# Runs Qwen2.5-VL-7B-Instruct on charades_sta with --limit to verify
+# that video metadata (fps, frames_indices) is correctly passed to the
+# processor, producing correct second_per_grid_ts values.
+
+accelerate launch --num_processes=1 --main_process_port=12346 -m lmms_eval \
+    --model qwen2_5_vl \
+    --model_args pretrained=Qwen/Qwen2.5-VL-7B-Instruct,max_pixels=12845056,max_num_frames=64,attn_implementation=flash_attention_2 \
+    --tasks temporal_grounding_charades \
+    --batch_size 1 \
+    --limit 10


### PR DESCRIPTION
## Summary

- Fixes #1260: `qwen2_5_vl` (chat variant) drops sampled video metadata before calling the processor, causing `second_per_grid_ts` to silently fall back to incorrect values (~0.0833 instead of the correct ~0.958 for typical videos), corrupting MRoPE temporal position IDs.
- Now calls `process_vision_info()` with `return_video_metadata=True` and passes `video_metadata` through to `Qwen2_5_VLProcessor`, following the same pattern already used in the Qwen3 VL implementation.

## Changes

- **`lmms_eval/models/chat/qwen2_5_vl.py`**: Updated `process_vision_info` call to return video metadata, unpacks `(tensor, metadata)` tuples, and passes `video_metadata=video_metadatas` to the processor.
- **`scripts/test_qwen2_5_vl_video_metadata.sh`**: Added a bash test script that runs `lmms_eval` on `temporal_grounding_charades` with Qwen2.5-VL-7B-Instruct (`--limit 10`).

## Testing

Verified end-to-end on `temporal_grounding_charades` with Qwen2.5-VL-7B-Instruct, batch_size=1, limit=10. All 10 samples inferred without errors, and `second_per_grid_ts` now reflects the correct temporal spacing.