### PR TITLE
feat: add OmniSpatial task

### DIFF
--- a/lmms_eval/tasks/omni_spatial/omni_spatial.yaml
+++ b/lmms_eval/tasks/omni_spatial/omni_spatial.yaml
@@ -1,0 +1,41 @@
+task: omni_spatial
+dataset_path: nv-njb/OmniSpatial-Test
+test_split: test
+output_type: generate_until
+
+doc_to_visual: !function utils.omni_spatial_doc_to_visual
+doc_to_text: !function utils.omni_spatial_doc_to_text
+doc_to_target: !function utils.omni_spatial_doc_to_answer
+process_results: !function utils.omni_spatial_process_results
+
+generation_kwargs:
+  max_new_tokens: 16
+  temperature: 0
+  top_p: 1.0
+  num_beams: 1
+  do_sample: false
+
+metric_list:
+  - metric: omni_spatial_score
+    aggregation: !function utils.omni_spatial_aggregate_overall
+    higher_is_better: true
+  - metric: complex_logic
+    aggregation: !function utils.omni_spatial_aggregate_complex_logic
+    higher_is_better: true
+  - metric: dynamic_reasoning
+    aggregation: !function utils.omni_spatial_aggregate_dynamic_reasoning
+    higher_is_better: true
+  - metric: perspective_taking
+    aggregation: !function utils.omni_spatial_aggregate_perspective_taking
+    higher_is_better: true
+  - metric: spatial_interaction
+    aggregation: !function utils.omni_spatial_aggregate_spatial_interaction
+    higher_is_better: true
+
+lmms_eval_specific_kwargs:
+  default:
+    eval_type: "direct"
+    prompt_type: "none"
+
+metadata:
+  version: 0.1

