### PR TITLE
fix(grounding/rec): guard empty metric bucket against ZeroDivisionError

### DIFF
--- a/lmms_eval/tasks/groundingme/utils.py
+++ b/lmms_eval/tasks/groundingme/utils.py
@@ -305,7 +305,14 @@ def groundingme_aggregation_result(results, metric):
         else:
             results_dict[metric].append(score)
 
-    results_dict[metric] = sum(results_dict[metric]) / len(results_dict[metric])
+    scores = results_dict[metric]
+    if not scores:
+        # No samples fell into this subtask bucket (e.g. when running with --limit).
+        # Guard against ZeroDivisionError, which would otherwise crash the whole run.
+        # Return NaN so an empty bucket is not conflated with a genuine 0.0 score.
+        eval_logger.warning(f"No samples for metric {metric}; returning NaN")
+        return float("nan")
+    results_dict[metric] = sum(scores) / len(scores)
     eval_logger.info(f"Aggregated {metric} score: {results_dict[metric]}")
     return results_dict[metric]
 

--- a/lmms_eval/tasks/refcoco+/utils_rec.py
+++ b/lmms_eval/tasks/refcoco+/utils_rec.py
@@ -188,7 +188,14 @@ def refcoco_bbox_rec_aggregation_result(results, metric):
         # Compute the specified metric between the ground truth and predicted bounding boxes
         score = scorers[metric](gt_bbox, pred_bbox)
         results_dict[metric].append(score)
-    results_dict[metric] = sum(results_dict[metric]) / len(results_dict[metric])
+    scores = results_dict[metric]
+    if not scores:
+        # No samples for this metric (e.g. when running with --limit); guard against
+        # ZeroDivisionError that would otherwise crash the whole run. Return NaN so an
+        # empty bucket is not conflated with a genuine 0.0 score.
+        eval_logger.warning(f"No samples for metric {metric}; returning NaN")
+        return float("nan")
+    results_dict[metric] = sum(scores) / len(scores)
     print(f"Aggregated {metric} score: {results_dict[metric]}")
     return results_dict[metric]
 

--- a/lmms_eval/tasks/refcoco/utils_rec.py
+++ b/lmms_eval/tasks/refcoco/utils_rec.py
@@ -188,7 +188,14 @@ def refcoco_bbox_rec_aggregation_result(results, metric):
         # Compute the specified metric between the ground truth and predicted bounding boxes
         score = scorers[metric](gt_bbox, pred_bbox)
         results_dict[metric].append(score)
-    results_dict[metric] = sum(results_dict[metric]) / len(results_dict[metric])
+    scores = results_dict[metric]
+    if not scores:
+        # No samples for this metric (e.g. when running with --limit); guard against
+        # ZeroDivisionError that would otherwise crash the whole run. Return NaN so an
+        # empty bucket is not conflated with a genuine 0.0 score.
+        eval_logger.warning(f"No samples for metric {metric}; returning NaN")
+        return float("nan")
+    results_dict[metric] = sum(scores) / len(scores)
     print(f"Aggregated {metric} score: {results_dict[metric]}")
     return results_dict[metric]
 

--- a/lmms_eval/tasks/refcocog/utils_rec.py
+++ b/lmms_eval/tasks/refcocog/utils_rec.py
@@ -188,7 +188,14 @@ def refcoco_bbox_rec_aggregation_result(results, metric):
         # Compute the specified metric between the ground truth and predicted bounding boxes
         score = scorers[metric](gt_bbox, pred_bbox)
         results_dict[metric].append(score)
-    results_dict[metric] = sum(results_dict[metric]) / len(results_dict[metric])
+    scores = results_dict[metric]
+    if not scores:
+        # No samples for this metric (e.g. when running with --limit); guard against
+        # ZeroDivisionError that would otherwise crash the whole run. Return NaN so an
+        # empty bucket is not conflated with a genuine 0.0 score.
+        eval_logger.warning(f"No samples for metric {metric}; returning NaN")
+        return float("nan")
+    results_dict[metric] = sum(scores) / len(scores)
     print(f"Aggregated {metric} score: {results_dict[metric]}")
     return results_dict[metric]
 


### PR DESCRIPTION
## Problem
  The grounding/REC aggregation functions compute `sum(scores) / len(scores)` without guarding the empty case. When a subtask bucket receives no samples (e.g. when running with `--limit`), this raises `ZeroDivisionError` and aborts the entire evaluation — one empty bucket takes down all metrics.

  ## Fix
  Return `NaN` (with a warning) for empty buckets, so the metric reads as "no data" instead of a misleading `0.0`. Each metric aggregates over its own filtered subset, so non-empty buckets are unaffected and a `NaN` does not poison other metrics. Applied to `groundingme` plus `refcoco`/`refcoco+`/`refcocog`, which share identical aggregation code.