### PR TITLE
feat: add TimeLens benchmark

### DIFF
--- a/lmms_eval/tasks/charades_sta/charades.yaml
+++ b/lmms_eval/tasks/charades_sta/charades.yaml
@@ -21,8 +21,17 @@ process_results: !function utils.temporal_grounding_process_results_generation
 
 
 metric_list:
-  - metric: submission
-    aggregation: !function utils.temporal_grounding_aggregate_charades
+  - metric: charades_sta_IOU@3
+    aggregation: !function utils.temporal_grounding_aggregate_iou3
+    higher_is_better: true
+  - metric: charades_sta_IOU@5
+    aggregation: !function utils.temporal_grounding_aggregate_iou5
+    higher_is_better: true
+  - metric: charades_sta_IOU@7
+    aggregation: !function utils.temporal_grounding_aggregate_iou7
+    higher_is_better: true
+  - metric: charades_sta_mIOU
+    aggregation: !function utils.temporal_grounding_aggregate_miou
     higher_is_better: true
 lmms_eval_specific_kwargs:
   default:

--- a/lmms_eval/tasks/charades_sta/utils.py
+++ b/lmms_eval/tasks/charades_sta/utils.py
@@ -1,6 +1,8 @@
+import ast
 import datetime
 import json
 import os
+import re
 import sys
 from pathlib import Path
 
@@ -57,10 +59,8 @@ def temporal_grounding_doc_to_text(doc, lmms_eval_specific_kwargs=None):
     if lmms_eval_specific_kwargs is None:
         lmms_eval_specific_kwargs = {}
 
-    if "pre_prompt" in lmms_eval_specific_kwargs:
-        pre_prompt = lmms_eval_specific_kwargs["pre_prompt"]
-    if "post_prompt" in lmms_eval_specific_kwargs:
-        post_prompt = lmms_eval_specific_kwargs["post_prompt"]
+    pre_prompt = lmms_eval_specific_kwargs.get("pre_prompt", "")
+    post_prompt = lmms_eval_specific_kwargs.get("post_prompt", "")
 
     question = doc["caption"]
 
@@ -74,7 +74,145 @@ def temporal_grounding_doc_to_answer(doc):
 # Process result for mcq answer generation
 def temporal_grounding_process_results_generation(doc, result):
     pred = result[0]
