### PR TITLE
fix: handle internvl_hf video-only inputs and enable frame sampling

### DIFF
--- a/lmms_eval/models/chat/internvl_hf.py
+++ b/lmms_eval/models/chat/internvl_hf.py
@@ -263,6 +263,8 @@ class InternVLHf(lmms):
             if self.accelerator.is_main_process and doc_id[0] % 100 == 0:
                 eval_logger.debug(f"Prompt for doc ID {doc_id[0]}:\n\n{text}\n")
 
+            if len(visuals) == 0:
+                visuals = None
             if len(videos) == 0:
                 videos = None
             inputs = self.processor(
@@ -278,7 +280,7 @@ class InternVLHf(lmms):
             # this is safe to assume because the `grouper` object ensures it.
             gen_kwargs = all_gen_kwargs[0]
 
-            gen_kwargs["image_sizes"] = [visuals[idx].size for idx in range(len(visuals))]
+            gen_kwargs["image_sizes"] = [visual.size for visual in visuals] if visuals is not None else []
             if "max_new_tokens" not in gen_kwargs:
                 gen_kwargs["max_new_tokens"] = 1024
             if "temperature" not in gen_kwargs:

--- a/lmms_eval/models/chat/internvl_hf.py
+++ b/lmms_eval/models/chat/internvl_hf.py
@@ -249,6 +249,9 @@ class InternVLHf(lmms):
                 images_kwargs["min_patches"] = self.min_patches
             if self.max_patches is not None:
                 images_kwargs["max_patches"] = self.max_patches
+            if self.num_frames is not None or self.fps is not None:
+                # InternVL only applies num_frames/fps when frame sampling is explicitly enabled.
+                videos_kwargs["do_sample_frames"] = True
             if self.num_frames is not None:
                 videos_kwargs["num_frames"] = self.num_frames
             if self.fps is not None:


### PR DESCRIPTION
## Summary

This PR fixes two `internvl_hf` video handling bugs in `lmms_eval/models/chat/internvl_hf.py`:

- explicitly enables frame sampling when `num_frames` or `fps` is configured
- normalizes empty image inputs to `None` for video-only examples
- avoids building `image_sizes` from an empty image list

## Why

This PR is motivated by two related `internvl_hf` bugs reported upstream:

- #1241 reports that video-only inputs can crash because `generate_until()` passes `images=[]` into the processor, and later also assumes `visuals` is non-empty when building `image_sizes`
- #1242 reports that `num_frames` is not actually applied, because InternVL video processing keeps `do_sample_frames=False` by default unless it is explicitly enabled

Together, these two issues make `internvl_hf` unreliable on video tasks:
video-only samples can raise an `IndexError`, and sampled-video runs can still process all frames and overflow the model context length.

Closes #1241  
Closes #1242

## Validation

- `pre-commit run --files lmms_eval/models/chat/internvl_hf.py`
- `python -m py_compile lmms_eval/models/chat/internvl_hf.py`
