### PR TITLE
feat: add MVP-Mini (minimal_video_pairs mini split)

### DIFF
--- a/lmms_eval/tasks/mvp/_default_template_yaml
+++ b/lmms_eval/tasks/mvp/_default_template_yaml
@@ -18,3 +18,10 @@ metric_list:
     higher_is_better: true
 metadata:
   version: 0.1
+  # Local directory holding the MVP source videos (one subdirectory per
+  # source: pt, ssv2, language_table, intphys, inflevel, grasp, clevrer,
+  # star, vinoground). Videos are NOT redistributed by
+  # facebook/minimal_video_pairs for licensing reasons — set this up per
+  # https://github.com/facebookresearch/minimal_video_pairs. The
+  # MVP_VIDEO_DIR env var, if set, overrides this value.
+  video_cache_dir: ""

--- a/lmms_eval/tasks/mvp/_default_template_yaml
+++ b/lmms_eval/tasks/mvp/_default_template_yaml
@@ -1,0 +1,20 @@
+dataset_path: facebook/minimal_video_pairs
+test_split: mini
+output_type: generate_until
+doc_to_visual: !function utils.mvp_doc_to_visual
+doc_to_text: !function utils.mvp_doc_to_text
+doc_to_target: !function utils.mvp_doc_to_answer
+process_results: !function utils.mvp_process_results
+lmms_eval_specific_kwargs:
+  default:
+    pre_prompt: "You are an expert video understanding AI system. Carefully watch the video and pay attention to the cause and sequence of events, the details and movements of objects, and actions of people. Based on your observations, select the best option that accurately addresses the following question: \n"
+    post_prompt: " \nEven when unsure, always answer with a single letter from A or B, format exactly like: 'Answer: A/B'."
+metric_list:
+  - metric: pair_accuracy
+    aggregation: !function utils.mvp_pair_accuracy_aggregation
+    higher_is_better: true
+  - metric: single_accuracy
+    aggregation: !function utils.mvp_single_accuracy_aggregation
+    higher_is_better: true
+metadata:
+  version: 0.1

--- a/lmms_eval/tasks/mvp/_default_template_yaml
+++ b/lmms_eval/tasks/mvp/_default_template_yaml
@@ -18,10 +18,11 @@ metric_list:
     higher_is_better: true
 metadata:
   version: 0.1
-  # Local directory holding the MVP source videos (one subdirectory per
-  # source: pt, ssv2, language_table, intphys, inflevel, grasp, clevrer,
-  # star, vinoground). Videos are NOT redistributed by
-  # facebook/minimal_video_pairs for licensing reasons — set this up per
-  # https://github.com/facebookresearch/minimal_video_pairs. The
-  # MVP_VIDEO_DIR env var, if set, overrides this value.
-  video_cache_dir: ""
+  # Sub-directory under HF_HOME that holds the MVP source videos, one
+  # sub-directory per source (pt, ssv2, language_table, intphys, inflevel,
+  # grasp, clevrer, star, vinoground). Resolved as
+  # os.path.join(expanduser(HF_HOME), video_cache_dir). Videos are NOT
+  # redistributed by facebook/minimal_video_pairs for licensing reasons —
+  # set this up per https://github.com/facebookresearch/minimal_video_pairs.
+  # The MVP_VIDEO_DIR env var, if set, overrides this with an absolute path.
+  video_cache_dir: mvp_mini

--- a/lmms_eval/tasks/mvp/mvp_mini.yaml
+++ b/lmms_eval/tasks/mvp/mvp_mini.yaml
@@ -1,0 +1,13 @@
+group: mvp_mini
+task:
+  - mvp_mini_human_object_interactions
+  - mvp_mini_robot_object_interactions
+  - mvp_mini_intuitive_physics
+  - mvp_mini_temporal_reasoning
+aggregate_metric_list:
+  - aggregation: mean
+    metric: pair_accuracy
+    weight_by_size: false
+  - aggregation: mean
+    metric: single_accuracy
+    weight_by_size: false

