### PR TITLE
fix(api/task): guard empty results list in process_results

### DIFF
--- a/lmms_eval/api/task.py
+++ b/lmms_eval/api/task.py
@@ -1576,7 +1576,10 @@ class ConfigurableTask(Task):
     @retry(stop=(stop_after_attempt(5) | stop_after_delay(1200)), wait=wait_fixed(2))
     def process_results(self, doc, results, full_docs=None):
         if self.OUTPUT_TYPE in ("generate_until", "generate_visual_cot"):
-            if isinstance(results, list) and isinstance(results[0], list):
+            # Guard empty results so results[0] below does not IndexError for
+            # samples whose generation failed. Downstream process_results then
+            # receives an empty list and can decide how to score the miss.
+            if results and isinstance(results, list) and isinstance(results[0], list):
                 results = [res.strip() for res in results[0]]
             else:
                 results = [res.strip() for res in results]


### PR DESCRIPTION
## Summary

For `generate_until` / `generate_visual_cot` tasks, when a sample's generation failed upstream (model raised, retries exhausted, returned `[]`), the results list handed to `ConfigurableTask.process_results` can be empty. The existing `isinstance` check then falls through to `results[0]` on the list-of-list branch and raises `IndexError` — which aborts the whole postprocess loop for that task, not just the missing sample.

## Change

Add a leading `results and` so an empty list routes to the else branch (which does `[res.strip() for res in results]` and produces `[]`). Downstream task-level `process_results` then receives an empty list and can decide how to score the missing sample without taking down the whole task.

```python
if self.OUTPUT_TYPE in ("generate_until", "generate_visual_cot"):
-   if isinstance(results, list) and isinstance(results[0], list):
+   # Guard empty results so results[0] below does not IndexError for
+   # samples whose generation failed. Downstream process_results then
+   # receives an empty list and can decide how to score the miss.
+   if results and isinstance(results, list) and isinstance(results[0], list):
        results = [res.strip() for res in results[0]]
    else:
        results = [res.strip() for res in results]
```

## Test plan

- [ ] Any task run where at least one generation produces `[]` — verify the task finishes and the missing sample is scored by downstream `process_results`.
- [ ] Happy-path run — verify no change in scores.