### PR TITLE
feat: add CC-OCR benchmark

### DIFF
--- a/lmms_eval/llm_judge/providers/bedrock.py
+++ b/lmms_eval/llm_judge/providers/bedrock.py
@@ -74,12 +74,15 @@ class BedrockProvider(ServerInterface):
                             media_type, b64_data = url.split(";base64,", 1)
                             media_type = media_type.replace("data:", "")
                             import base64
-                            content_blocks.append({
-                                "image": {
-                                    "format": media_type.split("/")[-1],
-                                    "source": {"bytes": base64.b64decode(b64_data)},
+
+                            content_blocks.append(
+                                {
+                                    "image": {
+                                        "format": media_type.split("/")[-1],
+                                        "source": {"bytes": base64.b64decode(b64_data)},
+                                    }
                                 }
-                            })
+                            )
             bedrock_messages.append({"role": m["role"], "content": content_blocks})
 
         inference_config = {

--- a/lmms_eval/tasks/cc_ocr/_default_yaml_template
+++ b/lmms_eval/tasks/cc_ocr/_default_yaml_template
@@ -1,0 +1,15 @@
+dataset_path: wulipc/CC-OCR
+test_split: test
+output_type: generate_until
+doc_to_visual: !function utils.cc_ocr_doc_to_visual
+doc_to_text: !function utils.cc_ocr_doc_to_text
+doc_to_target: !function utils.cc_ocr_doc_to_target
+
+generation_kwargs:
+  max_new_tokens: 4096
+  temperature: 0
+  top_p: 1.0
+  num_beams: 1
+  do_sample: false
+
+process_results: !function utils.cc_ocr_process_results

--- a/lmms_eval/tasks/cc_ocr/cc_ocr.yaml
+++ b/lmms_eval/tasks/cc_ocr/cc_ocr.yaml
@@ -1,0 +1,6 @@
+group: cc_ocr
+task:
+- cc_ocr_multi_scene_ocr
+- cc_ocr_multi_lan_ocr
+- cc_ocr_doc_parsing
+- cc_ocr_kie

--- a/lmms_eval/tasks/cc_ocr/cc_ocr_doc_parsing.yaml
+++ b/lmms_eval/tasks/cc_ocr/cc_ocr_doc_parsing.yaml
@@ -1,0 +1,24 @@
+include: _default_yaml_template
+
+task: cc_ocr_doc_parsing
+dataset_name: doc_parsing
+
+metric_list:
+  - metric: doc_score
+    aggregation: !function utils.cc_ocr_agg_dp_doc
+    higher_is_better: true
+  - metric: table_teds
+    aggregation: !function utils.cc_ocr_agg_dp_table
+    higher_is_better: true
+  - metric: formula_score
+    aggregation: !function utils.cc_ocr_agg_dp_formula
+    higher_is_better: true
+  - metric: molecular_score
+    aggregation: !function utils.cc_ocr_agg_dp_molecular
+    higher_is_better: true
+  - metric: overall_score
+    aggregation: !function utils.cc_ocr_agg_dp_overall
+    higher_is_better: true
+
+metadata:
+  - version: 0.0

--- a/lmms_eval/tasks/cc_ocr/cc_ocr_kie.yaml
+++ b/lmms_eval/tasks/cc_ocr/cc_ocr_kie.yaml
@@ -1,0 +1,15 @@
+include: _default_yaml_template
+
+task: cc_ocr_kie
+dataset_name: kie
+
+metric_list:
+  - metric: f1_score
+    aggregation: !function utils.cc_ocr_agg_kie_f1
+    higher_is_better: true
+  - metric: acc
+    aggregation: !function utils.cc_ocr_agg_kie_acc
+    higher_is_better: true
+
+metadata:
+  - version: 0.0

--- a/lmms_eval/tasks/cc_ocr/cc_ocr_multi_lan_ocr.yaml
+++ b/lmms_eval/tasks/cc_ocr/cc_ocr_multi_lan_ocr.yaml
@@ -1,0 +1,15 @@
+include: _default_yaml_template
+
+task: cc_ocr_multi_lan_ocr
+dataset_name: multi_lan_ocr
+
+metric_list:
+  - metric: macro_f1
+    aggregation: !function utils.cc_ocr_agg_ocr_macro_f1
+    higher_is_better: true
+  - metric: micro_f1
+    aggregation: !function utils.cc_ocr_agg_ocr_micro_f1
+    higher_is_better: true
+
+metadata:
+  - version: 0.0

--- a/lmms_eval/tasks/cc_ocr/cc_ocr_multi_scene_ocr.yaml
+++ b/lmms_eval/tasks/cc_ocr/cc_ocr_multi_scene_ocr.yaml
@@ -1,0 +1,15 @@
+include: _default_yaml_template
+
+task: cc_ocr_multi_scene_ocr
+dataset_name: multi_scene_ocr
+
+metric_list:
+  - metric: macro_f1
+    aggregation: !function utils.cc_ocr_agg_ocr_macro_f1
+    higher_is_better: true
+  - metric: micro_f1
+    aggregation: !function utils.cc_ocr_agg_ocr_micro_f1
+    higher_is_better: true
+
+metadata:
+  - version: 0.0

--- a/lmms_eval/tasks/cc_ocr/evaluators/__init__.py
+++ b/lmms_eval/tasks/cc_ocr/evaluators/__init__.py
@@ -1,0 +1,3 @@
+from lmms_eval.tasks.cc_ocr.evaluators import doc_parsing_metric, kie_metric, ocr_metric
+
+__all__ = ["ocr_metric", "kie_metric", "doc_parsing_metric"]

--- a/lmms_eval/tasks/cc_ocr/evaluators/common.py
+++ b/lmms_eval/tasks/cc_ocr/evaluators/common.py
@@ -1,0 +1,83 @@
+"""Common utilities shared across CC-OCR evaluators.
+
+Directly ported from the official CC-OCR evaluation code:
+https://github.com/AlibabaResearch/AdvancedLiterateMachinery/tree/main/Benchmarks/CC-OCR/evaluation/evaluator
+"""
+
+import json
+import re
+from typing import Any, Dict, List, Union
+
+
+def convert_to_halfwidth(text: str) -> str:
+    """Convert full-width ASCII characters to half-width."""
+    halfwidth_chars = str.maketrans(
+        "！＂＃＄％＆＇（）＊＋，－．／０１２３４５６７８９：；＜＝＞？＠"
+        "ＡＢＣＤＥＦＧＨＩＪＫＬＭＮＯＰＱＲＳＴＵＶＷＸＹＺ［＼］＾＿｀"
+        "ａｂｃｄｅｆｇｈｉｊｋｌｍｎｏｐｑｒｓｔｕｖｗｘｙｚ｛｜｝～",
+        '!"#$%&\'()*+,-./0123456789:;<=>?@'
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`"
+        "abcdefghijklmnopqrstuvwxyz{|}~",
+    )
+    return text.translate(halfwidth_chars)
+
+
+def fullwidth_to_halfwidth(text: str) -> str:
+    """CJK-aware full-width to half-width conversion (matches KIE evaluator)."""
+    result = ""
+    for char in text:
+        code_point = ord(char)
+        if code_point == 0x3000:
+            code_point = 0x0020
+        elif 0xFF01 <= code_point <= 0xFF5E:
+            code_point -= 0xFEE0
+        result += chr(code_point)
+    result = result.replace("、", ",")
+    return result
+
+
+def remove_unnecessary_spaces(text: str) -> str:
+    """Normalize spacing around CJK / ASCII / punctuation boundaries."""
+    text = re.sub(r"(?<=[\u4e00-\u9fff])\s+(?=[\u4e00-\u9fff])", "", text)
+    text = re.sub(r"(?<=[\u4e00-\u9fff])\s+(?=[a-zA-Z0-9])", "", text)
+    text = re.sub(r"(?<=[a-zA-Z0-9])\s+(?=[\u4e00-\u9fff])", "", text)
+    text = re.sub(r"(?<![0-9])\s*([,.!?:;])\s*", r"\1 ", text)
+    text = re.sub(r"(?<=[0-9])(?=[a-zA-Z])", " ", text)
+    text = re.sub(r"(?<=[a-zA-Z])(?=[0-9])", " ", text)
+    text = re.sub(r"\s+", " ", text)
+    return text
+
+
+def post_process_to_json(qwen_info_str: str, file_name: str = None) -> Union[Dict, List, None]:
+    """Extract a JSON object from a model response that may wrap it in ```json ... ```."""
+    if not isinstance(qwen_info_str, str):
+        return None
+    try:
+        if "```json" in qwen_info_str:
+            if "```" not in qwen_info_str.split("```json", 1)[1]:
+                qwen_info_str = qwen_info_str + "```"
+            m = re.search(r"```json(.*?)```", qwen_info_str, re.DOTALL)
+            if m is None:
+                return None
+            json_str = m.group(1).strip().replace("\n", "")
+        else:
+            json_str = qwen_info_str.strip().replace("\n", "")
+        return json.loads(json_str)
+    except Exception:
+        return None
+
+
+def normalize_values_of_nested_dict(d: Any, normalize_func) -> Any:
+    """Recursively normalize string leaves of a nested dict/list."""
+    if isinstance(d, dict):
+        return {k: normalize_values_of_nested_dict(v, normalize_func) for k, v in d.items()}
+    if isinstance(d, list):
+        return [normalize_values_of_nested_dict(x, normalize_func) if isinstance(x, (dict, list)) else normalize_func(x) if isinstance(x, str) else x for x in d]
+    if isinstance(d, str):
+        return normalize_func(d)
+    return d
+
+
+def kie_normalize_text(text: str) -> str:
+    """Full pipeline used for KIE string normalization."""
+    return remove_unnecessary_spaces(fullwidth_to_halfwidth(str(text)))

--- a/lmms_eval/tasks/cc_ocr/evaluators/common.py
+++ b/lmms_eval/tasks/cc_ocr/evaluators/common.py
@@ -12,12 +12,8 @@ from typing import Any, Dict, List, Union
 def convert_to_halfwidth(text: str) -> str:
     """Convert full-width ASCII characters to half-width."""
     halfwidth_chars = str.maketrans(
-        "！＂＃＄％＆＇（）＊＋，－．／０１２３４５６７８９：；＜＝＞？＠"
-        "ＡＢＣＤＥＦＧＨＩＪＫＬＭＮＯＰＱＲＳＴＵＶＷＸＹＺ［＼］＾＿｀"
-        "ａｂｃｄｅｆｇｈｉｊｋｌｍｎｏｐｑｒｓｔｕｖｗｘｙｚ｛｜｝～",
-        '!"#$%&\'()*+,-./0123456789:;<=>?@'
-        "ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`"
-        "abcdefghijklmnopqrstuvwxyz{|}~",
+        "！＂＃＄％＆＇（）＊＋，－．／０１２３４５６７８９：；＜＝＞？＠" "ＡＢＣＤＥＦＧＨＩＪＫＬＭＮＯＰＱＲＳＴＵＶＷＸＹＺ［＼］＾＿｀" "ａｂｃｄｅｆｇｈｉｊｋｌｍｎｏｐｑｒｓｔｕｖｗｘｙｚ｛｜｝～",
+        "!\"#$%&'()*+,-./0123456789:;<=>?@" "ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`" "abcdefghijklmnopqrstuvwxyz{|}~",
     )
     return text.translate(halfwidth_chars)
 

--- a/lmms_eval/tasks/cc_ocr/evaluators/doc_parsing_metric.py
+++ b/lmms_eval/tasks/cc_ocr/evaluators/doc_parsing_metric.py
@@ -64,13 +64,7 @@ def _eval_doc(pred: str, gt: str) -> float:
 
 
 def _eval_formula(pred: str, gt: str) -> float:
-    pred = (
-        pred.replace("\n", " ")
-        .replace("```latex", "")
-        .replace("```", "")
-        .replace("\t", " ")
-        .replace(" ", "")
-    )
+    pred = pred.replace("\n", " ").replace("```latex", "").replace("```", "").replace("\t", " ").replace(" ", "")
     gt = gt.replace(" ", "")
     denom = max(len(pred), len(gt))
     if denom == 0:
@@ -79,12 +73,7 @@ def _eval_formula(pred: str, gt: str) -> float:
 
 
 def _eval_molecular(pred: str, gt: str) -> float:
-    pred = (
-        pred.replace("\n", "")
-        .replace(" ", "")
-        .replace("<smiles>", "")
-        .replace("</smiles>", "")
-    )
+    pred = pred.replace("\n", "").replace(" ", "").replace("<smiles>", "").replace("</smiles>", "")
     gt = gt.replace(" ", "")
     denom = max(len(pred), len(gt))
     if denom == 0:

--- a/lmms_eval/tasks/cc_ocr/evaluators/doc_parsing_metric.py
+++ b/lmms_eval/tasks/cc_ocr/evaluators/doc_parsing_metric.py
@@ -1,0 +1,189 @@
+"""Document parsing metrics for CC-OCR.
+
+Four operations (identified by ``result["op"]`` derived from HF ``l2-category``):
+
+    doc        -> 1 - edit_distance / max_len  (LaTeX transcription)
+    table      -> TEDS on HTML                 (reuses ocrbench_v2 TEDS_metric)
+    formula    -> 1 - edit_distance / max_len  (LaTeX formula)
+    molecular  -> 1 - edit_distance / max_len  (SMILES)
+"""
+
+import re
+from typing import Dict, List
+
+import nltk
+
+from lmms_eval.tasks.cc_ocr.evaluators.common import convert_to_halfwidth
+
+# Patterns to strip from doc predictions before scoring
+_DOC_PATTERNS = [
+    r"\\documentclass\{.*?\}",
+    r"\\usepackage\[.*?\]\{.*?\}",
+    r"\\usepackage\{.*?\}",
+    r"\\geometry\{.*?\}",
+    r"\\begin\{document\}",
+    r"\\end\{document\}",
+    r"\\noindent",
+]
+
+
+def _extract_and_clean_tables(text: str) -> str:
+    if "</table>" not in text:
+        text = text + "</table>"
+    tables = re.findall(r"<table.*?>.*?</table>", text, re.DOTALL)
+    cleaned = []
+    for t in tables:
+        t = re.sub(r"<table.*?>", "<table>", t)
+        t = re.sub(r">\s+<", "><", t)
+        t = re.sub(
+            r">(.*?)<",
+            lambda m: ">" + m.group(1).replace("\n", "").replace(" ", "") + "<",
+            t,
+            flags=re.DOTALL,
+        )
+        cleaned.append(t.replace("\n", "").strip())
+    return "".join(cleaned)
+
+
+def _eval_doc(pred: str, gt: str) -> float:
+    for p in _DOC_PATTERNS:
+        pred = re.sub(p, "", pred)
+    m = re.search(r"```latex(.+?)```", pred, re.DOTALL)
+    if m is not None:
+        pred = m.group(1)
+    elif "```latex" in pred:
+        pred = pred.split("```latex", 1)[1]
+    pred = pred.replace(" ", "").replace("\n", "")
+    gt = gt.replace(" ", "").replace("\n", "")
+    if not pred and not gt:
+        return 1.0
+    denom = max(len(pred), len(gt))
+    if denom == 0:
+        return 0.0
+    return 1 - nltk.edit_distance(pred, gt) / denom
+
+
+def _eval_formula(pred: str, gt: str) -> float:
+    pred = (
+        pred.replace("\n", " ")
+        .replace("```latex", "")
+        .replace("```", "")
+        .replace("\t", " ")
+        .replace(" ", "")
+    )
+    gt = gt.replace(" ", "")
+    denom = max(len(pred), len(gt))
+    if denom == 0:
+        return 0.0
+    return 1 - nltk.edit_distance(pred, gt) / denom
+
+
+def _eval_molecular(pred: str, gt: str) -> float:
+    pred = (
+        pred.replace("\n", "")
+        .replace(" ", "")
+        .replace("<smiles>", "")
+        .replace("</smiles>", "")
+    )
+    gt = gt.replace(" ", "")
+    denom = max(len(pred), len(gt))
+    if denom == 0:
+        return 0.0
+    return 1 - nltk.edit_distance(pred, gt) / denom
+
+
+def _eval_table(pred: str, gt: str) -> float:
+    from lmms_eval.tasks.ocrbench_v2.TEDS_metric import TEDS
+
+    m = re.search(r"```html(.+?)```", pred, re.DOTALL)
+    if m is not None:
+        pred = m.group(1)
+    elif "```html" in pred:
+        pred = pred.split("```html", 1)[1]
+
+    pred = _extract_and_clean_tables(pred)
+    pred = convert_to_halfwidth(pred)
+    gt = _extract_and_clean_tables(gt)
+    gt = convert_to_halfwidth(gt)
+
+    pred_html = f"<html><body>{pred}</body></html>"
+    gt_html = f"<html><body>{gt}</body></html>"
+    teds = TEDS(structure_only=False, n_jobs=1)
+    try:
+        return teds.evaluate(pred_html, gt_html)
+    except Exception:
+        return 0.0
+
+
+_OP_TO_FUNC = {
+    "doc": _eval_doc,
+    "table": _eval_table,
+    "formula": _eval_formula,
+    "molecular": _eval_molecular,
+}
+
+
+def _filter_by_op(results: List[Dict], op: str) -> List[Dict]:
+    return [r for r in results if r.get("op") == op]
+
+
+def _compute_op_score(results: List[Dict], op: str) -> float:
+    """Average score across every subset of the given op."""
+    subset_samples: Dict[str, List[Dict]] = {}
+    for r in _filter_by_op(results, op):
+        subset_samples.setdefault(r["subset"], []).append(r)
+    if not subset_samples:
+        return 0.0
+    func = _OP_TO_FUNC[op]
+    subset_scores = {}
+    for subset, samples in subset_samples.items():
+        scores = []
+        for s in samples:
+            try:
+                scores.append(func(str(s["pred"]), str(s["gt"])))
+            except Exception:
+                scores.append(0.0)
+        subset_scores[subset] = sum(scores) / (len(scores) + 1e-9)
+    return sum(subset_scores.values()) / (len(subset_scores) + 1e-9)
+
+
+def compute_op(results: List[Dict], op: str) -> float:
+    return _compute_op_score(results, op)
+
+
+def compute_overall(results: List[Dict]) -> float:
+    """Average of the four op scores (ignoring absent ops)."""
+    op_scores = []
+    for op in ("doc", "table", "formula", "molecular"):
+        if any(r.get("op") == op for r in results):
+            op_scores.append(_compute_op_score(results, op))
+    if not op_scores:
+        return 0.0
+    return sum(op_scores) / len(op_scores)
+
+
+def compute_track_with_breakdown(results: List[Dict]) -> Dict:
+    """Return per-subset and per-op scores for logging."""
+    per_subset: Dict[str, float] = {}
+    per_op: Dict[str, float] = {}
+    for op in ("doc", "table", "formula", "molecular"):
+        subset_samples: Dict[str, List[Dict]] = {}
+        for r in _filter_by_op(results, op):
+            subset_samples.setdefault(r["subset"], []).append(r)
+        if not subset_samples:
+            continue
+        func = _OP_TO_FUNC[op]
+        op_subset_scores = []
+        for subset, samples in subset_samples.items():
+            scores = []
+            for s in samples:
+                try:
+                    scores.append(func(str(s["pred"]), str(s["gt"])))
+                except Exception:
+                    scores.append(0.0)
+            subset_score = sum(scores) / (len(scores) + 1e-9)
+            per_subset[subset] = subset_score
+            op_subset_scores.append(subset_score)
+        per_op[op] = sum(op_subset_scores) / (len(op_subset_scores) + 1e-9)
+    overall = sum(per_op.values()) / (len(per_op) + 1e-9) if per_op else 0.0
+    return {"subsets": per_subset, "ops": per_op, "overall_score": overall}

--- a/lmms_eval/tasks/cc_ocr/evaluators/kie_metric.py
+++ b/lmms_eval/tasks/cc_ocr/evaluators/kie_metric.py
@@ -1,0 +1,215 @@
+"""KIE evaluation: field-level F1 (flatten-based) + tree edit distance (Donut).
+
+Ported from CC-OCR kie_evaluator.py, which itself derives from the Donut paper.
+"""
+
+import json
+from collections import Counter
+from typing import Any, Dict, List, Union
+
+import zss
+from nltk import edit_distance
+from zss import Node
+
+from lmms_eval.tasks.cc_ocr.evaluators.common import kie_normalize_text, normalize_values_of_nested_dict, post_process_to_json
+
+
+def _flatten(data: dict) -> List:
+    """Turn nested dict/list into a flat list of (dotted_key, value)."""
+    out = []
+
+    def rec(value, key=""):
+        if isinstance(value, dict):
+            for k, v in value.items():
+                rec(v, f"{key}.{k}" if key else k)
+        elif isinstance(value, list):
+            for item in value:
+                rec(item, key)
+        else:
+            out.append((key, value))
+
+    rec(data)
+    return out
+
+
+def _normalize_dict(data: Any) -> Any:
+    """Sort keys, wrap scalars in list — matches Donut normalize_dict semantics."""
+    if isinstance(data, dict):
+        new_data = {}
+        for k in sorted(data.keys(), key=lambda k: (len(k), k)):
+            value = _normalize_dict(data[k])
+            if value:
+                if not isinstance(value, list):
+                    value = [value]
+                new_data[k] = value
+        return new_data
+    if isinstance(data, list):
+        if all(isinstance(item, dict) for item in data):
+            return [x for x in (_normalize_dict(item) for item in data) if x]
+        return [str(item).strip() for item in data if isinstance(item, (str, int, float)) and str(item).strip()]
+    return [str(data).strip()]
+
+
+def _update_cost(a: Node, b: Node) -> int:
+    la, lb = a.label, b.label
+    a_leaf, b_leaf = "<leaf>" in la, "<leaf>" in lb
+    if a_leaf and b_leaf:
+        return edit_distance(la.replace("<leaf>", ""), lb.replace("<leaf>", ""))
+    if not a_leaf and b_leaf:
+        return 1 + len(lb.replace("<leaf>", ""))
+    if a_leaf and not b_leaf:
+        return 1 + len(la.replace("<leaf>", ""))
+    return int(la != lb)
+
+
+def _insert_remove_cost(node: Node) -> int:
+    label = node.label
+    if "<leaf>" in label:
+        return len(label.replace("<leaf>", ""))
+    return 1
+
+
+def _dict_to_tree(data: Union[Dict, List], node_name: str = None) -> Node:
+    if node_name is None:
+        node_name = "<root>"
+    node = Node(node_name)
+    if isinstance(data, dict):
+        for k, v in data.items():
+            node.addkid(_dict_to_tree(v, k))
+    elif isinstance(data, list):
+        if all(isinstance(item, dict) for item in data):
+            for item in data:
+                node.addkid(_dict_to_tree(item, "<subtree>"))
+        else:
+            for item in data:
+                node.addkid(Node(f"<leaf>{item}"))
+    else:
+        raise ValueError(f"unexpected node: {data} ({node_name})")
+    return node
+
+
+def _cal_acc(pred: dict, answer: dict) -> float:
+    p_tree = _dict_to_tree(_normalize_dict(pred))
+    a_tree = _dict_to_tree(_normalize_dict(answer))
+    empty_tree = _dict_to_tree(_normalize_dict({}))
+    d = zss.distance(
+        p_tree, a_tree,
+        get_children=zss.Node.get_children,
+        insert_cost=_insert_remove_cost,
+        remove_cost=_insert_remove_cost,
+        update_cost=_update_cost,
+        return_operations=False,
+    )
+    denom = zss.distance(
+        empty_tree, a_tree,
+        get_children=zss.Node.get_children,
+        insert_cost=_insert_remove_cost,
+        remove_cost=_insert_remove_cost,
+        update_cost=_update_cost,
+        return_operations=False,
+    )
+    if denom <= 0:
+        return 0.0
+    return max(0.0, 1 - d / denom)
+
+
+def _cal_f1_over_samples(preds: Dict[str, Any], answers: Dict[str, Any]) -> float:
+    total_tp = 0
+    total_fn_fp = 0
+    for fname, ans in answers.items():
+        pred = preds.get(fname, {})
+        pred_flat = _flatten(_normalize_dict(pred))
+        ans_flat = _flatten(_normalize_dict(ans))
+        for field in pred_flat:
+            if field in ans_flat:
+                total_tp += 1
+                ans_flat.remove(field)
+            else:
+                total_fn_fp += 1
+        total_fn_fp += len(ans_flat)
+    return total_tp / (total_tp + total_fn_fp / 2 + 1e-6)
+
+
+def _cal_acc_over_samples(preds: Dict[str, Any], answers: Dict[str, Any]) -> float:
+    accs = []
+    for fname, ans in answers.items():
+        pred = preds.get(fname, {})
+        accs.append(_cal_acc(pred, ans))
+    return sum(accs) / (len(accs) + 1e-6)
+
+
+def _parse_pred_and_gt(sample: Dict) -> (Dict, Dict):
+    pred_raw = sample["pred"]
+    pred_json = post_process_to_json(pred_raw, file_name=sample.get("image_name"))
+    if pred_json is None:
+        pred_json = {}
+
+    gt_raw = sample["gt"]
+    if isinstance(gt_raw, str):
+        try:
+            gt_json = json.loads(gt_raw)
+        except Exception:
+            gt_json = {}
+    elif isinstance(gt_raw, list) and gt_raw and isinstance(gt_raw[0], str):
+        try:
+            gt_json = json.loads(gt_raw[0])
+        except Exception:
+            gt_json = {}
+    else:
+        gt_json = gt_raw or {}
+
+    pred_json = normalize_values_of_nested_dict(pred_json, kie_normalize_text)
+    gt_json = normalize_values_of_nested_dict(gt_json, kie_normalize_text)
+    return pred_json, gt_json
+
+
+def compute_track(results: List[Dict], key: str) -> float:
+    """Aggregate F1 or accuracy over the whole track (mean of per-subset scores)."""
+    if not results:
+        return 0.0
+    by_subset: Dict[str, List[Dict]] = {}
+    for r in results:
+        by_subset.setdefault(r["subset"], []).append(r)
+
+    subset_scores = {}
+    for subset, samples in by_subset.items():
+        preds, gts = {}, {}
+        for s in samples:
+            p, g = _parse_pred_and_gt(s)
+            fname = s["image_name"]
+            preds[fname] = p
+            gts[fname] = g
+        if key == "f1_score":
+            subset_scores[subset] = _cal_f1_over_samples(preds, gts)
+        elif key == "acc":
+            subset_scores[subset] = _cal_acc_over_samples(preds, gts)
+        else:
+            raise ValueError(f"unknown KIE metric key: {key}")
+
+    return sum(subset_scores.values()) / (len(subset_scores) + 1e-9)
+
+
+def compute_track_with_breakdown(results: List[Dict]) -> Dict:
+    """Return per-subset F1 and accuracy for logging."""
+    if not results:
+        return {"subsets": {}, "f1_score": 0.0, "acc": 0.0}
+    by_subset: Dict[str, List[Dict]] = {}
+    for r in results:
+        by_subset.setdefault(r["subset"], []).append(r)
+
+    subset_info = {}
+    for subset, samples in by_subset.items():
+        preds, gts = {}, {}
+        for s in samples:
+            p, g = _parse_pred_and_gt(s)
+            fname = s["image_name"]
+            preds[fname] = p
+            gts[fname] = g
+        subset_info[subset] = {
+            "f1_score": _cal_f1_over_samples(preds, gts),
+            "acc": _cal_acc_over_samples(preds, gts),
+            "num": len(samples),
+        }
+    f1_avg = sum(v["f1_score"] for v in subset_info.values()) / (len(subset_info) + 1e-9)
+    acc_avg = sum(v["acc"] for v in subset_info.values()) / (len(subset_info) + 1e-9)
+    return {"subsets": subset_info, "f1_score": f1_avg, "acc": acc_avg}

--- a/lmms_eval/tasks/cc_ocr/evaluators/kie_metric.py
+++ b/lmms_eval/tasks/cc_ocr/evaluators/kie_metric.py
@@ -11,7 +11,11 @@ import zss
 from nltk import edit_distance
 from zss import Node
 
-from lmms_eval.tasks.cc_ocr.evaluators.common import kie_normalize_text, normalize_values_of_nested_dict, post_process_to_json
+from lmms_eval.tasks.cc_ocr.evaluators.common import (
+    kie_normalize_text,
+    normalize_values_of_nested_dict,
+    post_process_to_json,
+)
 
 
 def _flatten(data: dict) -> List:
@@ -93,7 +97,8 @@ def _cal_acc(pred: dict, answer: dict) -> float:
     a_tree = _dict_to_tree(_normalize_dict(answer))
     empty_tree = _dict_to_tree(_normalize_dict({}))
     d = zss.distance(
-        p_tree, a_tree,
+        p_tree,
+        a_tree,
         get_children=zss.Node.get_children,
         insert_cost=_insert_remove_cost,
         remove_cost=_insert_remove_cost,
@@ -101,7 +106,8 @@ def _cal_acc(pred: dict, answer: dict) -> float:
         return_operations=False,
     )
     denom = zss.distance(
-        empty_tree, a_tree,
+        empty_tree,
+        a_tree,
         get_children=zss.Node.get_children,
         insert_cost=_insert_remove_cost,
         remove_cost=_insert_remove_cost,

--- a/lmms_eval/tasks/cc_ocr/evaluators/ocr_metric.py
+++ b/lmms_eval/tasks/cc_ocr/evaluators/ocr_metric.py
@@ -1,0 +1,136 @@
+"""OCR macro/micro F1 metric for CC-OCR multi_scene_ocr and multi_lan_ocr tracks.
+
+Directly ported from the official CC-OCR ocr_evaluator.py.
+"""
+
+import re
+from collections import Counter
+from typing import Dict, List, Tuple
+
+# Tracks where tokenization must be character-level (rather than word-level).
+_CHAR_LEVEL_SPLITS = {"Arabic", "Japanese", "Korean"}
+
+
+def _is_char_level(track: str, subset: str) -> bool:
+    """Whether to split into characters instead of words."""
+    if subset in _CHAR_LEVEL_SPLITS:
+        return True
+    if subset.startswith("zh"):
+        return True
+    return False
+
+
+def _token_normalize(token: str, is_lower: bool, is_alphanum_only: bool) -> str:
+    if is_lower:
+        token = token.lower()
+    if is_alphanum_only:
+        token = re.sub(r"[^A-Za-z0-9]+", "", token)
+    return token
+
+
+def _text_normalize_and_tokenize(text: str, is_keep_blank: bool, is_lower: bool, is_alphanum_only: bool) -> List[str]:
+    text = text.replace("\t", " ").replace("\n", " ").replace("###", "").replace("***", "")
+    text = re.sub(r"\s+", " ", text)
+    if not is_keep_blank:
+        text = text.replace(" ", "")
+    tokens = text.split(" ") if is_keep_blank else list(text)
+    tokens = [_token_normalize(t, is_lower, is_alphanum_only) for t in tokens]
+    return [t for t in tokens if len(t) > 0]
+
+
+def _match_count(gt_tokens: List[str], pd_tokens: List[str]) -> int:
+    gt_counter = dict(Counter(gt_tokens))
+    pd_counter = dict(Counter(pd_tokens))
+    right = 0
+    for tok, count in gt_counter.items():
+        right += min(count, pd_counter.get(tok, 0))
+    return right
+
+
+def _compute_pr_f1(gt_tokens: List[str], pd_tokens: List[str]) -> Tuple[float, float, float, int]:
+    right = _match_count(gt_tokens, pd_tokens)
+    recall = right / (len(gt_tokens) + 1e-9)
+    precision = right / (len(pd_tokens) + 1e-9)
+    f1 = 2 * recall * precision / (recall + precision + 1e-9)
+    return recall, precision, f1, right
+
+
+def _tokenize_for_sample(track: str, subset: str, gt: str, pred: str):
+    is_word_level = not _is_char_level(track, subset)
+    is_lower = True
+    is_alphanum_only = track == "multi_scene_ocr" and is_word_level
+    gt_tokens = _text_normalize_and_tokenize(str(gt).strip(), is_word_level, is_lower, is_alphanum_only)
+    pd_tokens = _text_normalize_and_tokenize(str(pred).strip(), is_word_level, is_lower, is_alphanum_only)
+    return gt_tokens, pd_tokens
+
+
+def compute_track(results: List[Dict], key: str) -> float:
+    """Return the aggregated metric value (0..1) for the whole track.
+
+    For each subset (defined by ``result["subset"]``):
+      - macro F1: mean of per-sample F1
+      - micro F1: total_right / (total_gt + total_pred) style harmonic mean
+    Track score = arithmetic mean over subsets (matches official summary).
+    """
+    if not results:
+        return 0.0
+
+    by_subset: Dict[str, List[Dict]] = {}
+    for r in results:
+        by_subset.setdefault(r["subset"], []).append(r)
+
+    subset_scores: Dict[str, float] = {}
+    for subset, samples in by_subset.items():
+        macro_f1_list = []
+        total_right = total_gt = total_pred = 0
+        for s in samples:
+            gt_tokens, pd_tokens = _tokenize_for_sample(s["track"], subset, s["gt"], s["pred"])
+            recall, precision, f1, right = _compute_pr_f1(gt_tokens, pd_tokens)
+            macro_f1_list.append(f1)
+            total_right += right
+            total_gt += len(gt_tokens)
+            total_pred += len(pd_tokens)
+        if key == "macro_f1":
+            subset_scores[subset] = sum(macro_f1_list) / (len(macro_f1_list) + 1e-9)
+        elif key == "micro_f1":
+            micro_r = total_right / (total_gt + 1e-9)
+            micro_p = total_right / (total_pred + 1e-9)
+            subset_scores[subset] = 2 * micro_r * micro_p / (micro_r + micro_p + 1e-9)
+        else:
+            raise ValueError(f"unknown OCR metric key: {key}")
+
+    return sum(subset_scores.values()) / (len(subset_scores) + 1e-9)
+
+
+def compute_track_with_breakdown(results: List[Dict]) -> Dict:
+    """Compute both macro and micro F1 for every subset (used for logging / submissions)."""
+    if not results:
+        return {"subsets": {}, "macro_f1": 0.0, "micro_f1": 0.0}
+
+    by_subset: Dict[str, List[Dict]] = {}
+    for r in results:
+        by_subset.setdefault(r["subset"], []).append(r)
+
+    subset_info: Dict[str, Dict[str, float]] = {}
+    for subset, samples in by_subset.items():
+        macro_f1_list = []
+        total_right = total_gt = total_pred = 0
+        for s in samples:
+            gt_tokens, pd_tokens = _tokenize_for_sample(s["track"], subset, s["gt"], s["pred"])
+            recall, precision, f1, right = _compute_pr_f1(gt_tokens, pd_tokens)
+            macro_f1_list.append(f1)
+            total_right += right
+            total_gt += len(gt_tokens)
+            total_pred += len(pd_tokens)
+        macro_f1 = sum(macro_f1_list) / (len(macro_f1_list) + 1e-9)
+        micro_r = total_right / (total_gt + 1e-9)
+        micro_p = total_right / (total_pred + 1e-9)
+        micro_f1 = 2 * micro_r * micro_p / (micro_r + micro_p + 1e-9)
+        subset_info[subset] = {
+            "macro_f1": macro_f1,
+            "micro_f1": micro_f1,
+            "num": len(samples),
+        }
+    macro_avg = sum(v["macro_f1"] for v in subset_info.values()) / (len(subset_info) + 1e-9)
+    micro_avg = sum(v["micro_f1"] for v in subset_info.values()) / (len(subset_info) + 1e-9)
+    return {"subsets": subset_info, "macro_f1": macro_avg, "micro_f1": micro_avg}

--- a/lmms_eval/tasks/cc_ocr/utils.py
+++ b/lmms_eval/tasks/cc_ocr/utils.py
@@ -1,0 +1,155 @@
+"""CC-OCR task utilities for lmms-eval.
+
+Provides:
+- Doc-to-visual / doc-to-text / doc-to-target hooks
+- process_results: packages one payload used by every metric in every track
+- One aggregator per metric declared in a track yaml
+
+The dataset ``wulipc/CC-OCR`` has four configs (multi_scene_ocr, multi_lan_ocr,
+doc_parsing, kie), each with a single ``test`` split. Each row carries a
+``split`` field naming its original subset (39 in total) and an
+``l2-category`` field naming the op group (used by doc_parsing).
+"""
+
+import base64
+import io
+import json
+from typing import Any, Dict, Optional
+
+from loguru import logger as eval_logger
+from PIL import Image
+
+from lmms_eval.tasks._task_utils.file_utils import generate_submission_file
+
+from lmms_eval.tasks.cc_ocr.evaluators import doc_parsing_metric, kie_metric, ocr_metric
+
+
+def _decode_image(image_obj: Any) -> Optional[Image.Image]:
+    if isinstance(image_obj, Image.Image):
+        return image_obj.convert("RGB")
+    if isinstance(image_obj, bytes):
+        return Image.open(io.BytesIO(image_obj)).convert("RGB")
+    if isinstance(image_obj, str):
+        try:
+            raw = base64.b64decode(image_obj)
+            return Image.open(io.BytesIO(raw)).convert("RGB")
+        except Exception:
+            return None
+    return None
+
+
+def cc_ocr_doc_to_visual(doc):
+    img = _decode_image(doc.get("image"))
+    if img is None:
+        eval_logger.warning(f"cc_ocr: failed to decode image for {doc.get('image_name')}")
+        return []
+    return [img]
+
+
+def cc_ocr_doc_to_text(doc, lmms_eval_specific_kwargs=None):
+    return doc["question"]
+
+
+def cc_ocr_doc_to_target(doc):
+    ans = doc.get("answer", "")
+    if isinstance(ans, list):
+        return ans[0] if ans else ""
+    return ans
+
+
+def _resolve_track(l2_category: str) -> str:
+    l2 = str(l2_category or "").strip()
+    if l2 in {"doc", "table", "formula", "molecular"}:
+        return "doc_parsing"
+    if l2 in {"constrained_category", "open_category"}:
+        return "kie"
+    if l2.endswith("_text"):
+        return "multi_scene_ocr"
+    return "multi_lan_ocr"
+
+
+def _resolve_op(track: str, l2_category: str) -> str:
+    """For doc_parsing, l2-category is the op label; empty for other tracks."""
+    if track == "doc_parsing":
+        return str(l2_category or "").strip()
+    return ""
+
+
+_METRIC_KEYS_BY_TRACK = {
+    "multi_scene_ocr": ("macro_f1", "micro_f1"),
+    "multi_lan_ocr": ("macro_f1", "micro_f1"),
+    "doc_parsing": ("doc_score", "table_teds", "formula_score", "molecular_score", "overall_score"),
+    "kie": ("f1_score", "acc"),
+}
+
+
+def cc_ocr_process_results(doc, results):
+    pred = results[0] if results else ""
+    l2_category = doc.get("l2-category", "")
+    track = _resolve_track(l2_category)
+    payload = {
+        "pred": pred,
+        "gt": doc.get("answer", ""),
+        "image_name": doc.get("image_name", ""),
+        "subset": doc.get("split", ""),
+        "l2_category": l2_category,
+        "op": _resolve_op(track, l2_category),
+        "track": track,
+    }
+    keys = _METRIC_KEYS_BY_TRACK.get(track, ())
+    return {key: payload for key in keys}
+
+
+def _write_submission(track: str, breakdown: Dict, args) -> None:
+    """Write per-subset breakdown as JSON alongside the aggregated metric."""
+    if args is None:
+        return
+    try:
+        path = generate_submission_file(f"cc_ocr_{track}_breakdown.json", args, subpath="results")
+        with open(path, "w") as f:
+            json.dump(breakdown, f, ensure_ascii=False, indent=2)
+        eval_logger.info(f"cc_ocr[{track}] breakdown written to {path}")
+    except Exception as e:
+        eval_logger.warning(f"cc_ocr[{track}] failed to write breakdown: {e}")
+
+
+def cc_ocr_agg_ocr_macro_f1(results, args):
+    breakdown = ocr_metric.compute_track_with_breakdown(results)
+    _write_submission(results[0]["track"] if results else "ocr", breakdown, args)
+    return breakdown["macro_f1"]
+
+
+def cc_ocr_agg_ocr_micro_f1(results, args):
+    return ocr_metric.compute_track(results, key="micro_f1")
+
+
+def cc_ocr_agg_dp_doc(results, args):
+    return doc_parsing_metric.compute_op(results, op="doc")
+
+
+def cc_ocr_agg_dp_table(results, args):
+    return doc_parsing_metric.compute_op(results, op="table")
+
+
+def cc_ocr_agg_dp_formula(results, args):
+    return doc_parsing_metric.compute_op(results, op="formula")
+
+
+def cc_ocr_agg_dp_molecular(results, args):
+    return doc_parsing_metric.compute_op(results, op="molecular")
+
+
+def cc_ocr_agg_dp_overall(results, args):
+    breakdown = doc_parsing_metric.compute_track_with_breakdown(results)
+    _write_submission("doc_parsing", breakdown, args)
+    return breakdown["overall_score"]
+
+
+def cc_ocr_agg_kie_f1(results, args):
+    breakdown = kie_metric.compute_track_with_breakdown(results)
+    _write_submission("kie", breakdown, args)
+    return breakdown["f1_score"]
+
+
+def cc_ocr_agg_kie_acc(results, args):
+    return kie_metric.compute_track(results, key="acc")

--- a/lmms_eval/tasks/cc_ocr/utils.py
+++ b/lmms_eval/tasks/cc_ocr/utils.py
@@ -20,7 +20,6 @@ from loguru import logger as eval_logger
 from PIL import Image
 
 from lmms_eval.tasks._task_utils.file_utils import generate_submission_file
-
 from lmms_eval.tasks.cc_ocr.evaluators import doc_parsing_metric, kie_metric, ocr_metric
 
 

--- a/lmms_eval/tasks/extremewhenbench/utils.py
+++ b/lmms_eval/tasks/extremewhenbench/utils.py
@@ -116,11 +116,7 @@ def ewb_doc_to_visual(doc: dict[str, Any]) -> list[str]:
     # process_docs preflight should have caught this already; fall back to a
     # per-doc error if the task is invoked without the preflight (e.g., when
     # users disable process_docs).
-    raise FileNotFoundError(
-        f"Video for qid={doc['qid']} ({corpus}/{vid}) not found. "
-        f"Download via:\n  {_DOWNLOAD_HINT[corpus]}\n"
-        f"or set EWB_{corpus.upper()}_PATH to a directory containing {vid}.mp4."
-    )
+    raise FileNotFoundError(f"Video for qid={doc['qid']} ({corpus}/{vid}) not found. " f"Download via:\n  {_DOWNLOAD_HINT[corpus]}\n" f"or set EWB_{corpus.upper()}_PATH to a directory containing {vid}.mp4.")
 
 
 DEFAULT_PROMPT = (


### PR DESCRIPTION
Integrate [CC-OCR](https://arxiv.org/abs/2412.02210), a comprehensive OCR benchmark from Alibaba, into lmms-eval.

## Overview

CC-OCR covers 4 tracks across 39 subsets (7,058 images):

| Track | Description | # subsets |
|---|---|---|
| `multi_scene_ocr` | Multi-scene text reading | 13 |
| `multi_lan_ocr` | Multilingual text reading (10 languages) | 10 |
| `doc_parsing` | Document parsing: doc / table / formula / molecular | 10 |
| `kie` | Key information extraction | 6 |

Uses the HF dataset [`wulipc/CC-OCR`](https://huggingface.co/datasets/wulipc/CC-OCR) (4 configs, one \`test\` split each; the 39 original subsets are recovered from each row's \`split\` field).

## Tasks exposed

- \`cc_ocr\` (group)
- \`cc_ocr_multi_scene_ocr\`
- \`cc_ocr_multi_lan_ocr\`
- \`cc_ocr_doc_parsing\`
- \`cc_ocr_kie\`

## Metrics

Ported 1:1 from the [official evaluator](https://github.com/AlibabaResearch/AdvancedLiterateMachinery/tree/main/Benchmarks/CC-OCR/evaluation):

- **OCR tracks** (\`macro_f1\`, \`micro_f1\`): token F1 with track-aware tokenization — word-level for Latin, char-level for Chinese / Japanese / Korean / Arabic, alphanum-only for \`multi_scene_ocr\`.
- **doc_parsing** (\`doc_score\`, \`table_teds\`, \`formula_score\`, \`molecular_score\`, \`overall_score\`): edit-distance-based scores for doc / formula / molecular; TEDS for tables (reuses \`ocrbench_v2.TEDS_metric\`).
- **kie** (\`f1_score\`, \`acc\`): Donut-style field-level F1 (after JSON extraction / normalization) and tree-edit-distance (nTED) accuracy.

Per-subset breakdowns for the 39 CC-OCR subsets are written to \`\$OUTPUT_PATH/results/cc_ocr_<track>_breakdown.json\` for direct comparison with the paper leaderboard.

## Layout

Followed the \`timelens\` pattern — one shared \`_default_yaml_template\`, one leaf yaml per track (4 leaves + 1 group). Track is auto-inferred from the row's \`l2-category\` field so \`process_results\` doesn't need custom kwargs plumbing.

## Testing

Verified end-to-end with Qwen3-VL-4B-Instruct via vLLM (limit=8 per track):

| Task | Metric | Value |
|---|---|---:|
| \`cc_ocr_multi_scene_ocr\` (CORD) | macro_f1 | 0.836 |
| \`cc_ocr_multi_lan_ocr\` (Arabic) | macro_f1 | 0.505 |
| \`cc_ocr_kie\` (CORD) | f1 / acc | 0.839 / 0.963 |
| \`cc_ocr_doc_parsing\` (doc, chn) | doc_score | 0.289 |

Numbers are in the right ballpark relative to the official leaderboard (Qwen-VL-72B multi_scene_ocr average = 0.7795, CORD is one of the easier subsets).