### PR TITLE
fix: guard choices[0] and message=None before content access (41 sites, 32 files)

### DIFF
--- a/lmms_eval/llm_judge/providers/azure_openai.py
+++ b/lmms_eval/llm_judge/providers/azure_openai.py
@@ -64,6 +64,8 @@ class AzureOpenAIProvider(OpenAIProvider):
             try:
                 if self.use_client:
                     response = self.client.chat.completions.create(**payload)
+                    if not response.choices or response.choices[0].message is None:
+                        raise ValueError("LLM returned empty or filtered response")
                     content = response.choices[0].message.content
                     model_used = response.model
                     usage = response.usage.model_dump() if hasattr(response.usage, "model_dump") else None

--- a/lmms_eval/llm_judge/providers/openai.py
+++ b/lmms_eval/llm_judge/providers/openai.py
@@ -64,6 +64,8 @@ class OpenAIProvider(ServerInterface):
             try:
                 if self.use_client:
                     response = self.client.chat.completions.create(**payload)
+                    if not response.choices or response.choices[0].message is None:
+                        raise ValueError("LLM returned empty or filtered response")
                     content = response.choices[0].message.content
                     model_used = response.model
                     usage = response.usage.model_dump() if hasattr(response.usage, "model_dump") else None

--- a/lmms_eval/models/chat/openai.py
+++ b/lmms_eval/models/chat/openai.py
@@ -86,6 +86,8 @@ class OpenAICompatible(OpenAICompatibleSimple):
                 try:
                     response = self.client.chat.completions.create(**payload)
                     elapsed = time.time() - started_at
+                    if not response.choices or response.choices[0].message is None:
+                        raise ValueError("LLM returned empty or filtered response")
                     response_text = response.choices[0].message.content
                     input_tokens = 0
                     output_tokens = 0

--- a/lmms_eval/models/simple/gpt4v.py
+++ b/lmms_eval/models/simple/gpt4v.py
@@ -195,6 +195,8 @@ class GPT4V(lmms):
             for attempt in range(MAX_RETRIES):
                 try:
                     response = self.client.chat.completions.create(**payload)
+                    if not response.choices or response.choices[0].message is None:
+                        raise ValueError("LLM returned empty or filtered response")
                     response_text = response.choices[0].message.content
                     break  # If successful, break out of the loop
 

--- a/lmms_eval/models/simple/openai.py
+++ b/lmms_eval/models/simple/openai.py
@@ -344,6 +344,8 @@ class OpenAICompatible(lmms):
             for attempt in range(self.max_retries):
                 try:
                     response = self.client.chat.completions.create(**payload)
+                    if not response.choices or response.choices[0].message is None:
+                        raise ValueError("LLM returned empty or filtered response")
                     response_text = _normalize_openai_message_content(response.choices[0].message.content)
                     token_counts = None
                     if hasattr(response, "usage") and response.usage:

--- a/lmms_eval/models/simple/srt_api.py
+++ b/lmms_eval/models/simple/srt_api.py
@@ -196,6 +196,8 @@ class SRT_API(lmms):
         for attempt in range(5):
             try:
                 response = await self.client.chat.completions.create(model=self.model_version, messages=messages, temperature=gen_kwargs["temperature"], max_tokens=gen_kwargs["max_new_tokens"], timeout=self.timeout)
+                if not response.choices or response.choices[0].message is None:
+                    raise ValueError("LLM returned empty or filtered response")
                 response_text = response.choices[0].message.content.strip()
                 break  # If successful, break out of the loop
 
@@ -259,6 +261,8 @@ class SRT_API(lmms):
         for attempt in range(5):
             try:
                 response = self.client.chat.completions.create(model=self.model_version, messages=messages, temperature=gen_kwargs["temperature"], max_tokens=gen_kwargs["max_new_tokens"], timeout=self.timeout)
+                if not response.choices or response.choices[0].message is None:
+                    raise ValueError("LLM returned empty or filtered response")
                 response_text = response.choices[0].message.content.strip()
                 break  # If successful, break out of the loop
 

--- a/lmms_eval/tasks/_task_utils/reasoning_utils.py
+++ b/lmms_eval/tasks/_task_utils/reasoning_utils.py
@@ -369,6 +369,8 @@ def llm_as_judge_sync(predict_str, ground_truth, extra_info):
     }
     response = client.chat.completions.create(**payload)
     try:
+        if not response.choices or response.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
         score = int(response.choices[0].message.content)
     except Exception:
         score = 0

