### PR TITLE
feat: add SAT task

### DIFF
--- a/lmms_eval/tasks/sat/sat.yaml
+++ b/lmms_eval/tasks/sat/sat.yaml
@@ -1,0 +1,37 @@
+dataset_path: nv-njb/SAT
+task: "sat"
+test_split: test
+output_type: generate_until
+doc_to_visual: !function utils.sat_doc_to_visual
+doc_to_text: !function utils.sat_doc_to_text
+doc_to_target: !function utils.sat_doc_to_target
+
+generation_kwargs:
+  max_new_tokens: 16
+  temperature: 0
+  top_p: 1.0
+  num_beams: 1
+  do_sample: false
+
+filter_list:
+  - name: "flexible-extract"
+    filter:
+      - function: !function utils.MultiChoiceRegexFilter
+        group_select: 0
+        ignore_case: true
+        ignore_punctuation: true
+        regex_pattern: "(\\([A-Z]\\))"
+
+metric_list:
+  - metric: exact_match
+    aggregation: mean
+    higher_is_better: true
+    ignore_case: true
+    ignore_punctuation: true
+      
+lmms_eval_specific_kwargs:
+  default:
+    pre_prompt: ""
+    post_prompt: "Please answer directly with only the letter of the correct option and nothing else."
+metadata:
+  version: 0.1

--- a/lmms_eval/tasks/sat/utils.py
+++ b/lmms_eval/tasks/sat/utils.py
@@ -1,0 +1,129 @@
+import re
+
+from lmms_eval.filters.extraction import ExtendedRegexFilter
+from lmms_eval.filters.transformation import MapFilter
+
+REPLACE_PROMPT = (
+    "Please answer directly with only the letter of the correct option and nothing else."
+)
+
+
+def sat_doc_to_visual(doc):
+    images = doc["image_bytes"]
+    images = [each.convert("RGB") for each in images]
+    return images
+
+
+def sat_doc_to_text(doc, lmms_eval_specific_kwargs=None):
+    if lmms_eval_specific_kwargs is None:
+        lmms_eval_specific_kwargs = {}
+
+    question = (
+        doc["question"].strip()
+        + "\n"
+        + "When multiple images are provided, You want to realize that when camera moves left, the objects in the image move right, and vice versa. And when you are asked about the movement of the same object captured in different images, you can compare the position of the object relative to other objects in the image to answer the question.\n"
+    )
+    candidates = doc["answers"]
+    candidates_str = ""
+    for i, candidate in enumerate(candidates):
+        option_letter = chr(ord("A") + i)
+        candidates_str += f"{option_letter}. {candidate}\n"
+
+    return (
+        question
+        + "\n"
+        + candidates_str
+        + "\n"
+        + "Only output the letter of the correct option and nothing else."
+    )
+
+
+def sat_doc_to_target(doc):
+    return chr(ord("A") + doc["correct_answer_idx"])
+
+
+class NumberWordsToDigitsFilter(MapFilter):
+    def __init__(self) -> None:
+        mapping_dict = {
+            "zero": "0",
+            "one": "1",
+            "two": "2",
+            "three": "3",
+            "four": "4",
+            "five": "5",
+            "six": "6",
+            "seven": "7",
+            "eight": "8",
+            "nine": "9",
+            "ten": "10",
+        }
+        super().__init__(mapping_dict, default_value=None)
+
+    def apply(self, resps, docs):
+        def filter_set(inst):
+            return [self.mapping_dict.get(resp.lower(), resp) for resp in inst]
+
+        return [filter_set(resp) for resp in resps]
+
+
+class MultiChoiceRegexFilter(ExtendedRegexFilter):
+    def __init__(self, *args, **kwargs):
+        """
+        regex_pattern: The basic regex pattern to use. If fails to match, we will use the customized match procedure
+                        - step 1 : We parse the choices between ([A-Z])s then try to find these choices in the response.
+                        - step 2 : We parse the choice with regex :[\s]*([A-?]), where ? varies by number of choices.
+        group_select: Selects the (group_select)th match from the findall result.
+        ignore_case: Ignores the case during step 1 matching
+        ignore_punctuation: Remove the punctuation during step 1 matching
+        regexes_to_ignore: Remove these regexes during step 1 matching
+        """
+        super().__init__(*args, **kwargs)
+
+    def apply(self, resps, docs):
+        # here, we assume we have a list, in which each element is
+        # a list of model responses for some particular input/target pair.
+        # so we process each of these (same input/target response sets)
+        # independently (and keep them a list.)
+
+        filtered_resps = []
+
+        for r, doc in zip(resps, docs):
+            fallback_regexes = []
+            choice_to_alpha = {}
+            next_alpha = "A"
+
+            without_paren_fallback_regexes = []
+            without_paren_to_target = {}
+
+            # Regex to extract multiple choice options from the question
+            multiple_choices_regex = re.compile(r"\b([A-Z])\.\s+([^\n]*)")
+            matches = multiple_choices_regex.findall(doc["question"])
+
+            # Build regex patterns and mappings for each choice
+            for m in matches:
+                choice_text = m[1].strip()
+                fallback_regexes.append(f"{re.escape(choice_text)}")
+                choice_to_alpha[choice_text] = next_alpha
+
+                next_alpha = chr(ord(next_alpha) + 1)
+
+            # Compile regex to match any of the extracted choices
+            fallback_regex = re.compile("|".join(fallback_regexes))
+
+            # Process each response
+            filtered = []
+            for resp in r:
+                # Remove any punctuation and extra spaces
+                cleaned_resp = re.sub(r"[^\w\s]", "", resp).strip()
+                # Try to match cleaned response with the choice text
+                match = fallback_regex.search(cleaned_resp)
+                if match and match.group() in choice_to_alpha:
+                    # Map the matched choice text back to its corresponding letter
+                    filtered.append(choice_to_alpha[match.group()])
+                else:
+                    # If no match, return the cleaned response
+                    filtered.append(cleaned_resp)
+
+            filtered_resps.append(filtered[0].split(" ")[0])
+
+        return filtered_resps


