### PR TITLE
feat: add COVER and WM-aBench video understanding benchmarks

### DIFF
--- a/lmms_eval/tasks/cover/cover.yaml
+++ b/lmms_eval/tasks/cover/cover.yaml
@@ -1,0 +1,35 @@
+# COVER: Counterfactual Video Reasoning (ACL Findings 2025)
+# Paper: https://arxiv.org/abs/2503.10691
+# Original: PeterPanonly/COVER (incompatible format, zips only)
+# Clean copy: lmms-lab-eval/COVER (pre-parsed QA from JSONL)
+#
+# Videos: VIDEO.zip must be in lmms-lab-eval/COVER or PeterPanonly/COVER.
+# Set COVER_DATA_DIR env var to override video directory.
+dataset_path: lmms-lab-eval/COVER
+dataset_kwargs:
+  token: True
+  cache_dir: cover
+  video: True
+task: cover
+test_split: test
+output_type: generate_until
+doc_to_visual: !function utils.cover_doc_to_visual
+doc_to_text: !function utils.cover_doc_to_text
+doc_to_target: "answer"
+generation_kwargs:
+  max_new_tokens: 16
+  temperature: 0
+  top_p: 1.0
+  num_beams: 1
+  do_sample: false
+process_results: !function utils.cover_process_results
+metric_list:
+  - metric: cover_accuracy
+    aggregation: !function utils.cover_aggregate_results
+    higher_is_better: true
+lmms_eval_specific_kwargs:
+  default:
+    pre_prompt: ""
+    post_prompt: "\nAnswer with the option's letter from the given choices directly."
+metadata:
+  version: 0.2

--- a/lmms_eval/tasks/cover/generate_qa.py
+++ b/lmms_eval/tasks/cover/generate_qa.py
@@ -1,0 +1,153 @@
+"""Pre-extract COVER videos and optionally dump the QA JSON.
+
+This is a convenience script for manual setup.  During normal lmms-eval
+runs, the task's utils.py handles everything automatically (downloads
+the HF repo, extracts videos, loads JSONL data in process_docs).
+
+Usage:
+    # Extract videos only (recommended before first eval run):
+    python -m lmms_eval.tasks.cover.generate_qa --extract-videos
+
+    # Also dump a standalone QA JSON for inspection:
+    python -m lmms_eval.tasks.cover.generate_qa \
+        --extract-videos --output $HF_HOME/cover/cover_qa.json
+"""
+
+import argparse
+import io
+import json
+import os
+import zipfile
+from collections import defaultdict
+
+from huggingface_hub import snapshot_download
+
+DATASET_REPO_ID = "PeterPanonly/COVER"
+
+
+def main():
+    parser = argparse.ArgumentParser(description="COVER dataset setup")
+    parser.add_argument(
+        "--output",
+        type=str,
+        default="",
+        help="Output JSON file path (optional). If set, writes a flat " "QA JSON with all samples.",
+    )
+    parser.add_argument(
+        "--cache-dir",
+        type=str,
+        default="",
+        help="Directory for extracted videos. Default: $HF_HOME/cover/",
+    )
+    parser.add_argument(
+        "--extract-videos",
+        action="store_true",
+        help="Extract VIDEO.zip into the cache directory.",
+    )
+    args = parser.parse_args()
+
+    hf_home = os.path.expanduser(os.getenv("HF_HOME", "~/.cache/huggingface"))
+    cache_dir = args.cache_dir or os.path.join(hf_home, "cover")
+
+    # Download the HF repo
+    print(f"Downloading {DATASET_REPO_ID} ...")
+    repo_dir = snapshot_download(
+        repo_id=DATASET_REPO_ID,
+        repo_type="dataset",
+        etag_timeout=60,
+    )
+    print(f"  Repo cached at: {repo_dir}")
+
+    # Extract videos
+    if args.extract_videos:
+        video_dir = os.path.join(cache_dir, "VIDEO")
+        if os.path.exists(video_dir):
+            print(f"  VIDEO directory already exists: {video_dir}")
+        else:
+            video_zip = os.path.join(repo_dir, "VIDEO.zip")
+            if not os.path.exists(video_zip):
+                print(f"  ERROR: VIDEO.zip not found at {video_zip}")
+                return
+            print(f"  Extracting VIDEO.zip to {cache_dir} ...")
+            os.makedirs(cache_dir, exist_ok=True)
+            with zipfile.ZipFile(video_zip) as zf:
+                zf.extractall(cache_dir)
+            print("  Done.")
+
+    # Optionally dump QA JSON
+    if args.output:
+        jsonl_zip_path = os.path.join(repo_dir, "jsonl.zip")
+        if not os.path.exists(jsonl_zip_path):
+            print(f"  ERROR: jsonl.zip not found at {jsonl_zip_path}")
+            return
+
+        samples = []
+        idx = 0
+        with zipfile.ZipFile(jsonl_zip_path) as zf:
+            for name in sorted(zf.namelist()):
+                if not name.endswith(".jsonl"):
+                    continue
+                aspect = os.path.basename(name).replace(".jsonl", "")
+                with zf.open(name) as f:
+                    for line in f:
+                        entry = json.loads(line)
+                        src = entry["src_dataset"]
+                        vname = entry["video_name"]
+                        text = entry["text"]
+
+                        video_path = f"VIDEO/{src}/{vname}"
+
+                        orig = text["original_qa"]
+                        samples.append(
+                            {
+                                "idx": idx,
+                                "video_path": video_path,
+                                "src_dataset": src,
+                                "video_name": vname,
+                                "question": orig["qs"],
+                                "choices": orig["choice"],
+                                "answer": orig["ans"],
+                                "qa_type": "original",
+                                "aspect": aspect,
+                            }
+                        )
+                        idx += 1
+
+                        cf = text["counterfactual_qa"]
+                        samples.append(
+                            {
+                                "idx": idx,
+                                "video_path": video_path,
+                                "src_dataset": src,
+                                "video_name": vname,
+                                "question": cf["qs"],
+                                "choices": cf["choice"],
+                                "answer": cf["ans"],
+                                "qa_type": "counterfactual",
+                                "aspect": aspect,
+                            }
+                        )
+                        idx += 1
+
+        os.makedirs(os.path.dirname(os.path.abspath(args.output)), exist_ok=True)
+        with open(args.output, "w") as f:
+            json.dump(samples, f, indent=2)
+
+        print(f"\n  {len(samples)} QA samples written to {args.output}")
+
+        by_type = defaultdict(int)
+        by_aspect = defaultdict(int)
+        for s in samples:
+            by_type[s["qa_type"]] += 1
+            by_aspect[s["aspect"]] += 1
+
+        print(f"  By qa_type: {dict(by_type)}")
+        print(f"  By aspect ({len(by_aspect)} categories):")
+        for aspect in sorted(by_aspect):
+            print(f"    {aspect}: {by_aspect[aspect]}")
+    elif not args.extract_videos:
+        print("Nothing to do. Use --extract-videos and/or --output.")
+
+
+if __name__ == "__main__":
+    main()

