### PR TITLE
Fix PointBench image/question misalignment and add binary metric

### DIFF
--- a/lmms_eval/tasks/pointbench/_default_template_yaml
+++ b/lmms_eval/tasks/pointbench/_default_template_yaml
@@ -13,6 +13,9 @@ metric_list:
   - metric: pointbench_acc
     aggregation: !function utils.pointbench_aggregate_results
     higher_is_better: true
+  - metric: pointbench_binary_acc
+    aggregation: !function utils.pointbench_binary_aggregate_results
+    higher_is_better: true
 
 generation_kwargs:
   max_new_tokens: 256

--- a/lmms_eval/tasks/pointbench/utils.py
+++ b/lmms_eval/tasks/pointbench/utils.py
@@ -1,4 +1,5 @@
 import re
+import unicodedata
 import zipfile
 from functools import lru_cache
 from io import BytesIO
@@ -6,14 +7,12 @@ from typing import Any, Dict, List
 
 import datasets
 import numpy as np
-import requests
 from PIL import Image
 
 from lmms_eval.tasks._task_utils.default_template_yaml import load_default_template_yaml
 from lmms_eval.utils import eval_logger
 
 POINTARENA_REPO = "PointArena/pointarena-data"
-POINTARENA_ROWS_API = "https://datasets-server.huggingface.co/rows"
 
 PROMPT_SUFFIX_0_999 = "Your answer should be formatted as a list of tuples, i.e. [(x1, y1), (x2, y2), ...], where each tuple contains the x and y coordinates of a point satisfying the conditions above. The coordinates should be integers between 0 and 999, representing the pixel locations scaled to a 1000x1000 grid."
 PROMPT_SUFFIX_ORIGINAL = "Your answer should be formatted as a list of tuples, i.e. [(x1, y1), (x2, y2), ...], where each tuple contains the x and y coordinates of a point satisfying the conditions above. The coordinates should be between 0 and 1, indicating the normalized pixel locations of the points in the image."
