### PR TITLE
fix(mmmu_pro_vision): apply post_prompt to vision-only split

### DIFF
--- a/lmms_eval/tasks/mmmu_pro/utils.py
+++ b/lmms_eval/tasks/mmmu_pro/utils.py
@@ -57,6 +57,10 @@ def mmmu_pro_doc_to_text(doc, lmms_eval_specific_kwargs=None):
         question = construct_prompt(doc, post_prompt)
         if config["metadata"]["interleaved_format"]:
             question = replace_images_tokens(question)
+    else:
+        # vision-only split: question/options 텍스트가 이미지에 합성되어 있어 doc에는 없다.
+        # 모델이 letter format을 따르도록 post_prompt만 전달한다 (paper Sec 3.3 참고).
+        question = post_prompt
     return question
 
 


### PR DESCRIPTION
## Bug
`mmmu_pro_doc_to_text` returns an empty string for `mmmu_pro_vision`: the vision split has no `question` field, so the standard prompt-construction branch is skipped and the YAML-configured `post_prompt` (`"Answer with the option letter from the given choices directly."`) is never sent to the model.

## Fix
Default `question` to `post_prompt` so the instruction reaches the model for vision-only docs. Standard split behavior is unchanged.