--- a/lmms_eval/tasks/cover/utils.py
+++ b/lmms_eval/tasks/cover/utils.py
@@ -1,0 +1,174 @@
+"""COVER benchmark -- counterfactual video reasoning (ACL Findings 2025).
+
+Dataset: lmms-lab-eval/COVER (clean QA data, parsed from PeterPanonly/COVER)
+Paper:   https://arxiv.org/abs/2503.10691
+
+The clean dataset has pre-parsed QA pairs with columns:
+  src_dataset, video_name, question, choices (JSON), answer, qa_type, aspect.
+
+Videos: VIDEO.zip must be extracted to $HF_HOME/cover/VIDEO/ or set
+COVER_DATA_DIR to the video root directory.
+"""
+
+import json
+import os
+import zipfile
+from collections import defaultdict
+
+from huggingface_hub import snapshot_download
+from loguru import logger as eval_logger
+
+# ---------------------------------------------------------------------------
+# Video directory resolution
+# ---------------------------------------------------------------------------
+_hf_home = os.path.expanduser(os.getenv("HF_HOME", "~/.cache/huggingface/"))
+_CACHE_DIR = os.path.join(_hf_home, "cover")
+
+
+def _get_cache_dir():
+    explicit = os.getenv("COVER_DATA_DIR", "").strip()
+    if explicit:
+        return os.path.expanduser(explicit)
+    return _CACHE_DIR
+
+
+_videos_ready = False
+
+
+def _ensure_videos():
+    """Download VIDEO.zip from PeterPanonly/COVER and extract if needed."""
+    global _videos_ready
+    if _videos_ready:
+        return
+
+    cache_dir = _get_cache_dir()
+    video_dir = os.path.join(cache_dir, "VIDEO")
+    if os.path.exists(video_dir):
+        _videos_ready = True
+        return
+
+    eval_logger.info("COVER: downloading VIDEO.zip from PeterPanonly/COVER ...")
+    repo_dir = snapshot_download(
+        repo_id="PeterPanonly/COVER",
+        repo_type="dataset",
+        etag_timeout=60,
+    )
+
+    video_zip = os.path.join(repo_dir, "VIDEO.zip")
+    if os.path.exists(video_zip):
+        eval_logger.info(f"COVER: extracting VIDEO.zip to {cache_dir} ...")
+        os.makedirs(cache_dir, exist_ok=True)
+        with zipfile.ZipFile(video_zip) as zf:
+            zf.extractall(cache_dir)
+        eval_logger.info("COVER: extraction complete.")
+    else:
+        eval_logger.warning(f"COVER: VIDEO.zip not found at {video_zip}. " f"Videos must be placed manually in {video_dir}.")
+    _videos_ready = True
+
+
+# ---------------------------------------------------------------------------
+# doc_to_visual / doc_to_text
+# ---------------------------------------------------------------------------
+def cover_doc_to_visual(doc):
+    _ensure_videos()
+    cache_dir = _get_cache_dir()
+    video_path = os.path.join(cache_dir, "VIDEO", doc["src_dataset"], doc["video_name"])
+
+    if os.path.exists(video_path):
+        return [video_path]
+
+    # Try extension variants
+    base, ext = os.path.splitext(video_path)
+    for alt_ext in [".mp4", ".MP4", ".avi", ".AVI", ".mkv"]:
+        if alt_ext != ext:
+            alt = base + alt_ext
+            if os.path.exists(alt):
+                return [alt]
+
+    eval_logger.warning(f"COVER video not found: {video_path}")
+    return [video_path]
+
+
+def cover_doc_to_text(doc, lmms_eval_specific_kwargs=None):
+    question = doc["question"]
+    choices = doc["choices"]
+    if isinstance(choices, str):
+        choices = json.loads(choices)
+
+    sorted_keys = sorted(choices.keys())
+    choices_str = "\n".join(f"{k}. {choices[k]}" for k in sorted_keys)
+
+    post_prompt = ""
+    if lmms_eval_specific_kwargs:
+        post_prompt = lmms_eval_specific_kwargs.get("default", {}).get("post_prompt", "")
+
+    return f"{question}\n{choices_str}{post_prompt}"
+
+
+# ---------------------------------------------------------------------------
+# process_results / aggregate_results
+# ---------------------------------------------------------------------------
+def _extract_answer(response):
+    import re
+
+    response = response.strip()
+    if not response:
+        return ""
+    # Direct single letter
+    if len(response) == 1 and response.upper() in "ABCDEF":
+        return response.upper()
+    # Pattern: (A), A., A:
+    m = re.match(r"[\(\s]*([A-Fa-f])[\)\.\:\s]", response)
+    if m:
+        return m.group(1).upper()
+    # First letter
+    m = re.match(r"^([A-Fa-f])\b", response)
+    if m:
+        return m.group(1).upper()
+    # Search in short response
+    if len(response) < 50:
+        m = re.search(r"\b([A-Da-d])\b", response)
+        if m:
+            return m.group(1).upper()
+    return response[:1].upper()
+
+
+def cover_process_results(doc, results):
+    pred = _extract_answer(results[0])
+    gt = doc["answer"].strip().upper()
+
+    return {
+        "cover_accuracy": {
+            "pred_answer": pred,
+            "answer": gt,
+            "qa_type": doc.get("qa_type", ""),
+            "aspect": doc.get("aspect", ""),
+            "score": 1.0 if pred == gt else 0.0,
+        }
+    }
+
+
+def cover_aggregate_results(results):
+    total = len(results)
+    correct = sum(r["score"] for r in results)
+
+    # Per qa_type
+    for qt in ("original", "counterfactual"):
+        subset = [r for r in results if r["qa_type"] == qt]
+        if subset:
+            acc = 100.0 * sum(r["score"] for r in subset) / len(subset)
+            eval_logger.info(f"COVER {qt}: {acc:.1f}% ({len(subset)} samples)")
+
+    # Per aspect
+    aspect_scores = defaultdict(lambda: {"correct": 0, "total": 0})
+    for r in results:
+        aspect_scores[r["aspect"]]["total"] += 1
+        aspect_scores[r["aspect"]]["correct"] += r["score"]
+    for aspect in sorted(aspect_scores):
+        s = aspect_scores[aspect]
+        acc = 100.0 * s["correct"] / s["total"] if s["total"] > 0 else 0.0
+        eval_logger.info(f"COVER {aspect}: {acc:.1f}% ({s['total']} samples)")
+
+    overall = 100.0 * correct / total if total > 0 else 0.0
+    eval_logger.info(f"COVER Overall: {overall:.1f}% ({total} samples)")
+    return overall