--- a/lmms_eval/tasks/omni_spatial/utils.py
+++ b/lmms_eval/tasks/omni_spatial/utils.py
@@ -1,0 +1,128 @@
+"""OmniSpatial task for lmms-eval.
+
+A 1,533-item single-image MCQ on comprehensive spatial reasoning, with
+four task types (Complex_Logic, Dynamic_Reasoning, Perspective_Taking,
+Spatial_Interaction) and ten sub-task types.
+
+Each item carries 2+ options with a 0-based ``answer`` index. The
+default scoring mode (``eval_type: direct``) does deterministic
+letter-match — the question prompt asks the model to reply with a
+single letter — so no LLM judge is required.
+
+Dataset: nv-njb/OmniSpatial-Test — a bundled re-host of the test split
+of qizekun/OmniSpatial (the canonical release ships a 1.66 GB zip
+that doesn't load directly via load_dataset).
+
+Reference: https://huggingface.co/datasets/qizekun/OmniSpatial
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, List
+
+from PIL import Image
+
+
+# ---------------------------------------------------------------------------
+# Prompting (matches the default direct-MCQ mode of the upstream OmniSpatial
+# reference implementation)
+# ---------------------------------------------------------------------------
+
+DEFAULT_SYSTEM_PROMPT = """\
+You are a spatial-reasoning assistant.
+
+Task
+-----
+You will receive
+1. **Image** - a single RGB frame depicting a scene.
+2. **Multi-View Image** - a RGB frame depicting a scene from 6 novel views.
+3. **Question** - a natural-language query about spatial relationships between objects in the image.
+4. **Options** - >=2 answer candidates, each tagged by a capital letter (A, B, C, D...).
+
+Based on the image and question, provide your answer.
+Always ground your answer in the visual evidence; do not hallucinate unseen objects.
+If uncertain, pick the most plausible option---never refuse or reply "insufficient information."
+"""
+
+DIRECT_FORMAT = "\nNote: You only need to respond with A, B, C, or D without providing any additional information.\n"
+
+
+def _strip_think(text: str) -> str:
+    text = re.sub(r"^.*?</think>", "", text, flags=re.DOTALL)
+    text = re.sub(r"^.*?</thought>", "", text, flags=re.DOTALL)
+    m = re.search(r"<answer>(.*?)</answer>", text, flags=re.DOTALL | re.IGNORECASE)
+    if m:
+        return m.group(1).strip()
+    return text.strip()
+
+
+def omni_spatial_doc_to_visual(doc: Dict[str, Any]) -> List[Image.Image]:
+    return [doc["image"].convert("RGB")]
+
+
+def omni_spatial_doc_to_text(doc: Dict[str, Any], lmms_eval_specific_kwargs: Dict[str, Any] | None = None) -> str:
+    prompt = DEFAULT_SYSTEM_PROMPT + DIRECT_FORMAT + "\n" + doc["question"]
+    for i, opt in enumerate(doc["options"]):
+        prompt += f"\n{chr(65 + i)}. {opt}"
+    return prompt
+
+
+def omni_spatial_doc_to_answer(doc: Dict[str, Any]) -> str:
+    return chr(65 + int(doc["answer"]))
+
+
+# ---------------------------------------------------------------------------
+# Scoring
+# ---------------------------------------------------------------------------
+
+def omni_spatial_process_results(doc: Dict[str, Any], results: List[str]) -> Dict[str, Any]:
+    raw = results[0] if results else ""
+    response = _strip_think(raw)
+    pred_letter = response.strip().upper()[:1] if response else ""
+    gt_letter = chr(65 + int(doc["answer"]))
+    score = int(pred_letter == gt_letter)
+    item = {
+        "score": score,
+        "task_type": str(doc.get("task_type", "")),
+        "sub_task_type": str(doc.get("sub_task_type", "")),
+    }
+    return {
+        "omni_spatial_score": item,
+        "complex_logic": item,
+        "dynamic_reasoning": item,
+        "perspective_taking": item,
+        "spatial_interaction": item,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Aggregation
+# ---------------------------------------------------------------------------
+
+def _mean(xs):
+    return sum(xs) / len(xs) if xs else 0.0
+
+
+def omni_spatial_aggregate_overall(results: List[Dict[str, Any]]) -> float:
+    return _mean([r["score"] for r in results])
+
+
+def _by_task(results, target):
+    return _mean([r["score"] for r in results if r["task_type"] == target])
+
+
+def omni_spatial_aggregate_complex_logic(results):
+    return _by_task(results, "Complex_Logic")
+
+
+def omni_spatial_aggregate_dynamic_reasoning(results):
+    return _by_task(results, "Dynamic_Reasoning")
+
+
+def omni_spatial_aggregate_perspective_taking(results):
+    return _by_task(results, "Perspective_Taking")
+
+
+def omni_spatial_aggregate_spatial_interaction(results):
+    return _by_task(results, "Spatial_Interaction")


### PR DESCRIPTION
## Summary

Adds **OmniSpatial**, a 1,533-item comprehensive spatial reasoning MCQ benchmark with:
- 4 task types: \`Complex_Logic\` (252), \`Dynamic_Reasoning\` (420), \`Perspective_Taking\` (561), \`Spatial_Interaction\` (300)
- 10 sub-task types (Motion_Analysis, Allocentric, Geometric_Reasoning, etc.)

Dataset: [\`nv-njb/OmniSpatial-Test\`](https://huggingface.co/datasets/nv-njb/OmniSpatial-Test) — a bundled re-host of the test split of [\`qizekun/OmniSpatial\`](https://huggingface.co/datasets/qizekun/OmniSpatial).

### Why a re-host

The canonical release ships \`OmniSpatial-test.zip\` (1.66 GB), which doesn't load directly via \`datasets.load_dataset\` — it has to be downloaded and extracted manually. The re-host bundles all 1,533 records (annotations + PNG bytes via \`Image()\`) into ~1.8 GB of parquet shards, so the task loads end-to-end through the standard HF pipeline.

## Files

- \`lmms_eval/tasks/omni_spatial/omni_spatial.yaml\` — task config (1 task, 5 metrics: overall + per-task-type).
- \`lmms_eval/tasks/omni_spatial/utils.py\` — doc transforms, direct-MCQ scoring (matches the reference impl's default \`eval_type: direct\` — no LLM judge required), per-task-type aggregators.

## Parity vs. local fork

Qwen3-VL-2B-Instruct, full \`test\` split (1,533 items), 8x H100, greedy decoding.

| Sub-metric          | Fork  | Upstream | Δ      |
|---------------------|------:|---------:|-------:|
| **Overall**         | 0.3875 | 0.3529  | -3.5 pp |
| Complex_Logic       | 0.2460 | 0.2063  | -4.0 pp |
| Dynamic_Reasoning   | 0.3524 | 0.3000  | -5.2 pp |
| Perspective_Taking  | 0.4332 | 0.3975  | -3.6 pp |
| Spatial_Interaction | 0.4700 | 0.4667  | -0.3 pp |

| | |
|---|---|
| Identical \`filtered_resps\` | 901 / 1,533 (58.8%) |
| Verdict agreement           | **89.8%** |

The per-doc divergence comes mainly from upstream's HF \`simple/qwen3_vl\` more frequently echoing prompt phrases verbatim ("insufficient information", "A/B") instead of producing a clean letter — same backend artifact we observed in the MVP-Mini PR (#1356). \`Spatial_Interaction\` is essentially identical (-0.3 pp); the other categories drift a few points. \`vllm\` / \`sglang\` backends should reproduce the fork numbers.

## Test plan

- [x] \`uv run lmms-eval --tasks omni_spatial --limit 8\` smoke
- [x] Full 1,533-doc run with Qwen3-VL-2B-Instruct; verdict agreement 89.8%
- [x] Per-task-type aggregation matches expected breakdown (262 Complex_Logic, 420 Dynamic_Reasoning, etc.)
- [x] Re-hosted parquet loads via \`load_dataset("nv-njb/OmniSpatial-Test")\` without external setup