### PR TITLE
Add `trust_remote_code` param for huggingface model.

### DIFF
--- a/lmms_eval/models/chat/huggingface.py
+++ b/lmms_eval/models/chat/huggingface.py
@@ -56,6 +56,7 @@ class Huggingface(lmms):
         system_prompt: Optional[str] = None,
         interleave_visuals: Optional[bool] = False,
         reasoning_prompt: Optional[str] = None,
+        trust_remote_code: Optional[bool] = False,
         **kwargs,
     ) -> None:
         super().__init__()
@@ -86,7 +87,8 @@ class Huggingface(lmms):
         if attn_implementation is not None:
             model_kwargs["attn_implementation"] = attn_implementation
 
-        config = AutoConfig.from_pretrained(pretrained)
+        self.trust_remote_code = trust_remote_code
+        config = AutoConfig.from_pretrained(pretrained, trust_remote_code=trust_remote_code)
         if config.model_type in AutoModelForCausalLM._model_mapping.keys():
             model_cls = AutoModelForCausalLM
         elif config.model_type in AutoModelForImageTextToText._model_mapping.keys():
@@ -94,7 +96,7 @@ class Huggingface(lmms):
         else:
             model_cls = AutoModel
 
-        self._model = model_cls.from_pretrained(pretrained, **model_kwargs).eval()
+        self._model = model_cls.from_pretrained(pretrained, trust_remote_code=trust_remote_code, **model_kwargs).eval()
         self.max_num_frames = max_num_frames
 
         raw_prompt = reasoning_prompt or system_prompt
@@ -102,8 +104,8 @@ class Huggingface(lmms):
             self.system_prompt = self._resolve_system_prompt(raw_prompt.replace("\\n", "\n"))
         else:
             self.system_prompt = None
-        self.processor = AutoProcessor.from_pretrained(pretrained)
-        self._tokenizer = AutoTokenizer.from_pretrained(pretrained)
+        self.processor = AutoProcessor.from_pretrained(pretrained, trust_remote_code=trust_remote_code)
+        self._tokenizer = AutoTokenizer.from_pretrained(pretrained, trust_remote_code=trust_remote_code)
         self.interleave_visuals = interleave_visuals
 
         self._config = self.model.config


### PR DESCRIPTION
## Summary
<!-- Max 3 bullets. -->
- Add `trust_remote_code` as configurable param for huggingface-compatible models. 
- 
- 

## In scope
<!-- Explicitly list what this PR changes. -->
- Add `trust_remote_code` as configurable param so it can be parsed via `--model huggingface   --model_args pretrained=<model_path>,trust_remote_code=True`

## Out of scope
<!-- Explicitly list what this PR does NOT change. -->
- Other model classes. 

## Validation
<!--
Max 3 bullets.
Use this format:
`<command>` | sample size: `N=<...>` | key metrics: `<...>` | result: `pass/fail`
If you ran tests/benchmarks with metrics, include concrete numbers.
-->
- 

## Risk / Compatibility
<!-- 1-2 bullets. Note breaking changes, behavior changes, or migration impact. -->
- No breaking changes is made. 

## Type of Change
- [ ] Bug fix (non-breaking change)
- [x] New feature
- [ ] New benchmark/task
- [ ] New model integration
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