--- a/lmms_eval/tasks/wm_abench/_default_template_yaml
+++ b/lmms_eval/tasks/wm_abench/_default_template_yaml
@@ -1,0 +1,33 @@
+dataset_path: maitrix-org/WM-ABench
+dataset_kwargs:
+  token: True
+test_split: test
+output_type: generate_until
+doc_to_visual: !function utils.wm_abench_doc_to_visual
+doc_to_text: !function utils.wm_abench_doc_to_text
+doc_to_target: !function utils.wm_abench_doc_to_target
+
+process_results: !function utils.wm_abench_process_results
+
+metric_list:
+  - metric: wm_abench_acc
+    aggregation: !function utils.wm_abench_aggregate_results
+    higher_is_better: true
+  - metric: wm_abench_acc_clean
+    aggregation: !function utils.wm_abench_aggregate_results_clean
+    higher_is_better: true
+  - metric: wm_abench_blocked_rate
+    aggregation: !function utils.wm_abench_aggregate_blocked_rate
+    higher_is_better: false
+
+generation_kwargs:
+  max_new_tokens: 16
+  temperature: 0
+  top_p: 1.0
+  num_beams: 1
+  do_sample: false
+
+lmms_eval_specific_kwargs:
+  default:
+    pre_prompt: ""
+    post_prompt: ""

