### PR TITLE
feat: add ExtremeWhenBench (hour-scale natural-language temporal grounding)

### DIFF
--- a/lmms_eval/tasks/extremewhenbench/README.md
+++ b/lmms_eval/tasks/extremewhenbench/README.md
@@ -1,0 +1,127 @@
+# ExtremeWhenBench — lmms-eval task
+
+Hour-scale natural-language temporal grounding benchmark. 2,273 questions
+over 194 hour-long videos (mean 75.7 min, max 9 hr) sourced from LVBench,
+MLVU, and VideoMME. Each prediction is a `[start, end]` interval in seconds;
+scoring is mIoU and R@{0.3, 0.5, 0.7}.
+
+Companion to the paper *Natural-Language Temporal Grounding in Hour-Long
+Videos is a Search Problem: A Benchmark and Empirical Decomposition*.
+
+## Files
+
+```
+extremewhenbench/
+├── extremewhenbench.yaml   # task config
+├── utils.py                # doc_to_visual, doc_to_text, IoU/R@τ aggregation
+└── README.md               # this file
+```
+
+The HF dataset (`min1321/extreme-when-bench`) ships annotations only.
+Videos are reused from the existing lmms-eval caches of the
+source-corpus tasks (`lvbench`, `mlvu`, `videomme`) — nothing is
+re-distributed.
+
+## Video resolution
+
+`utils.py:ewb_doc_to_visual` resolves each video by `source_corpus + video_id`:
+
+| Corpus    | Default lookup path                                       |
+| --------- | --------------------------------------------------------- |
+| LVBench   | `$HF_HOME/lvbench/all_videos/{video_id}.mp4`              |
+| MLVU      | `$HF_HOME/mlvu/{video_id}.mp4`                            |
+| VideoMME  | `$HF_HOME/videomme/data/{video_id}.mp4`                   |
+
+If the file is not under those paths, the resolver also walks one
+sub-directory level (matches the actual layout of the source-corpus HF
+caches). Override per corpus with:
+
+```bash
+export EWB_LVBENCH_PATH=/abs/path/to/lvbench/videos
+export EWB_MLVU_PATH=/abs/path/to/mlvu/videos
+export EWB_VIDEOMME_PATH=/abs/path/to/videomme/videos
+```
+
+Optional speed-up: set `EWB_PREEXTRACTED_DIR` to a directory of
+lightweight pre-encoded videos (e.g., uniform 1024-frame, 384×N re-encodes
+named `{video_id}.mp4`). The resolver tries it first, then falls back.
+
+## Running
+
+### Recommended: vLLM serve + openai adapter (matches paper)
+
+The paper uses vLLM's server-side video decoding (with frame timestamps
+attached) for hour-long temporal grounding. lmms-eval's default video
+preprocessing extracts frames client-side, which loses the absolute-time
+signal that the model needs for hour-scale videos. To reproduce the
+paper number, point lmms-eval's `openai` adapter at a vLLM serve with
+the `pass_video_url` and `enable_thinking_kwarg` options (added by a
+companion lmms-eval PR — see `patches/chat_openai_patched.py`).
+
+```bash
+export HF_HOME=/path/to/your/hf-cache   # used by both vLLM and lmms-eval
+
+# 1) Make sure source-corpus videos are cached under $HF_HOME
+#    (skip any corpus you have already downloaded)
+python -c "from datasets import load_dataset; load_dataset('lmms-lab/LVBench')"
+python -c "from datasets import load_dataset; load_dataset('sy1998/MLVU_dev')"
+python -c "from datasets import load_dataset; load_dataset('lmms-lab/Video-MME')"
+
+# 2) Serve Qwen3.5-9B (Qwen3_5ForConditionalGeneration)
+#    --allowed-local-media-path must cover wherever the videos live.
+#    Pointing it at HF_HOME covers all three source-corpus caches above.
+vllm serve /path/to/Qwen3.5-9B \
+    --served-model-name qwen3.5-9b \
+    --port 8000 \
+    --tensor-parallel-size 8 \
+    --max-model-len 65536 \
+    --gpu-memory-utilization 0.85 \
+    --reasoning-parser qwen3 \
+    --trust-remote-code \
+    --enforce-eager \
+    --allowed-local-media-path "$HF_HOME"
+
+# 3) Run lmms-eval against the server
+python -m lmms_eval \
+    --model openai \
+    --model_args "model=qwen3.5-9b,base_url=http://localhost:8000/v1,api_key=EMPTY,\
+                  pass_video_url=True,max_frames_num=768,enable_thinking_kwarg=False,\
+                  num_concurrent=32" \
+    --gen_kwargs "max_new_tokens=128,temperature=0,top_p=0.8" \
+    --tasks extremewhenbench \
+    --batch_size 1 \
+    --output_path ./logs/ewb \
+    --log_samples
+```
+
+Expected on full 2,273 q: `mIoU ≈ 0.047 ± 0.005` for Qwen3.5-9B at
+`num_frames=768`.
+
+### Other models
+
+Any model adapter that talks to a vLLM serve via OpenAI-compatible API
+should work the same way. For non-vLLM backends, the `pass_video_url`
+option is ignored — frames are extracted client-side and timestamps are
+injected as text annotations (lmms-eval default).
+
+## Notes
+
+- The prompt template includes the original video duration via
+  `{dur:.0f}-second long video`. This is **required** for hour-scale
+  performance — without explicit duration, the model defaults to short-clip
+  output (mIoU collapses by ~40%).
+- `parse_failures` count as `IoU = 0` (strict; matches the paper convention).
+- The 5 (qid, video_id, source_corpus, question, correct_interval) fields
+  are sufficient for evaluation; `event_summary`, `category`, and
+  `youtube_url` are provided for downstream analysis.
+
+## Citation
+
+```bibtex
+@inproceedings{seo2026hourlong,
+  title  = {Natural-Language Temporal Grounding in Hour-Long Videos
+            is a Search Problem: A Benchmark and Empirical Decomposition},
+  author = {Seo, Sukmin and Kim, Geewook},
+  year   = {2026}
+}
+```

