### PR TITLE
feat: add Open-X VQA task

### DIFF
--- a/lmms_eval/tasks/openxvqa/openxvqa.yaml
+++ b/lmms_eval/tasks/openxvqa/openxvqa.yaml
@@ -1,0 +1,24 @@
+dataset_path: nv-njb/OpenXVQA
+task: openxvqa
+test_split: test
+output_type: generate_until
+doc_to_visual: !function utils.openxvqa_doc_to_visual
+doc_to_text: !function utils.openxvqa_doc_to_text
+doc_to_target: !function utils.openxvqa_doc_to_target
+generation_kwargs:
+  max_new_tokens: 128
+  temperature: 0
+  top_p: 1.0
+  num_beams: 1
+  do_sample: false
+process_results: !function utils.openxvqa_process_results
+metric_list:
+  - metric: openxvqa_accuracy
+    aggregation: !function utils.openxvqa_aggregate_results
+    higher_is_better: true
+lmms_eval_specific_kwargs:
+  default:
+    pre_prompt: ""
+    post_prompt: "\nAnswer with the option's letter from the given choices directly and only give the best option. The best answer is: "
+metadata:
+  version: 0.1

--- a/lmms_eval/tasks/openxvqa/utils.py
+++ b/lmms_eval/tasks/openxvqa/utils.py
@@ -1,0 +1,93 @@
+import ast
+import io
+import re
+
+from loguru import logger as eval_logger
+from PIL import Image
+
+LETTERS = "ABCDEFG"
+
+
+def _parse_choices(choices_raw):
+    """Parse choices field which may be a string repr of a list or an actual list."""
+    if isinstance(choices_raw, str):
+        return ast.literal_eval(choices_raw)
+    return list(choices_raw)
+
+
+def _load_image(image_data):
+    """Load image from various formats (bytes, dict with bytes, PIL Image)."""
+    if isinstance(image_data, Image.Image):
+        return image_data
+    if isinstance(image_data, bytes):
+        return Image.open(io.BytesIO(image_data))
+    if isinstance(image_data, dict) and "bytes" in image_data:
+        return Image.open(io.BytesIO(image_data["bytes"]))
+    return image_data
+
+
+def openxvqa_doc_to_visual(doc):
+    return [_load_image(doc["image"])]
+
+
+def openxvqa_doc_to_text(doc, lmms_eval_specific_kwargs=None):
+    if lmms_eval_specific_kwargs is None:
+        lmms_eval_specific_kwargs = {}
+    pre_prompt = lmms_eval_specific_kwargs.get("pre_prompt", "")
+    post_prompt = lmms_eval_specific_kwargs.get("post_prompt", "")
+
+    choices = _parse_choices(doc["choices"])
+    opts_text = "\n".join(f"({LETTERS[i]}) {opt}" for i, opt in enumerate(choices))
+
+    question = f"Select the best answer to the following multiple-choice question based on the image.\n{doc['question']}\nOptions:\n{opts_text}"
+
+    return f"{pre_prompt}{question}{post_prompt}"
+
+
+def openxvqa_doc_to_target(doc):
+    choices = _parse_choices(doc["choices"])
+    idx = int(doc["correct_answer"])
+    return LETTERS[idx]
+
+
+def _extract_answer(response, choices):
+    """Extract answer letter from model response."""
+    num_choices = len(choices)
+    valid_letters = list(LETTERS[:num_choices])
+    last_letter = valid_letters[-1]
+
+    response = response.replace("answer", "").replace("Answer", "")
+    pred_answer = re.findall(rf"[\(\ ]*([{valid_letters[0]}-{last_letter}])[\)\ ]*", response)
+
+    if pred_answer:
+        pred_letter = pred_answer[0].strip()
+        if pred_letter in valid_letters:
+            return valid_letters.index(pred_letter)
+
+    # Fallback: match option text
+    for idx, opt in enumerate(choices):
+        opt = opt.strip().strip(".")
+        if opt.lower() in response.lower():
+            return idx
+
+    eval_logger.warning(f"Cannot extract answer from response: {response}")
+    return -1
+
+
+def openxvqa_process_results(doc, results):
+    pred = results[0]
+    choices = _parse_choices(doc["choices"])
+    pred_idx = _extract_answer(pred, choices)
+    gt_idx = int(doc["correct_answer"])
+
+    return {
+        "openxvqa_accuracy": {
+            "pred_answer": pred_idx,
+            "ground_truth": gt_idx,
+        }
+    }
+
+
+def openxvqa_aggregate_results(results):
+    correct = sum(1 for r in results if r["pred_answer"] == r["ground_truth"])
+    return correct / len(results) if results else 0


### PR DESCRIPTION
## Summary

Adds **Open-X VQA**, a multiple-choice VQA benchmark for embodied AI / robotic manipulation scenes derived from the Open-X-Embodiment data. Each item is a single-image MCQ where the model selects one of A-D.

- Dataset: [`nv-njb/OpenXVQA`](https://huggingface.co/datasets/nv-njb/OpenXVQA) on HuggingFace (6,676 test items, single \`test\` split).
- Metric: \`openxvqa_accuracy\` — exact-match on the extracted MCQ letter.

## Files

- \`lmms_eval/tasks/openxvqa/openxvqa.yaml\` — task config.
- \`lmms_eval/tasks/openxvqa/utils.py\` — image bytes -> PIL, MCQ letter extraction.

## Parity vs. local fork

Qwen3-VL-2B-Instruct, full \`test\` split (6,676 items), 8x H100, greedy decoding.

| Source   | Accuracy | Identical predictions |
|----------|---------:|----------------------:|
| Fork     |   0.5685 |                     - |
| Upstream |   0.5785 |       5,711 / 6,676 (85.6%) |

Delta of +1.0pp is within the noise we have seen on other ports caused by minor drift in the upstream \`qwen3_vl\` model class.

## Test plan

- [x] \`uv run lmms-eval --tasks openxvqa --limit 8\` smoke (single GPU)
- [x] Full \`test\` run on 8x H100 with Qwen3-VL-2B-Instruct, scores match the fork within noise
- [x] Per-doc analysis: 85.6% identical filtered_resps