--- a/lmms_eval/tasks/wm_abench/utils.py
+++ b/lmms_eval/tasks/wm_abench/utils.py
@@ -1,0 +1,282 @@
+import re
+from typing import Any, Dict, List, Optional
+
+from PIL import Image
+
+# Map 0-indexed int to letter
+INDEX_TO_LETTER = {0: "A", 1: "B", 2: "C", 3: "D", 4: "E", 5: "F"}
+# Map 1-indexed int to letter
+ONEIDX_TO_LETTER = {1: "A", 2: "B", 3: "C", 4: "D", 5: "E", 6: "F"}
+
+IMAGE_CHOICE_PROMPT_SUFFIX = "\nPlease answer with only the letter (A, B, C, or D) of the correct option."
+
+
+def _ensure_rgb(img) -> Image.Image:
+    """Convert a PIL Image to RGB, handling None and dict (lazy HF Image) gracefully."""
+    if img is None:
+        return Image.new("RGB", (224, 224))
+    if isinstance(img, dict):
+        # HF datasets Image feature may be a dict with 'bytes' or 'path'
+        if "bytes" in img and img["bytes"] is not None:
+            import io
+
+            return Image.open(io.BytesIO(img["bytes"])).convert("RGB")
+        if "path" in img and img["path"] is not None:
+            return Image.open(img["path"]).convert("RGB")
+        return Image.new("RGB", (224, 224))
+    if isinstance(img, Image.Image):
+        return img.convert("RGB")
+    return img
+
+
+def _has_image_choices(doc: dict) -> bool:
+    return "image_choices" in doc and doc["image_choices"] is not None and len(doc["image_choices"]) > 0
+
+
+def _has_letter_choices(doc: dict) -> bool:
+    return "choices_str_letter" in doc and doc["choices_str_letter"]
+
+
+def _normalize_answer(doc: dict) -> str:
+    """Normalize the ground-truth answer to a single uppercase letter (A-D).
+
+    Image-choice configs: answer is 0-indexed int -> map to A-D.
+    Text-choice configs with letter choices: answer may be 1-indexed int or letter string.
+    Open-ended configs: answer is a free-form string (e.g., 'yes'/'no').
+    """
+    answer = doc["answer"]
+
+    if _has_image_choices(doc):
+        # Image-choice: 0-indexed int
+        if isinstance(answer, int):
+            return INDEX_TO_LETTER.get(answer, str(answer))
+        try:
+            return INDEX_TO_LETTER.get(int(answer), str(answer))
+        except (ValueError, TypeError):
+            return str(answer).upper().strip()
+
+    if _has_letter_choices(doc):
+        # Text-choice with letter options available
+        if isinstance(answer, int):
+            return ONEIDX_TO_LETTER.get(answer, str(answer))
+        answer_str = str(answer).strip().upper()
+        if len(answer_str) == 1 and answer_str in "ABCDEF":
+            return answer_str
+        # Might be a number as string
+        try:
+            return ONEIDX_TO_LETTER.get(int(answer_str), answer_str)
+        except (ValueError, TypeError):
+            pass
+
+    # Open-ended or other: return as-is (lowered for comparison)
+    return str(doc["answer"]).strip().lower()
+
+
+def _make_montage(source_imgs: list, choice_imgs: list) -> Image.Image:
+    """Tile source images (top) and labeled choice images (bottom) into one image.
+
+    Layout: source images in top row, choice images A/B/C/D in bottom row.
+    Each cell is resized to a common size for uniformity.
+    """
+    from PIL import ImageDraw, ImageFont
+
+    CELL = 384  # px per cell
+    PAD = 4
+    LABEL_H = 28
+
+    all_sources = [img.resize((CELL, CELL)) for img in source_imgs]
+    all_choices = [img.resize((CELL, CELL)) for img in choice_imgs]
+
+    n_src = len(all_sources)
+    n_ch = len(all_choices)
+    cols = max(n_src, n_ch)
+
+    row_h = CELL + LABEL_H + PAD
+    width = cols * (CELL + PAD) + PAD
+    height = PAD + row_h + row_h + PAD  # 2 rows
+
+    canvas = Image.new("RGB", (width, height), (255, 255, 255))
+    draw = ImageDraw.Draw(canvas)
+
+    # Row 0: source images with "Source" label
+    y0 = PAD
+    for i, img in enumerate(all_sources):
+        x = PAD + i * (CELL + PAD)
+        draw.text((x + 2, y0), f"Source {i+1}" if n_src > 1 else "Source", fill=(0, 0, 0))
+        canvas.paste(img, (x, y0 + LABEL_H))
+
+    # Row 1: choice images with A/B/C/D labels
+    y1 = PAD + row_h
+    for i, img in enumerate(all_choices):
+        x = PAD + i * (CELL + PAD)
+        label = chr(65 + i)
+        draw.text((x + 2, y1), f"Option {label}", fill=(0, 0, 0))
+        canvas.paste(img, (x, y1 + LABEL_H))
+
+    return canvas
+
+
+def wm_abench_doc_to_visual(doc: dict) -> list:
+    """Return list of PIL Images for the model to see.
+
+    For image-choice configs: creates a labeled montage (source + choices)
+    as a SINGLE image to avoid multi-image → video_fps issues in vllm.
+    For text-choice / open-ended configs: only source images.
+    """
+    # Source images
+    source_imgs = []
+    source = doc.get("source")
+    if source is not None:
+        if isinstance(source, list):
+            for img in source:
+                source_imgs.append(_ensure_rgb(img))
+        else:
+            source_imgs.append(_ensure_rgb(source))
+
+    # Image choices → montage
+    if _has_image_choices(doc):
+        choice_imgs = [_ensure_rgb(img) for img in doc["image_choices"]]
+        montage = _make_montage(source_imgs, choice_imgs)
+        return [montage]
+
+    return source_imgs if source_imgs else [Image.new("RGB", (224, 224))]
+
+
+def wm_abench_doc_to_text(doc: dict, lmms_eval_specific_kwargs: Optional[dict] = None) -> str:
+    """Build the text prompt for the model.
+
+    Image-choice configs: append instructions referencing choice images by letter.
+    Text-choice configs with choices_str_letter: replace numeric choices with letter choices.
+    Open-ended configs: use prompt as-is.
+    """
+    if lmms_eval_specific_kwargs is None:
+        lmms_eval_specific_kwargs = {}
+
+    prompt = doc.get("prompt", "")
+
+    if _has_image_choices(doc):
+        n_choices = len(doc["image_choices"])
+        choice_labels = ", ".join(chr(65 + i) for i in range(n_choices))
+
+        text = f"{prompt}\n\n" f"The image shows the source (top row) and answer options {choice_labels} (bottom row). " f"Which option correctly shows what happens next?" f"{IMAGE_CHOICE_PROMPT_SUFFIX}"
+        return text
+
+    if _has_letter_choices(doc):
+        # Strip embedded numeric choices from the original prompt and use
+        # letter-labeled choices instead for consistent answer extraction.
+        choices_letter = doc["choices_str_letter"]
+
+        # Try to extract the base question before numeric choice list.
+        # Patterns: "... 1. choice1\n2. choice2..." or "... 1. choice1 2. choice2..."
+        base_prompt = re.split(r"\s*(?:1\.|A\.)\s", prompt, maxsplit=1)[0].strip()
+        if not base_prompt:
+            base_prompt = prompt
+
+        text = f"{base_prompt}\n{choices_letter}\n" f"Answer with the option's letter from the given choices directly."
+        return text
+
+    # Open-ended: use prompt as-is
+    return prompt
+
+
+def _extract_answer_letter(text: str) -> str:
+    """Extract a single answer letter (A-D) from model response."""
+    text = text.strip()
+    if not text:
+        return ""
+
+    # Direct single letter
+    if len(text) == 1 and text.upper() in "ABCDEF":
+        return text.upper()
+
+    # Pattern: (A), A., A), A:, etc.
+    match = re.match(r"[\(\s]*([A-Fa-f])[\)\.\:\s]", text)
+    if match:
+        return match.group(1).upper()
+
+    # Just starts with a letter followed by word boundary
+    match = re.match(r"^([A-Fa-f])\b", text)
+    if match:
+        return match.group(1).upper()
+
+    # Search anywhere in short responses
+    if len(text) < 30:
+        match = re.search(r"\b([A-Da-d])\b", text)
+        if match:
+            return match.group(1).upper()
+
+    return text.strip()
+
+
+def wm_abench_doc_to_target(doc: dict) -> str:
+    """Return the ground truth answer as a normalized string."""
+    return _normalize_answer(doc)
+
+
+def _is_safety_blocked(text: str) -> bool:
+    return text.startswith("[SAFETY_BLOCKED:")
+
+
+def wm_abench_process_results(doc: dict, results: List[str]) -> Dict[str, Any]:
+    """Process model output and compare to ground truth."""
+    pred_raw = results[0].strip()
+    gt = _normalize_answer(doc)
+    safety_blocked = _is_safety_blocked(pred_raw)
+
+    # For MC tasks (image-choice or letter-choice), extract letter
+    if safety_blocked:
+        pred = ""
+    elif _has_image_choices(doc) or _has_letter_choices(doc):
+        pred = _extract_answer_letter(pred_raw)
+    else:
+        # Open-ended: compare lowercase
+        pred = pred_raw.lower().strip()
+
+    is_correct = pred == gt
+
+    result_entry = {
+        "pred": pred,
+        "pred_raw": pred_raw,
+        "answer": gt,
+        "is_correct": is_correct,
+        "safety_blocked": safety_blocked,
+    }
+
+    return {
+        "wm_abench_acc": result_entry,
+        "wm_abench_acc_clean": result_entry,
+        "wm_abench_blocked_rate": result_entry,
+    }
+
+
+def wm_abench_aggregate_results(results: List[Dict]) -> float:
+    """Compute overall accuracy."""
+    if not results:
+        return 0.0
+    total = len(results)
+    correct = sum(1 for r in results if r["is_correct"])
+    blocked = sum(1 for r in results if r.get("safety_blocked", False))
+    if blocked:
+        from loguru import logger
+
+        logger.info(f"wm_abench_acc: {correct}/{total} correct, {blocked}/{total} safety_blocked")
+    return correct / total
+
+
+def wm_abench_aggregate_results_clean(results: List[Dict]) -> float:
+    """Compute accuracy excluding safety-blocked samples."""
+    if not results:
+        return 0.0
+    clean = [r for r in results if not r.get("safety_blocked", False)]
+    if not clean:
+        return 0.0
+    correct = sum(1 for r in clean if r["is_correct"])
+    return correct / len(clean)
+
+
+def wm_abench_aggregate_blocked_rate(results: List[Dict]) -> float:
+    """Compute fraction of samples that were safety-blocked."""
+    if not results:
+        return 0.0
+    blocked = sum(1 for r in results if r.get("safety_blocked", False))
+    return blocked / len(results)

