### PR TITLE
Add Qwen-native JSON coordinate variants for pointing tasks

### DIFF
--- a/lmms_eval/tasks/_task_utils/point_format.py
+++ b/lmms_eval/tasks/_task_utils/point_format.py
@@ -1,0 +1,31 @@
+"""Shared helper for Qwen-native point parsing.
+
+Qwen-VL grounding models emit points as a JSON list of
+``{"point_2d": [x, y], ...}`` entries on a 0-1000 normalized grid. The pointing
+tasks (where2place / refspatial / pointbench) ship ``*_json`` variants that
+prompt for this format and parse it with :func:`parse_point2d` below.
+"""
+
+import re
+
+import numpy as np
+
+
+def parse_point2d(text: str, width: int, height: int) -> np.ndarray:
+    """Parse ``[x, y]`` / ``(x, y)`` coordinate pairs into pixel points.
+
+    Integers are interpreted on a 0-1000 grid (divided by 1000, then scaled to
+    the image); floats are treated as already-normalized in [0, 1]. This covers
+    Qwen's native ``"point_2d": [x, y]`` JSON output as well as bare tuples.
+    """
+    pattern = r"[\[\(]\s*([-+]?\d+\.?\d*)\s*,\s*([-+]?\d+\.?\d*)\s*[\]\)]"
+    points = []
+    for xs, ys in re.findall(pattern, text):
+        xf, yf = float(xs), float(ys)
+        is_float = ("." in xs) or ("." in ys)
+        if is_float:
+            x, y = int(xf * width), int(yf * height)
+        else:
+            x, y = int(xf / 1000 * width), int(yf / 1000 * height)
+        points.append((x, y))
+    return np.array(points)

--- a/lmms_eval/tasks/pointbench/_default_template_yaml
+++ b/lmms_eval/tasks/pointbench/_default_template_yaml
@@ -13,6 +13,9 @@ metric_list:
   - metric: pointbench_acc
     aggregation: !function utils.pointbench_aggregate_results
     higher_is_better: true
+  - metric: pointbench_binary_acc
+    aggregation: !function utils.pointbench_binary_aggregate_results
+    higher_is_better: true
 
 generation_kwargs:
   max_new_tokens: 256

--- a/lmms_eval/tasks/pointbench/pointbench_json.yaml
+++ b/lmms_eval/tasks/pointbench/pointbench_json.yaml
@@ -1,0 +1,5 @@
+task: pointbench_json
+test_split: train
+include: _default_template_yaml
+doc_to_text: !function utils.pointbench_doc_to_text_json
+process_results: !function utils.pointbench_process_results_json

--- a/lmms_eval/tasks/pointbench/utils.py
+++ b/lmms_eval/tasks/pointbench/utils.py
@@ -1,4 +1,5 @@
 import re
+import unicodedata
 import zipfile
 from functools import lru_cache
 from io import BytesIO
@@ -6,14 +7,12 @@ from typing import Any, Dict, List
 
 import datasets
 import numpy as np
-import requests
 from PIL import Image
 
 from lmms_eval.tasks._task_utils.default_template_yaml import load_default_template_yaml
 from lmms_eval.utils import eval_logger
 
 POINTARENA_REPO = "PointArena/pointarena-data"
-POINTARENA_ROWS_API = "https://datasets-server.huggingface.co/rows"
 
 PROMPT_SUFFIX_0_999 = "Your answer should be formatted as a list of tuples, i.e. [(x1, y1), (x2, y2), ...], where each tuple contains the x and y coordinates of a point satisfying the conditions above. The coordinates should be integers between 0 and 999, representing the pixel locations scaled to a 1000x1000 grid."
 PROMPT_SUFFIX_ORIGINAL = "Your answer should be formatted as a list of tuples, i.e. [(x1, y1), (x2, y2), ...], where each tuple contains the x and y coordinates of a point satisfying the conditions above. The coordinates should be between 0 and 1, indicating the normalized pixel locations of the points in the image."
