### PR TITLE
fix(llava_onevision2): forward static images to image_processor

### DIFF
--- a/lmms_eval/models/chat/llava_onevision2.py
+++ b/lmms_eval/models/chat/llava_onevision2.py
@@ -305,6 +305,7 @@ class Llava_OneVision2(lmms):
                     content.append({"type": "text", "text": c.text})
                 elif c.type == "image":
                     content.append({"type": "image", "image": c.url})
+                    all_pil_images.append(c.url)
                 elif c.type == "video":
                     if "timestamp" in self.messages_format:
                         video_content, pil_images = self._process_video_with_timestamp(c.url)


### PR DESCRIPTION
## Summary

Fix a bug in the `llava_onevision2` chat wrapper added in #1337: static image inputs were not forwarded to the image processor, so the model received `<|image_pad|>` placeholders with no `pixel_values` attached and produced near-random answers on image-only tasks.

## Root cause

In `_build_messages` the image branch only appended the `{type: "image", image: c.url}` chat-template entry but did not add the image into `all_pil_images`. As a result `generate_until` passed `images=None` to `self.processor(...)`, leaving the `<|image_pad|>` placeholders unbacked by any vision features.

## Fix

Mirror the video branch and push `c.url` into `all_pil_images` so it is forwarded via `images=...` — matching the image-processor branch the model was trained on.

```python
elif c.type == "image":
    content.append({"type": "image", "image": c.url})
    all_pil_images.append(c.url)
```

## Checklist
- [x] `pre-commit run` passes (`black --line-length=240`, `isort`)
- [x] Verified on an image-only task that `pixel_values` is now populated