--- a/lmms_eval/tasks/wm_abench/wm_abench.yaml
+++ b/lmms_eval/tasks/wm_abench/wm_abench.yaml
@@ -1,0 +1,50 @@
+group: wm_abench
+task:
+  # Known-bad subtasks are intentionally excluded here so the group remains runnable:
+  # - wm_abench_visualattribute_color_tdw_subset
+  # - wm_abench_transitivity_habitat_lab_trans_ver_2_noback_subset
+  - wm_abench_compositionality_maniskill_lift_subset
+  - wm_abench_compositionality_maniskill_push_subset
+  - wm_abench_compositionality_maniskill_rotate_subset
+  - wm_abench_compositionality_tdw_two_sphere_2_14_subset
+  - wm_abench_discretecounting_tdw_top_subset
+  - wm_abench_mechanisticknowledge_maniskill_drop_subset
+  - wm_abench_mechanisticknowledge_maniskill_lift_subset
+  - wm_abench_mechanisticknowledge_maniskill_push_subset
+  - wm_abench_mechanisticknowledge_maniskill_rotate_subset
+  - wm_abench_mechanisticknowledge_physion_type_collision_v2_subset
+  - wm_abench_mechanisticknowledge_physion_type_drop_subset
+  - wm_abench_mechanisticknowledge_physion_type_slide_subset
+  - wm_abench_motiondirection_maniskill_subtask_subset
+  - wm_abench_motiondirection_maniskill_towards_subset
+  - wm_abench_motiondirection_tdw_subset
+  - wm_abench_motiondirection_tdw_subtask_subset
+  - wm_abench_motionspeed_maniskill_subset
+  - wm_abench_motionspeed_tdw_subset
+  - wm_abench_motiontrajectory_maniskill_path_choices_subset
+  - wm_abench_motiontrajectory_path_choices_subset
+  - wm_abench_multiview_maniskill_subset
+  - wm_abench_multiview_tdw_subset
+  - wm_abench_predictionnextstate_carla_next_state_prediction_02_08_subset
+  - wm_abench_quantitycontinuous_tdw_continuous_subset
+  - wm_abench_relativecounting_maniskill_subset
+  - wm_abench_relativecounting_tdw_color_letter_subset
+  - wm_abench_relativeposition_front_top_subset
+  - wm_abench_relativeposition_front_top_tdw_subset
+  - wm_abench_spatialoccupancy_maniskill_subset
+  - wm_abench_spatialoccupancy_occupancy_fitting_tdw_top_subset
+  - wm_abench_spatialoccupancy_occupancy_size_tdw_front_large_subset
+  - wm_abench_spatialoccupancy_volume_object_only_unfloat_top_subset
+  - wm_abench_speed_tdw_subset
+  - wm_abench_temporalextension_temporal_tdw_yjx_01_05_subset
+  - wm_abench_temporalpositioning_maniskill_subset
+  - wm_abench_visualattribute_color_subset
+  - wm_abench_visualattribute_material_diff_tdw_subset
+  - wm_abench_visualattribute_shape_tdw_subset
+aggregate_metric_list:
+  - metric: wm_abench_acc
+    aggregation: !function utils.wm_abench_aggregate_results
+  - metric: wm_abench_acc_clean
+    aggregation: !function utils.wm_abench_aggregate_results_clean
+  - metric: wm_abench_blocked_rate
+    aggregation: !function utils.wm_abench_aggregate_blocked_rate

--- a/lmms_eval/tasks/wm_abench/wm_abench_compositionality_maniskill_lift_subset.yaml
+++ b/lmms_eval/tasks/wm_abench/wm_abench_compositionality_maniskill_lift_subset.yaml
@@ -1,0 +1,4 @@
+dataset_name: "Compositionality_maniskill_lift_subset"
+tag: "wm_abench_subtasks"
+task: "wm_abench_compositionality_maniskill_lift_subset"
+include: _default_template_yaml

--- a/lmms_eval/tasks/wm_abench/wm_abench_compositionality_maniskill_push_subset.yaml
+++ b/lmms_eval/tasks/wm_abench/wm_abench_compositionality_maniskill_push_subset.yaml
@@ -1,0 +1,4 @@
+dataset_name: "Compositionality_maniskill_push_subset"
+tag: "wm_abench_subtasks"
+task: "wm_abench_compositionality_maniskill_push_subset"
+include: _default_template_yaml

--- a/lmms_eval/tasks/wm_abench/wm_abench_compositionality_maniskill_rotate_subset.yaml
+++ b/lmms_eval/tasks/wm_abench/wm_abench_compositionality_maniskill_rotate_subset.yaml
@@ -1,0 +1,4 @@
+dataset_name: "Compositionality_maniskill_rotate_subset"
+tag: "wm_abench_subtasks"
+task: "wm_abench_compositionality_maniskill_rotate_subset"
+include: _default_template_yaml

--- a/lmms_eval/tasks/wm_abench/wm_abench_compositionality_tdw_two_sphere_2_14_subset.yaml
+++ b/lmms_eval/tasks/wm_abench/wm_abench_compositionality_tdw_two_sphere_2_14_subset.yaml
@@ -1,0 +1,4 @@
+dataset_name: "Compositionality_tdw_two_sphere_2_14_subset"
+tag: "wm_abench_subtasks"
+task: "wm_abench_compositionality_tdw_two_sphere_2_14_subset"
+include: _default_template_yaml

--- a/lmms_eval/tasks/wm_abench/wm_abench_discretecounting_tdw_top_subset.yaml
+++ b/lmms_eval/tasks/wm_abench/wm_abench_discretecounting_tdw_top_subset.yaml
@@ -1,0 +1,4 @@
+dataset_name: "DiscreteCounting_tdw_top_subset"
+tag: "wm_abench_subtasks"
+task: "wm_abench_discretecounting_tdw_top_subset"
+include: _default_template_yaml

