### PR TITLE
feat: add Physical AI Understanding task

### DIFF
--- a/lmms_eval/tasks/physical_ai_understanding/physical_ai_understanding.yaml
+++ b/lmms_eval/tasks/physical_ai_understanding/physical_ai_understanding.yaml
@@ -1,0 +1,37 @@
+dataset_path: shi-labs/physical-ai-bench-understanding
+task: "physical_ai_understanding"
+test_split: test
+output_type: generate_until
+doc_to_visual: !function utils.physical_ai_understanding_doc_to_visual
+doc_to_text: !function utils.physical_ai_understanding_doc_to_text
+doc_to_target: "answer"
+
+generation_kwargs:
+  max_new_tokens: 2048
+  temperature: 0
+  top_p: 1.0
+  num_beams: 1
+  do_sample: false
+
+filter_list:
+  - name: "flexible-extract"
+    filter:
+      - function: !function utils.MultiChoiceRegexFilter
+        group_select: 0
+        ignore_case: true
+        ignore_punctuation: true
+        regex_pattern: "(\\([A-Z]\\))"
+
+metric_list:
+  - metric: exact_match
+    aggregation: mean
+    higher_is_better: true
+    ignore_case: true
+    ignore_punctuation: true
+
+lmms_eval_specific_kwargs:
+  default:
+    pre_prompt: ""
+    post_prompt: "Please answer directly with only the letter of the correct option and nothing else."
+metadata:
+  version: 0.1