-    return {"submission": {f'{doc["video"]}>>>{doc["caption"]}>>>{doc["timestamp"]}': pred}}
+    data_dict = {f'{doc["video"]}>>>{doc["caption"]}>>>{doc["timestamp"]}': pred}
+    return {f"charades_sta_{metric}": data_dict for metric in CHARADES_STA_METRICS}
+
+
+CHARADES_STA_METRICS = ["IOU@3", "IOU@5", "IOU@7", "mIOU"]
+
+
+def extract_time(paragraph):
+    prompt = "A specific example is : 20.8 - 30.0 seconds".lower()
+    paragraph = paragraph.lower().replace(prompt, "").replace("to", "-")
+    sentences = re.split(r"[!?\n]", paragraph)
+
+    keywords = ["starts", "ends", "happens in", "start time", "end time", "start", "end", "happen"]
+    candidates = [sentence for sentence in sentences if any(keyword in sentence for keyword in keywords)]
+    if not candidates:
+        candidates = sentences
+
+    timestamps = []
+    time_format_range_pattern = re.compile(r"\b(\d{1,2}:\d{2}(?::\d{2})?)\s*[–-]\s*(\d{1,2}:\d{2}(?::\d{2})?)\b")
+    main_pattern = re.compile(r"(\d+(?:\.\d+)?)\s*[–-]\s*(\d+(?:\.\d+)?)")
+    time_number_pattern = re.compile(r"\b(\d+(?:\.\d+)?)\b")
+    time_format_pattern = re.compile(r"\b(\d{1,2}:\d{2}(?::\d{2})?)\b")
+    fallback_pattern = re.compile(r"(\d+(?:\.\d+)?)\s*s?\s*[–-]\s*(\d+(?:\.\d+)?)\s*s?")
+
+    for sentence in candidates:
+        time_matches = time_format_range_pattern.findall(sentence)
+        if time_matches:
+            timestamps = [[_time_to_seconds(start), _time_to_seconds(end)] for start, end in time_matches]
+            break
+
+    if not timestamps:
+        for sentence in candidates:
+            time_matches = main_pattern.findall(sentence)
+            if time_matches:
+                timestamps = [[float(start), float(end)] for start, end in time_matches]
+                break
+
+    if not timestamps:
+        times = []
+        for sentence in candidates:
+            time = time_format_pattern.findall(sentence)
+            if not time:
+                continue
+            times.extend(_time_to_seconds(timestamp) for timestamp in time)
+        times = times[: len(times) // 2 * 2]
+        timestamps = [(times[i], times[i + 1]) for i in range(0, len(times), 2)]
+
+    if not timestamps:
+        times = []
+        for sentence in candidates:
+            time = time_number_pattern.findall(sentence)
+            if time:
+                times.append(float(time[0]))
+        times = times[: len(times) // 2 * 2]
+        timestamps = [(times[i], times[i + 1]) for i in range(0, len(times), 2)]
+
+    if not timestamps:
+        for sentence in candidates:
+            fallback_matches = fallback_pattern.findall(sentence)
+            if fallback_matches:
+                timestamps = [[float(start), float(end)] for start, end in fallback_matches]
+                break
+
+    results = []
+    for start, end in timestamps[:1]:
+        results.append([start, end] if end > start else [end, start])
+    return results
+
+
+def _time_to_seconds(timestamp):
+    parts = timestamp.split(":")
+    if len(parts) == 3:
+        hours, minutes, seconds = map(float, parts)
+        return hours * 3600 + minutes * 60 + seconds
+    minutes, seconds = map(float, parts)
+    return minutes * 60 + seconds
+
+
+def iou(a, b):
+    max0 = max(a[0], b[0])
+    min0 = min(a[0], b[0])
+    max1 = max(a[1], b[1])
+    min1 = min(a[1], b[1])
+    denom = max1 - min0
+    return 0.0 if denom <= 0 else max(min1 - max0, 0) / denom
+
+
+def _parse_ground_truth(raw_gt):
+    if isinstance(raw_gt, str):
+        raw_gt = ast.literal_eval(raw_gt)
+    return float(raw_gt[0]), float(raw_gt[1])
+
+
+def _temporal_grounding_compute_metrics(results):
+    combined_submission = {}
+    for submission_dict in results:
+        combined_submission.update(submission_dict)
+
+    ious = []
+    bad_pred = 0
+    for key, pred_text in combined_submission.items():
+        try:
+            gt = _parse_ground_truth(key.rsplit(">>>", 1)[-1])
+            pred_times = extract_time(pred_text)
+            if len(pred_times) != 1:
+                cur_iou = 0.0
+                bad_pred += 1
+            else:
+                cur_iou = iou(gt, pred_times[0])
+            ious.append(cur_iou)
+        except Exception as e:
+            eval_logger.warning(f"Failed to process Charades-STA result: {e}")
+            ious.append(0.0)
+            bad_pred += 1
+
+    total = len(ious)
+    eval_logger.info(f"Charades-STA bad predictions: {bad_pred}/{total}")
+    metrics = {}
+    for thr in [0.3, 0.5, 0.7]:
+        count = sum(1 for value in ious if value >= thr)
+        metrics[f"IOU@{int(thr * 10)}"] = count * 100 / total if total else 0
+    metrics["mIOU"] = sum(ious) * 100 / total if total else 0
+    return metrics
+
+
+def temporal_grounding_aggregate_iou3(results, args):
+    return _temporal_grounding_compute_metrics(results)["IOU@3"]
+
+
+def temporal_grounding_aggregate_iou5(results, args):
+    return _temporal_grounding_compute_metrics(results)["IOU@5"]
+
+
+def temporal_grounding_aggregate_iou7(results, args):
+    return _temporal_grounding_compute_metrics(results)["IOU@7"]
+
+
+def temporal_grounding_aggregate_miou(results, args):
+    return _temporal_grounding_compute_metrics(results)["mIOU"]
 
 
 def temporal_grounding_aggregate_charades(results, args):

--- a/lmms_eval/tasks/timelens/_default_yaml_template
+++ b/lmms_eval/tasks/timelens/_default_yaml_template
@@ -1,0 +1,36 @@
+dataset_path: kcz358/timelens
+dataset_kwargs:
+  cache_dir: timelens
+  video: True
+
+generation_kwargs:
+  max_new_tokens: 50
+  temperature: 0
+  top_p: 1.0
+  num_beams: 1
+  do_sample: false
+
+output_type: generate_until
+doc_to_visual: !function utils.timelens_doc_to_visual
+doc_to_text: !function utils.timelens_doc_to_text
+doc_to_target: !function utils.timelens_doc_to_target
+process_results: !function utils.timelens_process_results
+
+metric_list:
+  - metric: timelens_IOU@3
+    aggregation: !function utils.timelens_aggregate_iou3
+    higher_is_better: true
+  - metric: timelens_IOU@5
+    aggregation: !function utils.timelens_aggregate_iou5
+    higher_is_better: true
+  - metric: timelens_IOU@7
+    aggregation: !function utils.timelens_aggregate_iou7
+    higher_is_better: true
+  - metric: timelens_mIOU
+    aggregation: !function utils.timelens_aggregate_miou
+    higher_is_better: true
+
+lmms_eval_specific_kwargs:
+  default:
+    pre_prompt: "Please find the visual event described by the sentence '"
+    post_prompt: "', determining its starting and ending times. The format should be: 'The event happens in <start time> - <end time> seconds'."

--- a/lmms_eval/tasks/timelens/timelens.yaml
+++ b/lmms_eval/tasks/timelens/timelens.yaml
@@ -1,0 +1,5 @@
+group: timelens
+task:
+- timelens_activitynet
+- timelens_charades
+- timelens_qvhighlights

--- a/lmms_eval/tasks/timelens/timelens_activitynet.yaml
+++ b/lmms_eval/tasks/timelens/timelens_activitynet.yaml
@@ -1,0 +1,4 @@
+include: _default_yaml_template
+
+task: timelens_activitynet
+test_split: activitynet

--- a/lmms_eval/tasks/timelens/timelens_charades.yaml
+++ b/lmms_eval/tasks/timelens/timelens_charades.yaml
@@ -1,0 +1,4 @@
+include: _default_yaml_template
+
+task: timelens_charades
+test_split: charades

--- a/lmms_eval/tasks/timelens/timelens_qvhighlights.yaml
+++ b/lmms_eval/tasks/timelens/timelens_qvhighlights.yaml
@@ -1,0 +1,4 @@
+include: _default_yaml_template
+
+task: timelens_qvhighlights
+test_split: qvhighlights

--- a/lmms_eval/tasks/timelens/utils.py
+++ b/lmms_eval/tasks/timelens/utils.py
@@ -1,0 +1,190 @@
+import json
+import os
+import re
+from pathlib import Path
+
+import yaml
+from loguru import logger as eval_logger
+
+hf_home = os.getenv("HF_HOME", "~/.cache/huggingface/")
+base_cache_dir = os.path.expanduser(hf_home)
+
+with open(Path(__file__).parent / "_default_yaml_template", "r") as f:
+    raw_data = f.readlines()
+    safe_data = []
+    for i, line in enumerate(raw_data):
+        if "!function" not in line:
+            safe_data.append(line)
+    config = yaml.safe_load("".join(safe_data))
+    cache_name = config["dataset_kwargs"]["cache_dir"]
+
+
+video_cache_dir = os.path.join(base_cache_dir, cache_name)
+
+
+def extract_time(paragraph: str):
+    paragraph = paragraph.lower()
+    timestamps = []
+
+    time_regex = re.compile(r"\b(\d{1,2}:\d{2}:\d{2}(?:\.\d+)?|\d{1,2}:\d{2}(?:\.\d+)?)\b")
+    time_matches = re.findall(time_regex, paragraph)
+    time_matches = time_matches[: len(time_matches) // 2 * 2]
+
+    if time_matches:
+        conv = []
+        for t in time_matches:
+            parts = t.split(":")
+            if len(parts) == 3:
+                h, m = map(int, parts[:2])
+                s = float(parts[2])
+                conv.append(h * 3600 + m * 60 + s)
+            else:
+                m = int(parts[0])
+                s = float(parts[1])
+                conv.append(m * 60 + s)
+        timestamps = [(conv[i], conv[i + 1]) for i in range(0, len(conv), 2)]
+
+    if not timestamps:
+        patterns = [
+            r"(\d+\.?\d*)\s*-\s*(\d+\.?\d*)",
+            r"(\d+\.?\d*)\s+to\s+(\d+\.?\d*)",
+        ]
+        for p in patterns:
+            matches = re.findall(p, paragraph)
+            if matches:
+                timestamps = [(float(s), float(e)) for s, e in matches]
+                break
+
+    if not timestamps:
+        nums = re.findall(r"\b\d+\.?\d*\b", paragraph)
+        nums = nums[: len(nums) // 2 * 2]
+        timestamps = [(float(nums[i]), float(nums[i + 1])) for i in range(0, len(nums), 2)]
+
+    return timestamps
+
+
+def iou(a, b):
+    max0 = max(a[0], b[0])
+    min0 = min(a[0], b[0])
+    max1 = max(a[1], b[1])
+    min1 = min(a[1], b[1])
+    denom = max1 - min0
+    return 0.0 if denom <= 0 else max(min1 - max0, 0) / denom
+
+
+def parse_target_from_key(k: str):
+    try:
+        target_str = k.rsplit(">>>", 1)[-1]
+        tgt = json.loads(target_str)
+        return float(tgt[0][0]), float(tgt[0][1])
+    except Exception as e:
+        raise ValueError(f"Failed to parse target from key: {k}") from e
+
+
+def timelens_doc_to_visual(doc):
+    video_path = doc["video_path"]
+
+    full_video_path = os.path.join(video_cache_dir, video_path)
+
+    if os.path.exists(full_video_path):
+        return [full_video_path]
+    else:
+        eval_logger.warning(f"Video not found: {full_video_path}")
+        return [full_video_path]
+
+
+def timelens_doc_to_text(doc, lmms_eval_specific_kwargs=None):
+    if lmms_eval_specific_kwargs is None:
+        lmms_eval_specific_kwargs = {}
+
+    pre_prompt = lmms_eval_specific_kwargs.get("pre_prompt", "")
+    post_prompt = lmms_eval_specific_kwargs.get("post_prompt", "")
+
+    query = doc["query"]
+
+    return f"{pre_prompt}{query}{post_prompt}"
+
+
+def timelens_doc_to_target(doc):
+    return doc["span"]
+
+
+TIMELENS_METRICS = ["IOU@3", "IOU@5", "IOU@7", "mIOU"]
+
+
+def timelens_process_results(doc, result):
+    pred = result[0]
+
+    key = f'{doc["video_path"]}>>>{doc["query"]}>>>{doc["span"]}'
+
+    data_dict = {key: pred}
+
+    return {f"timelens_{metric}": data_dict for metric in TIMELENS_METRICS}
+
+
+def _timelens_compute_metrics(results, args=None):
+
+    combined_submission = {}
+    for submission_dict in results:
+        combined_submission.update(submission_dict)
+
+    ious = []
+    num_annos = 0
+    bad_pred = 0
+
+    for k, pred_text in combined_submission.items():
+        try:
+            target_str = k.rsplit(">>>", 1)[-1]
+            tgt = json.loads(target_str)
+            gt = (float(tgt[0][0]), float(tgt[0][1]))
+
+            pred_times = extract_time(pred_text)
+            if not pred_times:
+                cur_iou = 0.0
+                bad_pred += 1
+            else:
+                pred = pred_times[0]
+                cur_iou = iou(pred, gt)
+
+            ious.append(cur_iou)
+            num_annos += 1
+        except Exception as e:
+            eval_logger.warning(f"Failed to process result: {e}")
+
+    metrics = {}
+    for thr in [0.3, 0.5, 0.7]:
+        count = sum(1 for v in ious if v >= thr)
+        metrics[f"IOU@{int(thr*10)}"] = count * 100 / num_annos if num_annos > 0 else 0
+
+    metrics["mIOU"] = sum(ious) * 100 / num_annos if num_annos > 0 else 0
+
+    # eval_logger.info(
+    #     f"Num samples: {num_annos}\n"
+    #     f"Bad pred (no time parsed): {bad_pred}\n"
+    #     f"IOU@3: {metrics['IOU@3']:.2f}\n"
+    #     f"IOU@5: {metrics['IOU@5']:.2f}\n"
+    #     f"IOU@7: {metrics['IOU@7']:.2f}\n"
+    #     f"mIOU: {metrics['mIOU']:.2f}"
+    # )
+
+    return metrics
+
+
+def timelens_aggregate_iou3(results, args):
+    metrics = _timelens_compute_metrics(results, args)
+    return metrics["IOU@3"]
+
+
+def timelens_aggregate_iou5(results, args):
+    metrics = _timelens_compute_metrics(results, args)
+    return metrics["IOU@5"]
+
+
+def timelens_aggregate_iou7(results, args):
+    metrics = _timelens_compute_metrics(results, args)
+    return metrics["IOU@7"]
+
+
+def timelens_aggregate_miou(results, args):
+    metrics = _timelens_compute_metrics(results, args)
+    return metrics["mIOU"]


### PR DESCRIPTION
## Summary
- Adds TimeLens temporal grounding tasks for ActivityNet, Charades, and QVHighlights.
- Uses `kcz358/timelens` with lmms-eval's existing dataset video zip extraction flow.
- Reports Charades-STA IOU@3, IOU@5, IOU@7, and mIOU directly in lmms-eval results.

## Dataset Assets
- Uploaded 18 video zip archives to `kcz358/timelens` under `videos/`.
- Verified every archive is below 5GB and preserves relative paths such as `charades/<video>.mp4`.

## Testing
- `pre-commit run --files lmms_eval/tasks/timelens/timelens.yaml lmms_eval/tasks/timelens/_default_yaml_template lmms_eval/tasks/timelens/timelens_activitynet.yaml lmms_eval/tasks/timelens/timelens_charades.yaml lmms_eval/tasks/timelens/timelens_qvhighlights.yaml lmms_eval/tasks/timelens/utils.py lmms_eval/tasks/charades_sta/charades.yaml lmms_eval/tasks/charades_sta/utils.py`
- `python -m compileall -q lmms_eval/tasks/timelens lmms_eval/tasks/charades_sta`
- `scripts/run_timelens_qwen3vl4b.sh` with `LIMIT=4`
- Focused Charades-STA parsing and direct metric aggregation smoke checks.