--- a/lmms_eval/tasks/wm_abench/wm_abench_mechanisticknowledge_maniskill_drop_subset.yaml
+++ b/lmms_eval/tasks/wm_abench/wm_abench_mechanisticknowledge_maniskill_drop_subset.yaml
@@ -1,0 +1,4 @@
+dataset_name: "MechanisticKnowledge_maniskill_drop_subset"
+tag: "wm_abench_subtasks"
+task: "wm_abench_mechanisticknowledge_maniskill_drop_subset"
+include: _default_template_yaml

--- a/lmms_eval/tasks/wm_abench/wm_abench_mechanisticknowledge_maniskill_lift_subset.yaml
+++ b/lmms_eval/tasks/wm_abench/wm_abench_mechanisticknowledge_maniskill_lift_subset.yaml
@@ -1,0 +1,4 @@
+dataset_name: "MechanisticKnowledge_maniskill_lift_subset"
+tag: "wm_abench_subtasks"
+task: "wm_abench_mechanisticknowledge_maniskill_lift_subset"
+include: _default_template_yaml

--- a/lmms_eval/tasks/wm_abench/wm_abench_mechanisticknowledge_maniskill_push_subset.yaml
+++ b/lmms_eval/tasks/wm_abench/wm_abench_mechanisticknowledge_maniskill_push_subset.yaml
@@ -1,0 +1,4 @@
+dataset_name: "MechanisticKnowledge_maniskill_push_subset"
+tag: "wm_abench_subtasks"
+task: "wm_abench_mechanisticknowledge_maniskill_push_subset"
+include: _default_template_yaml

--- a/lmms_eval/tasks/wm_abench/wm_abench_mechanisticknowledge_maniskill_rotate_subset.yaml
+++ b/lmms_eval/tasks/wm_abench/wm_abench_mechanisticknowledge_maniskill_rotate_subset.yaml
@@ -1,0 +1,4 @@
+dataset_name: "MechanisticKnowledge_maniskill_rotate_subset"
+tag: "wm_abench_subtasks"
+task: "wm_abench_mechanisticknowledge_maniskill_rotate_subset"
+include: _default_template_yaml

--- a/lmms_eval/tasks/wm_abench/wm_abench_mechanisticknowledge_physion_type_collision_v2_subset.yaml
+++ b/lmms_eval/tasks/wm_abench/wm_abench_mechanisticknowledge_physion_type_collision_v2_subset.yaml
@@ -1,0 +1,4 @@
+dataset_name: "MechanisticKnowledge_physion_type_collision_v2_subset"
+tag: "wm_abench_subtasks"
+task: "wm_abench_mechanisticknowledge_physion_type_collision_v2_subset"
+include: _default_template_yaml

--- a/lmms_eval/tasks/wm_abench/wm_abench_mechanisticknowledge_physion_type_drop_subset.yaml
+++ b/lmms_eval/tasks/wm_abench/wm_abench_mechanisticknowledge_physion_type_drop_subset.yaml
@@ -1,0 +1,4 @@
+dataset_name: "MechanisticKnowledge_physion_type_drop_subset"
+tag: "wm_abench_subtasks"
+task: "wm_abench_mechanisticknowledge_physion_type_drop_subset"
+include: _default_template_yaml

--- a/lmms_eval/tasks/wm_abench/wm_abench_mechanisticknowledge_physion_type_slide_subset.yaml
+++ b/lmms_eval/tasks/wm_abench/wm_abench_mechanisticknowledge_physion_type_slide_subset.yaml
@@ -1,0 +1,4 @@
+dataset_name: "MechanisticKnowledge_physion_type_slide_subset"
+tag: "wm_abench_subtasks"
+task: "wm_abench_mechanisticknowledge_physion_type_slide_subset"
+include: _default_template_yaml

--- a/lmms_eval/tasks/wm_abench/wm_abench_motiondirection_maniskill_subtask_subset.yaml
+++ b/lmms_eval/tasks/wm_abench/wm_abench_motiondirection_maniskill_subtask_subset.yaml
@@ -1,0 +1,4 @@
+dataset_name: "MotionDirection_maniskill_subtask_subset"
+tag: "wm_abench_subtasks"
+task: "wm_abench_motiondirection_maniskill_subtask_subset"
+include: _default_template_yaml

--- a/lmms_eval/tasks/wm_abench/wm_abench_motiondirection_maniskill_towards_subset.yaml
+++ b/lmms_eval/tasks/wm_abench/wm_abench_motiondirection_maniskill_towards_subset.yaml
@@ -1,0 +1,4 @@
+dataset_name: "MotionDirection_maniskill_towards_subset"
+tag: "wm_abench_subtasks"
+task: "wm_abench_motiondirection_maniskill_towards_subset"
+include: _default_template_yaml

--- a/lmms_eval/tasks/wm_abench/wm_abench_motiondirection_tdw_subset.yaml
+++ b/lmms_eval/tasks/wm_abench/wm_abench_motiondirection_tdw_subset.yaml
@@ -1,0 +1,4 @@
+dataset_name: "MotionDirection_tdw_subset"
+tag: "wm_abench_subtasks"
+task: "wm_abench_motiondirection_tdw_subset"
+include: _default_template_yaml

--- a/lmms_eval/tasks/wm_abench/wm_abench_motiondirection_tdw_subtask_subset.yaml
+++ b/lmms_eval/tasks/wm_abench/wm_abench_motiondirection_tdw_subtask_subset.yaml
@@ -1,0 +1,4 @@
+dataset_name: "MotionDirection_tdw_subtask_subset"
+tag: "wm_abench_subtasks"
+task: "wm_abench_motiondirection_tdw_subtask_subset"
+include: _default_template_yaml

--- a/lmms_eval/tasks/wm_abench/wm_abench_motionspeed_maniskill_subset.yaml
+++ b/lmms_eval/tasks/wm_abench/wm_abench_motionspeed_maniskill_subset.yaml
@@ -1,0 +1,4 @@
+dataset_name: "MotionSpeed_maniskill_subset"
+tag: "wm_abench_subtasks"
+task: "wm_abench_motionspeed_maniskill_subset"
+include: _default_template_yaml

