### PR TITLE
fix(eval): abort all ranks on per-rank exception instead of deadlocking

### DIFF
--- a/lmms_eval/__main__.py
+++ b/lmms_eval/__main__.py
@@ -563,6 +563,16 @@ def cli_evaluate(args: Union[argparse.Namespace, None] = None) -> None:
                 traceback.print_exc()
                 eval_logger.error(f"Error during evaluation: {e}. Please set `--verbosity=DEBUG` to get more information.")
                 results_list.append(None)
+                # Under torchrun/accelerate, a rank returning after a local
+                # exception leaves peers blocked in NCCL collectives until
+                # the launcher's timeout. Abort all ranks so the launcher
+                # propagates the failure immediately instead of deadlocking.
+                if torch.distributed.is_available() and torch.distributed.is_initialized():
+                    try:
+                        torch.distributed.destroy_process_group()
+                    except Exception:
+                        pass
+                    sys.exit(1)
 
     for args, results in zip(args_list, results_list):
         # cli_evaluate will return none if the process is not the main process (rank 0)


### PR DESCRIPTION
## Summary

When `torchrun` / `accelerate` launches multiple ranks and one rank's `evaluate()` raises, today's handler in `cli_evaluate` logs the error, appends `None`, and lets the rank return normally. The other ranks keep going and block on the next collective (`gather_object`, `barrier`, etc.) on NCCL until the launcher's wall-clock timeout tears the job down — which on a SLURM cluster can waste hours of GPU time for a failure that is visible in rank 0's log at second zero.

## Change

If `torch.distributed` is initialized when the outer exception handler fires, destroy the process group and `sys.exit(1)` so the launcher's elastic supervisor sees a non-zero rank and tears down the rest of the world immediately.

```python
results_list.append(None)
+ if torch.distributed.is_available() and torch.distributed.is_initialized():
+     try:
+         torch.distributed.destroy_process_group()
+     except Exception:
+         pass
+     sys.exit(1)
```

## Non-goals / scope

- No behavior change for single-process runs — the `is_initialized()` check gates the new path entirely.
- Does not try to distinguish retriable from fatal errors. The outer handler only fires after the inner eval loop already gave up.

## Test plan

- [ ] Multi-rank run where rank N raises manually — verify all ranks exit within seconds instead of hitting wall-clock.
- [ ] Single-process run — verify no change in happy path.