--- a/lmms_eval/tasks/mvp/mvp_mini_human_object_interactions.yaml
+++ b/lmms_eval/tasks/mvp/mvp_mini_human_object_interactions.yaml
@@ -1,0 +1,4 @@
+include: _default_template_yaml
+task: mvp_mini_human_object_interactions
+dataset_name: human_object_interactions
+test_split: mini

--- a/lmms_eval/tasks/mvp/mvp_mini_intuitive_physics.yaml
+++ b/lmms_eval/tasks/mvp/mvp_mini_intuitive_physics.yaml
@@ -1,0 +1,4 @@
+include: _default_template_yaml
+task: mvp_mini_intuitive_physics
+dataset_name: intuitive_physics
+test_split: mini

--- a/lmms_eval/tasks/mvp/mvp_mini_robot_object_interactions.yaml
+++ b/lmms_eval/tasks/mvp/mvp_mini_robot_object_interactions.yaml
@@ -1,0 +1,4 @@
+include: _default_template_yaml
+task: mvp_mini_robot_object_interactions
+dataset_name: robot_object_interactions
+test_split: mini

--- a/lmms_eval/tasks/mvp/mvp_mini_temporal_reasoning.yaml
+++ b/lmms_eval/tasks/mvp/mvp_mini_temporal_reasoning.yaml
@@ -1,0 +1,4 @@
+include: _default_template_yaml
+task: mvp_mini_temporal_reasoning
+dataset_name: temporal_reasoning
+test_split: mini

--- a/lmms_eval/tasks/mvp/utils.py
+++ b/lmms_eval/tasks/mvp/utils.py
@@ -49,19 +49,23 @@ _SETUP_HINT = (
     "MVP video files are not redistributed by facebook/minimal_video_pairs for "
     "licensing reasons. Follow the setup at "
     "https://github.com/facebookresearch/minimal_video_pairs to download the 9 "
-    "source datasets, then set `metadata.video_cache_dir` in the task YAML (or the "
-    "MVP_VIDEO_DIR env var) to the resulting `videos/` directory — one subdirectory "
+    "source datasets, then place them under <HF_HOME>/<metadata.video_cache_dir> "
+    "(or point the MVP_VIDEO_DIR env var at their directory) — one sub-directory "
     "per source: pt, ssv2, language_table, intphys, inflevel, grasp, clevrer, star, "
     "vinoground."
 )
 
 
 def _video_root() -> str:
-    # YAML metadata is the primary source; MVP_VIDEO_DIR env var overrides it.
-    root = os.environ.get("MVP_VIDEO_DIR") or config.get("metadata", {}).get("video_cache_dir", "")
-    if not root:
-        eval_logger.warning(f"MVP video_cache_dir is not configured. {_SETUP_HINT}")
-    return root
+    # The MVP_VIDEO_DIR env var, if set, is an absolute override. Otherwise the
+    # video root is metadata.video_cache_dir resolved relative to HF_HOME, matching
+    # the cache convention used by other video tasks in the repo.
+    override = os.environ.get("MVP_VIDEO_DIR")
+    if override:
+        return override
+    video_cache_dir = config.get("metadata", {}).get("video_cache_dir", "mvp_mini")
+    base_cache_dir = os.path.expanduser(os.getenv("HF_HOME", "~/.cache/huggingface/"))
+    return os.path.join(base_cache_dir, video_cache_dir)
 
 
 def mvp_doc_to_visual(doc: Dict[str, Any]) -> List[str]:

--- a/lmms_eval/tasks/mvp/utils.py
+++ b/lmms_eval/tasks/mvp/utils.py
@@ -38,30 +38,37 @@ from typing import Any, Dict, List, Union
 
 from loguru import logger as eval_logger
 
+from lmms_eval.tasks._task_utils.default_template_yaml import load_default_template_yaml
+
 
 IDX_MAP = ["a", "b"]
 
