### PR TITLE
fix: pass list outputs through for generate_until_multi_round

### DIFF
--- a/lmms_eval/api/instance.py
+++ b/lmms_eval/api/instance.py
@@ -41,11 +41,13 @@ class GenerationResult:
 GenerationOutput = Union[str, GenerationResult]
 
 
-def unwrap_generation_output(output: Any) -> Tuple[str, Optional[TokenCounts]]:
-    """Normalize a model output into ``(text, token_counts | None)``.
+def unwrap_generation_output(output: Any) -> Tuple[Any, Optional[TokenCounts]]:
+    """Normalize a model output into ``(text_or_rounds, token_counts | None)``.
 
-    Accepts ``str``, ``GenerationResult``, or ``(str, dict)`` tuples for
-    maximum backward compatibility.
+    Accepts ``str``, ``GenerationResult``, ``(str, dict)`` tuples, or a
+    ``list[str]`` produced by ``generate_until_multi_round`` adapters
+    (one entry per round). The multi-round list is passed through as-is so
+    downstream task ``process_results`` can index each round's response.
     """
     if isinstance(output, GenerationResult):
         return output.text, output.token_counts
@@ -62,6 +64,9 @@ def unwrap_generation_output(output: Any) -> Tuple[str, Optional[TokenCounts]]:
                 output_tokens=meta.get("output_tokens"),
                 reasoning_tokens=meta.get("reasoning_tokens"),
             )
+
+    if isinstance(output, list) and all(isinstance(x, str) for x in output):
+        return output, None
 
     return str(output), None
 

--- a/lmms_eval/tasks/ovobench/utils.py
+++ b/lmms_eval/tasks/ovobench/utils.py
@@ -199,8 +199,6 @@ def ovo_back_real_process_results(doc, results):
 def ovo_forward_process_results(doc, results):
     """Map forward task responses back onto the original document structure."""
     if isinstance(results, list) and isinstance(results[0], list):
-        results = results[0][0]
-    else:
         results = results[0]
     for i in range(len(doc["test_info"])):
         doc["test_info"][i]["response"] = results[i]


### PR DESCRIPTION
## Problem

`unwrap_generation_output` (in `lmms_eval/api/instance.py`) does not recognize `list[str]` and falls through to `str(output)`, turning a per-round list like `['Yes.', 'No.']` into the string literal `"['Yes.', 'No.']"`. The string then lands in `req.filtered_resps[filter_key]`, so task `process_results` later indexes a string per character.

This silently corrupts every `generate_until_multi_round` task. I hit it with `ovo_forward`: model is healthy but the scored `test_info[i].response` becomes characters like `'['`, `"'"`, `'Y'`, `'e'`, `'s'`, … instead of round answers. `mmsearch_end2end` is on the same path and will hit the same issue.

## Fix

1. `unwrap_generation_output`: accept `list[str]` and pass it through unchanged. Single-round adapters returning `str` / `GenerationResult` / `(str, dict)` still work as before.
2. `ovo_forward_process_results`: when the harness wraps results in an outer list, take `results[0]` (the per-round list) instead of `results[0][0]` (only round 0). The old line looks like a workaround for the upstream bug above; with (1) fixed it must take the whole list.

## Verification

Reran the produced `*_samples_ovo_forward.jsonl` from the buggy version with the fixed task code on raw resps (parsed back from the str-ified list with `ast.literal_eval`) and got CRR/REC/SSR consistent with backward/realtime score scales for the same model (~34 vs ~3.8 before). End-to-end with `vllm` + `Qwen3-VL-4B-Instruct` on `limit=4` now writes `filtered_resps` as a real list and `test_info[i].response` as the full per-round string.

Affected tasks: `ovo_forward`, `mmsearch_end2end` (any `generate_until_multi_round` task).