@@ -37,67 +36,91 @@ def pointbench_doc_to_text(doc: Dict[str, Any], lmms_eval_specific_kwargs: Dict[
     return f"{pre_prompt}{user_input} {suffix} {FORMAT}{post_prompt}".strip()
 
 
-@lru_cache(maxsize=4096)
-def _get_image_url(row_idx: int) -> str:
-    response = requests.get(
-        POINTARENA_ROWS_API,
-        params={"dataset": POINTARENA_REPO, "config": "default", "split": "train", "offset": int(row_idx), "length": 1},
-        timeout=30,
-    )
-    response.raise_for_status()
-    payload = response.json()
-    rows = payload.get("rows", [])
-    if not rows:
-        raise ValueError(f"No rows found for row_idx={row_idx}")
-    return rows[0]["row"]["image"]["src"]
+def _zip_basename_key(name: str) -> str:
+    """NFC-normalized basename so accented filenames match across data.json/zip."""
+    return unicodedata.normalize("NFC", name.rsplit("/", 1)[-1])
 
 
-def _load_image(row_idx: int) -> Image.Image:
-    image_url = _get_image_url(row_idx)
-    response = requests.get(image_url, timeout=60)
-    if response.status_code == 403:
-        _get_image_url.cache_clear()
-        image_url = _get_image_url(row_idx)
-        response = requests.get(image_url, timeout=60)
-    response.raise_for_status()
-    return Image.open(BytesIO(response.content)).convert("RGB")
+def _lookup_member(member_map: Dict[str, str], filename: str) -> str | None:
+    """Look up a zip member by basename, tolerating Unicode (NFC/NFD) differences."""
+    if not filename:
+        return None
+    if filename in member_map:
+        return member_map[filename]
+    return member_map.get(_zip_basename_key(filename))
 
 
-def pointbench_doc_to_visual(doc: Dict[str, Any]) -> List[Image.Image]:
-    row_idx = doc.get("row_idx", doc.get("question_id"))
-    if row_idx is None:
-        eval_logger.warning("pointbench: missing row_idx for doc={}", doc.get("image_filename", "unknown"))
-        return []
-
-    try:
-        image = _load_image(int(row_idx))
-    except Exception as exc:
-        eval_logger.warning("pointbench: failed to load image for row_idx={} ({})", row_idx, exc)
-        return []
-    return [image]
-
-
-@lru_cache(maxsize=1)
-def _mask_zip_path() -> str:
+@lru_cache(maxsize=4)
+def _zip_path(filename: str) -> str:
     from huggingface_hub import hf_hub_download
 
-    return hf_hub_download(repo_id=POINTARENA_REPO, repo_type="dataset", filename="selected_masks.zip")
+    return hf_hub_download(repo_id=POINTARENA_REPO, repo_type="dataset", filename=filename)
+
+
+def _mask_zip_path() -> str:
+    return _zip_path("selected_masks.zip")
+
+
+def _image_zip_path() -> str:
+    return _zip_path("selected_images.zip")
+
+
+def _build_member_map(zip_path: str, suffixes: tuple) -> Dict[str, str]:
+    # Key on the raw basename, an NFC-normalized basename, and -- for archives
+    # written without the UTF-8 flag -- a cp437->utf-8 recovered basename, so
+    # lookups succeed regardless of how the filename was encoded upstream.
+    mapping: Dict[str, str] = {}
+    with zipfile.ZipFile(zip_path) as archive:
+        for info in archive.infolist():
+            member = info.filename
+            if not member.lower().endswith(suffixes):
+                continue
+            base = member.rsplit("/", 1)[-1]
+            mapping.setdefault(base, member)
+            mapping.setdefault(_zip_basename_key(base), member)
+            if not (info.flag_bits & 0x800):  # zipfile decoded the name as cp437
+                try:
+                    recovered = base.encode("cp437").decode("utf-8")
+                    mapping.setdefault(_zip_basename_key(recovered), member)
+                except (UnicodeEncodeError, UnicodeDecodeError):
+                    pass
+    return mapping
 
 
 @lru_cache(maxsize=1)
 def _mask_member_map() -> Dict[str, str]:
-    mapping: Dict[str, str] = {}
-    with zipfile.ZipFile(_mask_zip_path()) as archive:
-        for member in archive.namelist():
-            if not member.lower().endswith(".png"):
-                continue
-            mapping.setdefault(member.rsplit("/", 1)[-1], member)
-    return mapping
+    return _build_member_map(_mask_zip_path(), (".png",))
+
+
+@lru_cache(maxsize=1)
+def _image_member_map() -> Dict[str, str]:
+    return _build_member_map(_image_zip_path(), (".jpg", ".jpeg", ".png", ".webp"))
+
+
+def pointbench_doc_to_visual(doc: Dict[str, Any]) -> List[Image.Image]:
+    # Load the image from selected_images.zip keyed by image_filename. The HF
+    # datasets-server rows API serves an image-only ImageFolder in zip order,
+    # which does NOT match data.json's question order -- fetching by row index
+    # pairs each question with the wrong image. Keying by filename keeps the
+    # (question, image) pair aligned and avoids the flaky rows API entirely.
+    image_filename = str(doc.get("image_filename", ""))
+    member = _lookup_member(_image_member_map(), image_filename)
+    if not member:
+        eval_logger.warning("pointbench: image not found in selected_images.zip for file={}", image_filename)
+        return []
+    try:
+        with zipfile.ZipFile(_image_zip_path()) as archive:
+            with archive.open(member) as stream:
+                image = Image.open(BytesIO(stream.read())).convert("RGB")
+    except Exception as exc:
+        eval_logger.warning("pointbench: failed to load image for file={} ({})", image_filename, exc)
+        return []
+    return [image]
 
 
 @lru_cache(maxsize=4096)
 def _load_mask(mask_filename: str) -> np.ndarray | None:
-    member = _mask_member_map().get(mask_filename)
+    member = _lookup_member(_mask_member_map(), mask_filename)
     if not member:
         return None
 
@@ -132,40 +155,69 @@ def _text_to_points(text: str, width: int, height: int) -> np.ndarray:
     return np.array(points, dtype=np.int32)
 
 
+def _binary_score(points: np.ndarray, mask: np.ndarray, category: str, expected_count: int) -> int:
+    """Fork-style strict score: 1 if the prediction hits the mask, else 0.
+
+    For non-counting categories only the FIRST predicted point must fall in the
+    mask. For "counting" ALL predicted points must fall in the mask AND the
+    number of points must equal the expected count. Mirrors the fork's
+    pointbench `evaluate_answer`. ``points`` are already pixel coordinates.
+    """
+    if len(points) == 0:
+        return 0
+    height, width = mask.shape
+    to_check = points if category == "counting" else points[:1]
+    for x, y in to_check:
+        if not (0 <= x < width and 0 <= y < height and mask[y, x]):
+            return 0
+    if category == "counting" and len(points) != expected_count:
+        return 0
+    return 1
+
+
 def pointbench_process_results(doc: Dict[str, Any], result: List[str]) -> Dict[str, Dict[str, Any]]:
-    key_name = "pointbench_acc"
     mask_filename = str(doc.get("mask_filename", ""))
     mask = _load_mask(mask_filename)
     response = result[0] if result else ""
+    sample_id = doc.get("question_id", doc.get("image_filename", "unknown"))
+    category = doc.get("category", "unknown")
 
     if mask is None:
         eval_logger.warning("pointbench: failed to find mask for file={}", mask_filename)
-        submission = {
-            "id": doc.get("question_id", doc.get("image_filename", "unknown")),
-            "pred": response,
-            "parsed_points": [],
-            "accuracy": 0.0,
-            "category": doc.get("category", "unknown"),
-        }
-        return {key_name: submission}
+        frac = {"id": sample_id, "pred": response, "parsed_points": [], "accuracy": 0.0, "category": category}
+        binary = {"id": sample_id, "score": 0, "category": category}
+        return {"pointbench_acc": frac, "pointbench_binary_acc": binary}
 
     points = _text_to_points(response, mask.shape[1], mask.shape[0])
+
+    # Fraction metric (OSS native): mean mask value over all predicted points.
     acc = 0.0
     if len(points) > 0:
         in_range = (points[:, 0] >= 0) & (points[:, 0] < mask.shape[1]) & (points[:, 1] >= 0) & (points[:, 1] < mask.shape[0])
         acc = np.concatenate([mask[points[in_range, 1], points[in_range, 0]], np.zeros(points.shape[0] - in_range.sum())]).mean()
 
-    submission = {
-        "id": doc.get("question_id", doc.get("image_filename", "unknown")),
+    # Binary metric (fork-style): first point in mask (all + count for counting).
+    expected_count = int(doc.get("count", 0) or 0)
+    binary = _binary_score(points, mask, category, expected_count)
+
+    frac_submission = {
+        "id": sample_id,
         "pred": response,
         "parsed_points": list(map(tuple, points.tolist())),
         "accuracy": float(acc),
-        "category": doc.get("category", "unknown"),
+        "category": category,
     }
-    return {key_name: submission}
+    binary_submission = {"id": sample_id, "score": int(binary), "category": category}
+    return {"pointbench_acc": frac_submission, "pointbench_binary_acc": binary_submission}
 
 
 def pointbench_aggregate_results(results: List[Dict[str, Any]]) -> float:
     if not results:
         return 0.0
     return float(np.mean([sample.get("accuracy", 0.0) for sample in results]))
+
+
+def pointbench_binary_aggregate_results(results: List[Dict[str, Any]]) -> float:
+    if not results:
+        return 0.0
+    return float(np.mean([sample.get("score", 0) for sample in results]))


### PR DESCRIPTION
## Summary

Two fixes for the `pointbench` task:

1. **Fix image↔question misalignment (correctness bug).** `pointbench_doc_to_visual` fetched images positionally by row index from the HuggingFace datasets-server **rows API**. That API serves an image-only ImageFolder built from `selected_images.zip` in zip/alphabetical order — a *different* order than `data.json`'s question order. As a result **every question was paired with the wrong image**, so models answered "There are none" or pointed at the wrong scene and accuracy collapsed to near zero. It was also flaky (intermittent 502s / expiring presigned URLs).

   This PR loads images from `selected_images.zip` keyed by `image_filename`, mirroring how masks are already loaded from `selected_masks.zip`. This keeps each `(question, image)` pair aligned and removes the network dependency.

2. **Robust filename matching.** Both zips were written without the UTF‑8 flag, so non‑ASCII names (e.g. `Chamissostraße.jpg`, `Хліб_гречаний.jpg`) were cp437‑mangled and never matched. Added NFC + cp437→utf‑8 basename recovery to the shared member-map builder; this resolves **982/982** images and **982/982** masks (was 966 images + several mask-not-found failures).

3. **Add a `pointbench_binary_acc` metric** alongside the existing fraction metric: `1` if the first predicted point falls in the mask (all points + exact count for the `counting` category), else `0`. Both metrics are reported; the fraction metric is unchanged.

## Impact

Measured with Qwen3‑VL‑2B‑Instruct (vllm), full 982 samples:

| | "There are none" rate | `pointbench_acc` (fraction) |
| --- | --- | --- |
| before | 56% | 0.04 |
| after | 2.5% | 0.66 |

The remaining ~2.5% are the few questions whose source images are genuinely absent from the zip.

## Notes

- No new dependencies (stdlib `unicodedata`/`zipfile` only).
- The fraction metric and its aggregation are unchanged; the binary metric is purely additive.
- Removed the now-unused rows-API code (`requests` import, `_get_image_url`, `_load_image`).
