### PR TITLE
feat(llava_onevision2): add codec sub-mode (use_codec, codec_*)

### DIFF
--- a/examples/models/llava_onevision2.sh
+++ b/examples/models/llava_onevision2.sh
@@ -3,9 +3,51 @@ export HF_HOME="~/.cache/huggingface"
 # pip install git+https://github.com/EvolvingLMMs-Lab/lmms-eval.git
 # pip install qwen-vl-utils
 
-# Example: MLVU-dev with best config (min_pixels = max_pixels = 102400, max_num_frames = 384)
+# ============================================================
+# Example 1: frame-sampling video backend (default)
+# MLVU-dev with best config (min_pixels = max_pixels = 102400,
+# max_num_frames = 384).
+# ============================================================
 accelerate launch --num_processes=8 --main_process_port 12399 -m lmms_eval \
     --model=llava_onevision2 \
     --model_args=pretrained=lmms-lab-encoder/LLaVA-OneVision-2-8B-Instruct,attn_implementation=flash_attention_2,messages_format=timestamp,max_new_tokens=16,fps=1,max_num_frames=384,min_pixels=102400,max_pixels=102400 \
     --tasks=mlvu_dev \
     --batch_size=1
+
+# ============================================================
+# Example 2: codec video backend (recommended for long videos)
+# ============================================================
+# The codec backend replaces uniform frame sampling with codec-aware
+# canvas packing driven by motion vectors / bit-cost. It typically
+# yields stronger long-video accuracy at the same token budget.
+#
+# Extra requirements (only needed for `use_codec=true`):
+#   pip install codec-video-prep opencv-python
+#   ffmpeg 4.4.x - 7.x on PATH  (verify: `ffmpeg -version`)
+#
+# All canvas extraction / caching / chat-template rewriting happens
+# inside the model's processor via trust_remote_code; the adapter
+# only forwards the video URL.
+#
+# Optional cache location (defaults to $HF_HOME/online_codec):
+# export ONLINE_CODEC_CACHE_DIR=/path/to/codec_cache
+
+accelerate launch --num_processes=8 --main_process_port 12399 -m lmms_eval \
+    --model=llava_onevision2 \
+    --model_args=pretrained=lmms-lab-encoder/LLaVA-OneVision2-8B-Instruct,attn_implementation=flash_attention_2,messages_format=timestamp,max_new_tokens=16,use_codec=true,codec_target_canvas=32,codec_group_size=32,codec_images_per_group=4,codec_patch=14,max_pixels=150000 \
+    --tasks=videomme_long \
+    --batch_size=1
+
+# codec model_args reference:
+#   use_codec=true               : enable codec backend
+#   codec_target_canvas=32       : number of canvases per video (more -> more tokens)
+#   codec_group_size=32          : frames per readiness group (cv-preinfer knob)
+#   codec_images_per_group=4     : canvases produced per group
+#   codec_patch=14               : ViT patch size; must match the model
+#   max_pixels=150000            : per-canvas pixel budget (also fed to image_processor)
+#   codec_cache_root=/some/dir   : override the on-disk canvas cache root
+#                                  (otherwise uses $ONLINE_CODEC_CACHE_DIR or
+#                                   $HF_HOME/online_codec)
+#
+# Any codec_* kwarg you omit falls back to the default in the model
+# repo's preprocessor_config.json ("codec": {...} block).

--- a/lmms_eval/models/chat/llava_onevision2.py
+++ b/lmms_eval/models/chat/llava_onevision2.py
@@ -22,8 +22,9 @@ The wrapper:
 
 from __future__ import annotations
 
-import json
+import os
 import time
+from pathlib import Path
 from typing import List
 
 import cv2
@@ -49,6 +50,12 @@ from lmms_eval.models.model_utils.gen_metrics import log_metrics
 from lmms_eval.protocol import ChatMessages
 
 fetch_video, _ = optional_import("qwen_vl_utils", "fetch_video")
+
+
+def _as_bool(value: object) -> bool:
+    if isinstance(value, bool):
+        return value
+    return str(value).strip().lower() in {"1", "true", "yes", "y", "on"}
 
 
 @register_model("llava_onevision2_chat")
@@ -83,6 +90,21 @@ class Llava_OneVision2(lmms):
         fps: float = 1.0,
         messages_format: str = "timestamp",
         timestamp_decimals: int = 1,
