### PR TITLE
fix: core evaluator/cache/utils correctness fixes

### DIFF
--- a/lmms_eval/caching/cache.py
+++ b/lmms_eval/caching/cache.py
@@ -44,10 +44,13 @@ def save_to_cache(file_name, obj):
     serializable_obj = []
 
     for item in obj:
+        serializable_item = []
         for subitem in item:
             if hasattr(subitem, "arguments"):  # we need to handle the arguments specially since doc_to_visual is callable method and not serializable
                 serializable_arguments = tuple(arg if not callable(arg) else None for arg in subitem.arguments)
                 subitem.arguments = serializable_arguments
+            serializable_item.append(subitem)
+        serializable_obj.append(serializable_item)
 
     eval_logger.debug(f"Saving {file_path} to cache...")
     try:

--- a/lmms_eval/caching/response_cache.py
+++ b/lmms_eval/caching/response_cache.py
@@ -407,14 +407,21 @@ class ResponseCache:
             cache_root = os.path.dirname(os.path.abspath(cache_root))
         cache_root = os.path.abspath(cache_root)
 
-        # Task fingerprints
+        # Task fingerprints — recursively process nested groups so subtasks
+        # get proper fingerprints instead of falling back to empty strings.
         task_fingerprints = {}
         if task_dict:
-            for tname, tobj in task_dict.items():
-                if hasattr(tobj, "dump_config"):
-                    cfg_str = json.dumps(tobj.dump_config(), sort_keys=True, default=str)
-                    cfg_str = _FUNC_ADDR_RE.sub(">", cfg_str)
-                    task_fingerprints[tname] = hash_string(cfg_str)[:16]
+
+            def _collect_fingerprints(d):
+                for tname, tobj in d.items():
+                    if hasattr(tobj, "dump_config"):
+                        cfg_str = json.dumps(tobj.dump_config(), sort_keys=True, default=str)
+                        cfg_str = _FUNC_ADDR_RE.sub(">", cfg_str)
+                        task_fingerprints[tname] = hash_string(cfg_str)[:16]
+                    elif isinstance(tobj, dict):
+                        _collect_fingerprints(tobj)
+
+            _collect_fingerprints(task_dict)
 
         # Model fingerprint
         if isinstance(model_args, dict):

--- a/lmms_eval/evaluator.py
+++ b/lmms_eval/evaluator.py
@@ -81,13 +81,20 @@ _SENSITIVE_CONFIG_KEYS = {
     "huggingfacehub_api_token",
     "token",
 }
-_SECRET_ASSIGNMENT_RE = re.compile(r"(?i)(^|[,\s])(api_key|client_secret|hf_token|huggingface_hub_token|huggingfacehub_api_token|token)=([^,\s]+)")
+# Suffixes also catch prefixed variants: openai_api_key, github_token, my_secret, db_password.
+_SENSITIVE_KEY_SUFFIXES = ("api_key", "_token", "_secret", "password")
+_SECRET_ASSIGNMENT_RE = re.compile(r"(?i)(^|[,\s])(\w*(?:api_key|token|secret|password))=([^,\s]+)")
 _HF_TOKEN_VALUE_RE = re.compile(r"\bhf_[A-Za-z0-9]{20,}\b")
+
+
+def _is_sensitive_config_key(key) -> bool:
+    key_lower = str(key).lower()
+    return key_lower in _SENSITIVE_CONFIG_KEYS or key_lower.endswith(_SENSITIVE_KEY_SUFFIXES)
 
 
 def _redact_eval_config_secrets(value):
     if isinstance(value, dict):
-        return {key: ("[REDACTED]" if str(key).lower() in _SENSITIVE_CONFIG_KEYS else _redact_eval_config_secrets(item)) for key, item in value.items()}
+        return {key: ("[REDACTED]" if _is_sensitive_config_key(key) else _redact_eval_config_secrets(item)) for key, item in value.items()}
     if isinstance(value, (list, tuple)):
         return type(value)(_redact_eval_config_secrets(item) for item in value)
     if isinstance(value, str):
