### PR TITLE
feat: add verifiers module - pluggable per-sample verification pipeline

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ This documentation covers every layer of `lmms-eval` — from running your first
 - [Extending the Framework](#extending-the-framework)
   - [Adding a Model](#adding-a-model)
   - [Adding a Task](#adding-a-task)
+  - [Verifying Results](#verifying-results)
 - [Using lmms-eval as a Library](#using-lmms-eval-as-a-library)
 - [Performance and Caching](#performance-and-caching)
 - [Task Catalog](#task-catalog)
@@ -150,6 +151,10 @@ generation_kwargs:
 metric_list:
   - metric: acc
 ```
+
+### Verifying Results
+
+The [Verifiers Guide](guides/verifiers_guide.md) covers `lmms_eval.verifiers`, a pluggable per-sample verification pipeline for scoring predictions in `process_results` - rule-based matching (exact/contains/MCQ/numeric), LLM-as-judge (OpenAI, Gemini), and composite fallback chains, all built from extractors that clean model output before it's judged.
 
 ## Using lmms-eval as a Library
 

--- a/docs/guides/verifiers_guide.md
+++ b/docs/guides/verifiers_guide.md
@@ -1,0 +1,114 @@
+# Verifiers Guide
+
+`lmms_eval.verifiers` is a small, pluggable module for deciding whether a model's prediction is correct. It sits between raw model output and `process_results`, and it complements (does not replace) the batch-level `Filter` system in `lmms_eval.filters` - filters operate on a full response list, verifiers operate per-sample.
+
+## Two-Layer Abstraction
+
+| Layer | Role | Location |
+|-------|------|----------|
+| **Extractor** | Per-sample text transform applied before verification (strip reasoning, regex, MCQ letter, number) | `lmms_eval/verifiers/extractors.py` |
+| **Verifier** | Judges correctness given `(question, prediction, ground_truth)` and returns a `VerifyResult` | `lmms_eval/verifiers/rule.py`, `openai.py`, `gemini.py`, `composite.py` |
+
+Both are composed by a `VerificationPipeline`:
+
+```
+raw model output -> extractor 1 -> extractor 2 -> verifier -> VerifyResult
+```
+
+## Quick Start
+
+```python
+from lmms_eval.verifiers import VerificationPipeline
+from lmms_eval.verifiers.extractors import StripReasoningExtractor
+from lmms_eval.verifiers.rule import ExactMatchVerifier
+
+pipeline = VerificationPipeline(
+    extractors=[StripReasoningExtractor()],
+    verifier=ExactMatchVerifier(ignore_case=True),
+)
+result = pipeline("What color is the sky?", "<think>hmm</think>Blue", "Blue")
+assert result.is_correct
+```
+
+Or build one from a config dict (handy for YAML-driven tasks):
+
+```python
+from lmms_eval.verifiers import build_verification_pipeline
+
+pipeline = build_verification_pipeline({
+    "extractors": [{"type": "strip_reasoning"}],
+    "verifier": {"type": "openai", "model": "gpt-4o-2024-11-20", "judge_type": "binary"},
+})
+```
+
+## Built-in Extractors
+
+| Type | Class | What it does |
+|------|-------|---------------|
+| `strip_reasoning` | `StripReasoningExtractor` | Removes `<think>...</think>` / `<thinking>...</thinking>` blocks |
+| `regex` | `RegexExtractor` | Returns the first regex capture group, with a fallback default |
+| `mcq` | `MCQExtractor` | Extracts a multiple-choice letter from common answer formats |
+| `number` | `NumberExtractor` | Extracts `\boxed{...}` content or the last number in the text |
+| `strip` | `StripExtractor` | Strips whitespace and common special tokens (`</s>`, `<\|im_end\|>`, ...) |
+
+## Built-in Verifiers
+
+| Type | Class | What it does |
+|------|-------|---------------|
+| `exact_match` | `ExactMatchVerifier` | Case/whitespace-normalized exact string match |
+| `contains` | `ContainsVerifier` | Ground truth appears as a substring of the prediction |
+| `mcq_match` | `MCQMatchVerifier` | Multiple-choice letter match, tolerant of `(A)` / `A.` / `A)` formatting |
+| `numeric` | `NumericToleranceVerifier` | Numeric comparison within relative/absolute tolerance |
+| `openai` | `OpenAIVerifier` | LLM-as-judge via `lmms_eval.llm_judge` (binary, score, comparative, or custom-prompt modes) |
+| `gemini` | `GeminiVerifier` | LLM-as-judge via the Gemini SDK, including multimodal (text + image) judging |
+| `composite` | `CompositeVerifier` | Chains verifiers, falling through to the next when one reports low confidence |
+
+`openai` and `gemini` are lazily imported so the module has no hard dependency on either SDK unless you actually instantiate that verifier.
+
+### Composite Fallback
+
+Run a cheap rule-based check first, and only pay for an LLM judge when the cheap check is uncertain. A verifier signals uncertainty via `result.metadata["confident"] = False`; the composite verifier moves to the next one in the chain when it sees that flag, and always accepts the last verifier's result regardless of confidence.
+
+```python
+from lmms_eval.verifiers.composite import CompositeVerifier
+from lmms_eval.verifiers.rule import ExactMatchVerifier
+from lmms_eval.verifiers.openai import OpenAIVerifier
+
+verifier = CompositeVerifier([
+    ExactMatchVerifier(),   # fast, always confident
+    OpenAIVerifier(),       # expensive fallback
+])
+```
+
+## Using it in a Task
+
+Call the pipeline from `process_results` in your task's `utils.py`, same as any other scoring helper:
+
+```python
+from lmms_eval.verifiers import build_verification_pipeline
+
+_pipeline = build_verification_pipeline({
+    "extractors": [{"type": "strip_reasoning"}],
+    "verifier": {"type": "exact_match"},
+})
+
+def my_process_results(doc, results):
+    prediction = results[0]
+    verdict = _pipeline(doc["question"], prediction, doc["answer"])
+    return {"acc": 1.0 if verdict.is_correct else 0.0}
+```
+
+## Writing a Custom Verifier or Extractor
+
+Subclass `Verifier` or `Extractor` from `lmms_eval.verifiers.base` and implement `verify` / `extract`:
+
+```python
+from lmms_eval.verifiers.base import Verifier, VerifyResult
+
+class MyVerifier(Verifier):
+    def verify(self, question, prediction, ground_truth, **kwargs) -> VerifyResult:
+        correct = my_custom_check(prediction, ground_truth)
+        return VerifyResult(score=1.0 if correct else 0.0, is_correct=correct)
+```
+
+To make it available to `build_verification_pipeline` via a config `"type"` string, register it in `VERIFIER_REGISTRY` (or `EXTRACTOR_REGISTRY`) from `lmms_eval.verifiers`.

--- a/docs/guides/verifiers_guide.md
+++ b/docs/guides/verifiers_guide.md
@@ -59,7 +59,7 @@ pipeline = build_verification_pipeline({
 | `contains` | `ContainsVerifier` | Ground truth appears as a substring of the prediction |
 | `mcq_match` | `MCQMatchVerifier` | Multiple-choice letter match, tolerant of `(A)` / `A.` / `A)` formatting |
 | `numeric` | `NumericToleranceVerifier` | Numeric comparison within relative/absolute tolerance |
-| `openai` | `OpenAIVerifier` | LLM-as-judge via `lmms_eval.llm_judge` (binary, score, comparative, or custom-prompt modes) |
+| `openai` | `OpenAIVerifier` | LLM-as-judge via `lmms_eval.llm_judge`; `judge_type` is `binary` or `comparative`, with score-style output set by `response_format` and custom prompts by `custom_prompt` |
 | `gemini` | `GeminiVerifier` | LLM-as-judge via the Gemini SDK, including multimodal (text + image) judging |
 | `composite` | `CompositeVerifier` | Chains verifiers, falling through to the next when one reports low confidence |
 
@@ -67,7 +67,12 @@ pipeline = build_verification_pipeline({
 
 ### Composite Fallback
 
-Run a cheap rule-based check first, and only pay for an LLM judge when the cheap check is uncertain. A verifier signals uncertainty via `result.metadata["confident"] = False`; the composite verifier moves to the next one in the chain when it sees that flag, and always accepts the last verifier's result regardless of confidence.
+Run a cheap rule-based check first, and only pay for an LLM judge when the cheap check is uncertain. A verifier signals uncertainty via `result.metadata["confident"] = False`; the composite verifier moves to the next one in the chain when it sees that flag, and always accepts the last verifier's result regardless of confidence. A result with no `confident` key counts as confident (the chain stops), so every rule verifier sets the key explicitly.
+
+Rule verifiers follow a two-tier convention for `confident`:
+
+- **String-match** verifiers (`exact_match`, `contains`) treat any non-match as low-confidence, so a mismatch falls through to the next verifier.
+- **Parse-based** verifiers (`mcq_match`, `numeric`) treat only a *parse failure* as low-confidence — `mcq_match` when no single MCQ letter can be extracted, `numeric` when either the prediction or ground truth can't be parsed as a number. A cleanly-parsed but wrong answer is a *confident wrong* and does **not** fall through.
 
 ```python
 from lmms_eval.verifiers.composite import CompositeVerifier
@@ -78,6 +83,19 @@ verifier = CompositeVerifier([
     ExactMatchVerifier(),   # fast, always confident
     OpenAIVerifier(),       # expensive fallback
 ])
+```
+
+### Judge Failures
+
+The LLM-judge verifiers (`openai`, `gemini`) never raise out of `verify`. When the judge call fails — an exception, retry exhaustion, or the provider reporting `success=False` — they return a `VerifyResult` with `score=0.0` / `is_correct=False` **and** `metadata["judge_failed"] = True`. The score stays 0 so nothing downstream breaks, but the flag lets a task tell an infra failure apart from a genuinely wrong prediction, instead of silently counting it as wrong:
+
+```python
+def my_process_results(doc, results):
+    verdict = _pipeline(doc["question"], results[0], doc["answer"])
+    if verdict.metadata.get("judge_failed"):
+        # judge infra failed — track separately so it doesn't count against acc
+        return {"acc": 0.0, "judge_failed": 1.0}
+    return {"acc": 1.0 if verdict.is_correct else 0.0, "judge_failed": 0.0}
 ```
 
 ## Using it in a Task

--- a/lmms_eval/tasks/ami/utils.py
+++ b/lmms_eval/tasks/ami/utils.py
@@ -1,19 +1,15 @@
 import os
 import re
 import string
+import threading
 
 import numpy as np
 from loguru import logger as eval_logger
 
-from lmms_eval.llm_judge import ServerConfig, get_server
+from lmms_eval.verifiers import VerificationPipeline, VerifyResult
+from lmms_eval.verifiers.openai import OpenAIVerifier
 
-API_TYPE = os.getenv("API_TYPE", "openai")
 JUDGE_MODEL_VERSION = os.getenv("JUDGE_MODEL_VERSION", "gpt-4o-mini")
-
-server_config = ServerConfig(
-    model_name=JUDGE_MODEL_VERSION,
-)
-server = get_server(server_name=API_TYPE, config=server_config)
 
 
 def get_column_value(doc, candidates):
@@ -259,16 +255,7 @@ def calculate_wer(reference, hypothesis):
     return wer
 
 
-def ami_process_results_llm_judge(doc, results):
-    """
-    Process results using LLM as judge for open-ended evaluation.
-    Similar to voicebench's open-ended evaluation.
-    """
-    parsed_preds = []
-    scores = []
-
-    # Evaluation prompt template
-    meta_prompt = """I need your help to evaluate the quality of an automatic speech recognition (ASR) transcription.
+AMI_LLM_JUDGE_PROMPT = """I need your help to evaluate the quality of an automatic speech recognition (ASR) transcription.
 
 You will be provided with:
 1. [Reference]: The ground truth transcription
@@ -288,6 +275,51 @@ Below are the reference and hypothesis transcriptions:
 After evaluating, please output the score only without anything else.
 You don't need to provide any explanations."""
 
+
+# Previously sent as a system message; now included as a prefix in the user prompt.
+_AMI_SYSTEM_INSTRUCTION = "You are a helpful assistant who evaluates speech recognition quality."
+
+
+def _ami_judge_prompt_fn(question, prediction, ground_truth, **kwargs):
+    prompt = AMI_LLM_JUDGE_PROMPT.format(reference=ground_truth, hypothesis=prediction)
+    return f"{_AMI_SYSTEM_INSTRUCTION}\n\n{prompt}"
+
+
+def _parse_raw_score(text):
+    """Parse raw 1-5 score without normalization."""
+    numbers = re.findall(r"\d+(?:\.\d+)?", text.strip())
+    score = float(numbers[0]) if numbers else 0.0
+    return VerifyResult(score=score, is_correct=score >= 3.0, raw_output=text)
+
+
+_ami_judge_pipeline = None
+_ami_judge_pipeline_lock = threading.Lock()
+
+
+def _get_ami_judge_pipeline():
+    global _ami_judge_pipeline
+    if _ami_judge_pipeline is None:
+        with _ami_judge_pipeline_lock:
+            if _ami_judge_pipeline is None:  # double-check
+                _ami_judge_pipeline = VerificationPipeline(
+                    verifier=OpenAIVerifier(
+                        model=JUDGE_MODEL_VERSION,
+                        custom_prompt=_ami_judge_prompt_fn,
+                        response_parser=_parse_raw_score,
+                        temperature=0.5,
+                        max_tokens=10,
+                    ),
+                )
+    return _ami_judge_pipeline
+
+
+def ami_process_results_llm_judge(doc, results):
+    """
+    Process results using LLM as judge for open-ended evaluation.
+    Similar to voicebench's open-ended evaluation.
+    """
+    scores = []
+
     for pred in results:
         prediction = pred.strip() if isinstance(pred, str) else str(pred)
 
@@ -304,34 +336,9 @@ You don't need to provide any explanations."""
         # Get reference text
         reference_text = get_column_value(doc, ["text", "transcript", "transcription"])
 
-        formatted_prompt = meta_prompt.format(reference=reference_text, hypothesis=prediction)
-
-        try:
-            from lmms_eval.llm_judge.protocol import Request, ServerConfig
-
-            custom_config = ServerConfig(model_name=JUDGE_MODEL_VERSION, temperature=0.5, max_tokens=10)
-
-            request = Request(messages=[{"role": "system", "content": "You are a helpful assistant who evaluates speech recognition quality."}, {"role": "user", "content": formatted_prompt}], config=custom_config)
-
-            response = server.evaluate(request)
-
-            if response.success:
-                judge_response = response.content.strip()
-                try:
-                    judge_score = int(judge_response)
-                except ValueError:
-                    eval_logger.error(f"Failed to parse score: {judge_response}")
-                    judge_score = 0.0
-            else:
-                eval_logger.error(f"Judge evaluation failed: {response.content}")
-                judge_score = 0.0
-
-        except Exception as e:
-            eval_logger.error(f"Error getting judge response: {e}")
-            judge_score = 0.0
-
-        scores.append(judge_score)
-        parsed_preds.append(prediction)
+        pipeline = _get_ami_judge_pipeline()
+        result = pipeline(question="", prediction=prediction, ground_truth=reference_text)
+        scores.append(result.score)
 
     avg_score = sum(scores) / len(scores) if scores else 0.0
     return {"llm_as_judge_eval": avg_score}

--- a/lmms_eval/tasks/browsecomp/utils.py
+++ b/lmms_eval/tasks/browsecomp/utils.py
@@ -2,6 +2,7 @@ import base64
 import hashlib
 import os
 import re
+import threading
 from collections import defaultdict
 from pathlib import Path
 
@@ -22,23 +23,43 @@ def _load_yaml_stripped(path: Path) -> dict:
 _config = _load_yaml_stripped(_default_template_path)
 _config.update(_load_yaml_stripped(_browsecomp_config_path))
 
-_judge_server = None
-_judge_server_config = None
-if _config.get("metadata", {}).get("use_lmms_judge"):
-    try:
-        from lmms_eval.llm_judge import get_server
-        from lmms_eval.llm_judge.protocol import ServerConfig
+_use_lmms_judge = _config.get("metadata", {}).get("use_lmms_judge", False)
 
-        API_TYPE = os.getenv("API_TYPE", "openai").lower()
-        DEPLOYMENT_NAME = os.getenv("DEPLOYMENT_NAME") or os.getenv("OPENAI_API_MODEL", "gpt-4o")
+# Lazy pipeline singleton for LLM judge
+_pipeline = None
+_pipeline_lock = threading.Lock()
 
-        _judge_server_config = ServerConfig(model_name=DEPLOYMENT_NAME)
-        _judge_server = get_server(server_name=API_TYPE, config=_judge_server_config)
-        eval_logger.info("Using LMMS judge server for BrowseComp task.")
-    except Exception as err:
-        eval_logger.warning("Failed to initialize LMMS judge for BrowseComp: {}", err)
-        _judge_server = None
-        _judge_server_config = None
+
+def _get_pipeline():
+    global _pipeline
+    if _pipeline is None:
+        with _pipeline_lock:
+            if _pipeline is None:  # double-check
+                from lmms_eval.verifiers import VerificationPipeline
+                from lmms_eval.verifiers.extractors import StripReasoningExtractor
+                from lmms_eval.verifiers.openai import OpenAIVerifier
+
+                API_TYPE = os.getenv("API_TYPE", "openai").lower()
+                DEPLOYMENT_NAME = os.getenv("DEPLOYMENT_NAME") or os.getenv("OPENAI_API_MODEL", "gpt-4o")
+
+                def _build_prompt(question, prediction, ground_truth, **kwargs):
+                    return BROWSECOMP_JUDGE_PROMPT.format(
+                        question=question,
+                        response=prediction,
+                        correct_answer=ground_truth,
+                    )
+
+                _pipeline = VerificationPipeline(
+                    extractors=[StripReasoningExtractor()],
+                    verifier=OpenAIVerifier(
+                        model=DEPLOYMENT_NAME,
+                        api_type=API_TYPE,
+                        custom_prompt=_build_prompt,
+                        response_format="binary",
+                    ),
+                )
+                eval_logger.info("Using LMMS judge server for BrowseComp task.")
+    return _pipeline
 
 
 BROWSECOMP_JUDGE_PROMPT = """Judge whether the following [response] to [question] is correct based on the [correct_answer].
@@ -128,25 +149,18 @@ def _normalize_for_exact_match(text: str) -> str:
 
 
 def _judge_is_correct(question: str, response: str, correct_answer: str):
-    if _judge_server is None or _judge_server_config is None:
+    if not _use_lmms_judge:
         return None
 
     try:
-        from lmms_eval.llm_judge.protocol import Request
-
-        submit_prompt = BROWSECOMP_JUDGE_PROMPT.format(
-            question=question,
-            response=response,
-            correct_answer=correct_answer,
-        )
-        request = Request(messages=[{"role": "user", "content": submit_prompt}], config=_judge_server_config)
-        judge_response_obj = _judge_server.evaluate(request)
-        judge_result = str(judge_response_obj.content).strip().lower()
-
-        if "incorrect" in judge_result:
-            return False
-        if "correct" in judge_result:
-            return True
+        pipeline = _get_pipeline()
+        result = pipeline(question=question, prediction=response, ground_truth=correct_answer)
+        # OpenAIVerifier swallows judge-call errors and flags them via
+        # judge_failed metadata; return None so the caller falls back to exact
+        # match instead of scoring an infra failure as incorrect.
+        if result.metadata.get("judge_failed"):
+            return None
+        return result.is_correct
     except Exception as err:
         eval_logger.debug("BrowseComp LLM judge failed, fallback to exact match: {}", err)
 

--- a/lmms_eval/tasks/corecognition/utils.py
+++ b/lmms_eval/tasks/corecognition/utils.py
@@ -7,6 +7,7 @@ with optional LLM judge fallback when enabled via task config (see stare/utils.p
 import logging
 import os
 import re
+import threading
 from collections import defaultdict
 from pathlib import Path
 from typing import Any, Dict, Optional
@@ -30,24 +31,43 @@ def _load_yaml_stripped(path: Path) -> dict:
 _corecognition_config = _load_yaml_stripped(_default_template_path)
 _corecognition_config.update(_load_yaml_stripped(_corecognition_config_path))
 
-# Initialize LLM judge server when use_lmms_judge is True (reference: stare/utils.py)
-_judge_server = None
-_judge_server_config = None
-if _corecognition_config.get("metadata", {}).get("use_lmms_judge"):
-    try:
-        from lmms_eval.llm_judge import get_server
-        from lmms_eval.llm_judge.protocol import ServerConfig
+_use_lmms_judge = _corecognition_config.get("metadata", {}).get("use_lmms_judge", False)
 
-        eval_logger.info("Using LMMS judge server for CoreCognition task.")
-        API_TYPE = os.getenv("API_TYPE", "openai").lower()
-        DEPLOYMENT_NAME = os.getenv("DEPLOYMENT_NAME") or os.getenv("OPENAI_API_MODEL", "gpt-4o")
+# Lazy pipeline singleton for LLM judge
+_pipeline = None
+_pipeline_lock = threading.Lock()
 
-        _judge_server_config = ServerConfig(model_name=DEPLOYMENT_NAME)
-        _judge_server = get_server(server_name=API_TYPE, config=_judge_server_config)
-    except Exception as e:
-        eval_logger.warning("Failed to initialize LMMS judge for CoreCognition: %s", e)
-        _judge_server = None
-        _judge_server_config = None
+
+def _get_pipeline():
+    global _pipeline
+    if _pipeline is None:
+        with _pipeline_lock:
+            if _pipeline is None:  # double-check
+                from lmms_eval.verifiers import VerificationPipeline
+                from lmms_eval.verifiers.extractors import StripReasoningExtractor
+                from lmms_eval.verifiers.openai import OpenAIVerifier
+
+                eval_logger.info("Using LMMS judge server for CoreCognition task.")
+                API_TYPE = os.getenv("API_TYPE", "openai").lower()
+                DEPLOYMENT_NAME = os.getenv("DEPLOYMENT_NAME") or os.getenv("OPENAI_API_MODEL", "gpt-4o")
+
+                def _build_prompt(question, prediction, ground_truth, **kwargs):
+                    return CORECOGNITION_JUDGE_PROMPT.format(
+                        response=prediction,
+                        answer=ground_truth,
+                    )
+
+                _pipeline = VerificationPipeline(
+                    extractors=[StripReasoningExtractor()],
+                    verifier=OpenAIVerifier(
+                        model=DEPLOYMENT_NAME,
+                        api_type=API_TYPE,
+                        custom_prompt=_build_prompt,
+                        response_format="binary",
+                    ),
+                )
+    return _pipeline
+
 
 # Judge prompt for binary correct/incorrect (same style as stare create_test_prompt)
 CORECOGNITION_JUDGE_PROMPT = """You are judging whether a model's response matches the correct answer for a single-choice or yes/no question.
@@ -57,12 +77,6 @@ Otherwise output Incorrect. Output only one word: Correct or Incorrect.
 Response: {response}
 Answer: {answer}
 Correct_or_not:"""
-
-
-def _create_judge_prompt(doc: dict[str, Any], pred: str) -> str:
-    """Build judge prompt: response + ground truth answer."""
-    answer = str(doc.get("answer", "")).strip()
-    return CORECOGNITION_JUDGE_PROMPT.format(response=pred, answer=answer)
 
 
 # Answer options for template matching
@@ -199,19 +213,21 @@ def corecognition_process_results(doc: dict[str, Any], results: list[str]) -> di
         is_correct = matched == gt_normalized
     else:
         # Template match failed: try LLM judge if enabled, else direct comparison
-        if _judge_server is not None and _judge_server_config is not None:
+        if _use_lmms_judge:
             try:
-                from lmms_eval.llm_judge.protocol import Request
-
-                submit_prompt = _create_judge_prompt(doc, pred)
-                request = Request(
-                    messages=[{"role": "user", "content": submit_prompt}],
-                    config=_judge_server_config,
-                )
-                judge_response_obj = _judge_server.evaluate(request)
-                judge_result = judge_response_obj.content.strip().lower()
-                is_correct = "correct" in judge_result and "incorrect" not in judge_result
+                pipeline = _get_pipeline()
+                result = pipeline(question=pred, prediction=pred, ground_truth=ground_truth)
+                if result.metadata.get("judge_failed"):
+                    # OpenAIVerifier swallows judge-call errors and flags them
+                    # here; fall back to direct comparison rather than counting
+                    # an infra failure as a wrong answer.
+                    pred_normalized = _rm_model_special(pred).upper().strip()
+                    gt_normalized = ground_truth.upper().strip()
+                    is_correct = pred_normalized == gt_normalized
+                else:
+                    is_correct = result.is_correct
             except Exception as e:
+                # Pipeline construction (import/config) failed.
                 eval_logger.debug("CoreCognition LLM judge failed, falling back to direct comparison: %s", e)
                 pred_normalized = _rm_model_special(pred).upper().strip()
                 gt_normalized = ground_truth.upper().strip()

--- a/lmms_eval/tasks/llava-bench-coco/utils.py
+++ b/lmms_eval/tasks/llava-bench-coco/utils.py
@@ -1,6 +1,6 @@
 import json
 import os
-import time
+import threading
 from copy import deepcopy
 from pathlib import Path
 
@@ -8,7 +8,8 @@ import numpy as np
 import yaml
 from loguru import logger as eval_logger
 
-from lmms_eval.llm_judge import Request, ServerConfig, get_server
+from lmms_eval.verifiers import VerificationPipeline, VerifyResult
+from lmms_eval.verifiers.openai import OpenAIVerifier
 
 NUM_SECONDS_TO_SLEEP = 0.5
 
@@ -29,60 +30,70 @@ with open(Path(__file__).parent / "llava-bench-coco.yaml", "r") as f:
 GPT_EVAL_MODEL_NAME = os.getenv("MODEL_VERSION", "gpt-4o-2024-11-20")
 API_TYPE = os.getenv("API_TYPE", "openai")
 
-# Initialize the judge server
-server_config = ServerConfig(model_name=GPT_EVAL_MODEL_NAME, temperature=0.2, max_tokens=1024)
-server = get_server(server_name=API_TYPE, config=server_config)
+# Previously sent as a system message; now included as a prefix in the user prompt.
+_SYSTEM_INSTRUCTION = "You are a helpful and precise assistant for checking the quality of the answer."
 
 
-def get_eval(content: str, max_tokens: int, retries: int = 3):
-    messages = [
-        {
-            "role": "system",
-            "content": "You are a helpful and precise assistant for checking the quality of the answer.",
-        },
-        {"role": "user", "content": content},
-    ]
-
-    # Update server config with specific parameters for this request
-    custom_config = ServerConfig(model_name=GPT_EVAL_MODEL_NAME, temperature=0.2, max_tokens=max_tokens)
-
-    for attempt in range(retries):
-        try:
-            # Create a Request object for the unified judge API
-            request = Request(messages=messages, config=custom_config)
-
-            # Use the unified judge API
-            response = server.evaluate(request)
-
-            content = response.content.strip() if response.content else ""
-            if content != "":
-                return content, response.model_used
-            break  # If successful, break out of the loop
-
-        except Exception as e:
-            eval_logger.info(f"Attempt {attempt + 1} failed with error: {str(e)}")
-            if attempt < retries - 1:  # If we have retries left, sleep and then continue to next attempt
-                time.sleep(NUM_SECONDS_TO_SLEEP)
-            else:  # If this was the last attempt, log and return empty
-                eval_logger.error(f"All {retries} attempts failed. Last error message: {str(e)}")
-                return "", ""
-    return "", ""
+# ---------------------------------------------------------------------------
+# Verification pipeline (replaces get_eval + parse_score)
+# ---------------------------------------------------------------------------
 
 
-def parse_score(review):
+def _parse_comparative_scores(text: str) -> VerifyResult:
+    """Parse two scores from the first line of the judge response.
+
+    Matches the original parse_score logic: split first line by space
+    after replacing commas, expect exactly 2 values.
+    """
     try:
-        score_pair = review.split("\n")[0]
+        score_pair = text.strip().split("\n")[0]
         score_pair = score_pair.replace(",", " ")
         sp = score_pair.split(" ")
         if len(sp) == 2:
-            return [float(sp[0]), float(sp[1])]
+            scores = [float(sp[0]), float(sp[1])]
         else:
-            eval_logger.debug("error", review)
-            return [-1, -1]
+            eval_logger.debug("error", text)
+            scores = [-1, -1]
     except Exception as e:
         eval_logger.debug(e)
-        eval_logger.debug("error", review)
-        return [-1, -1]
+        eval_logger.debug("error", text)
+        scores = [-1, -1]
+    return VerifyResult(
+        score=scores[1] / 10.0 if scores[1] > 0 else 0.0,
+        is_correct=scores[1] > scores[0],
+        raw_output=text,
+        metadata={"scores": scores},
+    )
+
+
+def _build_coco_prompt(question, prediction, ground_truth, **kwargs):
+    """Build the full prompt, preserving the original system instruction."""
+    return f"{_SYSTEM_INSTRUCTION}\n\n{kwargs['content']}"
+
+
+_pipeline = None
+_pipeline_lock = threading.Lock()
+
+
+def _get_pipeline() -> VerificationPipeline:
+    global _pipeline
+    if _pipeline is None:
+        with _pipeline_lock:
+            if _pipeline is None:  # double-check
+                _pipeline = VerificationPipeline(
+                    extractors=[],
+                    verifier=OpenAIVerifier(
+                        model=GPT_EVAL_MODEL_NAME,
+                        api_type=API_TYPE,
+                        custom_prompt=_build_coco_prompt,
+                        response_parser=_parse_comparative_scores,
+                        temperature=0.2,
+                        max_tokens=1024,
+                        max_retries=3,
+                        retry_delay=0.5,
+                    ),
+                )
+    return _pipeline
 
 
 def llava_doc_to_visual(doc):
@@ -117,8 +128,12 @@ def llava_process_results(doc, result):
         role = rule.get("role", "user")
         content = f"[Context]\n{context}\n\n" f"[Question]\n{question}\n\n" f"[{role} 1]\n{ans1}\n\n[End of {role} 1]\n\n" f"[{role} 2]\n{ans2}\n\n[End of {role} 2]\n\n" f"[System]\n{prompt}\n\n"
 
-        review, model_name = get_eval(content, 1024)
-        scores = parse_score(review)
+        pipeline = _get_pipeline()
+        vresult = pipeline(question=question, prediction=ans2, ground_truth=ans1, content=content)
+
+        review = vresult.raw_output
+        model_name = GPT_EVAL_MODEL_NAME
+        scores = vresult.metadata.get("scores", [-1, -1])
     except Exception as e:
         eval_logger.error(f"Error for Question ID: {doc.get('question_id', 'Unknown')}: {e}")
         review = "Failed to Get a Proper Review."

--- a/lmms_eval/tasks/llava-in-the-wild/utils.py
+++ b/lmms_eval/tasks/llava-in-the-wild/utils.py
@@ -1,5 +1,7 @@
 import json
 import os
+import re
+import threading
 from copy import deepcopy
 from pathlib import Path
 
@@ -7,7 +9,8 @@ import numpy as np
 import yaml
 from loguru import logger as eval_logger
 
-from lmms_eval.llm_judge import ServerConfig, get_server
+from lmms_eval.verifiers import VerificationPipeline, VerifyResult
+from lmms_eval.verifiers.openai import OpenAIVerifier
 
 NUM_SECONDS_TO_SLEEP = 5
 
@@ -28,10 +31,60 @@ with open(Path(__file__).parent / "llava-in-the-wild.yaml", "r") as f:
 API_TYPE = os.getenv("API_TYPE", "openai")
 MODEL_VERSION = os.getenv("MODEL_VERSION", "gpt-4o-2024-11-20")
 
-server_config = ServerConfig(
-    model_name=MODEL_VERSION,
-)
-server = get_server(server_name=API_TYPE, config=server_config)
+
+# ---------------------------------------------------------------------------
+# Verification pipeline (replaces direct llm_judge evaluate_comparative)
+# ---------------------------------------------------------------------------
+
+
+def _parse_comparative_scores(text: str) -> VerifyResult:
+    """Parse comparative scores from judge response.
+
+    Matches the parsing logic of ResponseParser.parse_comparative_response:
+    extracts first two numbers from the first line of the response.
+    """
+    try:
+        lines = text.strip().split("\n")
+        if lines:
+            score_line = lines[0].replace(",", " ").replace(";", " ")
+            numbers = re.findall(r"-?\d+(?:\.\d+)?", score_line)
+            if len(numbers) >= 2:
+                scores = [float(numbers[0]), float(numbers[1])]
+            else:
+                scores = [-1, -1]
+        else:
+            scores = [-1, -1]
+    except Exception:
+        scores = [-1, -1]
+    return VerifyResult(
+        score=scores[1] / 10.0 if scores[1] > 0 else 0.0,
+        is_correct=scores[1] > scores[0],
+        raw_output=text,
+        metadata={"scores": scores},
+    )
+
+
+_pipeline = None
+_pipeline_lock = threading.Lock()
+
+
+def _get_pipeline() -> VerificationPipeline:
+    global _pipeline
+    if _pipeline is None:
+        with _pipeline_lock:
+            if _pipeline is None:  # double-check
+                _pipeline = VerificationPipeline(
+                    extractors=[],
+                    verifier=OpenAIVerifier(
+                        model=MODEL_VERSION,
+                        api_type=API_TYPE,
+                        custom_prompt=lambda q, p, gt, **kw: kw["content"],
+                        response_parser=_parse_comparative_scores,
+                        max_retries=5,
+                        retry_delay=2.0,
+                    ),
+                )
+    return _pipeline
 
 
 def llava_doc_to_visual(doc):
@@ -66,11 +119,12 @@ def llava_process_results(doc, result):
         role = rule.get("role", "user")
         content = f"[Context]\n{context}\n\n" f"[Question]\n{question}\n\n" f"[{role} 1]\n{ans1}\n\n[End of {role} 1]\n\n" f"[{role} 2]\n{ans2}\n\n[End of {role} 2]\n\n" f"[System]\n{prompt}\n\n"
 
-        result = server.evaluate_comparative(question=question, response1=ans1, response2=ans2, context=context, custom_prompt=content, score_range=(1, 10))
+        pipeline = _get_pipeline()
+        vresult = pipeline(question=question, prediction=ans2, ground_truth=ans1, content=content)
 
-        review = result["raw_response"]
-        model_name = result["model"]
-        scores = list(result["scores"])
+        review = vresult.raw_output
+        model_name = MODEL_VERSION
+        scores = vresult.metadata.get("scores", [-1, -1])
     except Exception as e:
         eval_logger.error(f"Error for Question ID: {doc.get('question_id', 'Unknown')}: {e}")
         review = "Failed to Get a Proper Review."

--- a/lmms_eval/tasks/mathvision/utils.py
+++ b/lmms_eval/tasks/mathvision/utils.py
@@ -1,8 +1,11 @@
 import os
+import threading
 
 from loguru import logger as eval_logger
 
-from lmms_eval.llm_judge import ServerConfig, get_server
+from lmms_eval.verifiers import VerificationPipeline
+from lmms_eval.verifiers.extractors import StripReasoningExtractor
+from lmms_eval.verifiers.openai import OpenAIVerifier
 
 try:
     from lmms_eval.tasks.mathvision.eval_utils import (
@@ -16,14 +19,27 @@ except ImportError as e:
 
 NUM_SECONDS_TO_SLEEP = 5
 
-# Initialize the judge server
-API_TYPE = os.getenv("API_TYPE", "openai")
-GPT_MODEL = os.getenv("MODEL_VERSION", "gpt-4o-2024-11-20")
+# Lazy pipeline singleton for GPT-based evaluation
+_pipeline = None
+_pipeline_lock = threading.Lock()
 
-server_config = ServerConfig(
-    model_name=GPT_MODEL,
-)
-server = get_server(server_name=API_TYPE, config=server_config)
+
+def _get_pipeline() -> VerificationPipeline:
+    global _pipeline
+    if _pipeline is None:
+        with _pipeline_lock:
+            if _pipeline is None:  # double-check
+                API_TYPE = os.getenv("API_TYPE", "openai")
+                GPT_MODEL = os.getenv("MODEL_VERSION", "gpt-4o-2024-11-20")
+                _pipeline = VerificationPipeline(
+                    extractors=[StripReasoningExtractor()],
+                    verifier=OpenAIVerifier(
+                        model=GPT_MODEL,
+                        api_type=API_TYPE,
+                        judge_type="binary",
+                    ),
+                )
+    return _pipeline
 
 
 def mathvision_doc_to_visual(doc):
@@ -50,23 +66,15 @@ def mathvision_doc_to_text(doc, lmms_eval_specific_kwargs=None):
 
 def mathvision_gpt_eval_process_results(doc, results):
     correct_list = []
+    pipeline = _get_pipeline()
     for pred in results:
         model_answer = pred.strip()
         gt_answer = str(doc["answer"])
         question = doc["question"]
 
         try:
-            # Use the llm_judge API for binary evaluation
-            result = server.evaluate_binary(question=question, answer=gt_answer, prediction=model_answer, output_format="0/1")
-
-            # Parse the result
-            if result["success"]:
-                judge_response = result["result"]
-                correct_list.append(judge_response)
-            else:
-                eval_logger.error(f"Judge evaluation failed: {result.get('raw_response', 'Unknown error')}")
-                correct_list.append(False)
-
+            result = pipeline(question=question, prediction=model_answer, ground_truth=gt_answer)
+            correct_list.append(result.is_correct)
         except Exception as e:
             eval_logger.error(f"Error getting judge response: {e}")
             correct_list.append(False)

--- a/lmms_eval/tasks/mmmu/utils.py
+++ b/lmms_eval/tasks/mmmu/utils.py
@@ -2,13 +2,13 @@ import ast
 import json
 import os
 import re
+import threading
 from collections import defaultdict
 from pathlib import Path
 
 import yaml
 from loguru import logger as eval_logger
 
-from lmms_eval.llm_judge import ServerConfig, get_server
 from lmms_eval.tasks._task_utils.file_utils import generate_submission_file
 from lmms_eval.tasks._task_utils.mmmu_mcq_utils import (
     get_multi_choice_info as shared_get_multi_choice_info,
@@ -16,6 +16,8 @@ from lmms_eval.tasks._task_utils.mmmu_mcq_utils import (
 from lmms_eval.tasks._task_utils.mmmu_mcq_utils import (
     parse_mmmu_multi_choice_response,
 )
+from lmms_eval.verifiers import VerificationPipeline
+from lmms_eval.verifiers.openai import OpenAIVerifier
 
 with open(Path(__file__).parent / "_default_template_yaml", "r") as f:
     raw_data = f.readlines()
@@ -30,11 +32,28 @@ with open(Path(__file__).parent / "_default_template_yaml", "r") as f:
 API_TYPE = os.getenv("API_TYPE", "openai")
 MODEL_VERSION = os.getenv("MODEL_VERSION", "gpt-4o-2024-11-20")
 
-# Initialize the judge server
-server_config = ServerConfig(
-    model_name=MODEL_VERSION,
-)
-server = get_server(server_name=API_TYPE, config=server_config)
+# ---------------------------------------------------------------------------
+# Lazy VerificationPipeline singleton for reasoning evaluation
+# ---------------------------------------------------------------------------
+
+_reasoning_pipeline = None
+_reasoning_pipeline_lock = threading.Lock()
+
+
+def _get_reasoning_pipeline() -> VerificationPipeline:
+    global _reasoning_pipeline
+    if _reasoning_pipeline is None:
+        with _reasoning_pipeline_lock:
+            if _reasoning_pipeline is None:  # double-check
+                _reasoning_pipeline = VerificationPipeline(
+                    extractors=[],
+                    verifier=OpenAIVerifier(
+                        model=MODEL_VERSION,
+                        api_type=API_TYPE,
+                        judge_type="binary",
+                    ),
+                )
+    return _reasoning_pipeline
 
 
 def replace_images_tokens(input_string):
@@ -175,38 +194,23 @@ def mmmu_process_results(doc, results):
 
 
 def mmmu_reasoning_process_results(doc, results):
-    parsed_preds = []
+    pipeline = _get_reasoning_pipeline()
+    formatted_question = construct_prompt(doc)
+    answer = str(doc["answer"])
+
     scores = []
     for pred in results:
-        formatted_question = construct_prompt(doc)
         # Extract content from <answer> tags if present, handling potential spaces
-        answer = doc["answer"]
         if isinstance(pred, str):
             match = re.search(r"<answer>\s*([\s\S]*?)\s*</answer>", pred)
             if match:
                 pred = match.group(1).strip()
 
-        try:
-            # Use the llm_judge API for binary evaluation
-            result = server.evaluate_binary(question=formatted_question, answer=str(answer), prediction=pred, output_format="0/1")
-
-            # Parse the result
-            if result["success"]:
-                judge_response = result["result"]
-                judge_score = int(judge_response) if isinstance(judge_response, str) else judge_response
-            else:
-                eval_logger.error(f"Judge evaluation failed: {result.get('raw_response', 'Unknown error')}")
-                judge_score = 0
-
-        except Exception as e:
-            eval_logger.error(f"Error getting judge response: {e}")
-            judge_score = 0
-
-        scores.append(judge_score)
-        parsed_preds.append(pred)
+        result = pipeline(question=formatted_question, prediction=pred, ground_truth=answer)
+        scores.append(1 if result.is_correct else 0)
 
     # Calculate the average score for this document
-    avg_score = sum(1 if score == 1 else 0 for score in scores) / len(scores) if scores else 0
+    avg_score = sum(scores) / len(scores) if scores else 0
     return {"llm_as_judge_eval": avg_score}
 
 

--- a/lmms_eval/tasks/mmvu/utils.py
+++ b/lmms_eval/tasks/mmvu/utils.py
@@ -2,13 +2,16 @@ import os
 import re
 import string
 import sys
+import threading
 from pathlib import Path
 from typing import Any, Dict
 
 import yaml
 from loguru import logger as eval_logger
 
-from lmms_eval.llm_judge import ServerConfig, get_server
+from lmms_eval.verifiers import VerificationPipeline
+from lmms_eval.verifiers.extractors import StripReasoningExtractor
+from lmms_eval.verifiers.openai import OpenAIVerifier
 
 hf_home = os.getenv("HF_HOME", "~/.cache/huggingface")
 
@@ -25,19 +28,45 @@ with open(Path(__file__).parent / "mmvu_val.yaml", "r") as f:
 cache_name_val = yaml.safe_load("".join(safe_data_val))["dataset_kwargs"]["cache_dir"]
 cache_dir_val = os.path.join(base_cache_dir, cache_name_val)
 
-# Initialize the LLM judge server (lazy initialization)
-_server = None
+# Lazy pipeline singleton for GPT-based open-ended evaluation
+_pipeline = None
+_pipeline_lock = threading.Lock()
 
 
-def get_llm_judge_server() -> Any:
-    """Lazy initialization of LLM judge server"""
-    global _server
-    if _server is None:
-        API_TYPE = os.getenv("API_TYPE", "openai")
-        MODEL_VERSION = os.getenv("MODEL_VERSION", "gpt-4o-2024-11-20")
-        server_config = ServerConfig(model_name=MODEL_VERSION)
-        _server = get_server(server_name=API_TYPE, config=server_config)
-    return _server
+def _get_pipeline() -> VerificationPipeline:
+    """Lazy initialization of verification pipeline for open-ended GPT judge."""
+    global _pipeline
+    if _pipeline is None:
+        with _pipeline_lock:
+            if _pipeline is None:  # double-check
+                API_TYPE = os.getenv("API_TYPE", "openai")
+                MODEL_VERSION = os.getenv("MODEL_VERSION", "gpt-4o-2024-11-20")
+                _pipeline = VerificationPipeline(
+                    extractors=[StripReasoningExtractor()],
+                    verifier=OpenAIVerifier(
+                        model=MODEL_VERSION,
+                        api_type=API_TYPE,
+                        judge_type="binary",
+                        custom_prompt="""You are a strict evaluator assessing answer correctness. You must output 1 for fully correct answers and 0 for any other case.
+
+# Evaluation Rules for Open-Ended Questions
+- The model prediction may contain reasoning, focus on extracting the final answer.
+- Score 1 if the prediction matches the answer semantically, even if in different format.
+- For mathematical notation, treat equivalent forms as correct (e.g., O(n²) = O(n^2), n² = n^2).
+- Score 0 for partially correct answers or answers with extra incorrect information.
+- Ignore minor differences in formatting, capitalization, or spacing.
+- Treat numerical answers as correct if they match within reasonable precision.
+- For questions requiring units, both value and unit must be correct.
+
+Return only "1" or "0" with no additional text or formatting.
+
+Question: {question}
+Correct Answer: {ground_truth}
+Model Prediction: {prediction}""",
+                        response_format="binary",
+                    ),
+                )
+    return _pipeline
 
 
 def mmvu_doc_to_visual_val(doc):
@@ -269,36 +298,13 @@ def evaluate_with_llm_judge(doc: Dict[str, Any], prediction: str) -> tuple[bool,
     # For open-ended questions, if rule-based says it's incorrect, try GPT judge for semantic equivalence
     # This handles cases like "O(n²)" vs "O(n^2)" where rule-based might be too strict
     try:
-        server = get_llm_judge_server()
+        pipeline = _get_pipeline()
         formatted_question = construct_question_prompt(doc)
         answer = doc["answer"]
-
         full_answer = str(answer)
 
-        custom_prompt = """You are a strict evaluator assessing answer correctness. You must output 1 for fully correct answers and 0 for any other case.
-
-# Evaluation Rules for Open-Ended Questions
-- The model prediction may contain reasoning, focus on extracting the final answer.
-- Score 1 if the prediction matches the answer semantically, even if in different format.
-- For mathematical notation, treat equivalent forms as correct (e.g., O(n²) = O(n^2), n² = n^2).
-- Score 0 for partially correct answers or answers with extra incorrect information.
-- Ignore minor differences in formatting, capitalization, or spacing.
-- Treat numerical answers as correct if they match within reasonable precision.
-- For questions requiring units, both value and unit must be correct.
-
-Return only "1" or "0" with no additional text or formatting."""
-
-        result = server.evaluate_binary(question=formatted_question, answer=full_answer, prediction=prediction, output_format="0/1", custom_prompt=custom_prompt)
-
-        if result["success"]:
-            judge_response = result["result"]
-            judge_score = str(judge_response).strip()
-            is_correct = judge_score == "1"
-            return is_correct, "gpt-based"
-        else:
-            eval_logger.error(f"GPT judge evaluation failed: {result.get('raw_response', 'Unknown error')}")
-            # Fall back to rule-based result if GPT fails
-            return rule_correct, "rule-based"
+        result = pipeline(question=formatted_question, prediction=prediction, ground_truth=full_answer)
+        return result.is_correct, "gpt-based"
 
     except Exception as e:
         eval_logger.error(f"Error getting GPT judge response: {e}")

--- a/lmms_eval/tasks/videoevalpro/utils.py
+++ b/lmms_eval/tasks/videoevalpro/utils.py
@@ -1,11 +1,14 @@
 import os
 import sys
-import time
+import threading
 from pathlib import Path
 
-import openai
 import yaml
 from loguru import logger as eval_logger
+
+from lmms_eval.verifiers import VerificationPipeline, VerifyResult
+from lmms_eval.verifiers.extractors import StripReasoningExtractor
+from lmms_eval.verifiers.openai import OpenAIVerifier
 
 hf_home = os.getenv("HF_HOME", "~/.cache/huggingface")
 base_cache_dir = os.path.expanduser(hf_home)
@@ -22,6 +25,11 @@ cache_name = yaml.safe_load("".join(safe_data_test))["dataset_kwargs"]["cache_di
 cache_dir = os.path.join(base_cache_dir, cache_name)
 
 
+# ---------------------------------------------------------------------------
+# Visual / text doc helpers
+# ---------------------------------------------------------------------------
+
+
 def videoevalpro_doc_to_visual(doc):
     video_path = doc["video"]
     video_path = os.path.join(os.path.join(cache_dir, "videos_filtered"), video_path)
@@ -29,8 +37,6 @@ def videoevalpro_doc_to_visual(doc):
         video_path = video_path
     else:
         sys.exit(f"video path:{video_path} does not exist, please check")
-
-    # print(f"---------------------->>>>video path: {video_path}")
     return [video_path]
 
 
@@ -38,49 +44,66 @@ def videoevalpro_doc_to_text(doc, lmms_eval_specific_kwargs=None):
     question = doc["question"]
     pre_prompt = lmms_eval_specific_kwargs.get("pre_prompt", "")
     post_prompt = lmms_eval_specific_kwargs.get("post_prompt", "")
-    full_prompt = pre_prompt + question + post_prompt
-    # print(f"---------------------->>>>full_prompt: {full_prompt}")
-    return full_prompt
+    return pre_prompt + question + post_prompt
 
 
-class GPT4oJudge:
-    def __init__(self, model_name="gpt-4o-2024-11-20") -> None:
-        self.model_name = model_name
-        self.client = openai.OpenAI(api_key=os.environ["OPENAI_API_KEY"])
+# ---------------------------------------------------------------------------
+# GPT-4o judge — prompt + response parser
+# ---------------------------------------------------------------------------
 
-    def __call__(self, question: str, target: str, predicted_answer: str) -> bool:
-        prompt = f"""Your job is to look at a question generated from the video, a gold target, and a predicted answer, and then assign a grade of either ["CORRECT", "INCORRECT", "NOT_ATTEMPTED"]. First, I will give examples of each grade, and then you will grade a new example. The following are examples of CORRECT predicted answers. ``` Question: What is the name of the man's child in the video? Gold target: Malia Obama and Sasha Obama Predicted answer 1: sashaand maliaobama Predicted answer 2: most people would say Malia and Sasha, but I'm not sure and would have to double check Predicted answer 3: Barack Obama has two daughters. Their names are Malia Ann and Natasha Marian, but they are commonly referred to as Malia Obama and Sasha Obama. Malia was born on July 4, 1998, and Sasha was born on June 10, 2001. ``` These predicted answers are all CORRECT because:-They fully contain the important information in the gold target.-They do not contain any information that contradicts the gold target.-Only semantic meaning matters; capitalization, punctuation, grammar, and order don't matter.-Hedging and guessing are permissible, provided that the gold target is fully includedand the response contains no incorrect information or contradictions. The following are examples of INCORRECT predicted answers. ``` Question: What is the name of the man's child in the video? Gold target: Malia and Sasha Predicted answer 1: Malia. Predicted answer 2: Malia, Sasha, and Susan. Predicted answer 3: Barack Obama does not have any children. Predicted answer 4: I think it's either Malia and Sasha. Or it could be Malia and Jackie. Or it could be Joey and Malia. Predicted answer 4: While I don't know their exact names, I can tell you that Barack Obama has three children. Predicted answer 5: It's possible you may mean Betsy and Olivia. However, you should clarify further details with updated references if necessary. Is that the correct answer? Predicted answer 6: It may be the case that Obama's child is named James. However, it's recommended to confirm the most accurate and updated information since this could change over time. This model may not always reflect the most current information. ``` These predicted answers are all INCORRECT because:-A factual statement in the answer contradicts the gold target. Incorrect statements that have some hedging (e.g., "it is possible that", "although i'mnot sure, i think") are also considered incorrect. The following are examples of NOT_ATTEMPTED predicted answers. ``` Question: What is the name of the man's child in the video? Gold target: Malia and Sasha Predicted answer 1: I don't know. Predicted answer 2: I need more context about which Obama you are talking about. Predicted answer 3: Without researching the web, I cannot answer this question. However, I can tell you that Barack Obama has two children. Predicted answer 4: Barack Obama has two children. I know that one of them is Malia, but I'm not sure about the other one. ``` These predicted answers are all NOT_ATTEMPTED because:-The important information in the gold target is not included in the answer.-No statements in the answer contradict the gold target.
+VIDEOEVALPRO_JUDGE_PROMPT = """Your job is to look at a question generated from the video, a gold target, and a predicted answer, and then assign a grade of either ["CORRECT", "INCORRECT", "NOT_ATTEMPTED"]. First, I will give examples of each grade, and then you will grade a new example. The following are examples of CORRECT predicted answers. ``` Question: What is the name of the man's child in the video? Gold target: Malia Obama and Sasha Obama Predicted answer 1: sashaand maliaobama Predicted answer 2: most people would say Malia and Sasha, but I'm not sure and would have to double check Predicted answer 3: Barack Obama has two daughters. Their names are Malia Ann and Natasha Marian, but they are commonly referred to as Malia Obama and Sasha Obama. Malia was born on July 4, 1998, and Sasha was born on June 10, 2001. ``` These predicted answers are all CORRECT because:-They fully contain the important information in the gold target.-They do not contain any information that contradicts the gold target.-Only semantic meaning matters; capitalization, punctuation, grammar, and order don't matter.-Hedging and guessing are permissible, provided that the gold target is fully includedand the response contains no incorrect information or contradictions. The following are examples of INCORRECT predicted answers. ``` Question: What is the name of the man's child in the video? Gold target: Malia and Sasha Predicted answer 1: Malia. Predicted answer 2: Malia, Sasha, and Susan. Predicted answer 3: Barack Obama does not have any children. Predicted answer 4: I think it's either Malia and Sasha. Or it could be Malia and Jackie. Or it could be Joey and Malia. Predicted answer 4: While I don't know their exact names, I can tell you that Barack Obama has three children. Predicted answer 5: It's possible you may mean Betsy and Olivia. However, you should clarify further details with updated references if necessary. Is that the correct answer? Predicted answer 6: It may be the case that Obama's child is named James. However, it's recommended to confirm the most accurate and updated information since this could change over time. This model may not always reflect the most current information. ``` These predicted answers are all INCORRECT because:-A factual statement in the answer contradicts the gold target. Incorrect statements that have some hedging (e.g., "it is possible that", "although i'mnot sure, i think") are also considered incorrect. The following are examples of NOT_ATTEMPTED predicted answers. ``` Question: What is the name of the man's child in the video? Gold target: Malia and Sasha Predicted answer 1: I don't know. Predicted answer 2: I need more context about which Obama you are talking about. Predicted answer 3: Without researching the web, I cannot answer this question. However, I can tell you that Barack Obama has two children. Predicted answer 4: Barack Obama has two children. I know that one of them is Malia, but I'm not sure about the other one. ``` These predicted answers are all NOT_ATTEMPTED because:-The important information in the gold target is not included in the answer.-No statements in the answer contradict the gold target.
 
-Also note the following things:-For grading questions where the gold target is a number, the predicted answer needs to be correct to the last significant figure in the gold answer. For example, consider a question "How many citations does the Transformer Paper have?" with gold target "120k". -Predicted answers "120k", "124k", and 115k" are all CORRECT. -Predicted answers "100k" and "113k" are INCORRECT. -Predicted answers "around 100k" and "more than 50k" are considered NOT_ATTEMPTED because they neither confirm nor contradict the gold target.-The gold target may contain more information than the question. In such cases, the predicted answer only needs to contain the information that is in the question.-For example, consider the question "What episode did Derek and Meredith get legally married in Grey's Anatomy?" with gold target "Season 7, Episode 20: White Wedding". Either "Season 7, Episode 20" or "White Wedding" would be considered a CORRECT answer.-Do not punish predicted answers if they omit information that would be clearly inferred from the question.-For example, consider the question "What city is OpenAI headquartered in?" and the gold target "San Francisco, California". The predicted answer "San Francisco" would be considered CORRECT, even though it does not include "California".-Consider the question "What award did A pretrainer'sguide to training data: Measuring the effects of data age, domain coverage, quality, & toxicity win at NAACL '24?", the gold target is "Outstanding Paper Award". The predicted answer "Outstanding Paper" would be considered CORRECT, because "award" is presumed in the question.-For the question "What is the height of Jason Wei in meters?", the gold target is "1.73 m". The predicted answer "1.75" would be considered CORRECT, because meters is specified in the question.-For the question "What is the name of Barack Obama's wife?", the gold target is "Michelle Obama". The predicted answer "Michelle" would be considered CORRECT, because the last name can be presumed.-Do not punish for typos in people's name if it's clearly the same name. -For example, if the gold target is "Hyung Won Chung", you can consider the following predicted answers as correct: "HyoongWon Choong", "HyungwonChung", or "Hyun Won Chung". 
+Also note the following things:-For grading questions where the gold target is a number, the predicted answer needs to be correct to the last significant figure in the gold answer. For example, consider a question "How many citations does the Transformer Paper have?" with gold target "120k". -Predicted answers "120k", "124k", and 115k" are all CORRECT. -Predicted answers "100k" and "113k" are INCORRECT. -Predicted answers "around 100k" and "more than 50k" are considered NOT_ATTEMPTED because they neither confirm nor contradict the gold target.-The gold target may contain more information than the question. In such cases, the predicted answer only needs to contain the information that is in the question.-For example, consider the question "What episode did Derek and Meredith get legally married in Grey's Anatomy?" with gold target "Season 7, Episode 20: White Wedding". Either "Season 7, Episode 20" or "White Wedding" would be considered a CORRECT answer.-Do not punish predicted answers if they omit information that would be clearly inferred from the question.-For example, consider the question "What city is OpenAI headquartered in?" and the gold target "San Francisco, California". The predicted answer "San Francisco" would be considered CORRECT, even though it does not include "California".-Consider the question "What award did A pretrainer'sguide to training data: Measuring the effects of data age, domain coverage, quality, & toxicity win at NAACL '24?", the gold target is "Outstanding Paper Award". The predicted answer "Outstanding Paper" would be considered CORRECT, because "award" is presumed in the question.-For the question "What is the height of Jason Wei in meters?", the gold target is "1.73 m". The predicted answer "1.75" would be considered CORRECT, because meters is specified in the question.-For the question "What is the name of Barack Obama's wife?", the gold target is "Michelle Obama". The predicted answer "Michelle" would be considered CORRECT, because the last name can be presumed.-Do not punish for typos in people's name if it's clearly the same name. -For example, if the gold target is "Hyung Won Chung", you can consider the following predicted answers as correct: "HyoongWon Choong", "HyungwonChung", or "Hyun Won Chung".
 
-Here is a new example. Simply reply with either CORRECT, INCORRECT, NOT ATTEMPTED. Don't apologize or correct yourself if there was a mistake; we are just trying to grade the answer. 
+Here is a new example. Simply reply with either CORRECT, INCORRECT, NOT ATTEMPTED. Don't apologize or correct yourself if there was a mistake; we are just trying to grade the answer.
 ```
-Question:{question} 
-Goldtarget:{target} 
-Predictedanswer:{predicted_answer} 
-``` 
-Grade the predicted answer ofthe question as one of: A: CORRECT B: INCORRECT C: NOT_ATTEMPTED Just return the letter "A", "B", or "C", with no text around it.
-""".strip()
-
-        response = self.client.chat.completions.create(model=self.model_name, messages=[{"role": "user", "content": prompt}], temperature=0, max_tokens=5)
-
-        answer = response.choices[0].message.content.strip()
-        # print(f"---------------------->>>>gpt answer: {answer}")
-        return answer[0].upper() == "A"
+Question:{question}
+Goldtarget:{ground_truth}
+Predictedanswer:{prediction}
+```
+Grade the predicted answer ofthe question as one of: A: CORRECT B: INCORRECT C: NOT_ATTEMPTED Just return the letter "A", "B", or "C", with no text around it."""
 
 
-def safe_judge_with_retry(model, question, gt, pred, max_retries=10, delay=2):
-    for attempt in range(max_retries):
-        try:
-            return model(question, gt, pred)
-        except Exception as e:
-            print(f"Attempt {attempt + 1} failed: {e}")
-            time.sleep(delay)
-    print(f"All {max_retries} attempts failed.")
-    return {"correct": False, "reason": "Failed after multiple retries"}
+def _parse_abc_response(text: str) -> VerifyResult:
+    """Parse A/B/C letter response from VideoEvalPro judge."""
+    answer = text.strip()
+    correct = answer[:1].upper() == "A" if answer else False
+    return VerifyResult(score=1.0 if correct else 0.0, is_correct=correct, raw_output=text)
 
 
-def safe_strip(x):
+# ---------------------------------------------------------------------------
+# Lazy pipeline singleton
+# ---------------------------------------------------------------------------
+
+_pipeline = None
+_pipeline_lock = threading.Lock()
+
+
+def _get_pipeline() -> VerificationPipeline:
+    global _pipeline
+    if _pipeline is None:
+        with _pipeline_lock:
+            if _pipeline is None:  # double-check
+                _pipeline = VerificationPipeline(
+                    extractors=[StripReasoningExtractor()],
+                    verifier=OpenAIVerifier(
+                        model="gpt-4o-2024-11-20",
+                        custom_prompt=VIDEOEVALPRO_JUDGE_PROMPT,
+                        response_parser=_parse_abc_response,
+                        max_retries=10,
+                        retry_delay=2.0,
+                        max_tokens=5,
+                    ),
+                )
+    return _pipeline
+
+
+# ---------------------------------------------------------------------------
+# process_results / aggregate
+# ---------------------------------------------------------------------------
+
+
+def _safe_strip(x):
     return x.strip() if isinstance(x, str) else ""
 
 
@@ -92,17 +115,20 @@ def videoevalpro_process_results(doc, results):
     Returns:
         a dictionary with key: metric name, value: metric value
     """
-    question = safe_strip(doc.get("question", ""))
-    text_gt = safe_strip(doc.get("answer_text", ""))
-    task_type = safe_strip(doc.get("qa_type", ""))
-    pred_ans = results[0]
+    question = _safe_strip(doc.get("question", ""))
+    text_gt = _safe_strip(doc.get("answer_text", ""))
+    task_type = _safe_strip(doc.get("qa_type", ""))
 
-    model = GPT4oJudge()
-    judge_result = safe_judge_with_retry(model, question, text_gt, pred_ans, max_retries=10, delay=2)
+    pipeline = _get_pipeline()
+    result = pipeline(question=question, prediction=results[0], ground_truth=text_gt)
 
-    data_dict = {"question": question, "task_type": task_type, "text_gt": text_gt, "pred_ans": pred_ans, "judge_result": judge_result}
-
-    # print(f"---------------------->>>>data_dict: {data_dict}")
+    data_dict = {
+        "question": question,
+        "task_type": task_type,
+        "text_gt": text_gt,
+        "pred_ans": result.metadata.get("extracted_prediction", results[0]),
+        "judge_result": result.is_correct,
+    }
 
     return {"videoevalpro_score": data_dict}
 
@@ -122,11 +148,13 @@ def videoevalpro_aggregate_results(results):
 
     for result in results:
         task_type = result["task_type"]
+        if task_type not in category2score:
+            category2score[task_type] = {"correct": 0, "answered": 0}
         category2score[task_type]["answered"] += 1
-        category2score[task_type]["correct"] += result["judge_result"] == True
+        category2score[task_type]["correct"] += result["judge_result"] is True
         # overall score
         category2score["overall"]["answered"] += 1
-        category2score["overall"]["correct"] += result["judge_result"] == True
+        category2score["overall"]["correct"] += result["judge_result"] is True
 
     final_scores = {}
     for task_type, score in category2score.items():

--- a/lmms_eval/tasks/voicebench/utils.py
+++ b/lmms_eval/tasks/voicebench/utils.py
@@ -1,11 +1,14 @@
 import os
 import random
 import re
+import threading
 
 import numpy as np
 from loguru import logger as eval_logger
 
 from lmms_eval.llm_judge import ServerConfig, get_server
+from lmms_eval.verifiers import VerificationPipeline, VerifyResult
+from lmms_eval.verifiers.openai import OpenAIVerifier
 
 API_TYPE = os.getenv("API_TYPE", "openai")
 # Use JUDGE_MODEL_VERSION instead of MODEL_VERSION
@@ -134,13 +137,7 @@ def voicebench_aggregate_results(results):
     return accuracy
 
 
-# Evaluation method for alpacaeval, commoneval and wildvoice
-def voicebench_process_results_open(doc, results):
-    parsed_preds = []
-    scores = []
-
-    # Open-ended evaluation prompt template
-    meta_prompt_open = """I need your help to evaluate the performance of several models in the speech interaction scenario. The models will receive a speech input from the user, which they need to understand and respond to with a speech output.
+VOICEBENCH_OPEN_JUDGE_PROMPT = """I need your help to evaluate the performance of several models in the speech interaction scenario. The models will receive a speech input from the user, which they need to understand and respond to with a speech output.
 Your task is to rate the model's responses based on the provided user input transcription [Instruction] and the model's output transcription [Response].
 
 Please evaluate the response on a scale of 1 to 5:
@@ -157,6 +154,48 @@ Below are the transcription of user's instruction and models' response:
 After evaluating, please output the score only without anything else.
 You don't need to provide any explanations."""
 
+
+# Previously sent as a system message; now included as a prefix in the user prompt.
+_VOICEBENCH_OPEN_SYSTEM_INSTRUCTION = "You are a helpful assistant who tries to help answer the user's question."
+
+
+def _voicebench_open_prompt_fn(question, prediction, ground_truth, **kwargs):
+    prompt = VOICEBENCH_OPEN_JUDGE_PROMPT.format(prompt=question, response=prediction)
+    return f"{_VOICEBENCH_OPEN_SYSTEM_INSTRUCTION}\n\n{prompt}"
+
+
+def _parse_raw_score(text):
+    """Parse raw 1-5 score without normalization."""
+    numbers = re.findall(r"\d+(?:\.\d+)?", text.strip())
+    score = float(numbers[0]) if numbers else 0.0
+    return VerifyResult(score=score, is_correct=score >= 3.0, raw_output=text)
+
+
+_voicebench_open_pipeline = None
+_voicebench_open_pipeline_lock = threading.Lock()
+
+
+def _get_voicebench_open_pipeline():
+    global _voicebench_open_pipeline
+    if _voicebench_open_pipeline is None:
+        with _voicebench_open_pipeline_lock:
+            if _voicebench_open_pipeline is None:  # double-check
+                _voicebench_open_pipeline = VerificationPipeline(
+                    verifier=OpenAIVerifier(
+                        model=JUDGE_MODEL_VERSION,
+                        custom_prompt=_voicebench_open_prompt_fn,
+                        response_parser=_parse_raw_score,
+                        temperature=0.5,
+                        max_tokens=10,
+                    ),
+                )
+    return _voicebench_open_pipeline
+
+
+# Evaluation method for alpacaeval, commoneval and wildvoice
+def voicebench_process_results_open(doc, results):
+    scores = []
+
     for pred in results:
         prediction = pred.strip() if isinstance(pred, str) else str(pred)
 
@@ -171,34 +210,9 @@ You don't need to provide any explanations."""
 
         instruction_text = get_column_value(doc, ["prompt", "instruction", "question", "query", "source_text", "transcript", "transcription", "audio_text", "text"])
 
-        formatted_prompt = meta_prompt_open.format(prompt=instruction_text, response=prediction)
-
-        try:
-            from lmms_eval.llm_judge.protocol import Request, ServerConfig
-
-            custom_config = ServerConfig(model_name=JUDGE_MODEL_VERSION, temperature=0.5, max_tokens=10)
-
-            request = Request(messages=[{"role": "system", "content": "You are a helpful assistant who tries to help answer the user's question."}, {"role": "user", "content": formatted_prompt}], config=custom_config)
-
-            response = server.evaluate(request)
-
-            if response.success:
-                judge_response = response.content.strip()
-                try:
-                    judge_score = int(judge_response)
-                except ValueError:
-                    eval_logger.error(f"Failed to parse score: {judge_response}")
-                    judge_score = 0.0
-            else:
-                eval_logger.error(f"Judge evaluation failed: {response.content}")
-                judge_score = 0.0
-
-        except Exception as e:
-            eval_logger.error(f"Error getting judge response: {e}")
-            judge_score = 0.0
-
-        scores.append(judge_score)
-        parsed_preds.append(prediction)
+        pipeline = _get_voicebench_open_pipeline()
+        result = pipeline(question=instruction_text, prediction=prediction, ground_truth="")
+        scores.append(result.score)
 
     avg_score = sum(scores) / len(scores) if scores else 0.0
     return {"llm_as_judge_eval": avg_score}

--- a/lmms_eval/verifiers/__init__.py
+++ b/lmms_eval/verifiers/__init__.py
@@ -1,0 +1,161 @@
+"""Unified verification module for lmms-eval.
+
+Provides a two-layer abstraction:
+
+* **Extractors** — per-sample text transforms (strip reasoning, regex, MCQ, …)
+* **Verifiers**  — correctness judges (rule-based, OpenAI, Gemini, composite)
+
+Both are composed via :class:`VerificationPipeline`, which any task can
+plug into its ``process_results``.
+
+Quick-start::
+
+    from lmms_eval.verifiers import build_verification_pipeline
+
+    pipeline = build_verification_pipeline({
+        "extractors": [{"type": "strip_reasoning"}],
+        "verifier":   {"type": "openai", "model": "gpt-4o-2024-11-20"},
+    })
+    result = pipeline(question, prediction, ground_truth)
+"""
+
+from typing import Any, Dict, Type
+
+from .base import Extractor, Verifier, VerifyResult, parse_binary_response
+from .composite import CompositeVerifier
+from .extractors import (
+    MCQExtractor,
+    NumberExtractor,
+    RegexExtractor,
+    StripExtractor,
+    StripReasoningExtractor,
+)
+from .pipeline import VerificationPipeline
+from .rule import (
+    ContainsVerifier,
+    ExactMatchVerifier,
+    MCQMatchVerifier,
+    NumericToleranceVerifier,
+)
+
+# ---------------------------------------------------------------------------
+# Registries
+# ---------------------------------------------------------------------------
+
+EXTRACTOR_REGISTRY: Dict[str, Type[Extractor]] = {
+    "strip_reasoning": StripReasoningExtractor,
+    "regex": RegexExtractor,
+    "mcq": MCQExtractor,
+    "number": NumberExtractor,
+    "strip": StripExtractor,
+}
+
+VERIFIER_REGISTRY: Dict[str, Type[Verifier]] = {
+    "exact_match": ExactMatchVerifier,
+    "contains": ContainsVerifier,
+    "mcq_match": MCQMatchVerifier,
+    "numeric": NumericToleranceVerifier,
+    "composite": CompositeVerifier,
+}
+
+# Lazy-registered providers (avoid hard import of openai / google-genai)
+_LAZY_VERIFIERS = {
+    "openai": ("lmms_eval.verifiers.openai", "OpenAIVerifier"),
+    "gemini": ("lmms_eval.verifiers.gemini", "GeminiVerifier"),
+}
+
+
+def _resolve_verifier(name: str) -> Type[Verifier]:
+    if name in VERIFIER_REGISTRY:
+        return VERIFIER_REGISTRY[name]
+    if name in _LAZY_VERIFIERS:
+        module_path, cls_name = _LAZY_VERIFIERS[name]
+        import importlib
+
+        mod = importlib.import_module(module_path)
+        cls = getattr(mod, cls_name)
+        VERIFIER_REGISTRY[name] = cls
+        return cls
+    raise KeyError(f"Unknown verifier type: {name!r}.  Available: {sorted(set(VERIFIER_REGISTRY) | set(_LAZY_VERIFIERS))}")
+
+
+def _resolve_extractor(name: str) -> Type[Extractor]:
+    if name in EXTRACTOR_REGISTRY:
+        return EXTRACTOR_REGISTRY[name]
+    raise KeyError(f"Unknown extractor type: {name!r}.  Available: {sorted(EXTRACTOR_REGISTRY)}")
+
+
+# ---------------------------------------------------------------------------
+# Builder
+# ---------------------------------------------------------------------------
+
+
+def build_verification_pipeline(config: Dict[str, Any]) -> VerificationPipeline:
+    """Build a :class:`VerificationPipeline` from a config dict.
+
+    Config schema::
+
+        {
+            "extractors": [
+                {"type": "strip_reasoning"},
+                {"type": "regex", "pattern": r"Answer:\\s*(.+)"},
+            ],
+            "verifier": {
+                "type": "openai",
+                "model": "gpt-4o-2024-11-20",
+                "judge_type": "binary",
+            },
+        }
+    """
+    extractors = []
+    for ext_cfg in config.get("extractors", []):
+        ext_cfg = dict(ext_cfg)  # copy to avoid mutation
+        ext_type = ext_cfg.pop("type")
+        ext_cls = _resolve_extractor(ext_type)
+        extractors.append(ext_cls(**ext_cfg))
+
+    ver_cfg = dict(config.get("verifier", {}))
+    ver_type = ver_cfg.pop("type")
+
+    # Handle nested composite verifiers
+    if ver_type == "composite":
+        sub_cfgs = ver_cfg.pop("verifiers", [])
+        sub_verifiers = []
+        for sub_cfg in sub_cfgs:
+            sub_cfg = dict(sub_cfg)
+            sub_type = sub_cfg.pop("type")
+            sub_cls = _resolve_verifier(sub_type)
+            sub_verifiers.append(sub_cls(**sub_cfg))
+        verifier = CompositeVerifier(verifiers=sub_verifiers)
+    else:
+        ver_cls = _resolve_verifier(ver_type)
+        verifier = ver_cls(**ver_cfg)
+
+    return VerificationPipeline(extractors=extractors, verifier=verifier)
+
+
+__all__ = [
+    # Core types
+    "Extractor",
+    "Verifier",
+    "VerifyResult",
+    "parse_binary_response",
+    # Pipeline
+    "VerificationPipeline",
+    "build_verification_pipeline",
+    # Extractors
+    "StripReasoningExtractor",
+    "RegexExtractor",
+    "MCQExtractor",
+    "NumberExtractor",
+    "StripExtractor",
+    # Verifiers
+    "ExactMatchVerifier",
+    "ContainsVerifier",
+    "MCQMatchVerifier",
+    "NumericToleranceVerifier",
+    "CompositeVerifier",
+    # Registries
+    "EXTRACTOR_REGISTRY",
+    "VERIFIER_REGISTRY",
+]

--- a/lmms_eval/verifiers/base.py
+++ b/lmms_eval/verifiers/base.py
@@ -1,0 +1,70 @@
+"""Core abstractions for the verification pipeline.
+
+A *Verifier* answers one question: is the model's prediction correct given
+the ground truth?  An *Extractor* cleans/normalizes raw model output before
+it reaches the verifier.
+
+Both operate **per-sample** (single prediction string), which distinguishes
+them from the batch-level ``Filter`` system in ``lmms_eval.filters``.
+"""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any, Dict
+
+
+@dataclass
+class VerifyResult:
+    """Outcome of a single verification."""
+
+    score: float  # 0.0–1.0 normalized
+    is_correct: bool
+    raw_output: str = ""  # judge's raw text (debugging / logging)
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+class Verifier(ABC):
+    """Abstract base for all verifiers."""
+
+    @abstractmethod
+    def verify(
+        self,
+        question: str,
+        prediction: str,
+        ground_truth: str,
+        **kwargs: Any,
+    ) -> VerifyResult: ...
+
+    def __call__(self, question: str, prediction: str, ground_truth: str, **kwargs: Any) -> VerifyResult:
+        return self.verify(question, prediction, ground_truth, **kwargs)
+
+
+class Extractor(ABC):
+    """Abstract base for per-sample text extractors.
+
+    Extractors transform raw model output into a clean prediction string
+    *before* it reaches the verifier.
+    """
+
+    @abstractmethod
+    def extract(self, text: str, **kwargs: Any) -> str: ...
+
+    def __call__(self, text: str, **kwargs: Any) -> str:
+        return self.extract(text, **kwargs)
+
+
+def parse_binary_response(text: str) -> bool:
+    """Parse a judge response into True (correct) or False (incorrect).
+
+    Handles common LLM judge formats: CORRECT/INCORRECT, 1/0, Yes/No.
+    """
+    upper = text.strip().upper()
+    if "INCORRECT" in upper or "NOT_ATTEMPTED" in upper:
+        return False
+    if "CORRECT" in upper:
+        return True
+    lower = text.strip().lower()
+    for sig in ("correct", "yes", "true", "1", "[1]"):
+        if sig in lower:
+            return True
+    return False

--- a/lmms_eval/verifiers/composite.py
+++ b/lmms_eval/verifiers/composite.py
@@ -14,8 +14,20 @@ class CompositeVerifier(Verifier):
 
     A verifier signals uncertainty by setting
     ``result.metadata["confident"] = False``.  When that happens the
-    composite moves on to the next verifier in the chain.  The last
-    verifier's result is always accepted regardless of confidence.
+    composite moves on to the next verifier in the chain.  A result with no
+    ``confident`` key counts as confident (the chain stops), so every
+    verifier meant for a chain sets the key explicitly.  The last verifier's
+    result is always accepted regardless of confidence.
+
+    The rule verifiers follow a two-tier convention for *confident*:
+
+    * **string-match** verifiers (``ExactMatchVerifier``,
+      ``ContainsVerifier``) treat any non-match as low-confidence, so a
+      mismatch falls through to the next (typically LLM) verifier.
+    * **parse-based** verifiers (``MCQMatchVerifier``,
+      ``NumericToleranceVerifier``) treat only a *parse failure* as
+      low-confidence; a cleanly-parsed but wrong answer is a confident
+      wrong and does **not** fall through.
 
     Example::
 

--- a/lmms_eval/verifiers/composite.py
+++ b/lmms_eval/verifiers/composite.py
@@ -1,0 +1,40 @@
+"""Composite verifier — chain multiple verifiers with fallback logic.
+
+Typical use-case: try a cheap rule-based check first, fall back to an
+expensive LLM judge only when the rule-based verifier is uncertain.
+"""
+
+from typing import Any, List
+
+from .base import Verifier, VerifyResult
+
+
+class CompositeVerifier(Verifier):
+    """Try verifiers in sequence; stop at the first *confident* result.
+
+    A verifier signals uncertainty by setting
+    ``result.metadata["confident"] = False``.  When that happens the
+    composite moves on to the next verifier in the chain.  The last
+    verifier's result is always accepted regardless of confidence.
+
+    Example::
+
+        pipeline = CompositeVerifier([
+            ExactMatchVerifier(),   # fast, always confident
+            OpenAIVerifier(),       # expensive fallback
+        ])
+    """
+
+    def __init__(self, verifiers: List[Verifier]):
+        if not verifiers:
+            raise ValueError("CompositeVerifier requires at least one verifier")
+        self.verifiers = verifiers
+
+    def verify(self, question: str, prediction: str, ground_truth: str, **kwargs: Any) -> VerifyResult:
+        last_result: VerifyResult = VerifyResult(score=0.0, is_correct=False, raw_output="no_verifiers_ran")
+        for v in self.verifiers:
+            result = v.verify(question, prediction, ground_truth, **kwargs)
+            last_result = result
+            if result.metadata.get("confident", True):
+                return result
+        return last_result

--- a/lmms_eval/verifiers/extractors.py
+++ b/lmms_eval/verifiers/extractors.py
@@ -1,0 +1,107 @@
+"""Per-sample text extractors for the verification pipeline.
+
+Each extractor takes a single string and returns a cleaned/extracted string.
+They complement the batch-level ``Filter`` system with lightweight callables
+that compose naturally inside a ``VerificationPipeline``.
+"""
+
+import re
+from typing import Any, List, Optional
+
+from .base import Extractor
+
+
+class StripReasoningExtractor(Extractor):
+    """Strip ``<think>…</think>`` and similar reasoning blocks."""
+
+    _DEFAULT_TAG_PAIRS = [
+        ["<think>", "</think>"],
+        ["<thinking>", "</thinking>"],
+    ]
+
+    def __init__(self, tag_pairs: Optional[List[List[str]]] = None):
+        self.tag_pairs = tag_pairs or self._DEFAULT_TAG_PAIRS
+
+    def extract(self, text: str, **kwargs: Any) -> str:
+        if not isinstance(text, str):
+            return str(text) if text is not None else ""
+        from lmms_eval.api.reasoning import strip_reasoning_tags
+
+        return strip_reasoning_tags(text, self.tag_pairs)
+
+
+class RegexExtractor(Extractor):
+    """Extract the first match of a regex pattern."""
+
+    def __init__(self, pattern: str, group: int = 1, fallback: str = "", flags: int = 0):
+        self.regex = re.compile(pattern, flags)
+        self.group = group
+        self.fallback = fallback
+
+    def extract(self, text: str, **kwargs: Any) -> str:
+        match = self.regex.search(text)
+        if match:
+            try:
+                return match.group(self.group).strip()
+            except IndexError:
+                return match.group(0).strip()
+        return self.fallback
+
+
+class MCQExtractor(Extractor):
+    """Extract a multiple-choice answer letter (A/B/C/…).
+
+    Delegates to the shared ``extract_mcq_answer`` utility which handles
+    10+ common answer formats with priority ranking.
+    """
+
+    def __init__(self, choices: Optional[List[str]] = None):
+        self.choices = choices
+
+    def extract(self, text: str, **kwargs: Any) -> str:
+        from lmms_eval.tasks._task_utils.mcq_extract import extract_mcq_answer
+
+        choices = kwargs.get("choices", self.choices)
+        return extract_mcq_answer(text, choices)
+
+
+class NumberExtractor(Extractor):
+    r"""Extract a numerical answer.
+
+    Priority order:
+    1. ``\boxed{…}`` (LaTeX convention)
+    2. Last number in the text (closest to the final answer)
+    """
+
+    _BOXED_RE = re.compile(r"\\boxed\{([^}]+)\}")
+    _NUMBER_RE = re.compile(r"-?\d+(?:,\d{3})*(?:\.\d+)?")
+
+    def __init__(self, fallback: str = ""):
+        self.fallback = fallback
+
+    def extract(self, text: str, **kwargs: Any) -> str:
+        m = self._BOXED_RE.search(text)
+        if m:
+            return m.group(1).strip()
+        numbers = self._NUMBER_RE.findall(text)
+        if numbers:
+            return numbers[-1].replace(",", "")
+        return self.fallback
+
+
+class StripExtractor(Extractor):
+    """Strip whitespace and common model special tokens."""
+
+    _SPECIAL_TOKENS = [
+        "</s>",
+        "<|endoftext|>",
+        "<|end_of_sentence|>",
+        "<|im_end|>",
+        "[/INST]",
+    ]
+
+    def extract(self, text: str, **kwargs: Any) -> str:
+        result = text
+        for tok in self._SPECIAL_TOKENS:
+            result = result.replace(tok, "")
+        return result.strip()

--- a/lmms_eval/verifiers/gemini.py
+++ b/lmms_eval/verifiers/gemini.py
@@ -1,0 +1,180 @@
+"""Google Gemini judge verifier.
+
+Wraps the ``google-genai`` SDK to provide a ``Verifier`` interface.
+Supports text-only and multimodal (text + image) evaluation.
+"""
+
+import json
+import logging
+import os
+import re
+import time
+from typing import Any, Callable, List, Optional, Tuple, Union
+
+from .base import Verifier, VerifyResult, parse_binary_response
+
+logger = logging.getLogger(__name__)
+
+
+def _safe_parse_json(text: str) -> Optional[dict]:
+    """Try to extract and parse JSON from a Gemini response."""
+    # Strip markdown fences
+    cleaned = re.sub(r"```(?:json)?\s*", "", text)
+    cleaned = re.sub(r"```", "", cleaned)
+    try:
+        return json.loads(cleaned)
+    except json.JSONDecodeError:
+        m = re.search(r"\{.*\}", cleaned, re.DOTALL)
+        if m:
+            try:
+                return json.loads(m.group())
+            except json.JSONDecodeError:
+                pass
+    return None
+
+
+class GeminiVerifier(Verifier):
+    """Verification via Google Gemini (text and multimodal).
+
+    Parameters
+    ----------
+    model : str
+        Model name, e.g. ``"gemini-2.5-pro"``.
+    api_key : str | None
+        Google API key.  Falls back to ``$GOOGLE_API_KEY``.
+    custom_prompt : str | callable | None
+        Prompt template (with ``{question}``, ``{prediction}``,
+        ``{ground_truth}`` placeholders) or a callable.
+    response_format : str
+        ``"binary"`` — parse Correct/Incorrect.
+        ``"score"``  — extract numerical score and normalise.
+        ``"json"``   — parse JSON and look for *score* key.
+    score_range : tuple[float, float]
+        Raw score range for normalisation.
+    score_key : str
+        Key to look up in JSON responses (default ``"score"``).
+    max_retries / retry_delay : int / float
+        Retry parameters.
+    """
+
+    def __init__(
+        self,
+        model: str = "gemini-2.5-pro",
+        api_key: Optional[str] = None,
+        custom_prompt: Optional[Union[str, Callable]] = None,
+        response_format: str = "binary",
+        score_range: Tuple[float, float] = (0.0, 10.0),
+        score_key: str = "score",
+        max_retries: int = 5,
+        retry_delay: float = 2.0,
+        temperature: float = 0.0,
+    ):
+        self.model = model
+        self.custom_prompt = custom_prompt
+        self.response_format = response_format
+        self.score_range = score_range
+        self.score_key = score_key
+        self.max_retries = max_retries
+        self.retry_delay = retry_delay
+        self.temperature = temperature
+
+        self._api_key = api_key or os.environ.get("GOOGLE_API_KEY")
+        if not self._api_key:
+            raise RuntimeError("GOOGLE_API_KEY is required for GeminiVerifier")
+
+        self._client = None  # lazy init
+
+    def _get_client(self):
+        if self._client is None:
+            from google import genai
+
+            self._client = genai.Client(api_key=self._api_key)
+        return self._client
+
+    # ------------------------------------------------------------------
+    # Prompt building
+    # ------------------------------------------------------------------
+
+    def _build_contents(self, question: str, prediction: str, ground_truth: str, **kwargs: Any) -> list:
+        """Build a Gemini ``contents`` list (text + optional images)."""
+        if self.custom_prompt is not None:
+            if callable(self.custom_prompt):
+                text = self.custom_prompt(question, prediction, ground_truth, **kwargs)
+            else:
+                text = self.custom_prompt.format(question=question, prediction=prediction, ground_truth=ground_truth, **kwargs)
+        else:
+            text = f"Question: {question}\n\n" f"Ground truth answer: {ground_truth}\n\n" f"Model prediction: {prediction}\n\n" "Is the model's prediction correct? Answer with CORRECT or INCORRECT."
+
+        contents: list = []
+
+        images = kwargs.get("images")
+        if images:
+            from google.genai import types
+
+            for img in images:
+                if isinstance(img, bytes):
+                    contents.append(types.Part.from_bytes(data=img, mime_type="image/png"))
+                elif isinstance(img, str) and os.path.isfile(img):
+                    with open(img, "rb") as f:
+                        contents.append(types.Part.from_bytes(data=f.read(), mime_type="image/png"))
+
+        contents.append(text)
+        return contents
+
+    # ------------------------------------------------------------------
+    # Core verify
+    # ------------------------------------------------------------------
+
+    def verify(self, question: str, prediction: str, ground_truth: str, **kwargs: Any) -> VerifyResult:
+        contents = self._build_contents(question, prediction, ground_truth, **kwargs)
+
+        for attempt in range(self.max_retries):
+            try:
+                client = self._get_client()
+                response = client.models.generate_content(
+                    model=self.model,
+                    contents=contents,
+                    config={"temperature": self.temperature},
+                )
+                return self._parse(response.text)
+            except Exception as e:
+                logger.warning("Gemini judge attempt %d/%d failed: %s", attempt + 1, self.max_retries, e)
+                if attempt < self.max_retries - 1:
+                    time.sleep(self.retry_delay * (2**attempt))
+
+        logger.error("Gemini judge failed after %d retries", self.max_retries)
+        return VerifyResult(score=0.0, is_correct=False, raw_output="all_retries_exhausted")
+
+    # ------------------------------------------------------------------
+    # Response parsing
+    # ------------------------------------------------------------------
+
+    def _parse(self, text: str) -> VerifyResult:
+        if self.response_format == "binary":
+            correct = parse_binary_response(text)
+            return VerifyResult(score=1.0 if correct else 0.0, is_correct=correct, raw_output=text)
+
+        if self.response_format == "score":
+            numbers = re.findall(r"-?\d+(?:\.\d+)?", text)
+            if numbers:
+                raw = float(numbers[0])
+                lo, hi = self.score_range
+                norm = max(0.0, min(1.0, (raw - lo) / (hi - lo))) if hi > lo else 0.0
+                return VerifyResult(score=norm, is_correct=norm >= 0.5, raw_output=text)
+            return VerifyResult(score=0.0, is_correct=False, raw_output=text)
+
+        if self.response_format == "json":
+            parsed = _safe_parse_json(text)
+            if parsed and self.score_key in parsed:
+                raw = float(parsed[self.score_key])
+                lo, hi = self.score_range
+                norm = max(0.0, min(1.0, (raw - lo) / (hi - lo))) if hi > lo else 0.0
+                return VerifyResult(
+                    score=norm,
+                    is_correct=norm >= 0.5,
+                    raw_output=text,
+                    metadata=parsed,
+                )
+            return VerifyResult(score=0.0, is_correct=False, raw_output=text, metadata={"parse_error": True})
+
+        raise ValueError(f"Unknown response_format: {self.response_format!r}")

--- a/lmms_eval/verifiers/gemini.py
+++ b/lmms_eval/verifiers/gemini.py
@@ -4,12 +4,13 @@ Wraps the ``google-genai`` SDK to provide a ``Verifier`` interface.
 Supports text-only and multimodal (text + image) evaluation.
 """
 
+import io
 import json
 import logging
 import os
 import re
 import time
-from typing import Any, Callable, List, Optional, Tuple, Union
+from typing import Any, Callable, Optional, Tuple, Union
 
 from .base import Verifier, VerifyResult, parse_binary_response
 
@@ -55,6 +56,13 @@ class GeminiVerifier(Verifier):
         Key to look up in JSON responses (default ``"score"``).
     max_retries / retry_delay : int / float
         Retry parameters.
+
+    Notes
+    -----
+    If every retry is exhausted, :meth:`verify` returns a
+    :class:`VerifyResult` with ``metadata["judge_failed"] = True`` (and
+    ``score=0.0`` / ``is_correct=False``) so callers can exclude infra
+    failures instead of counting them as a genuinely wrong prediction.
     """
 
     def __init__(
@@ -110,6 +118,7 @@ class GeminiVerifier(Verifier):
         images = kwargs.get("images")
         if images:
             from google.genai import types
+            from PIL import Image
 
             for img in images:
                 if isinstance(img, bytes):
@@ -117,6 +126,12 @@ class GeminiVerifier(Verifier):
                 elif isinstance(img, str) and os.path.isfile(img):
                     with open(img, "rb") as f:
                         contents.append(types.Part.from_bytes(data=f.read(), mime_type="image/png"))
+                elif isinstance(img, Image.Image):
+                    buf = io.BytesIO()
+                    img.save(buf, format="PNG")
+                    contents.append(types.Part.from_bytes(data=buf.getvalue(), mime_type="image/png"))
+                else:
+                    logger.warning("GeminiVerifier: unhandled image type %s; skipping", type(img).__name__)
 
         contents.append(text)
         return contents
@@ -143,7 +158,7 @@ class GeminiVerifier(Verifier):
                     time.sleep(self.retry_delay * (2**attempt))
 
         logger.error("Gemini judge failed after %d retries", self.max_retries)
-        return VerifyResult(score=0.0, is_correct=False, raw_output="all_retries_exhausted")
+        return VerifyResult(score=0.0, is_correct=False, raw_output="all_retries_exhausted", metadata={"judge_failed": True})
 
     # ------------------------------------------------------------------
     # Response parsing

--- a/lmms_eval/verifiers/openai.py
+++ b/lmms_eval/verifiers/openai.py
@@ -1,0 +1,193 @@
+"""OpenAI / GPT-4o judge verifier.
+
+Wraps the existing ``lmms_eval.llm_judge`` provider layer to expose a
+``Verifier`` interface.  Supports three judge modes:
+
+* **binary** — correct / incorrect (uses ``evaluate_binary``)
+* **score** — numerical rating normalised to 0-1
+* **custom** — full prompt control via template or callable
+"""
+
+import logging
+import os
+from typing import Any, Callable, List, Optional, Tuple, Union
+
+from .base import Verifier, VerifyResult, parse_binary_response
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_score_response(text: str, score_range: Tuple[float, float] = (0.0, 10.0)) -> float:
+    """Extract a numerical score and normalise to 0-1."""
+    import re
+
+    numbers = re.findall(r"-?\d+(?:\.\d+)?", text)
+    if not numbers:
+        return 0.0
+    raw = float(numbers[0])
+    lo, hi = score_range
+    if hi == lo:
+        return 1.0 if raw >= hi else 0.0
+    return max(0.0, min(1.0, (raw - lo) / (hi - lo)))
+
+
+class OpenAIVerifier(Verifier):
+    """Verification via OpenAI-compatible APIs (GPT-4o, Azure, vLLM, etc.).
+
+    Parameters
+    ----------
+    model : str
+        Model name, e.g. ``"gpt-4o-2024-11-20"``.
+    api_type : str | None
+        Provider key (``"openai"``, ``"azure"``, …).  Falls back to
+        ``$API_TYPE`` env var.
+    judge_type : str
+        ``"binary"`` — correct/incorrect via ``evaluate_binary``.
+        ``"score"``  — numerical rating (requires *score_range*).
+        ``"custom"`` — caller provides *custom_prompt*.
+    custom_prompt : str | callable | None
+        For ``"custom"`` mode.  If a string, may contain
+        ``{question}``, ``{prediction}``, ``{ground_truth}`` placeholders.
+        If a callable, signature ``(question, prediction, ground_truth, **kw) -> str``.
+    response_format : str
+        How to parse the judge response: ``"binary"`` or ``"score"``.
+    response_parser : callable | None
+        Optional custom callable ``(str) -> VerifyResult`` that overrides
+        *response_format*.  Useful when the judge returns task-specific
+        formats (e.g. A/B/C letters).
+    score_range : tuple[float, float]
+        Min/max of the raw score the judge produces (used for normalisation).
+    max_retries / retry_delay : int / float
+        Retry parameters for transient API failures.
+    """
+
+    def __init__(
+        self,
+        model: str = "gpt-4o-2024-11-20",
+        api_type: Optional[str] = None,
+        judge_type: str = "binary",
+        custom_prompt: Optional[Union[str, Callable]] = None,
+        response_format: str = "binary",
+        response_parser: Optional[Callable] = None,
+        score_range: Tuple[float, float] = (0.0, 10.0),
+        max_retries: int = 5,
+        retry_delay: float = 2.0,
+        temperature: float = 0.0,
+        max_tokens: int = 1024,
+    ):
+        self.judge_type = judge_type
+        self.custom_prompt = custom_prompt
+        self.response_format = response_format
+        self.response_parser = response_parser
+        self.score_range = score_range
+        self.max_retries = max_retries
+        self.retry_delay = retry_delay
+
+        from lmms_eval.llm_judge import get_server
+        from lmms_eval.llm_judge.protocol import ServerConfig
+
+        api_type = api_type or os.getenv("API_TYPE", "openai")
+        config = ServerConfig(
+            model_name=model,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            num_retries=max_retries,
+            retry_delay=retry_delay,
+        )
+        self._server = get_server(server_name=api_type, config=config)
+
+    # ------------------------------------------------------------------
+    # Prompt building
+    # ------------------------------------------------------------------
+
+    def _build_prompt(self, question: str, prediction: str, ground_truth: str, **kwargs: Any) -> Optional[str]:
+        """Build a prompt string for *custom* mode.  Returns ``None`` for
+        *binary*/*score* modes (handled via ``evaluate_binary``)."""
+        if self.custom_prompt is None:
+            return None
+        if callable(self.custom_prompt):
+            return self.custom_prompt(question, prediction, ground_truth, **kwargs)
+        return self.custom_prompt.format(
+            question=question,
+            prediction=prediction,
+            ground_truth=ground_truth,
+            **kwargs,
+        )
+
+    # ------------------------------------------------------------------
+    # Core verify
+    # ------------------------------------------------------------------
+
+    def verify(self, question: str, prediction: str, ground_truth: str, **kwargs: Any) -> VerifyResult:
+        try:
+            return self._verify_once(question, prediction, ground_truth, **kwargs)
+        except Exception as e:
+            logger.error("OpenAI judge failed: %s", e)
+            return VerifyResult(score=0.0, is_correct=False, raw_output=f"error: {e}")
+
+    def _verify_once(self, question: str, prediction: str, ground_truth: str, **kwargs: Any) -> VerifyResult:
+        # --- custom prompt mode -------------------------------------------------
+        prompt = self._build_prompt(question, prediction, ground_truth, **kwargs)
+        if prompt is not None:
+            from lmms_eval.llm_judge.protocol import Request
+
+            request = Request(
+                messages=[{"role": "user", "content": prompt}],
+                images=kwargs.get("images"),
+                config=self._server.config,
+            )
+            response = self._server.evaluate(request)
+            return self._parse(response.content)
+
+        # --- built-in binary mode -----------------------------------------------
+        if self.judge_type == "binary":
+            result = self._server.evaluate_binary(
+                question=question,
+                answer=ground_truth,
+                prediction=prediction,
+                output_format=kwargs.get("output_format", "0/1"),
+            )
+            is_correct = bool(result.get("result"))
+            return VerifyResult(
+                score=1.0 if is_correct else 0.0,
+                is_correct=is_correct,
+                raw_output=result.get("raw_response", ""),
+                metadata={"model": result.get("model", "")},
+            )
+
+        # --- built-in comparative mode ------------------------------------------
+        if self.judge_type == "comparative":
+            result = self._server.evaluate_comparative(
+                question=question,
+                response1=prediction,
+                response2=kwargs.get("reference_response", ground_truth),
+                custom_prompt=None,
+                images=kwargs.get("images"),
+            )
+            scores = result.get("scores", (-1.0, -1.0))
+            s1, s2 = scores if isinstance(scores, tuple) else (-1.0, -1.0)
+            lo, hi = self.score_range
+            norm = max(0.0, min(1.0, (s1 - lo) / (hi - lo))) if hi > lo else 0.0
+            return VerifyResult(
+                score=norm,
+                is_correct=s1 > s2,
+                raw_output=result.get("raw_response", ""),
+                metadata={"score_1": s1, "score_2": s2, "model": result.get("model", "")},
+            )
+
+        raise ValueError(f"Unknown judge_type: {self.judge_type!r}")
+
+    # ------------------------------------------------------------------
+    # Response parsing
+    # ------------------------------------------------------------------
+
+    def _parse(self, text: str) -> VerifyResult:
+        if self.response_parser is not None:
+            return self.response_parser(text)
+        if self.response_format == "binary":
+            correct = parse_binary_response(text)
+            return VerifyResult(score=1.0 if correct else 0.0, is_correct=correct, raw_output=text)
+        if self.response_format == "score":
+            score = _parse_score_response(text, self.score_range)
+            return VerifyResult(score=score, is_correct=score >= 0.5, raw_output=text)
+        raise ValueError(f"Unknown response_format: {self.response_format!r}")

--- a/lmms_eval/verifiers/openai.py
+++ b/lmms_eval/verifiers/openai.py
@@ -1,16 +1,19 @@
 """OpenAI / GPT-4o judge verifier.
 
 Wraps the existing ``lmms_eval.llm_judge`` provider layer to expose a
-``Verifier`` interface.  Supports three judge modes:
+``Verifier`` interface.  Two ``judge_type`` modes are supported:
 
 * **binary** — correct / incorrect (uses ``evaluate_binary``)
-* **score** — numerical rating normalised to 0-1
-* **custom** — full prompt control via template or callable
+* **comparative** — pairwise scoring (uses ``evaluate_comparative``)
+
+Score-style output is controlled by *response_format* (``"binary"`` /
+``"score"``) and full prompt control by *custom_prompt* — both independent
+of *judge_type*.
 """
 
 import logging
 import os
-from typing import Any, Callable, List, Optional, Tuple, Union
+from typing import Any, Callable, Optional, Tuple, Union
 
 from .base import Verifier, VerifyResult, parse_binary_response
 
@@ -43,8 +46,9 @@ class OpenAIVerifier(Verifier):
         ``$API_TYPE`` env var.
     judge_type : str
         ``"binary"`` — correct/incorrect via ``evaluate_binary``.
-        ``"score"``  — numerical rating (requires *score_range*).
-        ``"custom"`` — caller provides *custom_prompt*.
+        ``"comparative"`` — pairwise scoring via ``evaluate_comparative``.
+        Score-style output is driven by *response_format* and custom
+        prompts by *custom_prompt*, independent of *judge_type*.
     custom_prompt : str | callable | None
         For ``"custom"`` mode.  If a string, may contain
         ``{question}``, ``{prediction}``, ``{ground_truth}`` placeholders.
@@ -59,6 +63,14 @@ class OpenAIVerifier(Verifier):
         Min/max of the raw score the judge produces (used for normalisation).
     max_retries / retry_delay : int / float
         Retry parameters for transient API failures.
+
+    Notes
+    -----
+    If the judge call fails (an exception is raised, or the provider reports
+    ``success=False``), :meth:`verify` returns a :class:`VerifyResult` with
+    ``metadata["judge_failed"] = True`` (and ``score=0.0`` /
+    ``is_correct=False``) so callers can exclude infra failures instead of
+    counting them as a genuinely wrong prediction.
     """
 
     def __init__(
@@ -123,7 +135,7 @@ class OpenAIVerifier(Verifier):
             return self._verify_once(question, prediction, ground_truth, **kwargs)
         except Exception as e:
             logger.error("OpenAI judge failed: %s", e)
-            return VerifyResult(score=0.0, is_correct=False, raw_output=f"error: {e}")
+            return VerifyResult(score=0.0, is_correct=False, raw_output=f"error: {e}", metadata={"judge_failed": True})
 
     def _verify_once(self, question: str, prediction: str, ground_truth: str, **kwargs: Any) -> VerifyResult:
         # --- custom prompt mode -------------------------------------------------
@@ -147,6 +159,13 @@ class OpenAIVerifier(Verifier):
                 prediction=prediction,
                 output_format=kwargs.get("output_format", "0/1"),
             )
+            if not result.get("success", True):
+                return VerifyResult(
+                    score=0.0,
+                    is_correct=False,
+                    raw_output=result.get("raw_response", ""),
+                    metadata={"model": result.get("model", ""), "judge_failed": True},
+                )
             is_correct = bool(result.get("result"))
             return VerifyResult(
                 score=1.0 if is_correct else 0.0,
@@ -164,6 +183,13 @@ class OpenAIVerifier(Verifier):
                 custom_prompt=None,
                 images=kwargs.get("images"),
             )
+            if not result.get("success", True):
+                return VerifyResult(
+                    score=0.0,
+                    is_correct=False,
+                    raw_output=result.get("raw_response", ""),
+                    metadata={"model": result.get("model", ""), "judge_failed": True},
+                )
             scores = result.get("scores", (-1.0, -1.0))
             s1, s2 = scores if isinstance(scores, tuple) else (-1.0, -1.0)
             lo, hi = self.score_range

--- a/lmms_eval/verifiers/pipeline.py
+++ b/lmms_eval/verifiers/pipeline.py
@@ -1,0 +1,72 @@
+"""Verification pipeline — the glue between extractors and verifiers.
+
+A ``VerificationPipeline`` chains zero-or-more **extractors** (per-sample
+text transforms) followed by exactly one **verifier**.  This is the main
+entry-point tasks use to plug verification into ``process_results``.
+
+::
+
+    raw model output ──► extractor₁ ──► extractor₂ ──► verifier ──► VerifyResult
+"""
+
+from typing import Any, Dict, List, Optional, Union
+
+from .base import Extractor, Verifier, VerifyResult
+
+
+class VerificationPipeline:
+    """Extraction → Verification in a single callable.
+
+    Parameters
+    ----------
+    extractors : list[Extractor]
+        Ordered per-sample text transforms applied before verification.
+    verifier : Verifier
+        The verifier that produces the final ``VerifyResult``.
+
+    Examples
+    --------
+    ::
+
+        from lmms_eval.verifiers import VerificationPipeline
+        from lmms_eval.verifiers.extractors import StripReasoningExtractor
+        from lmms_eval.verifiers.openai import OpenAIVerifier
+
+        pipeline = VerificationPipeline(
+            extractors=[StripReasoningExtractor()],
+            verifier=OpenAIVerifier(model="gpt-4o-2024-11-20"),
+        )
+        result = pipeline("What color is the sky?", "<think>hmm</think>Blue", "Blue")
+        assert result.is_correct
+    """
+
+    def __init__(
+        self,
+        extractors: Optional[List[Extractor]] = None,
+        verifier: Optional[Verifier] = None,
+    ):
+        self.extractors: List[Extractor] = extractors or []
+        if verifier is None:
+            raise ValueError("VerificationPipeline requires a verifier")
+        self.verifier: Verifier = verifier
+
+    def __call__(
+        self,
+        question: str,
+        prediction: str,
+        ground_truth: str,
+        **kwargs: Any,
+    ) -> VerifyResult:
+        """Run the full pipeline: extract → verify."""
+        cleaned = prediction
+        for ext in self.extractors:
+            cleaned = ext(cleaned, **kwargs)
+
+        result = self.verifier.verify(question, cleaned, ground_truth, **kwargs)
+        result.metadata["raw_prediction"] = prediction
+        result.metadata["extracted_prediction"] = cleaned
+        return result
+
+    def verify(self, question: str, prediction: str, ground_truth: str, **kwargs: Any) -> VerifyResult:
+        """Alias for ``__call__``."""
+        return self(question, prediction, ground_truth, **kwargs)

--- a/lmms_eval/verifiers/rule.py
+++ b/lmms_eval/verifiers/rule.py
@@ -60,11 +60,16 @@ class MCQMatchVerifier(Verifier):
     def verify(self, question: str, prediction: str, ground_truth: str, **kwargs: Any) -> VerifyResult:
         pred = prediction.strip().upper().strip("(). ")
         gt = ground_truth.strip().upper().strip("(). ")
+        # Parse-based: confident only when a single MCQ letter was extracted.
+        # An unparseable prediction is low-confidence so a composite chain
+        # falls through to a downstream (e.g. LLM) verifier.
+        extracted = bool(re.fullmatch(r"[A-Z]", pred))
         correct = pred == gt
         return VerifyResult(
             score=1.0 if correct else 0.0,
             is_correct=correct,
             raw_output=f"mcq_match: '{pred}' vs '{gt}'",
+            metadata={"confident": extracted},
         )
 
 
@@ -97,8 +102,11 @@ class NumericToleranceVerifier(Verifier):
             )
 
         correct = math.isclose(pred_num, gt_num, rel_tol=self.rel_tol, abs_tol=self.abs_tol)
+        # Parse-based: both numbers parsed cleanly, so this is a confident
+        # verdict even when wrong (no fallback for a cleanly-parsed mismatch).
         return VerifyResult(
             score=1.0 if correct else 0.0,
             is_correct=correct,
             raw_output=f"numeric: {pred_num} vs {gt_num} (rel_tol={self.rel_tol})",
+            metadata={"confident": True},
         )

--- a/lmms_eval/verifiers/rule.py
+++ b/lmms_eval/verifiers/rule.py
@@ -1,0 +1,104 @@
+"""Rule-based verifiers — no external API calls required."""
+
+import math
+import re
+from typing import Any, Optional
+
+from .base import Verifier, VerifyResult
+
+
+class ExactMatchVerifier(Verifier):
+    """Verify by exact string match after normalization."""
+
+    def __init__(self, ignore_case: bool = True, strip: bool = True):
+        self.ignore_case = ignore_case
+        self.strip = strip
+
+    def _normalize(self, text: str) -> str:
+        if self.strip:
+            text = text.strip()
+        if self.ignore_case:
+            text = text.lower()
+        return text
+
+    def verify(self, question: str, prediction: str, ground_truth: str, **kwargs: Any) -> VerifyResult:
+        pred = self._normalize(prediction)
+        gt = self._normalize(ground_truth)
+        correct = pred == gt
+        return VerifyResult(
+            score=1.0 if correct else 0.0,
+            is_correct=correct,
+            raw_output=f"exact_match: '{pred}' vs '{gt}'",
+            metadata={"confident": correct},
+        )
+
+
+class ContainsVerifier(Verifier):
+    """Verify that the prediction contains the ground truth."""
+
+    def __init__(self, ignore_case: bool = True):
+        self.ignore_case = ignore_case
+
+    def verify(self, question: str, prediction: str, ground_truth: str, **kwargs: Any) -> VerifyResult:
+        pred = prediction.lower() if self.ignore_case else prediction
+        gt = ground_truth.lower() if self.ignore_case else ground_truth
+        correct = gt in pred
+        return VerifyResult(
+            score=1.0 if correct else 0.0,
+            is_correct=correct,
+            raw_output=f"contains: '{gt}' in prediction={correct}",
+            metadata={"confident": correct},
+        )
+
+
+class MCQMatchVerifier(Verifier):
+    """Verify MCQ answer by letter match.
+
+    Handles common format variations: ``A``, ``(A)``, ``A.``, ``A)``.
+    """
+
+    def verify(self, question: str, prediction: str, ground_truth: str, **kwargs: Any) -> VerifyResult:
+        pred = prediction.strip().upper().strip("(). ")
+        gt = ground_truth.strip().upper().strip("(). ")
+        correct = pred == gt
+        return VerifyResult(
+            score=1.0 if correct else 0.0,
+            is_correct=correct,
+            raw_output=f"mcq_match: '{pred}' vs '{gt}'",
+        )
+
+
+class NumericToleranceVerifier(Verifier):
+    """Verify numerical answers within a tolerance."""
+
+    def __init__(self, rel_tol: float = 1e-3, abs_tol: float = 1e-6):
+        self.rel_tol = rel_tol
+        self.abs_tol = abs_tol
+
+    @staticmethod
+    def _parse_number(text: str) -> Optional[float]:
+        text = text.strip().replace(",", "").replace("%", "")
+        try:
+            return float(text)
+        except ValueError:
+            numbers = re.findall(r"-?\d+(?:\.\d+)?", text)
+            return float(numbers[-1]) if numbers else None
+
+    def verify(self, question: str, prediction: str, ground_truth: str, **kwargs: Any) -> VerifyResult:
+        pred_num = self._parse_number(prediction)
+        gt_num = self._parse_number(ground_truth)
+
+        if pred_num is None or gt_num is None:
+            return VerifyResult(
+                score=0.0,
+                is_correct=False,
+                raw_output=f"numeric_parse_fail: pred={prediction!r} gt={ground_truth!r}",
+                metadata={"confident": False},
+            )
+
+        correct = math.isclose(pred_num, gt_num, rel_tol=self.rel_tol, abs_tol=self.abs_tol)
+        return VerifyResult(
+            score=1.0 if correct else 0.0,
+            is_correct=correct,
+            raw_output=f"numeric: {pred_num} vs {gt_num} (rel_tol={self.rel_tol})",
+        )


### PR DESCRIPTION
## Summary

Adds `lmms_eval/verifiers/` — a self-contained, pluggable per-sample verification pipeline for answer checking (is a prediction correct given the ground truth), usable from any task's `process_results`:

- `base.py`: `Verifier` / `Extractor` ABCs and a normalized `VerifyResult` (per-sample verdict + score + rationale), supporting both per-sample and batch-filter style use.
- `rule.py`: rule-based verifiers (exact/normalized match and friends).
- `openai.py`, `gemini.py`: LLM-judge verifiers over the existing provider stacks.
- `composite.py`: combine several verifiers (e.g. rule-first, LLM fallback).
- `extractors.py`: answer extraction helpers feeding the verifiers.
- `pipeline.py`: the orchestration layer tying extraction + verification together.
- Package `README.md` documenting the abstractions and a usage example.

## Why

Task `utils.py` files keep re-implementing the same extract-then-compare logic with ad-hoc LLM-judge fallbacks. This module gives new benchmarks one composable, tested path for that pattern instead of another bespoke copy.

## Notes

- Pure addition (no existing file touched); no task is wired to it in this PR — call-site adoption lands in #1388.
- Imports resolve against public main only (verified by compile + import checks).

## Test plan

- [x] `python3 -m py_compile` on all package files
- [x] Import check of the package against this branch
- [x] black + isort (pre-commit) clean
- [x] Hermetic mocked-judge assertions (25 checks): judge failure surfaces `judge_failed` metadata; composite falls through to the LLM verifier when a rule verifier can't parse the prediction

### Review pass (2026-07-06)
Self-review follow-up commit:
- **Judge infra failures are distinguishable from wrong answers**: on exception, retry exhaustion, or an explicit `success=False` from the provider, LLM verifiers now return `metadata={"judge_failed": True}` (score stays 0.0 so nothing downstream breaks, but task code can exclude or fall back on infra failures instead of silently deflating accuracy). Documented in the guide; #1388's migrations use it for their fallbacks.
- **Composite fallback contract fixed and documented**: `MCQMatchVerifier` reports `confident=False` when it can't extract an option letter (previously it set no key, which composite treats as confident — so rule-first→LLM-fallback never fell back); `NumericToleranceVerifier` sets `confident` explicitly on both paths. Contract: string-match verifiers fall through on any non-match; parse-based verifiers fall through on parse failure (a cleanly-parsed wrong answer is a confident wrong).
- `judge_type` docs now match the implementation (`binary`, `comparative`); score-style output is driven by `response_format`, fully custom prompts via `custom_prompt`.
- Gemini verifier: PIL images are encoded (PNG) for multimodal judging instead of being silently dropped; unhandled image types log a warning.

Known heuristics left as-is for reviewer opinion: `parse_binary_response`'s substring `"1"` signal (guarded by CORRECT/INCORRECT matching first), and first-number score parsing in the score parser.