--- a/lmms_eval/tasks/wm_abench/wm_abench_motionspeed_tdw_subset.yaml
+++ b/lmms_eval/tasks/wm_abench/wm_abench_motionspeed_tdw_subset.yaml
@@ -1,0 +1,4 @@
+dataset_name: "MotionSpeed_tdw_subset"
+tag: "wm_abench_subtasks"
+task: "wm_abench_motionspeed_tdw_subset"
+include: _default_template_yaml

--- a/lmms_eval/tasks/wm_abench/wm_abench_motiontrajectory_maniskill_path_choices_subset.yaml
+++ b/lmms_eval/tasks/wm_abench/wm_abench_motiontrajectory_maniskill_path_choices_subset.yaml
@@ -1,0 +1,4 @@
+dataset_name: "MotionTrajectory_maniskill_path_choices_subset"
+tag: "wm_abench_subtasks"
+task: "wm_abench_motiontrajectory_maniskill_path_choices_subset"
+include: _default_template_yaml

--- a/lmms_eval/tasks/wm_abench/wm_abench_motiontrajectory_path_choices_subset.yaml
+++ b/lmms_eval/tasks/wm_abench/wm_abench_motiontrajectory_path_choices_subset.yaml
@@ -1,0 +1,4 @@
+dataset_name: "MotionTrajectory_path_choices_subset"
+tag: "wm_abench_subtasks"
+task: "wm_abench_motiontrajectory_path_choices_subset"
+include: _default_template_yaml

--- a/lmms_eval/tasks/wm_abench/wm_abench_multiview_maniskill_subset.yaml
+++ b/lmms_eval/tasks/wm_abench/wm_abench_multiview_maniskill_subset.yaml
@@ -1,0 +1,4 @@
+dataset_name: "Multiview_maniskill_subset"
+tag: "wm_abench_subtasks"
+task: "wm_abench_multiview_maniskill_subset"
+include: _default_template_yaml

--- a/lmms_eval/tasks/wm_abench/wm_abench_multiview_tdw_subset.yaml
+++ b/lmms_eval/tasks/wm_abench/wm_abench_multiview_tdw_subset.yaml
@@ -1,0 +1,4 @@
+dataset_name: "Multiview_tdw_subset"
+tag: "wm_abench_subtasks"
+task: "wm_abench_multiview_tdw_subset"
+include: _default_template_yaml

--- a/lmms_eval/tasks/wm_abench/wm_abench_predictionnextstate_carla_next_state_prediction_02_08_subset.yaml
+++ b/lmms_eval/tasks/wm_abench/wm_abench_predictionnextstate_carla_next_state_prediction_02_08_subset.yaml
@@ -1,0 +1,4 @@
+dataset_name: "PredictionNextState_carla_next_state_prediction_02_08_subset"
+tag: "wm_abench_subtasks"
+task: "wm_abench_predictionnextstate_carla_next_state_prediction_02_08_subset"
+include: _default_template_yaml

--- a/lmms_eval/tasks/wm_abench/wm_abench_quantitycontinuous_tdw_continuous_subset.yaml
+++ b/lmms_eval/tasks/wm_abench/wm_abench_quantitycontinuous_tdw_continuous_subset.yaml
@@ -1,0 +1,4 @@
+dataset_name: "QuantityContinuous_tdw_continuous_subset"
+tag: "wm_abench_subtasks"
+task: "wm_abench_quantitycontinuous_tdw_continuous_subset"
+include: _default_template_yaml

--- a/lmms_eval/tasks/wm_abench/wm_abench_relativecounting_maniskill_subset.yaml
+++ b/lmms_eval/tasks/wm_abench/wm_abench_relativecounting_maniskill_subset.yaml
@@ -1,0 +1,4 @@
+dataset_name: "RelativeCounting_maniskill_subset"
+tag: "wm_abench_subtasks"
+task: "wm_abench_relativecounting_maniskill_subset"
+include: _default_template_yaml

--- a/lmms_eval/tasks/wm_abench/wm_abench_relativecounting_tdw_color_letter_subset.yaml
+++ b/lmms_eval/tasks/wm_abench/wm_abench_relativecounting_tdw_color_letter_subset.yaml
@@ -1,0 +1,4 @@
+dataset_name: "RelativeCounting_tdw_color_letter_subset"
+tag: "wm_abench_subtasks"
+task: "wm_abench_relativecounting_tdw_color_letter_subset"
+include: _default_template_yaml

--- a/lmms_eval/tasks/wm_abench/wm_abench_relativeposition_front_top_subset.yaml
+++ b/lmms_eval/tasks/wm_abench/wm_abench_relativeposition_front_top_subset.yaml
@@ -1,0 +1,4 @@
+dataset_name: "RelativePosition_front_top_subset"
+tag: "wm_abench_subtasks"
+task: "wm_abench_relativeposition_front_top_subset"
+include: _default_template_yaml

--- a/lmms_eval/tasks/wm_abench/wm_abench_relativeposition_front_top_tdw_subset.yaml
+++ b/lmms_eval/tasks/wm_abench/wm_abench_relativeposition_front_top_tdw_subset.yaml
@@ -1,0 +1,4 @@
+dataset_name: "RelativePosition_front_top_tdw_subset"
+tag: "wm_abench_subtasks"
+task: "wm_abench_relativeposition_front_top_tdw_subset"
+include: _default_template_yaml

--- a/lmms_eval/tasks/wm_abench/wm_abench_spatialoccupancy_maniskill_subset.yaml
+++ b/lmms_eval/tasks/wm_abench/wm_abench_spatialoccupancy_maniskill_subset.yaml
@@ -1,0 +1,4 @@
+dataset_name: "SpatialOccupancy_maniskill_subset"
+tag: "wm_abench_subtasks"
+task: "wm_abench_spatialoccupancy_maniskill_subset"
+include: _default_template_yaml

--- a/lmms_eval/tasks/wm_abench/wm_abench_spatialoccupancy_occupancy_fitting_tdw_top_subset.yaml
+++ b/lmms_eval/tasks/wm_abench/wm_abench_spatialoccupancy_occupancy_fitting_tdw_top_subset.yaml
@@ -1,0 +1,4 @@
+dataset_name: "SpatialOccupancy_occupancy_fitting_tdw_top_subset"
+tag: "wm_abench_subtasks"
+task: "wm_abench_spatialoccupancy_occupancy_fitting_tdw_top_subset"
+include: _default_template_yaml