--- a/lmms_eval/tasks/aime/utils.py
+++ b/lmms_eval/tasks/aime/utils.py
@@ -180,6 +180,8 @@ class ChatCompletionSampler:
                     temperature=self.temperature,
                     max_tokens=self.max_tokens,
                 )
+                if not response.choices or response.choices[0].message is None:
+                    raise ValueError("LLM returned empty or filtered response")
                 return response.choices[0].message.content
             # NOTE: BadRequestError is triggered once for MMMU, please uncomment if you are reruning MMMU
             except openai.BadRequestError as e:

--- a/lmms_eval/tasks/babyvision/utils.py
+++ b/lmms_eval/tasks/babyvision/utils.py
@@ -175,6 +175,8 @@ def babyvision_process_results(doc, results, **kwargs):
             temperature=0.0,
         )
 
+        if not response.choices or response.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
         judge_response = response.choices[0].message.content
         correct = parse_bool_response(judge_response)
 

--- a/lmms_eval/tasks/babyvision_gen/utils.py
+++ b/lmms_eval/tasks/babyvision_gen/utils.py
@@ -106,6 +106,8 @@ def _call_openai_for_evaluation(
             temperature=0.0,
         )
 
+        if not response.choices or response.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
         return response.choices[0].message.content
     except Exception as e:
         eval_logger.error(f"Error calling OpenAI API: {e}")

--- a/lmms_eval/tasks/gpqa/openai/utils.py
+++ b/lmms_eval/tasks/gpqa/openai/utils.py
@@ -138,6 +138,8 @@ class ChatCompletionSampler:
                     temperature=self.temperature,
                     max_tokens=self.max_tokens,
                 )
+                if not response.choices or response.choices[0].message is None:
+                    raise ValueError("LLM returned empty or filtered response")
                 return response.choices[0].message.content
             # NOTE: BadRequestError is triggered once for MMMU, please uncomment if you are reruning MMMU
             except openai.BadRequestError as e:

--- a/lmms_eval/tasks/imgedit/utils.py
+++ b/lmms_eval/tasks/imgedit/utils.py
@@ -201,6 +201,8 @@ def _call_openai_for_evaluation(
             temperature=0.1,
         )
 
+        if not response.choices or response.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
         return response.choices[0].message.content
     except Exception as e:
         eval_logger.error(f"Error calling OpenAI API: {e}")