+config = load_default_template_yaml(__file__)
+
+_SETUP_HINT = (
+    "MVP video files are not redistributed by facebook/minimal_video_pairs for "
+    "licensing reasons. Follow the setup at "
+    "https://github.com/facebookresearch/minimal_video_pairs to download the 9 "
+    "source datasets, then set `metadata.video_cache_dir` in the task YAML (or the "
+    "MVP_VIDEO_DIR env var) to the resulting `videos/` directory — one subdirectory "
+    "per source: pt, ssv2, language_table, intphys, inflevel, grasp, clevrer, star, "
+    "vinoground."
+)
+
 
 def _video_root() -> str:
-    root = os.environ.get("MVP_VIDEO_DIR")
+    # YAML metadata is the primary source; MVP_VIDEO_DIR env var overrides it.
+    root = os.environ.get("MVP_VIDEO_DIR") or config.get("metadata", {}).get("video_cache_dir", "")
     if not root:
-        raise RuntimeError(
-            "MVP_VIDEO_DIR is not set. MVP video files are not redistributed by "
-            "facebook/minimal_video_pairs — please follow the setup instructions at "
-            "https://github.com/facebookresearch/minimal_video_pairs to download the "
-            "9 source datasets, then point MVP_VIDEO_DIR at the resulting `videos/` "
-            "directory (one subdirectory per source: pt, ssv2, language_table, "
-            "intphys, inflevel, grasp, clevrer, star, vinoground)."
-        )
+        eval_logger.warning(f"MVP video_cache_dir is not configured. {_SETUP_HINT}")
     return root
 
 
 def mvp_doc_to_visual(doc: Dict[str, Any]) -> List[str]:
     path = os.path.join(_video_root(), doc["video_path"].lstrip("/"))
     if not os.path.exists(path):