+        # Codec sub-mode (in-processor preprocessing via cv-preinfer).
+        # When ``use_codec=True``, video items are forwarded to the bundled
+        # ``processor(video_backend='codec', ...)`` entry shipped with the
+        # checkpoint; the wrapper itself contains no codec-specific logic.
+        # ``max_pixels`` doubles as the codec canvas pixel budget so users
+        # configure a single knob.
+        use_codec: bool | str = False,
+        codec_target_canvas: int | str | None = None,
+        codec_group_size: int | str | None = None,
+        codec_images_per_group: int | str | None = None,
+        codec_patch: int | str | None = None,
+        codec_min_group_frames: int | str | None = None,
+        codec_max_group_frames: int | str | None = None,
+        codec_spatial_mask_mode: str | None = None,
+        codec_cache_dir: str | None = None,
         **kwargs,
     ):
         super().__init__()
@@ -193,6 +215,39 @@ class Llava_OneVision2(lmms):
         self.messages_format = str(messages_format)
         self.timestamp_decimals = int(timestamp_decimals)
 
+        # --- Codec sub-mode (in-processor) -------------------------------
+        # The wrapper holds no codec logic. We only collect user overrides
+        # for ``codec_config`` and the optional cache dir, then forward both
+        # to the bundled ``processor(video_backend='codec', ...)`` at call
+        # time. Defaults come from preprocessor_config.json (model repo).
+        self.use_codec = _as_bool(use_codec)
+        codec_overrides: dict = {}
+        for k, v in (
+            ("target_canvas", codec_target_canvas),
+            ("group_size", codec_group_size),
+            ("images_per_group", codec_images_per_group),
+            ("patch", codec_patch),
+            ("min_group_frames", codec_min_group_frames),
+            ("max_group_frames", codec_max_group_frames),
+            ("spatial_mask_mode", codec_spatial_mask_mode),
+        ):
+            if v is not None and v != "":
+                codec_overrides[k] = (
+                    int(v) if k != "spatial_mask_mode" else str(v)
+                )
+        if codec_cache_dir or os.getenv("ONLINE_CODEC_CACHE_DIR"):
+            codec_overrides["cache_root"] = Path(
+                codec_cache_dir or os.getenv("ONLINE_CODEC_CACHE_DIR")
+            )
+        self.codec_overrides = codec_overrides
+        if self.use_codec:
+            eval_logger.info(
+                f"[codec] pixel budget unified: max_pixels={max_pixels}; "
+                f"codec_overrides={codec_overrides}"
+            )
+        # Per-build_messages scratch for codec video URLs.
+        self._current_codec_video_urls: list = []
+
         # --- Distributed bookkeeping --------------------------------------
         self.accelerator = accelerator
         if accelerator.num_processes > 1:
@@ -223,13 +278,24 @@ class Llava_OneVision2(lmms):
 
     # ---------------------------------------------------- message building
 
+    # ----------------------------- standard video timestamp path --------
+
     def _process_video_with_timestamp(self, video_url: str):
         """Decode a video and build a per-frame ``[timestamp, image, ...]`` content list.
 
         Frames are fetched via ``qwen_vl_utils.fetch_video`` and converted to
         PIL images; the caller passes the resulting list via ``images=...`` to
         the processor (the image-processor branch the model was trained on).
+
+        When ``use_codec=True``, this short-circuits and emits a single
+        ``{"type": "video", "video": url}`` content item; the bundled
+        ``processor(video_backend='codec', ...)`` entry does the codec
+        preprocessing + text rewrite downstream.
         """