@@ -37,67 +36,91 @@ def pointbench_doc_to_text(doc: Dict[str, Any], lmms_eval_specific_kwargs: Dict[
     return f"{pre_prompt}{user_input} {suffix} {FORMAT}{post_prompt}".strip()
 
 
-@lru_cache(maxsize=4096)
-def _get_image_url(row_idx: int) -> str:
-    response = requests.get(
-        POINTARENA_ROWS_API,
-        params={"dataset": POINTARENA_REPO, "config": "default", "split": "train", "offset": int(row_idx), "length": 1},
-        timeout=30,
-    )
-    response.raise_for_status()
-    payload = response.json()
-    rows = payload.get("rows", [])
-    if not rows:
-        raise ValueError(f"No rows found for row_idx={row_idx}")
-    return rows[0]["row"]["image"]["src"]
+def _zip_basename_key(name: str) -> str:
+    """NFC-normalized basename so accented filenames match across data.json/zip."""
+    return unicodedata.normalize("NFC", name.rsplit("/", 1)[-1])
 
 
-def _load_image(row_idx: int) -> Image.Image:
-    image_url = _get_image_url(row_idx)
-    response = requests.get(image_url, timeout=60)
-    if response.status_code == 403:
-        _get_image_url.cache_clear()
-        image_url = _get_image_url(row_idx)
-        response = requests.get(image_url, timeout=60)
-    response.raise_for_status()
-    return Image.open(BytesIO(response.content)).convert("RGB")
+def _lookup_member(member_map: Dict[str, str], filename: str) -> str | None:
+    """Look up a zip member by basename, tolerating Unicode (NFC/NFD) differences."""
+    if not filename:
+        return None
+    if filename in member_map:
+        return member_map[filename]
+    return member_map.get(_zip_basename_key(filename))
 
 
-def pointbench_doc_to_visual(doc: Dict[str, Any]) -> List[Image.Image]:
-    row_idx = doc.get("row_idx", doc.get("question_id"))
-    if row_idx is None:
-        eval_logger.warning("pointbench: missing row_idx for doc={}", doc.get("image_filename", "unknown"))
-        return []
-
-    try:
-        image = _load_image(int(row_idx))
-    except Exception as exc:
-        eval_logger.warning("pointbench: failed to load image for row_idx={} ({})", row_idx, exc)
-        return []
-    return [image]
-
-
-@lru_cache(maxsize=1)
-def _mask_zip_path() -> str:
+@lru_cache(maxsize=4)
+def _zip_path(filename: str) -> str:
     from huggingface_hub import hf_hub_download
 
-    return hf_hub_download(repo_id=POINTARENA_REPO, repo_type="dataset", filename="selected_masks.zip")
+    return hf_hub_download(repo_id=POINTARENA_REPO, repo_type="dataset", filename=filename)
+
+
+def _mask_zip_path() -> str:
+    return _zip_path("selected_masks.zip")
+
+
+def _image_zip_path() -> str:
+    return _zip_path("selected_images.zip")
+
+
+def _build_member_map(zip_path: str, suffixes: tuple) -> Dict[str, str]:
+    # Key on the raw basename, an NFC-normalized basename, and -- for archives
+    # written without the UTF-8 flag -- a cp437->utf-8 recovered basename, so
+    # lookups succeed regardless of how the filename was encoded upstream.
+    mapping: Dict[str, str] = {}
+    with zipfile.ZipFile(zip_path) as archive:
+        for info in archive.infolist():
+            member = info.filename
+            if not member.lower().endswith(suffixes):
+                continue
+            base = member.rsplit("/", 1)[-1]
+            mapping.setdefault(base, member)
+            mapping.setdefault(_zip_basename_key(base), member)
+            if not (info.flag_bits & 0x800):  # zipfile decoded the name as cp437
+                try:
+                    recovered = base.encode("cp437").decode("utf-8")
+                    mapping.setdefault(_zip_basename_key(recovered), member)
+                except (UnicodeEncodeError, UnicodeDecodeError):
+                    pass
+    return mapping
 
 
 @lru_cache(maxsize=1)
 def _mask_member_map() -> Dict[str, str]:
-    mapping: Dict[str, str] = {}
-    with zipfile.ZipFile(_mask_zip_path()) as archive:
-        for member in archive.namelist():
-            if not member.lower().endswith(".png"):
-                continue
-            mapping.setdefault(member.rsplit("/", 1)[-1], member)
-    return mapping
+    return _build_member_map(_mask_zip_path(), (".png",))
+
+
+@lru_cache(maxsize=1)
+def _image_member_map() -> Dict[str, str]:
+    return _build_member_map(_image_zip_path(), (".jpg", ".jpeg", ".png", ".webp"))
+
+
+def pointbench_doc_to_visual(doc: Dict[str, Any]) -> List[Image.Image]:
+    # Load the image from selected_images.zip keyed by image_filename. The HF
+    # datasets-server rows API serves an image-only ImageFolder in zip order,
+    # which does NOT match data.json's question order -- fetching by row index
+    # pairs each question with the wrong image. Keying by filename keeps the
+    # (question, image) pair aligned and avoids the flaky rows API entirely.
+    image_filename = str(doc.get("image_filename", ""))
+    member = _lookup_member(_image_member_map(), image_filename)
+    if not member:
+        eval_logger.warning("pointbench: image not found in selected_images.zip for file={}", image_filename)
+        return []
+    try:
+        with zipfile.ZipFile(_image_zip_path()) as archive:
+            with archive.open(member) as stream:
+                image = Image.open(BytesIO(stream.read())).convert("RGB")
+    except Exception as exc:
+        eval_logger.warning("pointbench: failed to load image for file={} ({})", image_filename, exc)
+        return []
+    return [image]
 
 
 @lru_cache(maxsize=4096)
 def _load_mask(mask_filename: str) -> np.ndarray | None:
-    member = _mask_member_map().get(mask_filename)
+    member = _lookup_member(_mask_member_map(), mask_filename)
     if not member:
         return None
 
@@ -132,40 +155,69 @@ def _text_to_points(text: str, width: int, height: int) -> np.ndarray:
     return np.array(points, dtype=np.int32)
 
 
+def _binary_score(points: np.ndarray, mask: np.ndarray, category: str, expected_count: int) -> int:
+    """Fork-style strict score: 1 if the prediction hits the mask, else 0.
+
+    For non-counting categories only the FIRST predicted point must fall in the
+    mask. For "counting" ALL predicted points must fall in the mask AND the
+    number of points must equal the expected count. Mirrors the fork's
+    pointbench `evaluate_answer`. ``points`` are already pixel coordinates.
+    """
+    if len(points) == 0:
+        return 0
+    height, width = mask.shape
+    to_check = points if category == "counting" else points[:1]
+    for x, y in to_check:
+        if not (0 <= x < width and 0 <= y < height and mask[y, x]):
+            return 0
+    if category == "counting" and len(points) != expected_count:
+        return 0
+    return 1
+
+
 def pointbench_process_results(doc: Dict[str, Any], result: List[str]) -> Dict[str, Dict[str, Any]]:
-    key_name = "pointbench_acc"
     mask_filename = str(doc.get("mask_filename", ""))
     mask = _load_mask(mask_filename)
     response = result[0] if result else ""
+    sample_id = doc.get("question_id", doc.get("image_filename", "unknown"))
+    category = doc.get("category", "unknown")
 
     if mask is None:
         eval_logger.warning("pointbench: failed to find mask for file={}", mask_filename)
-        submission = {
-            "id": doc.get("question_id", doc.get("image_filename", "unknown")),
-            "pred": response,
-            "parsed_points": [],
-            "accuracy": 0.0,
-            "category": doc.get("category", "unknown"),
-        }
-        return {key_name: submission}
+        frac = {"id": sample_id, "pred": response, "parsed_points": [], "accuracy": 0.0, "category": category}
+        binary = {"id": sample_id, "score": 0, "category": category}
+        return {"pointbench_acc": frac, "pointbench_binary_acc": binary}
 
     points = _text_to_points(response, mask.shape[1], mask.shape[0])
+
+    # Fraction metric (OSS native): mean mask value over all predicted points.
     acc = 0.0
     if len(points) > 0:
         in_range = (points[:, 0] >= 0) & (points[:, 0] < mask.shape[1]) & (points[:, 1] >= 0) & (points[:, 1] < mask.shape[0])
         acc = np.concatenate([mask[points[in_range, 1], points[in_range, 0]], np.zeros(points.shape[0] - in_range.sum())]).mean()
 
-    submission = {
-        "id": doc.get("question_id", doc.get("image_filename", "unknown")),
+    # Binary metric (fork-style): first point in mask (all + count for counting).
+    expected_count = int(doc.get("count", 0) or 0)
+    binary = _binary_score(points, mask, category, expected_count)
+
+    frac_submission = {
+        "id": sample_id,
         "pred": response,
         "parsed_points": list(map(tuple, points.tolist())),
         "accuracy": float(acc),
-        "category": doc.get("category", "unknown"),
+        "category": category,
     }
-    return {key_name: submission}
+    binary_submission = {"id": sample_id, "score": int(binary), "category": category}
+    return {"pointbench_acc": frac_submission, "pointbench_binary_acc": binary_submission}
 
 
 def pointbench_aggregate_results(results: List[Dict[str, Any]]) -> float:
     if not results:
         return 0.0
     return float(np.mean([sample.get("accuracy", 0.0) for sample in results]))
+
+
+def pointbench_binary_aggregate_results(results: List[Dict[str, Any]]) -> float:
+    if not results:
+        return 0.0
+    return float(np.mean([sample.get("score", 0) for sample in results]))

--- a/lmms_eval/tasks/pointbench/utils.py
+++ b/lmms_eval/tasks/pointbench/utils.py
@@ -3,13 +3,14 @@ import unicodedata
 import zipfile
 from functools import lru_cache
 from io import BytesIO
-from typing import Any, Dict, List
+from typing import Any, Callable, Dict, List
 
 import datasets
 import numpy as np
 from PIL import Image
 
 from lmms_eval.tasks._task_utils.default_template_yaml import load_default_template_yaml
+from lmms_eval.tasks._task_utils.point_format import parse_point2d
 from lmms_eval.utils import eval_logger
 
 POINTARENA_REPO = "PointArena/pointarena-data"
@@ -34,6 +35,23 @@ def pointbench_doc_to_text(doc: Dict[str, Any], lmms_eval_specific_kwargs: Dict[
     post_prompt = kwargs.get("post_prompt", "")
     user_input = str(doc.get("user_input", "")).strip()
     return f"{pre_prompt}{user_input} {suffix} {FORMAT}{post_prompt}".strip()
+
+
+def pointbench_doc_to_text_json(doc: Dict[str, Any], lmms_eval_specific_kwargs: Dict[str, Any] | None = None) -> str:
+    """Qwen-native variant: 'pointing:' framing + JSON point_2d on a 0-1000 grid.
+
+    A bare coordinate suffix makes the model decline with "There are none"; the
+    "pointing:" framing elicits its native point_2d JSON.
+    """
+    kwargs = lmms_eval_specific_kwargs or {}
+    pre_prompt = kwargs.get("pre_prompt", "")
+    post_prompt = kwargs.get("post_prompt", "")
+    user_input = str(doc.get("user_input", "")).strip()
+    if doc.get("category", "") == "counting":
+        question = f"pointing: {user_input}, You should point to all the objects in the image that are mentioned in the question."
+    else:
+        question = f"pointing: {user_input}"
+    return f"{pre_prompt}{question}\nReturn points in JSON format and normalized to the range [0, 1000].{post_prompt}".strip()
 
 
 def _zip_basename_key(name: str) -> str:
@@ -175,7 +193,9 @@ def _binary_score(points: np.ndarray, mask: np.ndarray, category: str, expected_
     return 1
 
 
-def pointbench_process_results(doc: Dict[str, Any], result: List[str]) -> Dict[str, Dict[str, Any]]:
+def _pointbench_eval(doc: Dict[str, Any], result: List[str], parser: Callable[[str, int, int], np.ndarray]) -> Dict[str, Dict[str, Any]]:
+    """Score one example with ``parser`` (tuples for the default task, JSON for
+    the ``_json`` variant). Emits both the fraction and the binary metric."""
     mask_filename = str(doc.get("mask_filename", ""))
     mask = _load_mask(mask_filename)
     response = result[0] if result else ""
@@ -188,7 +208,7 @@ def pointbench_process_results(doc: Dict[str, Any], result: List[str]) -> Dict[s
         binary = {"id": sample_id, "score": 0, "category": category}
         return {"pointbench_acc": frac, "pointbench_binary_acc": binary}
 
-    points = _text_to_points(response, mask.shape[1], mask.shape[0])
+    points = parser(response, mask.shape[1], mask.shape[0])
 
     # Fraction metric (OSS native): mean mask value over all predicted points.
     acc = 0.0
@@ -209,6 +229,15 @@ def pointbench_process_results(doc: Dict[str, Any], result: List[str]) -> Dict[s
     }
     binary_submission = {"id": sample_id, "score": int(binary), "category": category}
     return {"pointbench_acc": frac_submission, "pointbench_binary_acc": binary_submission}
+
+
+def pointbench_process_results(doc: Dict[str, Any], result: List[str]) -> Dict[str, Dict[str, Any]]:
+    return _pointbench_eval(doc, result, _text_to_points)
+
+
+def pointbench_process_results_json(doc: Dict[str, Any], result: List[str]) -> Dict[str, Dict[str, Any]]:
+    """Qwen-native variant: parse JSON point_2d; identical fraction + binary scoring."""
+    return _pointbench_eval(doc, result, parse_point2d)
 
 
 def pointbench_aggregate_results(results: List[Dict[str, Any]]) -> float:

--- a/lmms_eval/tasks/refspatial/refspatial_location_json.yaml
+++ b/lmms_eval/tasks/refspatial/refspatial_location_json.yaml
@@ -1,0 +1,5 @@
+test_split: location
+task: "refspatial_location_json"
+include: _default_template_yaml
+doc_to_text: !function utils.refspatial_doc_to_text_json
+process_results: !function utils.refspatial_process_results_json

--- a/lmms_eval/tasks/refspatial/refspatial_placement_json.yaml
+++ b/lmms_eval/tasks/refspatial/refspatial_placement_json.yaml
@@ -1,0 +1,5 @@
+test_split: placement
+task: "refspatial_placement_json"
+include: _default_template_yaml
+doc_to_text: !function utils.refspatial_doc_to_text_json
+process_results: !function utils.refspatial_process_results_json

--- a/lmms_eval/tasks/refspatial/refspatial_unseen_json.yaml
+++ b/lmms_eval/tasks/refspatial/refspatial_unseen_json.yaml
@@ -1,0 +1,5 @@
+test_split: unseen
+task: "refspatial_unseen_json"
+include: _default_template_yaml
+doc_to_text: !function utils.refspatial_doc_to_text_json
+process_results: !function utils.refspatial_process_results_json

--- a/lmms_eval/tasks/refspatial/utils.py
+++ b/lmms_eval/tasks/refspatial/utils.py
@@ -5,6 +5,8 @@ from typing import Any, Dict, List
 import numpy as np
 import yaml
 
+from lmms_eval.tasks._task_utils.point_format import parse_point2d
+
 PROMPT_SUFFIX_0_999 = (
     "Your answer should be formatted as a list of tuples, i.e. [(x1, y1)], "
     "where each tuple contains the x and y coordinates of a point satisfying the conditions above. "
@@ -12,6 +14,17 @@ PROMPT_SUFFIX_0_999 = (
 )
 
 FORMAT = "Return only list of tuples, don't add anything else."
+
+# JSON ("json") variant: replace the dataset's default tuple-format suffix with a
+# Qwen-native single-point JSON instruction on a 0-1000 grid. Any task-specific
+# clarification suffix is kept.
+_SUFFIX_TO_STRIP = "Your answer should be formatted as a list of tuples, i.e. [(x1, y1)], where each tuple contains the x and y coordinates of a point satisfying the conditions above. The coordinates should be between 0 and 1, indicating the normalized pixel locations of the points in the image."
+
+_JSON_POST_PROMPT = """Pinpoint the SINGLE best 2D point that satisfies the description. Output exactly one coordinate pair in JSON, normalized to [0, 1000]:
+```json
+[{"point_2d": [x, y], "label": "target"}]
+```
+Do not output more than one point. Do not include additional text after the JSON block."""
 
 with open(Path(__file__).parent / "_default_template_yaml", "r") as f:
     raw_data = f.readlines()
@@ -29,6 +42,15 @@ def refspatial_doc_to_text(doc: dict[str, Any]) -> str:
         print(config)
         return f"{doc['prompt']} {PROMPT_SUFFIX_0_999} {FORMAT}"
     return f"{doc['prompt']} {doc['suffix']} {FORMAT}"
+
+
+def refspatial_doc_to_text_json(doc: dict[str, Any]) -> str:
+    """Qwen-native variant: ask for a single point_2d in JSON on a 0-1000 grid."""
+    prompt = doc["prompt"]
+    suffix = doc.get("suffix", "")
+    if suffix and suffix.strip() != _SUFFIX_TO_STRIP.strip():
+        prompt = f"{prompt} {suffix}"
+    return f"{prompt}\n{_JSON_POST_PROMPT}"
 
 
 def refspatial_doc_to_visual(doc: dict) -> list:
@@ -53,6 +75,14 @@ def _text2pts(text: str, width: int = 640, height: int = 480, normalization_cons
     return np.array(points)
 
 
+def _refspatial_acc(mask: np.ndarray, points: np.ndarray) -> float:
+    acc = 0.0
+    if len(points) > 0:
+        in_range = (points[:, 0] >= 0) & (points[:, 0] < mask.shape[1]) & (points[:, 1] >= 0) & (points[:, 1] < mask.shape[0])
+        acc = np.concatenate([mask[points[in_range, 1], points[in_range, 0]], np.zeros(points.shape[0] - in_range.sum())]).mean()
+    return acc
+
+
 # inspired by original work: https://github.com/Zhoues/RoboRefer/blob/main/Evaluation/summarize_acc.py
 def refspatial_process_results(doc: Dict, result: List[str]) -> Dict[str, Dict]:
     key_name = "refspatial_acc"
@@ -73,15 +103,24 @@ def refspatial_process_results(doc: Dict, result: List[str]) -> Dict[str, Dict]:
     normalization_constant = 1000 if prompt_suffix_type == "0_999" else 1
     points = _text2pts(response, mask.shape[1], mask.shape[0], normalization_constant)
 
-    # process the answer
-    acc = 0.0
-    if len(points) > 0:
-        in_range = (points[:, 0] >= 0) & (points[:, 0] < mask.shape[1]) & (points[:, 1] >= 0) & (points[:, 1] < mask.shape[0])
-        acc = np.concatenate([mask[points[in_range, 1], points[in_range, 0]], np.zeros(points.shape[0] - in_range.sum())]).mean()
-
+    acc = _refspatial_acc(mask, points)
     query = refspatial_doc_to_text(doc)
     omnispatial_submission = {"id": doc["id"], "query": query, "pred": response, "parsed_points": list(map(tuple, points)), "accuracy": acc}
     return {key_name: omnispatial_submission}
+
+
+def refspatial_process_results_json(doc: Dict, result: List[str]) -> Dict[str, Dict]:
+    """Qwen-native variant: parse JSON point_2d; identical mask scoring."""
+    mask = np.array(doc["mask"]) / 255.0
+    mask = np.round(mask, 0).astype(int)
+    if mask.ndim == 3:
+        mask = mask[:, :, 0]
+
+    response = result[0]
+    points = parse_point2d(response, mask.shape[1], mask.shape[0])
+    acc = _refspatial_acc(mask, points)
+    submission = {"id": doc["id"], "query": refspatial_doc_to_text_json(doc), "pred": response, "parsed_points": list(map(tuple, points)), "accuracy": acc}
+    return {"refspatial_acc": submission}
 
 
 def refspatial_aggregate_results(results: List[Dict]) -> float:

--- a/lmms_eval/tasks/where2place/utils.py
+++ b/lmms_eval/tasks/where2place/utils.py
@@ -4,9 +4,12 @@ from typing import Any, Dict, List
 import numpy as np
 
 from lmms_eval.tasks._task_utils.default_template_yaml import load_default_template_yaml
+from lmms_eval.tasks._task_utils.point_format import parse_point2d
 
 PROMPT_SUFFIX_0_999 = "Your answer should be formatted as a list of tuples, i.e. [(x1, y1), (x2, y2), ...], where each tuple contains the x and y coordinates of a point satisfying the conditions above. The coordinates should be integers between 0 and 999, representing the pixel locations scaled to a 1000×1000 grid."
 PROMPT_SUFFIX_ORIGINAL = "Your answer should be formatted as a list of tuples, i.e. [(x1, y1), (x2, y2), ...], where each tuple contains the x and y coordinates of a point satisfying the conditions above. The coordinates should be between 0 and 1, indicating the normalized pixel locations of the points in the image."
+# Qwen-native grounding prompt: a JSON list of point_2d entries on a 0-1000 grid.
+PROMPT_SUFFIX_JSON = "Your answer should be JSON format. The coordinates should be between 0 and 1000, indicating the normalized pixel locations of the points in the image."
 FORMAT = "Return only list of tuples, don't add anything else."
 
 
@@ -17,6 +20,11 @@ def where2place_doc_to_text(doc: dict[str, Any]) -> str:
     if config.get("metadata", {}).get("prompt_suffix_type", {}) == "0_999":
         return f"{doc['question']} {PROMPT_SUFFIX_0_999} {FORMAT}"
     return f"{doc['question']} {PROMPT_SUFFIX_ORIGINAL} {FORMAT}"
+
+
+def where2place_doc_to_text_json(doc: dict[str, Any]) -> str:
+    """Qwen-native variant: ask for a JSON list of point_2d on a 0-1000 grid."""
+    return f"{doc['question']} {PROMPT_SUFFIX_JSON}"
 
 
 def where2place_doc_to_visual(doc: dict) -> list:
@@ -41,6 +49,14 @@ def _text2pts(text: str, width: int = 640, height: int = 480, normalization_cons
     return np.array(points)
 
 
+def _where2place_acc(mask: np.ndarray, points: np.ndarray) -> float:
+    acc = 0.0
+    if len(points) > 0:
+        in_range = (points[:, 0] >= 0) & (points[:, 0] < mask.shape[1]) & (points[:, 1] >= 0) & (points[:, 1] < mask.shape[0])
+        acc = np.concatenate([mask[points[in_range, 1], points[in_range, 0]], np.zeros(points.shape[0] - in_range.sum())]).mean()
+    return acc
+
+
 # inspired by original work: https://github.com/wentaoyuan/RoboPoint/blob/master/robopoint/eval/summarize_vqa.py
 def where2place_process_results(doc: Dict, result: List[str]) -> Dict[str, Dict]:
     key_name = "where2place_acc"
@@ -61,13 +77,23 @@ def where2place_process_results(doc: Dict, result: List[str]) -> Dict[str, Dict]
     normalization_constant = 1000 if prompt_suffix_type == "0_999" else 1
     points = _text2pts(response, mask.shape[1], mask.shape[0], normalization_constant)
 
-    # process the answer
-    acc = 0.0
-    if len(points) > 0:
-        in_range = (points[:, 0] >= 0) & (points[:, 0] < mask.shape[1]) & (points[:, 1] >= 0) & (points[:, 1] < mask.shape[0])
-        acc = np.concatenate([mask[points[in_range, 1], points[in_range, 0]], np.zeros(points.shape[0] - in_range.sum())]).mean()
+    acc = _where2place_acc(mask, points)
     where2place_submission = {"id": doc["question_id"], "pred": response, "parsed_points": list(map(tuple, points)), "accuracy": acc}
     return {key_name: where2place_submission}
+
+
+def where2place_process_results_json(doc: Dict, result: List[str]) -> Dict[str, Dict]:
+    """Qwen-native variant: parse JSON point_2d; identical mask scoring."""
+    mask = np.array(doc["mask"]) / 255.0
+    mask = np.round(mask, 0).astype(int)
+    if mask.ndim == 3:
+        mask = mask[:, :, 0]
+
+    response = result[0]
+    points = parse_point2d(response, mask.shape[1], mask.shape[0])
+    acc = _where2place_acc(mask, points)
+    where2place_submission = {"id": doc["question_id"], "pred": response, "parsed_points": list(map(tuple, points)), "accuracy": acc}
+    return {"where2place_acc": where2place_submission}
 
 
 def where2place_aggregate_results(results: List[Dict]) -> float:

--- a/lmms_eval/tasks/where2place/where2place_json.yaml
+++ b/lmms_eval/tasks/where2place/where2place_json.yaml
@@ -1,0 +1,5 @@
+task: where2place_json
+test_split: test
+include: _default_template_yaml
+doc_to_text: !function utils.where2place_doc_to_text_json
+process_results: !function utils.where2place_process_results_json


### PR DESCRIPTION
## Summary

Qwen-VL grounding models emit points as a JSON list of `{"point_2d": [x, y], ...}` entries on a 0-1000 normalized grid. The existing pointing tasks prompt for and parse `(x, y)` tuples, so the default parser returns nothing on this native output.

This PR adds opt-in `*_json` task variants that prompt for, and parse, Qwen's native format:

- `where2place_json`
- `refspatial_location_json`, `refspatial_placement_json`, `refspatial_unseen_json`
- `pointbench_json`

Each variant overrides only `doc_to_text` and `process_results` and shares a small `parse_point2d` helper (`lmms_eval/tasks/_task_utils/point_format.py`). The existing tuple tasks, their metrics, and aggregation are **unchanged** (verified: no diff to the existing `doc_to_text`/prompt constants).

Stacks on #1360 — `pointbench_json` relies on that PR's image-alignment fix and binary metric so its parsed points are scored against the correct images.

## Validation

Run against a Qwen3-VL-8B grounding fine-tune (vllm) and compared to a reference fork that uses the same JSON prompt + parser:

| Benchmark | this PR (`*_json`) | reference | Δ |
| --- | --- | --- | --- |
| where2place | 0.6815 | 0.6829 | −0.001 |
| refspatial (size-weighted) | 0.560 | 0.592 | −0.032 |
| pointbench (binary) | 0.677 | 0.632 | +0.045 |

where2place matches almost exactly. The refspatial gap is borderline single-point flips on the harder splits. pointbench runs slightly higher because `parse_point2d` recovers points from mildly malformed JSON that a strict fenced-JSON parser drops, and because the reference injects an extra steerable-category hint not ported here.
