### PR TITLE
fix: release accelerator model refs during cleanup

### DIFF
--- a/lmms_eval/api/model.py
+++ b/lmms_eval/api/model.py
@@ -164,6 +164,10 @@ class lmms(abc.ABC):
         self.cache_hook = cache_hook
 
     def clean(self):
+        accelerator = getattr(self, "accelerator", None)
+        if accelerator is not None and hasattr(accelerator, "free_memory"):
+            accelerator.free_memory()
+
         for attr_name in list(vars(self)):
             attr_value = getattr(self, attr_name)
             if isinstance(attr_value, nn.Module):

--- a/test/models/test_model_cleanup.py
+++ b/test/models/test_model_cleanup.py
@@ -1,0 +1,38 @@
+import torch
+
+from lmms_eval.api.model import lmms
+
+
+class _DummyLM(lmms):
+    def loglikelihood(self, requests):
+        return []
+
+    def generate_until(self, requests):
+        return []
+
+    def generate_until_multi_round(self, requests):
+        return []
+
+
+class _FakeAccelerator:
+    def __init__(self, model):
+        self._models = [model]
+        self.free_memory_calls = 0
+
+    def free_memory(self):
+        self.free_memory_calls += 1
+        self._models = []
+
+
+def test_clean_releases_accelerator_model_references():
+    lm = _DummyLM()
+    model = torch.nn.Linear(1, 1)
+    accelerator = _FakeAccelerator(model)
+    lm._model = model
+    lm.accelerator = accelerator
+
+    lm.clean()
+
+    assert accelerator.free_memory_calls == 1
+    assert accelerator._models == []
+    assert not hasattr(lm, "_model")


### PR DESCRIPTION
## Summary
- Release Accelerate-held model references during `lmms.clean()` by calling `Accelerator.free_memory()` when an accelerator is attached.
- Fixes a post-inference GPU memory retention path where prepared models remain referenced by Accelerate even after direct `nn.Module` attributes are deleted.
- Add regression coverage for accelerator-retained model references.

## In scope
- Update `lmms_eval/api/model.py` so base model cleanup clears Accelerate internal model references before existing module deletion, garbage collection, and CUDA cache clearing.
- Add `test/models/test_model_cleanup.py` to verify cleanup calls `free_memory()` and removes direct model attributes.

## Out of scope
- Does not change model generation, postprocessing, distributed gather behavior, sample logging, or task metrics.
- Does not add model-specific cleanup logic for `llava_onevision1_5`; the fix applies through the shared base cleanup path.

## Validation
- `python -m compileall -q lmms_eval/api/model.py test/models/test_model_cleanup.py` | sample size: `N=2 files` | key metrics: `syntax/import bytecode compilation` | result: `pass`
- `python -m pytest -q test/models/test_model_cleanup.py` | sample size: `N=1 test` | key metrics: `accelerator model references released during clean()` | result: `pass` (`1 passed in 3.47s`)

## Risk / Compatibility
- Low risk: this only runs during explicit model cleanup after inference; normal model execution is unchanged.
- For Accelerate-backed models, `free_memory()` clears Accelerate internal references before the existing direct module cleanup and CUDA cache clearing, reducing rank memory pressure before postprocessing/gathering.

## Type of Change
- [x] Bug fix (non-breaking change)
- [ ] New feature
- [ ] New benchmark/task
- [ ] New model integration
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring (no functional changes)