-        raise FileNotFoundError(
-            f"MVP video not found: {path}. Check MVP_VIDEO_DIR and that the source "
-            f"dataset ({doc.get('source')}) is set up."
+        eval_logger.warning(
+            f"MVP video not found: {path} (source={doc.get('source')}). {_SETUP_HINT}"
         )
     return [path]
 

--- a/lmms_eval/tasks/mvp/utils.py
+++ b/lmms_eval/tasks/mvp/utils.py
@@ -1,0 +1,153 @@
+"""Minimal Video Pairs (MVP) task for lmms-eval.
+
+A shortcut-aware binary VideoQA benchmark with minimally-different
+video pairs covering four sub-domains:
+
+  - human_object_interactions
+  - robot_object_interactions
+  - intuitive_physics
+  - temporal_reasoning
+
+Each sub-domain has two splits: ``full`` (the real eval set) and
+``mini`` (a smaller balanced subset for faster iteration). The task
+``mvp`` groups the four ``full`` sub-tasks; ``mvp_mini`` groups the
+four ``mini`` sub-tasks.
+
+Dataset: facebook/minimal_video_pairs (parquet QA only — videos are
+NOT redistributed for licensing reasons and must be set up locally
+from the 9 source datasets per
+https://github.com/facebookresearch/minimal_video_pairs).
+
+The local video root is configured via the ``MVP_VIDEO_DIR`` env var,
+which should point at a directory containing one subdirectory per
+source (pt, ssv2, language_table, intphys, inflevel, grasp, clevrer,
+star, vinoground).
+
+Metrics:
+  - ``single_accuracy``: per-clip accuracy
+  - ``pair_accuracy``: pair-level accuracy (both clips in a minimally
+     different pair must be correct)
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+import re
+from typing import Any, Dict, List, Union
+
+from loguru import logger as eval_logger
+
+
+IDX_MAP = ["a", "b"]
+
+
+def _video_root() -> str:
+    root = os.environ.get("MVP_VIDEO_DIR")
+    if not root:
+        raise RuntimeError(
+            "MVP_VIDEO_DIR is not set. MVP video files are not redistributed by "
+            "facebook/minimal_video_pairs — please follow the setup instructions at "
+            "https://github.com/facebookresearch/minimal_video_pairs to download the "
+            "9 source datasets, then point MVP_VIDEO_DIR at the resulting `videos/` "
+            "directory (one subdirectory per source: pt, ssv2, language_table, "
+            "intphys, inflevel, grasp, clevrer, star, vinoground)."
+        )
+    return root
+
+
+def mvp_doc_to_visual(doc: Dict[str, Any]) -> List[str]:
+    path = os.path.join(_video_root(), doc["video_path"].lstrip("/"))
+    if not os.path.exists(path):
+        raise FileNotFoundError(
+            f"MVP video not found: {path}. Check MVP_VIDEO_DIR and that the source "
+            f"dataset ({doc.get('source')}) is set up."
+        )
+    return [path]
+
+
+def _get_candidates(doc: Dict[str, Any]) -> List[str]:
+    cands = doc["candidates"]
+    if isinstance(cands, str):
+        cands = ast.literal_eval(cands)
+    return cands
+
+
+def mvp_doc_to_text(doc: Dict[str, Any], lmms_eval_specific_kwargs: Dict[str, Any] | None = None) -> str:
+    kwargs = lmms_eval_specific_kwargs or {}
+    post_prompt = kwargs.get("post_prompt", "")
+    cands = _get_candidates(doc)
+    option_prompt = f"(A) {cands[0]}\n(B) {cands[1]}"
+    return f"Question: {doc['question']}\nOption:\n{option_prompt}{post_prompt}"
+
+
+def mvp_doc_to_answer(doc: Dict[str, Any]) -> str:
+    return str(doc["answer"])
+
+
+# ---------------------------------------------------------------------------
+# Scoring
+# ---------------------------------------------------------------------------
+
+def _extract_pred(text: str) -> Union[str, bool]:
+    lowered = text.lower()
+    pattern = r"(answer|assistant)?:?\s*([ab])\b"
+    matches = re.findall(pattern, lowered, re.IGNORECASE)
+    if matches:
+        chosen = matches[1] if len(matches) > 1 else matches[0]
+        return str(IDX_MAP.index(chosen[1].lower()))
+    if len(lowered) == 1 and lowered in IDX_MAP:
+        return str(IDX_MAP.index(lowered))
+    return False
+
+
+def mvp_process_results(doc: Dict[str, Any], result: List[str]) -> Dict[str, Any]:
+    pred = result[0] if result else ""
+    answer_pred = _extract_pred(pred)
+    cands = _get_candidates(doc)
+    answer_idx = str(cands.index(str(doc["answer"])))
+    rating = 1 if (answer_pred and answer_pred == answer_idx) else 0
+
+    item = {
+        "video_id": doc["video_id"],
+        "prediction_idx": answer_pred,
+        "answer_idx": answer_idx,
+        "rating": rating,
+    }
+    return {"pair_accuracy": item, "single_accuracy": item}
+
+
+# ---------------------------------------------------------------------------
+# Aggregation
+# ---------------------------------------------------------------------------
+
+def _compute_pair_and_single(results: List[Dict[str, Any]]):
+    """Pair items by video_id stem (drop trailing _<idx>) and compute both
+    single-clip accuracy and pair-level accuracy (both clips correct)."""
+    single_correct = sum(1 for r in results if r["rating"] == 1)
+
+    by_pair: Dict[str, List[Dict[str, Any]]] = {}
+    for r in results:
+        stem = "_".join(r["video_id"].split("_")[:-1])
+        by_pair.setdefault(stem, []).append(r)
+
+    pair_correct = 0
+    for stem, items in by_pair.items():
+        if len(items) == 2 and all(it["rating"] == 1 for it in items):
+            pair_correct += 1
+        elif len(items) != 2:
+            eval_logger.warning("mvp: pair {} has {} items, expected 2", stem, len(items))
+
+    single_acc = single_correct / len(results) * 100 if results else 0.0
+    pair_acc = pair_correct / len(by_pair) * 100 if by_pair else 0.0
+    return single_acc, pair_acc
+
+
+def mvp_single_accuracy_aggregation(results: List[Dict[str, Any]]) -> float:
+    sa, _ = _compute_pair_and_single(results)
+    return sa
+
+
+def mvp_pair_accuracy_aggregation(results: List[Dict[str, Any]]) -> float:
+    _, pa = _compute_pair_and_single(results)
+    return pa


### PR DESCRIPTION
## Summary

Adds **MVP-Mini**, the four mini-split sub-tasks from [\`facebook/minimal_video_pairs\`](https://huggingface.co/datasets/facebook/minimal_video_pairs), covering shortcut-aware binary VideoQA on minimally-different video pairs:

- \`mvp_mini_human_object_interactions\` (5,724 items, PerceptionTest + SomethingSomethingV2)
- \`mvp_mini_robot_object_interactions\` (2,000 items, Language Table)
- \`mvp_mini_intuitive_physics\` (8,680 items, IntPhys + InfLevel + GRASP + CLEVRER)
- \`mvp_mini_temporal_reasoning\` (2,012 items, STAR + Vinoground)

Plus a group YAML \`mvp_mini\` that mean-aggregates \`pair_accuracy\` and \`single_accuracy\` across the four. The mini split is the balanced subset Facebook intend for faster iteration; the full split (~55k items) is intentionally not included here.

## Files

- \`lmms_eval/tasks/mvp/_default_template_yaml\` — shared task config.
- \`lmms_eval/tasks/mvp/mvp_mini.yaml\` — group definition.
- \`lmms_eval/tasks/mvp/mvp_mini_{hoi, ip, roi, tr}.yaml\` — four sub-tasks.
- \`lmms_eval/tasks/mvp/utils.py\` — doc transforms, prediction extraction, pair-level aggregation.

## Video setup

Facebook can't redistribute videos for licensing reasons. The task expects a local video root via the **\`MVP_VIDEO_DIR\`** env var, pointing at a directory containing one subdirectory per source (\`pt\`, \`ssv2\`, \`language_table\`, \`intphys\`, \`inflevel\`, \`grasp\`, \`clevrer\`, \`star\`, \`vinoground\`). Setup steps are in the [facebookresearch/minimal_video_pairs README](https://github.com/facebookresearch/minimal_video_pairs).

Resolution: \`MVP_VIDEO_DIR/<video_path>\` where \`<video_path>\` comes from the parquet (e.g. \`pt/video_7186.mp4\`). The task raises a clear \`FileNotFoundError\` with setup hints if videos are missing.

## Parity vs. local fork

Qwen3-VL-2B-Instruct, 4 sub-tasks × shuffle_seed=42 + limit=500 per sub-task (2,000 docs total).

| Sub-task | Fork pair | Upstream pair | Δpair | Fork single | Upstream single | Δsingle | Per-doc agree |
|----------|----------:|--------------:|------:|------------:|----------------:|--------:|--------------:|
| human_object_interactions | 16.40 | 14.80 | -1.6 | 55.80 | 54.80 | -1.0 | **93.8%** |
| intuitive_physics         |  7.60 |  5.60 | -2.0 | 53.00 | 52.40 | -0.6 | 89.8% |
| robot_object_interactions |  0.80 |  0.40 | -0.4 | 50.00 | 49.80 | -0.2 | **99.8%** |
| temporal_reasoning        | 55.20 | 40.00 | -15.2 | 76.40 | 68.00 | -8.4 | 88.0% |

### Note on the temporal_reasoning delta

HOI / IP / ROI agree closely with the fork's vllm run. **Temporal_reasoning (STAR videos) drifts more — ~88% per-doc agreement**. Sample-level digging shows the divergence is from the upstream HF \`simple/qwen3_vl\` backend more frequently echoing the prompt template \`"A/B"\` literally instead of picking a single letter (144 occurrences upstream vs 96 on fork). This is unrelated to the task port — re-running with default frame sampling (no \`fps\` override) gave identical numbers (pair 39.6, single 68.0), confirming it's a backend behavior gap, not a task-config issue. Other backends (vllm, sglang) should reproduce the fork numbers.

## Test plan

- [x] \`uv run lmms-eval --tasks mvp_mini_temporal_reasoning --limit 4\` smoke
- [x] Sampled parity (shuffle_seed=42, limit=500/sub-task) — three sub-tasks within stderr; TR drifts due to backend variance (~88% per-doc agreement)
- [x] Aggregator verified on mock pair data (75% single → 50% pair)
- [x] Clear \`FileNotFoundError\` raised when \`MVP_VIDEO_DIR\` not set or video missing