### PR TITLE
fix(visualwebbench): allow anonymous dataset load

### DIFF
--- a/lmms_eval/tasks/visualwebbench/visualwebbench_action_ground.yaml
+++ b/lmms_eval/tasks/visualwebbench/visualwebbench_action_ground.yaml
@@ -1,5 +1,5 @@
 dataset_kwargs:
-  token: true
+  token: false
 dataset_name: action_ground
 dataset_path: lmms-lab/VisualWebBench
 doc_to_target: !function utils.visualwebbench_doc_to_target

--- a/lmms_eval/tasks/visualwebbench/visualwebbench_action_prediction.yaml
+++ b/lmms_eval/tasks/visualwebbench/visualwebbench_action_prediction.yaml
@@ -1,5 +1,5 @@
 dataset_kwargs:
-  token: true
+  token: false
 dataset_name: action_prediction
 dataset_path: lmms-lab/VisualWebBench
 doc_to_target: !function utils.visualwebbench_doc_to_target

--- a/lmms_eval/tasks/visualwebbench/visualwebbench_element_ground.yaml
+++ b/lmms_eval/tasks/visualwebbench/visualwebbench_element_ground.yaml
@@ -1,5 +1,5 @@
 dataset_kwargs:
-  token: true
+  token: false
 dataset_name: element_ground
 dataset_path: lmms-lab/VisualWebBench
 doc_to_target: !function utils.visualwebbench_doc_to_target

--- a/lmms_eval/tasks/visualwebbench/visualwebbench_element_ocr.yaml
+++ b/lmms_eval/tasks/visualwebbench/visualwebbench_element_ocr.yaml
@@ -1,5 +1,5 @@
 dataset_kwargs:
-  token: true
+  token: false
 dataset_name: element_ocr
 dataset_path: lmms-lab/VisualWebBench
 doc_to_target: !function utils.visualwebbench_doc_to_target

--- a/lmms_eval/tasks/visualwebbench/visualwebbench_heading_ocr.yaml
+++ b/lmms_eval/tasks/visualwebbench/visualwebbench_heading_ocr.yaml
@@ -1,5 +1,5 @@
 dataset_kwargs:
-  token: true
+  token: false
 dataset_name: heading_ocr
 dataset_path: lmms-lab/VisualWebBench
 doc_to_target: !function utils.visualwebbench_doc_to_target

--- a/lmms_eval/tasks/visualwebbench/visualwebbench_web_caption.yaml
+++ b/lmms_eval/tasks/visualwebbench/visualwebbench_web_caption.yaml
@@ -1,5 +1,5 @@
 dataset_kwargs:
-  token: true
+  token: false
 dataset_name: web_caption
 dataset_path: lmms-lab/VisualWebBench
 doc_to_target: !function utils.visualwebbench_doc_to_target

--- a/lmms_eval/tasks/visualwebbench/visualwebbench_webqa.yaml
+++ b/lmms_eval/tasks/visualwebbench/visualwebbench_webqa.yaml
@@ -1,5 +1,5 @@
 dataset_kwargs:
-  token: true
+  token: false
 dataset_name: webqa
 dataset_path: lmms-lab/VisualWebBench
 doc_to_target: !function utils.visualwebbench_doc_to_target


### PR DESCRIPTION
## Problem
  All 7 VisualWebBench subtask configs set `dataset_kwargs.token: true`, which forces huggingface_hub to require a locally stored token and raises `LocalTokenNotFoundError` on machines without one.
  
  ## Fix
  `lmms-lab/VisualWebBench` is a public dataset, so set `token: false` in all 7 yamls to permit anonymous access.
  
  ## Verification
  - `token=True`  → `LocalTokenNotFoundError: Token is required ... but no token found`
  - `token=False` → streams successfully on a machine with no HF token