--- a/lmms_eval/tasks/wm_abench/wm_abench_spatialoccupancy_occupancy_size_tdw_front_large_subset.yaml
+++ b/lmms_eval/tasks/wm_abench/wm_abench_spatialoccupancy_occupancy_size_tdw_front_large_subset.yaml
@@ -1,0 +1,4 @@
+dataset_name: "SpatialOccupancy_occupancy_size_tdw_front_large_subset"
+tag: "wm_abench_subtasks"
+task: "wm_abench_spatialoccupancy_occupancy_size_tdw_front_large_subset"
+include: _default_template_yaml

--- a/lmms_eval/tasks/wm_abench/wm_abench_spatialoccupancy_volume_object_only_unfloat_top_subset.yaml
+++ b/lmms_eval/tasks/wm_abench/wm_abench_spatialoccupancy_volume_object_only_unfloat_top_subset.yaml
@@ -1,0 +1,4 @@
+dataset_name: "SpatialOccupancy_volume_object_only_unfloat_top_subset"
+tag: "wm_abench_subtasks"
+task: "wm_abench_spatialoccupancy_volume_object_only_unfloat_top_subset"
+include: _default_template_yaml

--- a/lmms_eval/tasks/wm_abench/wm_abench_speed_tdw_subset.yaml
+++ b/lmms_eval/tasks/wm_abench/wm_abench_speed_tdw_subset.yaml
@@ -1,0 +1,4 @@
+dataset_name: "speed_tdw_subset"
+tag: "wm_abench_subtasks"
+task: "wm_abench_speed_tdw_subset"
+include: _default_template_yaml

--- a/lmms_eval/tasks/wm_abench/wm_abench_temporalextension_temporal_tdw_yjx_01_05_subset.yaml
+++ b/lmms_eval/tasks/wm_abench/wm_abench_temporalextension_temporal_tdw_yjx_01_05_subset.yaml
@@ -1,0 +1,4 @@
+dataset_name: "TemporalExtension_temporal_tdw_yjx_01_05_subset"
+tag: "wm_abench_subtasks"
+task: "wm_abench_temporalextension_temporal_tdw_yjx_01_05_subset"
+include: _default_template_yaml

--- a/lmms_eval/tasks/wm_abench/wm_abench_temporalpositioning_maniskill_subset.yaml
+++ b/lmms_eval/tasks/wm_abench/wm_abench_temporalpositioning_maniskill_subset.yaml
@@ -1,0 +1,4 @@
+dataset_name: "TemporalPositioning_maniskill_subset"
+tag: "wm_abench_subtasks"
+task: "wm_abench_temporalpositioning_maniskill_subset"
+include: _default_template_yaml

--- a/lmms_eval/tasks/wm_abench/wm_abench_transitivity_habitat_lab_trans_ver_2_noback_subset.yaml
+++ b/lmms_eval/tasks/wm_abench/wm_abench_transitivity_habitat_lab_trans_ver_2_noback_subset.yaml
@@ -1,0 +1,4 @@
+dataset_name: "Transitivity_habitat_lab_trans_ver_2_noback_subset"
+tag: "wm_abench_subtasks"
+task: "wm_abench_transitivity_habitat_lab_trans_ver_2_noback_subset"
+include: _default_template_yaml

--- a/lmms_eval/tasks/wm_abench/wm_abench_visualattribute_color_subset.yaml
+++ b/lmms_eval/tasks/wm_abench/wm_abench_visualattribute_color_subset.yaml
@@ -1,0 +1,4 @@
+dataset_name: "VisualAttribute_color_subset"
+tag: "wm_abench_subtasks"
+task: "wm_abench_visualattribute_color_subset"
+include: _default_template_yaml

--- a/lmms_eval/tasks/wm_abench/wm_abench_visualattribute_color_tdw_subset.yaml
+++ b/lmms_eval/tasks/wm_abench/wm_abench_visualattribute_color_tdw_subset.yaml
@@ -1,0 +1,4 @@
+dataset_name: "VisualAttribute_color_tdw_subset"
+tag: "wm_abench_subtasks"
+task: "wm_abench_visualattribute_color_tdw_subset"
+include: _default_template_yaml

--- a/lmms_eval/tasks/wm_abench/wm_abench_visualattribute_material_diff_tdw_subset.yaml
+++ b/lmms_eval/tasks/wm_abench/wm_abench_visualattribute_material_diff_tdw_subset.yaml
@@ -1,0 +1,4 @@
+dataset_name: "VisualAttribute_material_diff_tdw_subset"
+tag: "wm_abench_subtasks"
+task: "wm_abench_visualattribute_material_diff_tdw_subset"
+include: _default_template_yaml

--- a/lmms_eval/tasks/wm_abench/wm_abench_visualattribute_shape_tdw_subset.yaml
+++ b/lmms_eval/tasks/wm_abench/wm_abench_visualattribute_shape_tdw_subset.yaml
@@ -1,0 +1,4 @@
+dataset_name: "VisualAttribute_shape_tdw_subset"
+tag: "wm_abench_subtasks"
+task: "wm_abench_visualattribute_shape_tdw_subset"
+include: _default_template_yaml


### PR DESCRIPTION
## Summary
- Add COVER (Counterfactual Video Reasoning, ACL Findings 2025) benchmark for causal video understanding
- Add WM-aBench (World Models aBench) with 36+ task variants for comprehensive world model evaluation

## Benchmarks

### COVER
Tests causal understanding in videos via counterfactual question generation. Includes `generate_qa.py` for automatic QA pair generation from video annotations.

### WM-aBench
Evaluates world model capabilities across multiple dimensions:
- **Spatial**: relative position, occupancy, multiview
- **Motion**: direction, speed, trajectory
- **Physical**: mechanistic knowledge, compositionality
- **Temporal**: extension, positioning, transitivity
- **Visual**: attribute recognition (color, shape, material)
- **Counting**: discrete counting, relative counting

Uses ManISkill, TDW, Physion, Habitat, and CARLA simulation environments.

## Test plan
- [ ] Verify task registration with `lmms-eval --tasks list | grep -E "cover|wm_abench"`
- [ ] Run COVER with a video-capable model
- [ ] Run a WM-aBench subset task
- [ ] Confirm group yaml correctly aggregates all subtasks