+        if self.use_codec:
+            self._current_codec_video_urls.append(video_url)
+            return [{"type": "video", "video": video_url}], []
+
         assert fetch_video is not None, "qwen_vl_utils is required. Please install it via `pip install qwen-vl-utils`"
 
         video_request = {
@@ -282,13 +348,11 @@ class Llava_OneVision2(lmms):
     def _build_messages(self, chat_message: ChatMessages):
         """Convert lmms-eval ChatMessages -> HF chat-template list.
 
-        ``video`` items are expanded to per-frame timestamp text + image
-        pairs via ``qwen_vl_utils.fetch_video``. The caller feeds the
-        returned PIL list via ``images=...`` (not ``videos=``), matching
-        the image-processor branch the model was trained on.
-
-        Returns: ``(messages, pil_images)``.
+        Returns ``(messages, pil_images, codec_video_urls)``. ``codec_video_urls``
+        is populated only when ``use_codec=True`` and the message contained a
+        video item; otherwise empty.
         """
+        self._current_codec_video_urls = []
         out_msgs = []
         all_pil_images: list = []
         if self.system_prompt:
@@ -315,7 +379,7 @@ class Llava_OneVision2(lmms):
                         # Fall back to bundled video pipeline (non-timestamp)
                         content.append({"type": "video", "video": c.url})
             out_msgs.append({"role": message.role, "content": content})
-        return out_msgs, all_pil_images
+        return out_msgs, all_pil_images, list(self._current_codec_video_urls)
 
     # -------------------------------------------------------- main loop
 
@@ -346,12 +410,14 @@ class Llava_OneVision2(lmms):
             # Build chat messages for each doc in chunk.
             hf_messages_batch = []
             pil_images_batch: List[list] = []
+            codec_urls_batch: List[list] = []
             for did in doc_ids:
                 raw = doc_to_messages[0](self.task_dict[task][split][did])
                 cm = ChatMessages(**{"messages": raw})
-                msgs, pil_imgs = self._build_messages(cm)
+                msgs, pil_imgs, codec_urls = self._build_messages(cm)
                 hf_messages_batch.append(msgs)
                 pil_images_batch.append(pil_imgs)
+                codec_urls_batch.append(codec_urls)
 
             texts = [self.processor.apply_chat_template(m, tokenize=False, add_generation_prompt=True) for m in hf_messages_batch]
 
@@ -359,16 +425,37 @@ class Llava_OneVision2(lmms):
             # image-processor branch used during training.
             images_arg = None
             first_pil = pil_images_batch[0] if pil_images_batch else []
+            first_codec_urls = codec_urls_batch[0] if codec_urls_batch else []
             if first_pil:
                 images_arg = first_pil
 
-            inputs = self.processor(
-                text=texts,
-                images=images_arg,
-                videos=None,
-                return_tensors="pt",
-                padding=True,
-            )
+            if self.use_codec and first_codec_urls:
+                if len(texts) != 1:
+                    raise ValueError(
+                        "codec path currently expects batch_size=1"
+                    )
+                # Single entry point: defer all codec preprocessing to the
+                # bundled ``processor(video_backend='codec')`` shipped with
+                # the checkpoint (trust_remote_code).
+                proc_kwargs = dict(
+                    text=[texts[0]],
+                    videos=[first_codec_urls[0]],
+                    video_backend="codec",
+                    max_pixels=self.max_pixels,
+                    return_tensors="pt",
+                    padding=True,
+                )
+                if self.codec_overrides:
+                    proc_kwargs["codec_config"] = self.codec_overrides
+                inputs = self.processor(**proc_kwargs)
+            else:
+                inputs = self.processor(
+                    text=texts,
+                    images=images_arg,
+                    videos=None,
+                    return_tensors="pt",
+                    padding=True,
+                )
 
             # Move to device. Under multi-GPU sharding, send inputs to the
             # device where the embedding layer lives.


### PR DESCRIPTION
Add an opt-in codec preprocessing path to the LLaVA-OneVision2 chat wrapper. When 'use_codec=true' is passed via --model_args, video items are forwarded to the bundled processor(video_backend='codec', ...) entry shipped with the checkpoint instead of qwen-vl-utils frame sampling; the wrapper itself contains no codec-specific logic.

- New model_args: use_codec, codec_target_canvas, codec_group_size, codec_images_per_group, codec_patch, codec_min_group_frames, codec_max_group_frames, codec_spatial_mask_mode, codec_cache_dir. Any omitted codec_* falls back to preprocessor_config.json defaults.
- max_pixels doubles as the per-canvas pixel budget so users tune a single knob; cache root honors ONLINE_CODEC_CACHE_DIR / HF_HOME.
- _build_messages now also returns codec_video_urls; the standard qwen-vl-utils timestamp path is unchanged when use_codec is false.
- examples/models/llava_onevision2.sh: keep the original mlvu_dev recipe and add a videomme_long codec example with knob reference.

## Summary
<!-- Max 3 bullets. -->
- 
- 
- 

## In scope
<!-- Explicitly list what this PR changes. -->
- 

## Out of scope
<!-- Explicitly list what this PR does NOT change. -->
- 

## Validation
<!--
Max 3 bullets.
Use this format:
`<command>` | sample size: `N=<...>` | key metrics: `<...>` | result: `pass/fail`
If you ran tests/benchmarks with metrics, include concrete numbers.
-->
- 

## Risk / Compatibility
<!-- 1-2 bullets. Note breaking changes, behavior changes, or migration impact. -->
- 

## Type of Change
- [ ] Bug fix (non-breaking change)
- [ ] New feature
- [ ] New benchmark/task
- [ ] New model integration
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