--- a/lmms_eval/tasks/live_bench/utils.py
+++ b/lmms_eval/tasks/live_bench/utils.py
@@ -114,6 +114,8 @@ def get_chat_response(gpt_model_name, base64_images, question, ground_truth_answ
     for attempt in range(max_retries):
         try:
             response = client.chat.completions.create(model=gpt_model_name, messages=messages, max_tokens=1024, response_format={"type": "json_object"}, temperature=0.0)
+            if not response.choices or response.choices[0].message is None:
+                raise ValueError("LLM returned empty or filtered response")
             response_data = response.choices[0].message.content
             # print(response_data)
             response_data = json.loads(response_data)

--- a/lmms_eval/tasks/live_bench/utils_v2.py
+++ b/lmms_eval/tasks/live_bench/utils_v2.py
@@ -113,6 +113,8 @@ def get_chat_response(gpt_model_name, base64_images, question, ground_truth_answ
     for attempt in range(max_retries):
         try:
             response = client.chat.completions.create(model=gpt_model_name, messages=messages, max_tokens=1024, response_format={"type": "json_object"}, temperature=0.0)
+            if not response.choices or response.choices[0].message is None:
+                raise ValueError("LLM returned empty or filtered response")
             response_data = response.choices[0].message.content
             # print(response_data)
             response_data = json.loads(response_data)

--- a/lmms_eval/tasks/mathverse/mathverse_evals.py
+++ b/lmms_eval/tasks/mathverse/mathverse_evals.py
@@ -46,6 +46,8 @@ class MathVerseEvaluator:
             try:
                 response = self.client.chat.completions.create(**payload)
                 if n == 1:
+                    if not response.choices or response.choices[0].message is None:
+                        raise ValueError("LLM returned empty or filtered response")
                     prediction = response.choices[0].message.content.strip()
                     if prediction and prediction != "":
                         return prediction

--- a/lmms_eval/tasks/mix_evals/image2text/utils.py
+++ b/lmms_eval/tasks/mix_evals/image2text/utils.py
@@ -158,6 +158,8 @@ def get_eval(question, model_response: str, ground_truth: str, max_tokens: int, 
             # response.raise_for_status()
 
             # content = response_data["choices"][0]["message"]["content"].strip()
+            if not response.choices or response.choices[0].message is None:
+                raise ValueError("LLM returned empty or filtered response")
             content = response.choices[0].message.content.strip()
             if content != "":
                 return content
@@ -359,6 +361,8 @@ class GPTMultiChoiceFilter(Filter):
                     # response.raise_for_status()
 
                     # content =["choices"][0]["message"]["content"].strip()
+                    if not response.choices or response.choices[0].message is None:
+                        raise ValueError("LLM returned empty or filtered response")
                     content = response.choices[0].message.content
                     # print("content:", content)
                     if content:

--- a/lmms_eval/tasks/mix_evals/video2text/utils.py
+++ b/lmms_eval/tasks/mix_evals/video2text/utils.py
@@ -109,6 +109,8 @@ def get_eval(question, model_response: str, ground_truth: str, max_tokens: int, 
             # response.raise_for_status()
 
             # content = response_data["choices"][0]["message"]["content"].strip()
+            if not response.choices or response.choices[0].message is None:
+                raise ValueError("LLM returned empty or filtered response")
             content = response.choices[0].message.content.strip()
             if content != "":
                 return content
@@ -379,6 +381,8 @@ class GPTMultiChoiceFilter(Filter):
                     # response.raise_for_status()
 
                     # content =["choices"][0]["message"]["content"].strip()
+                    if not response.choices or response.choices[0].message is None:
+                        raise ValueError("LLM returned empty or filtered response")
                     content = response.choices[0].message.content
                     print("content:", content)
                     if content:

--- a/lmms_eval/tasks/mme_sci/utils.py
+++ b/lmms_eval/tasks/mme_sci/utils.py
@@ -142,6 +142,8 @@ def mmesci_agg(results: List[Dict[str, Any]]) -> Dict[str, float]:
                 max_tokens=8,
                 timeout=TIMEOUT,
             )
+            if not resp.choices or resp.choices[0].message is None:
+                raise ValueError("LLM returned empty or filtered response")
             judge_result = resp.choices[0].message.content.strip()
             if judge_result not in ["correct", "incorrect"]:
                 judge_result = "error"

--- a/lmms_eval/tasks/mme_sci_image/utils.py
+++ b/lmms_eval/tasks/mme_sci_image/utils.py
@@ -138,6 +138,8 @@ def mmesci_agg(results: List[Dict[str, Any]]) -> Dict[str, float]:
                 max_tokens=8,
                 timeout=TIMEOUT,
             )
+            if not resp.choices or resp.choices[0].message is None:
+                raise ValueError("LLM returned empty or filtered response")
             judge_result = resp.choices[0].message.content.strip()
             if judge_result not in ["correct", "incorrect"]:
                 judge_result = "error"

--- a/lmms_eval/tasks/mmrefine/mmrefine_evals.py
+++ b/lmms_eval/tasks/mmrefine/mmrefine_evals.py
@@ -56,6 +56,8 @@ class MMRefineEvaluator:
             try:
                 response = self.client.chat.completions.create(**payload)
                 if n == 1:
+                    if not response.choices or response.choices[0].message is None:
+                        raise ValueError("LLM returned empty or filtered response")
                     prediction = response.choices[0].message.content.strip()
                     if prediction and prediction != "":
                         return prediction

--- a/lmms_eval/tasks/openai_math/utils.py
+++ b/lmms_eval/tasks/openai_math/utils.py
@@ -177,6 +177,8 @@ class ChatCompletionSampler:
                     temperature=self.temperature,
                     max_tokens=self.max_tokens,
                 )
+                if not response.choices or response.choices[0].message is None:
+                    raise ValueError("LLM returned empty or filtered response")
                 return response.choices[0].message.content
             # NOTE: BadRequestError is triggered once for MMMU, please uncomment if you are reruning MMMU
             except openai.BadRequestError as e:

--- a/lmms_eval/tasks/phyx/phyx_evals.py
+++ b/lmms_eval/tasks/phyx/phyx_evals.py
@@ -53,6 +53,8 @@ class PhyXEvaluator:
             try:
                 response = self.client.chat.completions.create(**payload)
                 if n == 1:
+                    if not response.choices or response.choices[0].message is None:
+                        raise ValueError("LLM returned empty or filtered response")
                     prediction = response.choices[0].message.content.strip()
                     if prediction and prediction != "":
                         return prediction

--- a/lmms_eval/tasks/step2_audio_paralinguistic/utils.py
+++ b/lmms_eval/tasks/step2_audio_paralinguistic/utils.py
@@ -193,6 +193,8 @@ def judge_semantic_match(answer, asr_text, prompt_template):
 
         response = client.chat.completions.create(model="gpt-3.5-turbo", messages=[{"role": "system", "content": "你是一个专业的文本评估助手"}, {"role": "user", "content": formatted_prompt}], temperature=0)
 
+        if not response.choices or response.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
         result = response.choices[0].message.content.strip().lower()
         return 1 if result == "yes" else 0
 

--- a/lmms_eval/tasks/tomato/utils.py
+++ b/lmms_eval/tasks/tomato/utils.py
@@ -206,6 +206,8 @@ Your extracted letter is:
         "temperature": 0.0,
     }
     response = client.chat.completions.create(**params)