### PR DESCRIPTION
## Summary

Adds **SAT** (Spatial Aptitude Test) — a 150-item binary-MCQ spatial-reasoning benchmark with 1-2 images per item. Items cover object movement, ego movement, action consequences, perspective, and goal-aim reasoning.

Dataset: [`nv-njb/SAT`](https://huggingface.co/datasets/nv-njb/SAT) — a re-host of the original [`array/SAT`](https://huggingface.co/datasets/array/SAT) with two upstream-friendly fixes:

1. **Images stored as \`Sequence(Image())\`** so non-streaming \`load_dataset\` works. The original parquet uses a nested \`list<binary>\` schema for \`image_bytes\` that trips pyarrow's chunked-array conversion (\`Nested data conversions not implemented for chunked array outputs\`). Streaming would dodge this, but lmms-eval's \`api/task.py\` calls \`load_dataset\` with \`num_proc=1\`, which is incompatible with streaming — so neither path works on the original.
2. **Answer order pre-shuffled** with \`random.Random(42)\` and \`correct_answer_idx\` baked in. The downstream fork's \`api/task.py\` had a SAT-specific branch that shuffled answer order at load time with a non-deterministic seed; baking it in makes evaluation reproducible without any framework patch.

All other fields (\`question\`, \`question_type\`, \`correct_answer\`) pass through unchanged. See the dataset card for the full schema and a citation.

## Files

- \`lmms_eval/tasks/sat/sat.yaml\` — task config.
- \`lmms_eval/tasks/sat/utils.py\` — doc transforms, \`MultiChoiceRegexFilter\`, \`NumberWordsToDigitsFilter\`.

## Parity vs. local fork

Qwen3-VL-2B-Instruct, full test split (150 items), 8x H100, greedy decoding.

| Source   | exact_match | Stderr | Notes |
|----------|------------:|-------:|-------|
| Fork     |      0.6267 | ±0.0396 | non-deterministic answer order shuffle at load time |
| Upstream |      0.5933 | ±0.0402 | deterministic seed=42 shuffle baked into the dataset |

Per-doc correctness agreement: 78.0% (117/150 same verdict). The 3.3pp delta is within 1 stderr — consistent with binary-MCQ noise on 150 items plus the \`qwen3_vl\` model-class drift we have observed on prior ports (egotaskqa, egoplan2, metavqa, openxvqa, robo_spatial).

## Background — why this supersedes the earlier draft

A previous draft PR (#1342, closed) hit two blockers that prevented an end-to-end run on upstream main. Both are addressed by the re-host described above; no framework changes are required.

## Test plan

- [x] \`uv run lmms-eval --tasks sat --limit 4\` smoke test
- [x] Full \`test\` run on 8x H100 with Qwen3-VL-2B-Instruct; score matches the fork within stderr
- [x] Non-streaming \`load_dataset(\"nv-njb/SAT\")\` returns 150 docs without pyarrow errors
- [x] \`correct_answer_idx\` matches \`answers.index(correct_answer)\` for all 150 docs