--- a/lmms_eval/tasks/physical_ai_understanding/utils.py
+++ b/lmms_eval/tasks/physical_ai_understanding/utils.py
@@ -1,0 +1,145 @@
+"""Physical AI Understanding task for lmms-eval.
+
+A video MCQ benchmark from NVIDIA's Cosmos PhysicalAI family covering
+embodied/AV/robotics reasoning. The HF dataset bundles the QA parquet at
+``data/test-*.parquet`` and the source videos at ``videos/<subset>/<id>.mp4``.
+
+Each item carries a structured ``index2ans`` mapping ({"A": ..., "B": ...,
+"C": ..., "D": ...}) so we don't need to re-parse choices from the prompt.
+
+Reference dataset: https://huggingface.co/datasets/shi-labs/physical-ai-bench-understanding
+"""
+
+from __future__ import annotations
+
+import os
+import os.path as osp
+import re
+from functools import lru_cache
+from typing import Any, Dict, List
+
+from huggingface_hub import snapshot_download
+
+from lmms_eval.filters.extraction import ExtendedRegexFilter
+from lmms_eval.filters.transformation import MapFilter
+
+
+REPO_ID = "shi-labs/physical-ai-bench-understanding"
+
+REPLACE_PROMPT = (
+    "Please answer directly with only the letter of the correct option and nothing else."
+)
+
+
+@lru_cache(maxsize=1)
+def _video_root() -> str:
+    """Download (once) and return the local path to the dataset snapshot."""
+    return snapshot_download(
+        repo_id=REPO_ID,
+        repo_type="dataset",
+        allow_patterns=["videos/**"],
+    )
+
+
+def physical_ai_understanding_doc_to_visual(doc: Dict[str, Any]) -> List[str]:
+    path = osp.join(_video_root(), doc["video_path"])
+    if not osp.exists(path):
+        raise FileNotFoundError(f"video not found: {path}")
+    return [path]
+
+
+def physical_ai_understanding_doc_to_text(
+    doc: Dict[str, Any],
+    lmms_eval_specific_kwargs: Dict[str, Any] | None = None,
+) -> str:
+    kwargs = lmms_eval_specific_kwargs or {}
+    pre_prompt = kwargs.get("pre_prompt", "")
+    post_prompt = kwargs.get("post_prompt", "")
+    question = doc["question"].strip()
+    if post_prompt:
+        question = question.replace(REPLACE_PROMPT, "")
+
+    index2ans = doc.get("index2ans") or {}
+    options = []
+    for letter in sorted(index2ans.keys()):
+        ans_text = index2ans[letter]
+        if ans_text is not None:
+            options.append(f"{letter}. {ans_text}")
+
+    return f"{pre_prompt}{question}\n\n" + "\n".join(options) + f"\n{post_prompt}"
+
+
+class NumberWordsToDigitsFilter(MapFilter):
+    def __init__(self) -> None:
+        mapping_dict = {
+            "zero": "0", "one": "1", "two": "2", "three": "3", "four": "4",
+            "five": "5", "six": "6", "seven": "7", "eight": "8", "nine": "9",
+            "ten": "10",
+        }
+        super().__init__(mapping_dict, default_value=None)
+
+    def apply(self, resps, docs):
+        def filter_set(inst):
+            return [self.mapping_dict.get(resp.lower(), resp) for resp in inst]
+        return [filter_set(resp) for resp in resps]
+
+
+class MultiChoiceRegexFilter(ExtendedRegexFilter):
+    """Letter-or-choice-text extractor for index2ans-style MCQ.
+
+    Tries (1) a leading uppercase letter, then (2) match against any
+    choice text from ``index2ans`` (falling back to parsing ``A. ...``
+    style options out of the question text if ``index2ans`` is missing).
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def apply(self, resps, docs):
+        filtered_resps = []
+        for r, doc in zip(resps, docs):
+            fallback_regexes = []
+            choice_to_alpha = {}
+
+            index2ans = doc.get("index2ans") or {}
+            if index2ans:
+                for letter in sorted(index2ans.keys()):
+                    ans_text = index2ans[letter]
+                    if ans_text is not None:
+                        choice_text = ans_text.strip()
+                        fallback_regexes.append(re.escape(choice_text))
+                        choice_to_alpha[choice_text] = letter
+            else:
+                # No structured choices — parse from question
+                for m in re.finditer(r"\b([A-Z])\.\s+([^\n]*)", doc.get("question", "")):
+                    choice_text = m.group(2).strip()
+                    fallback_regexes.append(re.escape(choice_text))
+                    choice_to_alpha[choice_text] = m.group(1)
+
+            letter_regex = re.compile(r"^([A-Z])\b")
+
+            filtered = []
+            for resp in r:
+                resp = re.sub(r"<think>.*?</think>", "", resp, flags=re.DOTALL).strip()
+                resp = re.sub(r"<thought>.*?</thought>", "", resp, flags=re.DOTALL).strip()
+                ans_match = re.search(r"<answer>(.*?)</answer>", resp, flags=re.DOTALL)
+                if ans_match:
+                    resp = ans_match.group(1).strip()
+                cleaned = re.sub(r"[^\w\s]", "", resp).strip()
+
+                letter_match = letter_regex.match(cleaned)
+                if letter_match and letter_match.group(1) in index2ans:
+                    filtered.append(letter_match.group(1))
+                elif fallback_regexes:
+                    fallback_regex = re.compile("|".join(fallback_regexes))
+                    match = fallback_regex.search(cleaned)
+                    if match and match.group() in choice_to_alpha:
+                        filtered.append(choice_to_alpha[match.group()])
+                    else:
+                        filtered.append(cleaned)
+                else:
+                    filtered.append(cleaned)
+
+            filtered_resps.append(filtered[0])
+
+        return filtered_resps


### PR DESCRIPTION
## Summary

Adds **Physical AI Understanding**, a 1,214-item video MCQ benchmark from NVIDIA's [Cosmos PhysicalAI](https://huggingface.co/datasets/shi-labs/physical-ai-bench-understanding) family covering embodied / autonomous-vehicle / robotics reasoning.

Each item carries a structured ``index2ans`` mapping ({"A": ..., "B": ..., "C": ..., "D": ...}) and a target letter, so we don't need to re-parse choices from the prompt.

Dataset: [\`shi-labs/physical-ai-bench-understanding\`](https://huggingface.co/datasets/shi-labs/physical-ai-bench-understanding) — parquet QA at \`data/test-*.parquet\` and 1,027 source videos at \`videos/<subset>/<id>.mp4\` in the same HF repo. Videos are fetched once via \`snapshot_download\` and cached on disk for subsequent \`doc_to_visual\` lookups.

## Files

- \`lmms_eval/tasks/physical_ai_understanding/physical_ai_understanding.yaml\` — task config.
- \`lmms_eval/tasks/physical_ai_understanding/utils.py\` — doc transforms, \`MultiChoiceRegexFilter\` (letter-first, then choice-text substring; strips \`<think>\` / \`<answer>\` wrappers).

## Parity vs. local fork

Qwen3-VL-2B-Instruct, full \`test\` split (1,214 items).

| Source                                | Accuracy | Stderr |
|---------------------------------------|---------:|-------:|
| Fork (vllm backend)                   |   0.4992 | ±0.014 |
| Upstream (HF simple/qwen3_vl, fps=2)  |   0.4786 | ±0.014 |

| | |
|---|---|
| Identical \`filtered_resps\`           | 1,087 / 1,214 (89.5%) |
| Verdict agreement                     | 91.7% |
| Δ                                     | -2.1 pp (within stderr) |

Different inference backends (vllm vs HF simple) account for the small per-doc divergence; this is in line with the drift we've seen on prior video-MCQ ports (egotaskqa, metavqa).

## Notes on short videos

A handful of clips have only ~6 frames. The upstream \`simple/qwen3_vl\` model defaults to strict \`nframes=32\` via \`qwen_vl_utils\`, which errors on these. Running with \`model_args=fps=2.0,max_num_frames=32\` flips it to lenient \`max_frames\` mode and the task runs end-to-end. (No code changes needed — just a model-args note for reproducibility.)

## Test plan

- [x] \`uv run lmms-eval --tasks physical_ai_understanding --limit 4\` smoke
- [x] Full 1,214-doc run on 8x H100 with Qwen3-VL-2B-Instruct; scores within stderr of the fork's vllm run
- [x] Per-doc analysis: 89.5% identical predictions, 91.7% verdict agreement
- [x] Video cache via \`snapshot_download\` works (1,027 files cached on first call, reused on subsequent calls)