+    if not response.choices or response.choices[0].message is None:
+        raise ValueError("LLM returned empty or filtered response")
     response = response.choices[0].message.content
 
     return response

--- a/lmms_eval/tasks/unig2u/auxsolidmath/utils.py
+++ b/lmms_eval/tasks/unig2u/auxsolidmath/utils.py
@@ -48,6 +48,8 @@ class AzureJudgeClient:
 
     def chat_completion(self, *, messages, **kwargs) -> str:
         resp = self.client.chat.completions.create(model=self.deployment, messages=messages, **kwargs)
+        if not resp.choices or resp.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
         return resp.choices[0].message.content
 
 
@@ -64,6 +66,8 @@ class OpenAIJudgeClient:
 
     def chat_completion(self, *, messages, **kwargs) -> str:
         resp = self.client.chat.completions.create(model=self.deployment, messages=messages, **kwargs)
+        if not resp.choices or resp.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
         return resp.choices[0].message.content
 
 
@@ -76,6 +80,8 @@ class AzureEndpointJudgeClient:
     def chat_completion(self, *, messages, **kwargs) -> str:
         client, deployment = build_azure_compat_client(model=self.deployment)
         resp = client.chat.completions.create(model=deployment, messages=messages, **kwargs)
+        if not resp.choices or resp.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
         return resp.choices[0].message.content
 
 

--- a/lmms_eval/tasks/unig2u/babyvision/utils.py
+++ b/lmms_eval/tasks/unig2u/babyvision/utils.py
@@ -50,6 +50,8 @@ class AzureJudgeClient:
 
     def chat_completion(self, *, messages, **kwargs) -> str:
         resp = self.client.chat.completions.create(model=self.deployment, messages=messages, **kwargs)
+        if not resp.choices or resp.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
         return resp.choices[0].message.content
 
 
@@ -66,6 +68,8 @@ class OpenAIJudgeClient:
 
     def chat_completion(self, *, messages, **kwargs) -> str:
         resp = self.client.chat.completions.create(model=self.deployment, messages=messages, **kwargs)
+        if not resp.choices or resp.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
         return resp.choices[0].message.content
 
 
@@ -78,6 +82,8 @@ class AzureEndpointJudgeClient:
     def chat_completion(self, *, messages, **kwargs) -> str:
         client, deployment = build_azure_compat_client(model=self.deployment)
         resp = client.chat.completions.create(model=deployment, messages=messages, **kwargs)
+        if not resp.choices or resp.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
         return resp.choices[0].message.content
 
 

--- a/lmms_eval/tasks/unig2u/geometry3k/utils.py
+++ b/lmms_eval/tasks/unig2u/geometry3k/utils.py
@@ -47,6 +47,8 @@ class AzureJudgeClient:
 
     def chat_completion(self, *, messages, **kwargs) -> str:
         resp = self.client.chat.completions.create(model=self.deployment, messages=messages, **kwargs)
+        if not resp.choices or resp.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
         return resp.choices[0].message.content
 
 
@@ -63,6 +65,8 @@ class OpenAIJudgeClient:
 
     def chat_completion(self, *, messages, **kwargs) -> str:
         resp = self.client.chat.completions.create(model=self.deployment, messages=messages, **kwargs)
+        if not resp.choices or resp.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
         return resp.choices[0].message.content
 
 
@@ -75,6 +79,8 @@ class AzureEndpointJudgeClient:
     def chat_completion(self, *, messages, **kwargs) -> str:
         client, deployment = build_azure_compat_client(model=self.deployment)
         resp = client.chat.completions.create(model=deployment, messages=messages, **kwargs)
+        if not resp.choices or resp.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
         return resp.choices[0].message.content
 
 

