### PR TITLE
fix(mmmu_pro_vision): apply post_prompt to vision-only split

### DIFF
--- a/lmms_eval/tasks/mmmu_pro/utils.py
+++ b/lmms_eval/tasks/mmmu_pro/utils.py
@@ -52,7 +52,7 @@ def mmmu_pro_doc_to_text(doc, lmms_eval_specific_kwargs=None):
         return mmmu_doc_to_text_qwen3vl(doc, lmms_eval_specific_kwargs)
 
     post_prompt = lmms_eval_specific_kwargs["post_prompt"]
-    question = doc.get("question", "")
+    question = post_prompt  # vision-only fallback: question and options are rendered in the image
     if "question" in doc and "options" in doc:  # original operation
         question = construct_prompt(doc, post_prompt)
         if config["metadata"]["interleaved_format"]:


### PR DESCRIPTION
## Bug
`mmmu_pro_doc_to_text` returns an empty string for `mmmu_pro_vision`: the vision split has no `question` field, so the standard prompt-construction branch is skipped and the YAML-configured `post_prompt` (`"Answer with the option letter from the given choices directly."`) is never sent to the model.

## Fix
Default `question` to `post_prompt` so the instruction reaches the model for vision-only docs. Standard split behavior is unchanged.