@@ -896,15 +903,6 @@ def evaluate(
     global_rank = int(os.environ.get("RANK", 0))
     world_size = int(os.environ.get("WORLD_SIZE", 1))
 
-    # Auto-init torch.distributed for multi-rank launches where the model
-    # backend did not call init_process_group itself (e.g. video generation
-    # models using diffusers).  Without this, evaluator collectives like
-    # gather_object / barrier crash with "process group not initialized".
-    # gloo is used because it requires no GPU and works everywhere.
-    if world_size > 1 and dist.is_available() and not dist.is_initialized():
-        dist.init_process_group(backend="gloo")
-        eval_logger.info(f"evaluator: auto-initialized gloo process group (world={world_size})")
-
     eval_logger.info(f"Running on rank {global_rank} (local rank {local_rank})")
 
     def _infer_task_request_type(task_obj: Task) -> Optional[str]:
@@ -925,8 +923,24 @@ def evaluate(
         if not all("bypass" not in getattr(task_output.task, "_metric_fn_list", {}).keys() for task_output in eval_tasks):
             raise ValueError("log_samples must be True for 'bypass' metric-only tasks")
 
-    if distributed_executor_backend == "accelerate" and not hasattr(lm, "accelerator"):
-        lm.accelerator = Accelerator()
+    if distributed_executor_backend == "accelerate":
+        if not hasattr(lm, "accelerator"):
+            lm.accelerator = Accelerator()
+    else:
+        # Torchrun/native path: auto-init a process group for multi-rank runs
+        # whose model backend never called init_process_group (e.g. diffusers
+        # video-gen models), so evaluator collectives don't crash. gloo needs no
+        # GPU. Gated out of the accelerate path on purpose: pre-initializing here
+        # would make Accelerator() adopt this gloo group instead of building NCCL,
+        # silently running GPU collectives on CPU.
+        if world_size > 1 and dist.is_available() and not dist.is_initialized():
+            if os.environ.get("MASTER_ADDR") and os.environ.get("MASTER_PORT"):
+                dist.init_process_group(backend="gloo")
+                eval_logger.info(f"evaluator: auto-initialized gloo process group (world={world_size})")
+            else:
+                eval_logger.warning(
+                    f"evaluator: WORLD_SIZE={world_size} but MASTER_ADDR/MASTER_PORT are unset; skipping torch.distributed auto-init. Distributed collectives will fail unless the model backend initializes the process group itself."
+                )
 
     # Inject rank/world_size into the model so that logging (tqdm disable)
     # and rank-conditional logic work on non-zero ranks.  Many simple models
@@ -1053,8 +1067,8 @@ def evaluate(
             if pad_source is None:
                 eval_logger.warning(f"Running {reqtype} requests but could not find a pad source request on rank {global_rank}; skipping rank padding.")
             else:
-                pad_instance = _clone_padding_request(pad_source)
                 for _ in range(padding_requests[reqtype]):
+                    pad_instance = _clone_padding_request(pad_source)
                     cloned_reqs.extend([pad_instance] * pad_instance.repeats)
 
         # run requests through model (with optional response cache)

--- a/lmms_eval/evaluator.py
+++ b/lmms_eval/evaluator.py
@@ -73,6 +73,36 @@ from lmms_eval.utils import (
 )
 
 IMAGE_EXTENSIONS = (".png", ".jpg", ".jpeg", ".webp", ".gif", ".bmp", ".tif", ".tiff")
+_SENSITIVE_CONFIG_KEYS = {
+    "api_key",
+    "client_secret",
+    "hf_token",
+    "huggingface_hub_token",
+    "huggingfacehub_api_token",
+    "token",
+}
+_SECRET_ASSIGNMENT_RE = re.compile(r"(?i)(^|[,\s])(api_key|client_secret|hf_token|huggingface_hub_token|huggingfacehub_api_token|token)=([^,\s]+)")
+_HF_TOKEN_VALUE_RE = re.compile(r"\bhf_[A-Za-z0-9]{20,}\b")
+
+
+def _redact_eval_config_secrets(value):
+    if isinstance(value, dict):
+        return {key: ("[REDACTED]" if str(key).lower() in _SENSITIVE_CONFIG_KEYS else _redact_eval_config_secrets(item)) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return type(value)(_redact_eval_config_secrets(item) for item in value)
+    if isinstance(value, str):
+        value = _SECRET_ASSIGNMENT_RE.sub(r"\1\2=[REDACTED]", value)
+        return _HF_TOKEN_VALUE_RE.sub("[REDACTED]", value)
+    return value
+
+
+def _clone_padding_request(pad_source: Instance) -> Instance:
+    pad_instance = copy.copy(pad_source)
+    pad_instance.metadata = dict(pad_source.metadata or {})
+    pad_instance.metadata["__padding_only__"] = True
+    pad_instance.resps = []
+    pad_instance.token_counts = []
+    return pad_instance
 
 
 def _enable_reentrant_filelocks() -> None:
@@ -531,6 +561,7 @@ def simple_evaluate(
         # add info about execution
         results["config"].update(
             {
+                "model_backend": f"{type(lm).__module__}.{type(lm).__name__} ({task_type})",
                 "batch_size": batch_size,
                 "batch_sizes": (list(lm.batch_sizes.values()) if hasattr(lm, "batch_sizes") else []),
                 "device": device,
@@ -555,6 +586,8 @@ def simple_evaluate(
                 except (TypeError, ValueError):
                     resolved[key] = str(value)
             results["config"]["resolved_cli_args"] = resolved
+
+        results["config"] = _redact_eval_config_secrets(results["config"])
 
         results["git_hash"] = get_git_commit_hash()
         results["git_branch"] = get_git_branch_name()
@@ -862,6 +895,16 @@ def evaluate(
     local_rank = int(os.environ.get("LOCAL_RANK", 0))
     global_rank = int(os.environ.get("RANK", 0))
     world_size = int(os.environ.get("WORLD_SIZE", 1))
+
+    # Auto-init torch.distributed for multi-rank launches where the model
+    # backend did not call init_process_group itself (e.g. video generation
+    # models using diffusers).  Without this, evaluator collectives like
+    # gather_object / barrier crash with "process group not initialized".
+    # gloo is used because it requires no GPU and works everywhere.
+    if world_size > 1 and dist.is_available() and not dist.is_initialized():
+        dist.init_process_group(backend="gloo")
+        eval_logger.info(f"evaluator: auto-initialized gloo process group (world={world_size})")
+
     eval_logger.info(f"Running on rank {global_rank} (local rank {local_rank})")
 
     def _infer_task_request_type(task_obj: Task) -> Optional[str]:
@@ -884,6 +927,14 @@ def evaluate(
 
     if distributed_executor_backend == "accelerate" and not hasattr(lm, "accelerator"):
         lm.accelerator = Accelerator()
+
+    # Inject rank/world_size into the model so that logging (tqdm disable)
+    # and rank-conditional logic work on non-zero ranks.  Many simple models
+    # only read LOCAL_RANK for device binding and leave _rank/_world_size
+    # at their defaults (0, 1).
+    if world_size > 1:
+        lm._rank = global_rank
+        lm._world_size = world_size
 
     for task_output in eval_tasks:
         task = task_output.task
@@ -950,8 +1001,8 @@ def evaluate(
                 instances_rnk = torch.tensor(len(task._instances), device=lm.device)
                 gathered_item = lm.accelerator.gather(instances_rnk).cpu().detach().numpy().tolist()
             elif distributed_executor_backend == "torchrun":
-                instances_rnk = torch.tensor(len(task._instances), device=lm.device)
-                gathered_item = torch.zeros(world_size * 1, dtype=instances_rnk.dtype, device=lm.device)
+                instances_rnk = torch.tensor([len(task._instances)], device=lm.device)
+                gathered_item = torch.zeros(world_size, dtype=instances_rnk.dtype, device=lm.device)
                 dist.all_gather_into_tensor(gathered_item, instances_rnk)
                 gathered_item = gathered_item.cpu().detach().numpy().tolist()
             else:
@@ -1002,8 +1053,9 @@ def evaluate(
             if pad_source is None:
                 eval_logger.warning(f"Running {reqtype} requests but could not find a pad source request on rank {global_rank}; skipping rank padding.")
             else:
+                pad_instance = _clone_padding_request(pad_source)
                 for _ in range(padding_requests[reqtype]):
-                    cloned_reqs.extend([pad_source] * pad_source.repeats)
+                    cloned_reqs.extend([pad_instance] * pad_instance.repeats)
 
         # run requests through model (with optional response cache)
         if reqtype == "generate_until_agentic":
@@ -1124,6 +1176,12 @@ def evaluate(
             pbar = tqdm(total=total_docs, desc="Postprocessing", disable=(RANK != 0))
             for doc_id, doc in doc_iterator:
                 requests = instances_by_doc_id[doc_id]
+                # Defensive skip: if a doc landed in this rank's shard but has
+                # no requests (e.g. a split mismatch during a partial rerun),
+                # skip rather than crashing at `requests[0].doc` below.
+                if not requests:
+                    pbar.update(1)
+                    continue
 
                 # Strip reasoning tags before scoring
                 if reasoning_tags is not None:

--- a/lmms_eval/utils.py
+++ b/lmms_eval/utils.py
@@ -919,31 +919,6 @@ def get_datetime_str(timezone="Asia/Singapore"):
     return local_time.strftime("%Y%m%d_%H%M%S")
 
 
-def build_eval_output_dir(output_root: str, model_name: str, tasks: str, datetime_str: str) -> str:
-    """Build a structured eval output directory.
-
-    Returns ``{output_root}/{model}_{tasks}/{YYYY_MM_DD_HHMMSS}``.
-
-    *model_name* should already be sanitized (e.g. from
-    ``GeneralConfigTracker.model_name_sanitized`` or the CLI ``--model`` value).
-    *tasks* is a comma-separated task string (sanitized to underscores).
-    *datetime_str* is ``YYYYMMDD_HHMMSS`` (from :func:`get_datetime_str`)
-    and reformatted to ``YYYY_MM_DD_HHMMSS``.
-    """
-    model_sanitized = model_name or ""
-
-    # Sanitize task string: replace commas and non-word chars
-    tasks_sanitized = re.sub(r"\W+", "_", tasks.strip()).strip("_") if tasks else "unknown"
-
-    # Reformat YYYYMMDD_HHMMSS → YYYY_MM_DD_HHMMSS
-    dt = datetime_str.replace(":", "-")
-    if len(dt) >= 15 and dt[8] == "_":
-        dt = f"{dt[:4]}_{dt[4:6]}_{dt[6:]}"
-
-    subdir = f"{model_sanitized}_{tasks_sanitized}" if model_sanitized else tasks_sanitized
-    return os.path.join(output_root, subdir, dt)
-
-
 def sanitize_long_string(s, max_length=40):
     if len(s) > max_length:
         return s[: max_length // 2] + "..." + s[-max_length // 2 :]

--- a/lmms_eval/utils.py
+++ b/lmms_eval/utils.py
@@ -76,7 +76,7 @@ def escaped_split(text, sep_char, maxsplit=-1):
         return text
     maxsplit = max(0, maxsplit)
 
-    return re.split(r"(?<!\\)" + sep_char, text, maxsplit)
+    return re.split(r"(?<!\\)" + sep_char, text, maxsplit=maxsplit)
 
 
 def handle_arg_string(arg):
@@ -775,27 +775,65 @@ def run_task_tests(task_list: List[str]):
         raise ValueError(f"Not all tests for the specified tasks ({task_list}) ran successfully! Error code: {pytest_return_val}")
 
 
+def _lmms_eval_repo_root() -> pathlib.Path:
+    return pathlib.Path(__file__).resolve().parents[1]
+
+
+def _git_output(*args: str) -> str:
+    return (
+        subprocess.check_output(
+            ["git", "-C", str(_lmms_eval_repo_root()), *args],
+            stderr=subprocess.DEVNULL,
+        )
+        .strip()
+        .decode()
+    )
+
+
+def _first_env(*names: str) -> str | None:
+    for name in names:
+        value = os.environ.get(name, "").strip()
+        if value:
+            return value
+    return None
+
+
+def _normalize_branch_name(branch: str) -> str:
+    return branch.removeprefix("remotes/origin/")
+
+
+def _is_exact_git_ref_name(branch: str) -> bool:
+    return bool(branch and branch != "undefined" and "^" not in branch and "~" not in branch)
+
+
 def get_git_commit_hash():
-    """
-    Gets the git commit hash of your current repo (if it exists).
-    Source: https://github.com/EleutherAI/gpt-neox/blob/b608043be541602170bfcfb8ec9bf85e8a0799e0/megatron/neox_arguments/neox_args.py#L42
-    """
     try:
-        git_hash = subprocess.check_output(["git", "describe", "--always"]).strip()
-        git_hash = git_hash.decode()
+        git_hash = _git_output("describe", "--always")
     except (subprocess.CalledProcessError, FileNotFoundError):
-        # FileNotFoundError occurs when git not installed on system
-        git_hash = None
+        git_hash = _first_env("LMMS_EVAL_GIT_COMMIT", "GIT_COMMIT", "GITHUB_SHA")
     return git_hash
 
 
 def get_git_branch_name():
-    """Gets the current git branch name (if in a repo)."""
     try:
-        branch = subprocess.check_output(["git", "rev-parse", "--abbrev-ref", "HEAD"]).strip()
-        return branch.decode()
+        branch = _git_output("branch", "--show-current")
+        if branch:
+            return _normalize_branch_name(branch)
     except (subprocess.CalledProcessError, FileNotFoundError):
-        return None
+        pass
+
+    branch = _first_env("LMMS_EVAL_GIT_BRANCH", "GIT_BRANCH", "BRANCH_NAME", "GITHUB_REF_NAME")
+    if branch:
+        return _normalize_branch_name(branch)
+
+    try:
+        branch = _git_output("name-rev", "--name-only", "--exclude=tags/*", "HEAD")
+        if _is_exact_git_ref_name(branch):
+            return _normalize_branch_name(branch)
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        pass
+
+    return "detached" if get_git_commit_hash() else None
 
 
 def get_lmms_eval_version_string():
@@ -881,6 +919,31 @@ def get_datetime_str(timezone="Asia/Singapore"):
     return local_time.strftime("%Y%m%d_%H%M%S")
 
 
+def build_eval_output_dir(output_root: str, model_name: str, tasks: str, datetime_str: str) -> str:
+    """Build a structured eval output directory.
+
+    Returns ``{output_root}/{model}_{tasks}/{YYYY_MM_DD_HHMMSS}``.
+
+    *model_name* should already be sanitized (e.g. from
+    ``GeneralConfigTracker.model_name_sanitized`` or the CLI ``--model`` value).
+    *tasks* is a comma-separated task string (sanitized to underscores).
+    *datetime_str* is ``YYYYMMDD_HHMMSS`` (from :func:`get_datetime_str`)
+    and reformatted to ``YYYY_MM_DD_HHMMSS``.
+    """
+    model_sanitized = model_name or ""
+
+    # Sanitize task string: replace commas and non-word chars
+    tasks_sanitized = re.sub(r"\W+", "_", tasks.strip()).strip("_") if tasks else "unknown"
+
+    # Reformat YYYYMMDD_HHMMSS → YYYY_MM_DD_HHMMSS
+    dt = datetime_str.replace(":", "-")
+    if len(dt) >= 15 and dt[8] == "_":
+        dt = f"{dt[:4]}_{dt[4:6]}_{dt[6:]}"
+
+    subdir = f"{model_sanitized}_{tasks_sanitized}" if model_sanitized else tasks_sanitized
+    return os.path.join(output_root, subdir, dt)
+
+
 def sanitize_long_string(s, max_length=40):
     if len(s) > max_length:
         return s[: max_length // 2] + "..." + s[-max_length // 2 :]
@@ -917,6 +980,58 @@ def import_function(loader, node):
     except Exception as ex:
         # Re-raise with context to aid debugging
         raise ImportError(f"Failed to import function '{function_name}' from module '{module_name}'. " f"Tried relative path '{module_path}' and absolute import.") from ex
+
+
+_LOCAL_BUILDERS = frozenset({"csv", "json", "parquet", "text", "pandas", "arrow"})
+
+
+def _looks_like_url(value: str) -> bool:
+    return value.startswith(("http://", "https://", "s3://", "gs://", "ftp://", "ftps://"))
+
+
+def _resolve_local_data_files(value, yaml_dir: str):
+    """Rewrite relative ``data_files`` paths to absolute paths anchored at ``yaml_dir``.
+
+    Conservative: only rewrites a string when it's a relative path AND the
+    resolved absolute path exists on disk. Leaves absolute paths, URLs, and
+    non-existent relatives untouched. Recurses into dict/list to handle the
+    ``data_files: {train: <path>, validation: <path>}`` and ``data_files:
+    [<path>, <path>]`` shapes that ``datasets.load_dataset`` accepts.
+    """
+    if isinstance(value, str):
+        if not value or _looks_like_url(value) or os.path.isabs(value):
+            return value
+        candidate = os.path.join(yaml_dir, value)
+        if os.path.isfile(candidate):
+            return candidate
+        return value
+    if isinstance(value, dict):
+        return {k: _resolve_local_data_files(v, yaml_dir) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_resolve_local_data_files(v, yaml_dir) for v in value]
+    return value
+
+
+def _maybe_resolve_yaml_local_data_files(yaml_config: dict, yaml_dir: str) -> dict:
+    """Resolve ``dataset_kwargs.data_files`` relative paths against ``yaml_dir``.
+
+    Only applied for the generic local builders (``csv``, ``json``,
+    ``parquet``, ``text``, ``pandas``, ``arrow``). For HF hub dataset
+    paths (e.g. ``lmms-lab-eval/ssv2``) ``data_files`` is left as-is to
+    preserve the upstream behavior of letting HF resolve relative paths
+    against the dataset's hub root.
+    """
+    dataset_path = yaml_config.get("dataset_path")
+    if not isinstance(dataset_path, str) or dataset_path not in _LOCAL_BUILDERS:
+        return yaml_config
+    dataset_kwargs = yaml_config.get("dataset_kwargs")
+    if not isinstance(dataset_kwargs, dict) or "data_files" not in dataset_kwargs:
+        return yaml_config
+    resolved = _resolve_local_data_files(dataset_kwargs["data_files"], yaml_dir)
+    if resolved is dataset_kwargs["data_files"]:
+        return yaml_config
+    new_kwargs = {**dataset_kwargs, "data_files": resolved}
+    return {**yaml_config, "dataset_kwargs": new_kwargs}
 
 
 def load_yaml_config(yaml_path=None, yaml_config=None, yaml_dir=None, mode="full"):
@@ -962,8 +1077,8 @@ def load_yaml_config(yaml_path=None, yaml_config=None, yaml_dir=None, mode="full
                 raise ex
 
         final_yaml_config.update(yaml_config)
-        return final_yaml_config
-    return yaml_config
+        return _maybe_resolve_yaml_local_data_files(final_yaml_config, yaml_dir)
+    return _maybe_resolve_yaml_local_data_files(yaml_config, yaml_dir)
 
 
 def regex_replace(string, pattern, repl, count: int = 0):


### PR DESCRIPTION
## Core evaluator / cache / utils correctness fixes

A cluster of standalone correctness fixes for the eval pipeline, response cache, and utils. No new dependencies; all changes are additive or in-place bug fixes.

### `lmms_eval/caching/cache.py`
- `save_to_cache` accumulated per-item results into `serializable_item` and appended to `serializable_obj`. Before, the loop mutated `subitem.arguments` but never appended anything, so the cache always pickled an **empty list**.
- Reviewer caveat: the request cache key does not fingerprint dataset contents, so with `--cache_requests` (opt-in, default off) a dataset changed in place under an unchanged task config will reuse stale requests. That key design predates this PR — flagging it because the cache now actually works and the caveat becomes reachable.

### `lmms_eval/caching/response_cache.py`
- Task fingerprinting now recurses into nested task groups (`_collect_fingerprints`), so subtasks get real config fingerprints instead of silently falling back to empty strings.

### `lmms_eval/evaluator.py`
- **Secret redaction**: sensitive keys are redacted from `results["config"]` before it is written out. Matching is suffix-based (`*api_key` / `*_token` / `*_secret` / `*password`, plus the exact-name set and `key=value` assignments inside `model_args` strings), so `openai_api_key=` and friends don't slip through.
- **Padding aliasing fix**: rank-padding built `[pad_source] * n`, aliasing a single `Instance` so all padding requests shared one `resps`/`token_counts` list. Now each padding slot is a distinct isolated clone (`_clone_padding_request` inside the loop).
- **Multi-rank auto-init (torchrun path only)**: on `distributed_executor_backend="torchrun"`, when `world_size > 1` and `torch.distributed` is uninitialized, auto-init a `gloo` process group so backends that never call `init_process_group` don't crash evaluator collectives — guarded on `MASTER_ADDR`/`MASTER_PORT` being present (clear warning + skip otherwise, instead of raising). The default `accelerate` path is untouched: the evaluator's `Accelerator()` fallback creates its own state, so GPU collectives are never silently downgraded onto a pre-created gloo group.
- **torchrun gather fix**: `all_gather_into_tensor` now uses a 1-D input tensor and a `world_size`-sized buffer.
- **Defensive skip**: docs that land in a rank's shard with no requests are skipped instead of crashing at `requests[0].doc`.

### `lmms_eval/utils.py`
- Robust `get_git_commit_hash` / `get_git_branch_name`: anchored at the repo root (works regardless of CWD), with env fallbacks (`LMMS_EVAL_GIT_COMMIT` / `GIT_COMMIT` / `GITHUB_SHA`, `LMMS_EVAL_GIT_BRANCH` / `GIT_BRANCH` / `BRANCH_NAME` / `GITHUB_REF_NAME`) and detached-HEAD handling.
- Local dataset builders (`csv`/`json`/`parquet`/`text`/`pandas`/`arrow`) now resolve relative `dataset_kwargs.data_files` paths to absolute against the YAML dir; HF-hub dataset paths are left untouched.
- py3.13 fix: `re.split(..., maxsplit=maxsplit)` (positional `maxsplit` is deprecated in 3.13).

### Validation
- `py_compile` clean on all four files; pre-commit black+isort clean; `ruff` introduces no new findings.
- Ported helpers unit-exercised: git resolution + env fallbacks + detached HEAD, `data_files` resolution, secret redaction (prefixed keys + string-form assignments), and padding-clone isolation (N distinct objects for N slots).

### Review pass (2026-07-06)
Self-review follow-up commit: gated the gloo auto-init to the torchrun path with the MASTER_ADDR/PORT guard (see above), moved the padding clone inside the loop so slots are truly isolated, switched redaction to suffix matching, and dropped an unused `build_eval_output_dir` helper that had no callers.