--- a/lmms_eval/tasks/unig2u/phyx/utils.py
+++ b/lmms_eval/tasks/unig2u/phyx/utils.py
@@ -46,6 +46,8 @@ class AzureJudgeClient:
 
     def chat_completion(self, *, messages, **kwargs) -> str:
         resp = self.client.chat.completions.create(model=self.deployment, messages=messages, **kwargs)
+        if not resp.choices or resp.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
         return resp.choices[0].message.content
 
 
@@ -62,6 +64,8 @@ class OpenAIJudgeClient:
 
     def chat_completion(self, *, messages, **kwargs) -> str:
         resp = self.client.chat.completions.create(model=self.deployment, messages=messages, **kwargs)
+        if not resp.choices or resp.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
         return resp.choices[0].message.content
 
 
@@ -74,6 +78,8 @@ class AzureEndpointJudgeClient:
     def chat_completion(self, *, messages, **kwargs) -> str:
         client, deployment = build_azure_compat_client(model=self.deployment)
         resp = client.chat.completions.create(model=deployment, messages=messages, **kwargs)
+        if not resp.choices or resp.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
         return resp.choices[0].message.content
 
 

--- a/lmms_eval/tasks/unig2u/uni_mmmu/utils.py
+++ b/lmms_eval/tasks/unig2u/uni_mmmu/utils.py
@@ -70,6 +70,8 @@ def call_gpt4o(prompt: str, max_tokens: int = 512) -> str:
             max_tokens=max_tokens,
             temperature=0,
         )
+        if not resp.choices or resp.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
         return resp.choices[0].message.content
     except Exception as e:
         print(f"[GPT-4o Error] {e}")

--- a/lmms_eval/tasks/videoevalpro/utils.py
+++ b/lmms_eval/tasks/videoevalpro/utils.py
@@ -64,6 +64,8 @@ Grade the predicted answer ofthe question as one of: A: CORRECT B: INCORRECT C: 
 
         response = self.client.chat.completions.create(model=self.model_name, messages=[{"role": "user", "content": prompt}], temperature=0, max_tokens=5)
 
+        if not response.choices or response.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
         answer = response.choices[0].message.content.strip()
         # print(f"---------------------->>>>gpt answer: {answer}")
         return answer[0].upper() == "A"

--- a/lmms_eval/tasks/videomme/convert_mcq_oe/utils.py
+++ b/lmms_eval/tasks/videomme/convert_mcq_oe/utils.py
@@ -95,6 +95,8 @@ def _llm_match_option(question, model_answer, options):
             temperature=0,
         )
 
+        if not response.choices or response.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
         result = response.choices[0].message.content.strip()
         return _extract_abcdx(result)
 

--- a/test/models/test_litellm.py
+++ b/test/models/test_litellm.py
@@ -37,6 +37,8 @@ class TestLiteLLMShim(unittest.TestCase):
             messages=[{"role": "user", "content": "ping"}],
         )
 
+        if not resp.choices or resp.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
         self.assertEqual(resp.choices[0].message.content, "pong")
         completion.assert_called_once()
         kwargs = completion.call_args.kwargs


### PR DESCRIPTION
## Summary

OpenAI-compatible APIs can return **empty `choices`** on error or rate-limiting, causing `IndexError` at `choices[0]`. Gemini additionally returns `choices[0].message = None` on `PROHIBITED_CONTENT` safety filtering (HTTP 200 — no exception raised), causing `AttributeError` at `.content`.

This PR adds the comprehensive guard:
```python
if not response.choices or response.choices[0].message is None:
    raise ValueError("LLM returned empty or filtered response")
```
before every bare `choices[0].message.content` access across **32 files, 41 sites**.

## Impact

Affected subsystems:
- `lmms_eval/llm_judge/providers/` — OpenAI and Azure OpenAI judge providers
- `lmms_eval/models/` — core model implementations (chat/openai, simple/openai, srt_api, gpt4v)
- `lmms_eval/tasks/` — 25+ task evaluation utilities across aime, babyvision, gpqa, live_bench, mathverse, mix_evals, mme_sci, openai_math, phyx, tomato, videoevalpro, videomme, and unig2u tasks
- `test/models/test_litellm.py`

## Verification

The Gemini `choices[0].message = None` crash is a documented production behavior on `PROHIBITED_CONTENT` safety filtering. Static analysis via [pact](https://github.com/qizwiz/pact) (Z3 Fixedpoint datalog, `llm_response_unguarded` rule) found all 41 sites; post-fix scan returns 0 violations.