--- a/lmms_eval/tasks/extremewhenbench/extremewhenbench.yaml
+++ b/lmms_eval/tasks/extremewhenbench/extremewhenbench.yaml
@@ -1,0 +1,45 @@
+# ExtremeWhenBench
+# Copyright (c) 2026-present NAVER Cloud Corp.
+# Apache-2.0
+
+task: extremewhenbench
+dataset_path: min1321/extreme-when-bench
+dataset_kwargs:
+  token: True
+  cache_dir: extreme_when_bench
+test_split: test
+output_type: generate_until
+
+process_docs:  !function utils.ewb_process_docs
+doc_to_visual: !function utils.ewb_doc_to_visual
+doc_to_text: !function utils.ewb_doc_to_text
+doc_to_target: !function utils.ewb_doc_to_target
+process_results: !function utils.ewb_process_results
+
+generation_kwargs:
+  max_new_tokens: 50
+  temperature: 0
+  do_sample: false
+
+metric_list:
+  - metric: ewb_mIoU
+    aggregation: !function utils.ewb_aggregate_miou
+    higher_is_better: true
+  - metric: ewb_R@0.3
+    aggregation: !function utils.ewb_aggregate_r03
+    higher_is_better: true
+  - metric: ewb_R@0.5
+    aggregation: !function utils.ewb_aggregate_r05
+    higher_is_better: true
+  - metric: ewb_R@0.7
+    aggregation: !function utils.ewb_aggregate_r07
+    higher_is_better: true
+  - metric: ewb_parse_fail
+    aggregation: !function utils.ewb_aggregate_parse_fail
+    higher_is_better: false
+
+lmms_eval_specific_kwargs:
+  default: {}
+
+metadata:
+  version: '0.1'

