### PR TITLE
feat(visfactor): add VisFactor benchmark task

### DIFF
--- a/lmms_eval/tasks/visfactor/README.md
+++ b/lmms_eval/tasks/visfactor/README.md
@@ -1,0 +1,57 @@
+# VisFactor
+
+[VisFactor](https://github.com/CUHK-ARISE/VisFactor) is a benchmark derived
+from the Factor-Referenced Cognitive Test (FRCT) that digitizes 20
+vision-centric subtests from established cognitive psychology assessments
+to probe the visual-cognition abilities of MLLMs.
+
+* **Paper / repo**: <https://github.com/CUHK-ARISE/VisFactor>
+* **Original source data**: `VisFactor.tsv` from
+  `https://opencompass.openxlab.space/utils/VLMEval/VisFactor.tsv`
+* **HF mirror used here**:
+  [`lmms-lab-encoder/visfactor`](https://huggingface.co/datasets/lmms-lab-encoder/visfactor)
+  (parquet conversion of the official tsv; `image` is stored as a list of
+  `{bytes, path}` structs).
+
+## Tasks
+
+| Task        | Split | Metric            |
+| ----------- | ----- | ----------------- |
+| `visfactor` | test  | `visfactor_score` |
+
+## Scoring
+
+Ported verbatim from the official VLMEvalKit evaluator
+(`vlmeval/dataset/visfactor.py`):
+
+1. Each row's prediction is judged against its `(category_id, additional)`
+   pair using the official extraction rules (JSON `{"answer": ...}`,
+   followed by category-specific normalisation: boolean / string-list /
+   number / coordinate / uppercase-letter).
+2. A *test item* is `(category_id, eval_index)` and may span multiple rows;
+   an item is correct iff **all** its rows are correct.
+3. Per-category accuracy is the fraction of correct items.
+4. `visfactor_score` is the macro-average over the 20 categories.
+
+## Usage
+
+```bash
+accelerate launch --num_processes=1 -m lmms_eval \
+    --model qwen2_vl \
+    --model_args pretrained=Qwen/Qwen2-VL-7B-Instruct \
+    --tasks visfactor \
+    --batch_size 1 \
+    --output_path ./logs/
+```
+
+## Citation
+
+```bibtex
+@article{visfactor2025,
+  title  = {VisFactor: Benchmarking Multimodal Large Language Models on
+            Human Visual Cognition},
+  author = {CUHK-ARISE},
+  year   = {2025},
+  url    = {https://github.com/CUHK-ARISE/VisFactor}
+}
+```

--- a/lmms_eval/tasks/visfactor/utils.py
+++ b/lmms_eval/tasks/visfactor/utils.py
@@ -1,0 +1,201 @@
+"""lmms-eval task adapter for VisFactor.
+
+Paper:  VisFactor: Benchmarking Multimodal Large Language Models on Human
+        Visual Cognition (CUHK-ARISE).
+Source: https://github.com/CUHK-ARISE/VisFactor
+        (data file: VisFactor.tsv from opencompass.openxlab.space)
+
+This module ports the official VLMEvalKit evaluator
+(``vlmeval/dataset/visfactor.py``) to the lmms-eval framework.
+
+Scoring (verbatim from the official implementation):
+
+* A *test item* is identified by ``(category_id, eval_index)``; it may span
+  multiple rows. An item is correct iff every row is correct (logical AND).
+* Per-category accuracy = ``#correct_items / #items``.
+* The final score is the macro-average over all categories.
+"""
+
+from __future__ import annotations
+
+import io
+import re
+from collections import defaultdict
+from typing import Any, Dict, List, Tuple
+
+from PIL import Image
+
+# ---------------------------------------------------------------------------
+# Tokens used in the prompt template.
+# ---------------------------------------------------------------------------
+_ADDITIONAL_RE = re.compile(r"<ADDITIONAL_(\d+)>")
+_IMAGE_RE = re.compile(r"<IMAGE_\d+>")
+_JSON_ANSWER_RE = re.compile(r'\{\s*"answer"\s*:\s*(.+?)\s*\}')
+
+# ---------------------------------------------------------------------------
+# Category groups (sets are tiny -> use frozenset for clarity & immutability).
+# Mirrors the conditional in the official ``evaluate``.
+# ---------------------------------------------------------------------------
+# Boolean answer in {"T", "F"}.
+_BOOL_CIDS = frozenset({"CF1", "CF2", "MV1", "MV2", "MV3", "P3",
+                        "RL2", "S1", "S2", "SS2", "VZ1", "VZ2"})
+# Answer is a comma-separated list; prediction matches if it's in the list.
+_STR_LIST_CIDS = frozenset({"CS1", "CS2", "CS3"})
+# Number / coordinate / letter answers.
+_NUM_LIKE_CIDS = frozenset({"CF3", "I3", "MA1", "SS3", "VZ3"})
+
+_BOOL_TRUE = frozenset({"t", "y", "1", "true", "yes"})
+_BOOL_FALSE = frozenset({"f", "n", "0", "false", "no"})
+
+
+# ---------------------------------------------------------------------------
+# doc_to_visual
+# ---------------------------------------------------------------------------
+def _to_pil(item: Any) -> Image.Image:
+    if isinstance(item, Image.Image):
+        return item.convert("RGB")
+    if isinstance(item, dict) and item.get("bytes") is not None:
+        return Image.open(io.BytesIO(item["bytes"])).convert("RGB")
+    raise TypeError(f"unsupported image cell type: {type(item).__name__}")
+
+
+def visfactor_doc_to_visual(doc: Dict[str, Any]) -> List[Image.Image]:
+    return [_to_pil(x) for x in doc["image"]]
+
+
+# ---------------------------------------------------------------------------
+# doc_to_text
+# ---------------------------------------------------------------------------
+def _resolve_additional(text: str, additional: str) -> str:
+    """Substitute ``<ADDITIONAL_i>`` with the i-th ``;``-separated part."""
+    parts = additional.replace("<br>", "\n").split(";")
+
+    def repl(m: re.Match) -> str:
+        i = int(m.group(1))
+        return parts[i] if 0 <= i < len(parts) else m.group(0)
+
+    return _ADDITIONAL_RE.sub(repl, text)
+
+
+def visfactor_doc_to_text(doc: Dict[str, Any],
+                          lmms_eval_specific_kwargs: Dict[str, str] | None = None) -> str:
+    text = doc["question"].replace("<br>", "\n")
+
+    # ``additional`` may be NaN (pandas) or "" (already cleaned).
+    additional = doc.get("additional", "")
+    additional = "" if additional is None else str(additional)
+    if additional and additional.lower() != "nan":
+        text = _resolve_additional(text, additional)
+
+    # lmms-eval passes images out-of-band -> strip the placeholders.
+    text = _IMAGE_RE.sub("", text)
+
+    if lmms_eval_specific_kwargs:
+        text = (lmms_eval_specific_kwargs.get("pre_prompt", "")
+                + text
+                + lmms_eval_specific_kwargs.get("post_prompt", ""))
+    return text
+
+
+# ---------------------------------------------------------------------------
+# Prediction extraction helpers (ported verbatim from official impl).
+# ---------------------------------------------------------------------------
+def _extract_last_json_answer(s: str) -> str:
+    matches = list(_JSON_ANSWER_RE.finditer(s))
+    if not matches:
+        return ""
+    raw = matches[-1].group(1).strip()
+    if len(raw) >= 2 and raw[0] == raw[-1] and raw[0] in ("'", '"'):
+        raw = raw[1:-1]
+    return raw
+
+
+def _extract_last_numbers(s: str) -> List[str]:
+    return re.findall(r"\d+", s)
+
+
+def _extract_last_uppercase_letter(s: str) -> str:
+    for ch in reversed(s):
+        if ch.isupper():
+            return ch
+    return ""
+
+
+# ---------------------------------------------------------------------------
+# Per-row scoring (1/0). Mirrors the branch structure of the official impl.
+# ---------------------------------------------------------------------------
+def _score_row(cid: str, raw_pred: str, gold: str, additional: str) -> int:
+    pred = _extract_last_json_answer(raw_pred)
+
+    # Boolean branch (also catches VZ3 when ``additional`` is non-numeric).
+    if cid in _BOOL_CIDS or (cid == "VZ3" and not additional.isdigit()):
+        lower = pred.lower()
+        if lower in _BOOL_TRUE:
+            tok = "T"
+        elif lower in _BOOL_FALSE:
+            tok = "F"
+        else:
+            tok = ""
+        return int(tok == gold)
+
+    if cid in _STR_LIST_CIDS:
+        choices = [g.strip().lower() for g in gold.split(",")]
+        return int(pred.strip().lower() in choices)
+
+    if cid in _NUM_LIKE_CIDS:
+        # Official falls back to the raw prediction if JSON extraction fails,
+        # so the number/letter scanners still have something to chew on.
+        if pred == "":
+            pred = raw_pred
+        if cid == "VZ3":  # VZ3 + digit-additional -> single uppercase letter
+            pred = _extract_last_uppercase_letter(pred)
+        elif cid == "CF3":  # coordinate pair
+            nums = _extract_last_numbers(pred)
+            pred = "" if len(nums) < 2 else f"({nums[-2]}, {nums[-1]})"
+        else:  # last integer
+            nums = _extract_last_numbers(pred)
+            pred = nums[-1] if nums else ""
+        return int(pred == gold)
+
+    # Unknown category: fail closed.
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# lmms-eval integration
+# ---------------------------------------------------------------------------
+def visfactor_process_results(doc: Dict[str, Any],
+                              results: List[str]) -> Dict[str, Any]:
+    pred = results[0] if results else ""
+    additional = doc.get("additional", "") or ""
+    correct = _score_row(
+        cid=str(doc["category_id"]),
+        raw_pred=str(pred),
+        gold=str(doc["answer"]),
+        additional=str(additional),
+    )
+    return {
+        "visfactor_score": {
+            "category_id": str(doc["category_id"]),
+            "eval_index": int(doc["eval_index"]),
+            "correct": int(correct),
+        }
+    }
+
+
+def visfactor_aggregate(results: List[Dict[str, Any]]) -> float:
+    """AND over rows of an item -> mean over items -> macro over categories."""
+    # (category_id, eval_index) -> list of per-row correctness
+    items: Dict[Tuple[str, int], List[int]] = defaultdict(list)
+    for r in results:
+        items[(r["category_id"], r["eval_index"])].append(r["correct"])
+
+    # Collapse rows with AND, then group by category.
+    per_cat: Dict[str, List[int]] = defaultdict(list)
+    for (cid, _eid), rows in items.items():
+        per_cat[cid].append(int(all(rows)))
+
+    if not per_cat:
+        return 0.0
+    cat_acc = [sum(v) / len(v) for v in per_cat.values()]
+    return sum(cat_acc) / len(cat_acc)

--- a/lmms_eval/tasks/visfactor/utils.py
+++ b/lmms_eval/tasks/visfactor/utils.py
@@ -37,8 +37,7 @@ _JSON_ANSWER_RE = re.compile(r'\{\s*"answer"\s*:\s*(.+?)\s*\}')
 # Mirrors the conditional in the official ``evaluate``.
 # ---------------------------------------------------------------------------
 # Boolean answer in {"T", "F"}.
-_BOOL_CIDS = frozenset({"CF1", "CF2", "MV1", "MV2", "MV3", "P3",
-                        "RL2", "S1", "S2", "SS2", "VZ1", "VZ2"})
+_BOOL_CIDS = frozenset({"CF1", "CF2", "MV1", "MV2", "MV3", "P3", "RL2", "S1", "S2", "SS2", "VZ1", "VZ2"})
 # Answer is a comma-separated list; prediction matches if it's in the list.
 _STR_LIST_CIDS = frozenset({"CS1", "CS2", "CS3"})
 # Number / coordinate / letter answers.
@@ -77,8 +76,7 @@ def _resolve_additional(text: str, additional: str) -> str:
     return _ADDITIONAL_RE.sub(repl, text)
 
 
-def visfactor_doc_to_text(doc: Dict[str, Any],
-                          lmms_eval_specific_kwargs: Dict[str, str] | None = None) -> str:
+def visfactor_doc_to_text(doc: Dict[str, Any], lmms_eval_specific_kwargs: Dict[str, str] | None = None) -> str:
     text = doc["question"].replace("<br>", "\n")
 
     # ``additional`` may be NaN (pandas) or "" (already cleaned).
@@ -91,9 +89,7 @@ def visfactor_doc_to_text(doc: Dict[str, Any],
     text = _IMAGE_RE.sub("", text)
 
     if lmms_eval_specific_kwargs:
-        text = (lmms_eval_specific_kwargs.get("pre_prompt", "")
-                + text
-                + lmms_eval_specific_kwargs.get("post_prompt", ""))
+        text = lmms_eval_specific_kwargs.get("pre_prompt", "") + text + lmms_eval_specific_kwargs.get("post_prompt", "")
     return text
 
 
@@ -164,8 +160,7 @@ def _score_row(cid: str, raw_pred: str, gold: str, additional: str) -> int:
 # ---------------------------------------------------------------------------
 # lmms-eval integration
 # ---------------------------------------------------------------------------
-def visfactor_process_results(doc: Dict[str, Any],
-                              results: List[str]) -> Dict[str, Any]:
+def visfactor_process_results(doc: Dict[str, Any], results: List[str]) -> Dict[str, Any]:
     pred = results[0] if results else ""
     additional = doc.get("additional", "") or ""
     correct = _score_row(

--- a/lmms_eval/tasks/visfactor/visfactor.yaml
+++ b/lmms_eval/tasks/visfactor/visfactor.yaml
@@ -1,0 +1,31 @@
+dataset_path: lmms-lab-encoder/visfactor
+dataset_kwargs:
+  token: true
+task: "visfactor"
+test_split: test
+output_type: generate_until
+doc_to_visual: !function utils.visfactor_doc_to_visual
+doc_to_text: !function utils.visfactor_doc_to_text
+doc_to_target: "answer"
+
+generation_kwargs:
+  max_new_tokens: 1024
+  temperature: 0
+  top_p: 1.0
+  num_beams: 1
+  do_sample: false
+
+process_results: !function utils.visfactor_process_results
+
+metric_list:
+  - metric: visfactor_score
+    aggregation: !function utils.visfactor_aggregate
+    higher_is_better: true
+
+lmms_eval_specific_kwargs:
+  default:
+    pre_prompt: ""
+    post_prompt: ""
+
+metadata:
+  - version: 0.0


### PR DESCRIPTION
## Summary

Adds a new task adapter for **[VisFactor](https://github.com/CUHK-ARISE/VisFactor)** — a vision-cognition benchmark from CUHK-ARISE that digitizes 20 vision-centric subtests from the Factor-Referenced Cognitive Test (FRCT). It probes MLLM abilities on closure, mental rotation, spatial relations, perceptual speed, etc., over 3046 rows / 808 test items across 20 categories.

* Paper / official code: https://github.com/CUHK-ARISE/VisFactor
* Original data source: `VisFactor.tsv` from `opencompass.openxlab.space/utils/VLMEval/VisFactor.tsv`
* HF mirror (parquet conversion of the official tsv): [`lmms-lab-encoder/visfactor`](https://huggingface.co/datasets/lmms-lab-encoder/visfactor) (public)

## Design

The scoring logic is ported verbatim from the official VLMEvalKit evaluator (`vlmeval/dataset/visfactor.py`):

1. Extract the last `{\"answer\": ...}` JSON from the model output.
2. Normalise per category (boolean / string-list / number / coordinate / uppercase-letter) and compare to the gold answer.
3. A *test item* is `(category_id, eval_index)`, which may span multiple rows; the item is correct iff **all** its rows are correct.
4. Final `visfactor_score` is the macro-average over the 20 categories.

**No LLM judge is required** — scoring is purely rule-based and fully deterministic.

Files added:

```
lmms_eval/tasks/visfactor/
├── README.md          # task description, dataset & scoring notes
├── utils.py           # doc_to_visual / doc_to_text / process_results / aggregate
└── visfactor.yaml     # task config (points to lmms-lab-encoder/visfactor on the Hub)
```

## Verification

* **Unit tests** — 18 hand-crafted cases covering every scoring branch (BOOL / STR_LIST / NUM_LIKE numeric / NUM_LIKE letter / unknown cid). All pass.
* **Regression vs prior unofficial impl** — compared per-row `correct` over **6092 real model predictions** (two prior runs: think-enabled-16k and think-disabled-512). **0 / 6092 differences**, identical aggregate scores (19.66% / 12.93%).
* **YAML loader** — verified with `lmms_eval.utils.load_yaml_config` (the `!function` tag binds to the correct callables in `utils.py`).

## Test plan

- [ ] Maintainer review of `visfactor.yaml` (HF dataset path + generation kwargs)
- [ ] Optional smoke run: `python -m lmms_eval --model <vlm> --tasks visfactor --limit 50 --output_path logs/`
- [ ] CI passes