--- a/lmms_eval/tasks/extremewhenbench/utils.py
+++ b/lmms_eval/tasks/extremewhenbench/utils.py
@@ -1,0 +1,224 @@
+# ExtremeWhenBench
+# Copyright (c) 2026-present NAVER Cloud Corp.
+# Apache-2.0
+
+"""ExtremeWhenBench: hour-scale natural-language temporal grounding.
+
+Videos are sourced from LVBench / MLVU / VideoMME and are NOT redistributed
+with this task. ``ewb_doc_to_visual`` locates each video in the lmms-eval
+cache for its source corpus, with optional env-var overrides.
+"""
+
+import os
+import re
+import sys
+from typing import Any, Optional
+
+from loguru import logger as eval_logger
+
+HF_HOME = os.path.expanduser(os.getenv("HF_HOME", "~/.cache/huggingface"))
+
+CORPUS_CACHE = {
+    "LVBench": os.path.join(HF_HOME, "lvbench"),
+    "MLVU": os.path.join(HF_HOME, "mlvu"),
+    "VideoMME": os.path.join(HF_HOME, "videomme", "data"),
+}
+
+EXTS = (".mp4", ".MP4", ".mkv", ".webm", ".avi")
+
+_TIME_RE = re.compile(r"(\d+(?:\.\d+)?)\s*(?:-|to|~|–|—)\s*(\d+(?:\.\d+)?)")
+
+
+def _candidate_paths(corpus: str, vid: str) -> list[str]:
+    """Build an ordered list of plausible video paths for a corpus/video-id.
+
+    EWB_PREEXTRACTED_DIR is checked first: if set, point it at a directory of
+    pre-extracted lightweight videos (e.g., 1024-frame, 384x re-encodes named
+    ``{video_id}.mp4``). This skips the full hour-long source decode and
+    typically gives a ~10x speedup with no metric change at N<=1024.
+    """
+    bases: list[str] = []
+    preextracted = os.getenv("EWB_PREEXTRACTED_DIR")
+    if preextracted:
+        bases.append(preextracted)
+    override = os.getenv(f"EWB_{corpus.upper()}_PATH")
+    if override:
+        bases.append(override)
+    bases.append(CORPUS_CACHE[corpus])
+
+    paths: list[str] = []
+    for base in bases:
+        for ext in EXTS:
+            paths.append(os.path.join(base, vid + ext))
+        if os.path.isdir(base):
+            for sub in os.listdir(base):
+                sub_path = os.path.join(base, sub)
+                if not os.path.isdir(sub_path):
+                    continue
+                for ext in EXTS:
+                    paths.append(os.path.join(sub_path, vid + ext))
+    return paths
+
+
+_DOWNLOAD_HINT = {
+    "LVBench": "python -c \"from datasets import load_dataset; load_dataset('lmms-lab/LVBench')\"",
+    "MLVU": "python -c \"from datasets import load_dataset; load_dataset('sy1998/MLVU_dev')\"",
+    "VideoMME": "python -c \"from datasets import load_dataset; load_dataset('lmms-lab/Video-MME')\"",
+}
+
+
+def ewb_process_docs(dataset):
+    """Preflight: verify every source-corpus video is resolvable before any inference.
+
+    Aggregates missing items across all three corpora and raises a single
+    actionable error, so the user does not hit a FileNotFoundError several
+    hours into a full run after only one corpus was downloaded.
+    """
+    missing: dict[str, list[str]] = {}
+    seen: set[tuple[str, str]] = set()
+    for doc in dataset:
+        key = (doc["source_corpus"], doc["video_id"])
+        if key in seen:
+            continue
+        seen.add(key)
+        corpus, vid = key
+        if not any(os.path.exists(p) for p in _candidate_paths(corpus, vid)):
+            missing.setdefault(corpus, []).append(vid)
+    if missing:
+        lines = [
+            "",
+            "=" * 70,
+            "ExtremeWhenBench preflight: video files missing for the corpora below.",
+            "=" * 70,
+        ]
+        for corpus in sorted(missing):
+            vids = missing[corpus]
+            lines.append(f"")
+            lines.append(f"  [{corpus}] {len(vids)} video(s) missing under {CORPUS_CACHE[corpus]}")
+            lines.append(f"    Download:  {_DOWNLOAD_HINT[corpus]}")
+            lines.append(f"    Or set:    export EWB_{corpus.upper()}_PATH=/abs/path/to/{corpus.lower()}/videos")
+        lines.append("")
+        lines.append("See lmms_eval/tasks/extremewhenbench/README.md for the full setup guide.")
+        lines.append("=" * 70)
+        # Print + SystemExit so the message is visible — tenacity's retry on
+        # task.download() catches normal exceptions and hides the body.
+        print("\n".join(lines), file=sys.stderr, flush=True)
+        sys.exit(1)
+    return dataset
+
+
+def ewb_doc_to_visual(doc: dict[str, Any]) -> list[str]:
+    corpus = doc["source_corpus"]
+    vid = doc["video_id"]
+    for p in _candidate_paths(corpus, vid):
+        if os.path.exists(p):
+            return [p]
+    # process_docs preflight should have caught this already; fall back to a
+    # per-doc error if the task is invoked without the preflight (e.g., when
+    # users disable process_docs).
+    raise FileNotFoundError(
+        f"Video for qid={doc['qid']} ({corpus}/{vid}) not found. "
+        f"Download via:\n  {_DOWNLOAD_HINT[corpus]}\n"
+        f"or set EWB_{corpus.upper()}_PATH to a directory containing {vid}.mp4."
+    )
+
+
+DEFAULT_PROMPT = (
+    "[Video Temporal Grounding]\n"
+    "You are watching a {dur:.0f}-second long video.\n"
+    "Please find the moment described by the following question, "
+    "determining its starting and ending times. The format should be: "
+    "'The event happens in the start time - end time'. "
+    "For example, The event 'person turn a light on' happens in the "
+    "24.3 - 30.4 seconds. "
+    'Now I will give you the question: "{question}"\n'
+    "Please return its start time and end time."
+)
+
+
+def ewb_doc_to_text(doc: dict[str, Any], lmms_eval_specific_kwargs: Optional[dict] = None) -> str:
+    lmms_eval_specific_kwargs = lmms_eval_specific_kwargs or {}
+    template = lmms_eval_specific_kwargs.get("prompt_template", DEFAULT_PROMPT)
+    dur = float(doc.get("video_duration_s") or 0)
+    return template.format(dur=dur, question=doc["question"])
+
+
+def ewb_doc_to_target(doc: dict[str, Any]) -> list[float]:
+    return [float(x) for x in doc["correct_interval"]]
+
+
+def _parse_interval(text: str) -> Optional[tuple[float, float]]:
+    matches = _TIME_RE.findall(text)
+    if not matches:
+        return None
+    s, e = matches[-1]
+    s_f, e_f = float(s), float(e)
+    if s_f > e_f:
+        s_f, e_f = e_f, s_f
+    return s_f, e_f
+
+
+def _iou(pred: tuple[float, float], gt: tuple[float, float]) -> float:
+    inter = max(0.0, min(pred[1], gt[1]) - max(pred[0], gt[0]))
+    union = max(pred[1], gt[1]) - min(pred[0], gt[0])
+    return inter / union if union > 0 else 0.0
+
+
+def ewb_process_results(doc: dict[str, Any], results: list[str]) -> dict[str, dict[str, Any]]:
+    pred_text = results[0] if results else ""
+    interval = _parse_interval(pred_text)
+    gt = (float(doc["correct_interval"][0]), float(doc["correct_interval"][1]))
+    if interval is None:
+        iou_val = 0.0
+        parsed = False
+    else:
+        iou_val = _iou(interval, gt)
+        parsed = True
+
+    rec = {
+        "qid": doc["qid"],
+        "video_id": doc["video_id"],
+        "source_corpus": doc["source_corpus"],
+        "pred_raw": pred_text,
+        "pred_interval": list(interval) if interval else None,
+        "gt": list(gt),
+        "iou": iou_val,
+        "parsed": parsed,
+    }
+    return {
+        "ewb_mIoU": rec,
+        "ewb_R@0.3": rec,
+        "ewb_R@0.5": rec,
+        "ewb_R@0.7": rec,
+        "ewb_parse_fail": rec,
+    }
+
+
+def ewb_aggregate_miou(records: list[dict[str, Any]]) -> float:
+    if not records:
+        return 0.0
+    return sum(r["iou"] for r in records) / len(records)
+
+
+def _recall_at(records: list[dict[str, Any]], tau: float) -> float:
+    if not records:
+        return 0.0
+    return sum(1 for r in records if r["iou"] >= tau) / len(records)
+
+
+def ewb_aggregate_r03(records: list[dict[str, Any]]) -> float:
+    return _recall_at(records, 0.3)
+
+
+def ewb_aggregate_r05(records: list[dict[str, Any]]) -> float:
+    return _recall_at(records, 0.5)
+
+
+def ewb_aggregate_r07(records: list[dict[str, Any]]) -> float:
+    return _recall_at(records, 0.7)
+
+
+def ewb_aggregate_parse_fail(records: list[dict[str, Any]]) -> float:
+    if not records:
+        return 0.0
+    return sum(1 for r in records if not r["parsed"]) / len(records)


### PR DESCRIPTION
> Depends on the companion `openai`-adapter PR (`feat(openai): add pass_video_url and enable_thinking_kwarg`). The task loads and runs without it, but mIoU drops ~10× on hour-long inputs because the default path extracts frames client-side and strips absolute-time signal.

**Links**
- Paper (preprint): [arXiv:2606.12300](https://arxiv.org/abs/2606.12300)
- HF dataset: [`min1321/extreme-when-bench`](https://huggingface.co/datasets/min1321/extreme-when-bench) (CC-BY-4.0, annotations only)
- Companion repo: <https://github.com/naver-ai/ExtremeWhenBench>

## Summary

- Add `extremewhenbench`: a 2,273-question natural-language temporal grounding benchmark over 194 hour-long videos (mean 75.7 min, max 9 hr) sourced from LVBench, MLVU, and VideoMME.
- The released HF dataset (`min1321/extreme-when-bench`) is annotations-only; videos are reused from the source-corpus caches (`lvbench`, `mlvu`, `videomme`) — nothing is re-distributed.
- Metrics: mIoU, R@0.3 / R@0.5 / R@0.7, parse-failure rate.

## In scope

- `lmms_eval/tasks/extremewhenbench/extremewhenbench.yaml`: task config (HF dataset path, prompt template, four metrics).
- `lmms_eval/tasks/extremewhenbench/utils.py`: `doc_to_visual` (source-corpus → cached video path; supports `EWB_<CORPUS>_PATH` env overrides and an optional `EWB_PREEXTRACTED_DIR`), `doc_to_text` (paper's prompt template with `{dur}` injection), `process_results` + IoU / R@τ aggregators, and a `process_docs` preflight that aggregates every missing source-corpus video into one actionable error before any inference (so users do not hit a per-corpus FileNotFoundError several hours in).
- `lmms_eval/tasks/extremewhenbench/README.md`: recommended vLLM-serve invocation that reproduces the paper number.

## Out of scope

- Pipeline / dataset construction code (lives in the companion paper release, not in lmms-eval).
- Other Video-LLM benchmarks built on the same data sources.

## Validation

- `python -m lmms_eval --model openai --tasks extremewhenbench --model_args "model=qwen3.5-9b,base_url=...,pass_video_url=True,max_frames_num=768,enable_thinking_kwarg=False,..."` on Qwen3.5-9B served via vLLM | sample size: `N=2,273` | key metrics: mIoU | result: **0.0485 — pass** (within ±0.005 of a hand-rolled paper-style reference eval `0.0469`; paper Table 4 reports 0.053).
- Smoke test on n=5 per source corpus: parses without error, produces well-formed IoU per question | result: **pass**.

## Risk / Compatibility

- Drop-in new task — no changes to any existing task or model. Annotations-only HF dataset → no large download triggered by `--tasks extremewhenbench`; videos are pulled from the source-corpus caches users already have when they have run `lvbench` / `mlvu` / `videomme` tasks (overridable via env vars).
- Recommended invocation depends on the companion `openai`-adapter PR (`pass_video_url`, `enable_thinking_kwarg`). Without it the task still loads and runs but mIoU drops ~10× on hour-long inputs. The task README notes this and links the companion PR.

## Type of Change
- [ ] Bug fix (non-breaking change)
- [ ] New feature
- [x] New benchmark/task
- [ ] New model integration
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
