### PR TITLE
fix(llm_judge): OpenAI base URL, max_completion_tokens for reasoning models, PIL image support

### DIFF
--- a/lmms_eval/llm_judge/protocol.py
+++ b/lmms_eval/llm_judge/protocol.py
@@ -35,7 +35,7 @@ class Request:
     """Standard request format for judge evaluation"""
 
     messages: List[Dict[str, Any]]
-    images: Optional[List[Union[str, bytes]]] = None  # Image paths or base64 encoded
+    images: Optional[List[Union[str, bytes, "Image.Image"]]] = None  # Image paths, base64 bytes, or PIL images
     config: Optional[ServerConfig] = None
 
     # Structured input for specific judge types

--- a/lmms_eval/llm_judge/providers/async_openai.py
+++ b/lmms_eval/llm_judge/providers/async_openai.py
@@ -18,14 +18,15 @@ class AsyncOpenAIProvider(AsyncServerInterface):
     def __init__(self, config: Optional[ServerConfig] = None):
         super().__init__(config)
         self.api_key = os.getenv("OPENAI_API_KEY", "")
-        self.api_url = os.getenv("OPENAI_API_URL", "https://api.openai.com/v1/chat/completions")
+        base_url = os.getenv("OPENAI_API_URL", "https://api.openai.com/v1")
+        self.api_url = base_url.rstrip("/") + "/chat/completions"
 
         # Try to use async OpenAI client if available
         self.use_async_client = False
         try:
             from openai import AsyncOpenAI
 
-            self.async_client = AsyncOpenAI(api_key=self.api_key)
+            self.async_client = AsyncOpenAI(api_key=self.api_key, base_url=base_url)
             self.use_async_client = True
         except ImportError:
             eval_logger.warning("AsyncOpenAI client not available, using aiohttp")

--- a/lmms_eval/llm_judge/providers/async_openai.py
+++ b/lmms_eval/llm_judge/providers/async_openai.py
@@ -4,12 +4,13 @@ from typing import Dict, List, Optional, Union
 
 import aiohttp
 from loguru import logger as eval_logger
+from PIL import Image
 
 from lmms_eval.models.model_utils.usage_metrics import log_usage
 
 from ..base import AsyncServerInterface
 from ..protocol import Request, Response, ServerConfig
-from .openai import OpenAIProvider
+from .openai import OpenAIProvider, build_sampling_kwargs
 
 
 class AsyncOpenAIProvider(AsyncServerInterface):
@@ -50,8 +51,7 @@ class AsyncOpenAIProvider(AsyncServerInterface):
         payload = {
             "model": config.model_name,
             "messages": messages,
-            "temperature": config.temperature,
-            "max_tokens": config.max_tokens,
+            **build_sampling_kwargs(config),
         }
 
         if config.top_p is not None:
@@ -119,7 +119,7 @@ class AsyncOpenAIProvider(AsyncServerInterface):
                 response.raise_for_status()
                 return await response.json()
 
-    def _add_images_to_messages(self, messages: List[Dict], images: List[Union[str, bytes]]) -> List[Dict]:
+    def _add_images_to_messages(self, messages: List[Dict], images: List[Union[str, bytes, Image.Image]]) -> List[Dict]:
         """Add images to messages - reuse from base implementation"""
         return OpenAIProvider._add_images_to_messages(self, messages, images)
 

--- a/lmms_eval/llm_judge/providers/openai.py
+++ b/lmms_eval/llm_judge/providers/openai.py
@@ -4,6 +4,7 @@ from typing import Dict, List, Optional, Union
 
 import requests
 from loguru import logger as eval_logger
+from PIL import Image
 
 from lmms_eval.models.model_utils.media_encoder import encode_image_to_base64
 from lmms_eval.models.model_utils.usage_metrics import log_usage
@@ -18,13 +19,13 @@ class OpenAIProvider(ServerInterface):
     def __init__(self, config: Optional[ServerConfig] = None):
         super().__init__(config)
         self.api_key = os.getenv("OPENAI_API_KEY", "")
-        self.api_url = os.getenv("OPENAI_API_URL", "https://api.openai.com/v1/chat/completions/v1")
+        self.base_url = os.getenv("OPENAI_API_URL", "https://api.openai.com/v1")
 
         # Initialize OpenAI client
         try:
             from openai import OpenAI
 
-            self.client = OpenAI(api_key=self.api_key, base_url=self.api_url)
+            self.client = OpenAI(api_key=self.api_key, base_url=self.base_url)
             self.use_client = True
         except ImportError:
             eval_logger.warning("OpenAI client not available, falling back to requests")
@@ -45,12 +46,14 @@ class OpenAIProvider(ServerInterface):
         if request.images:
             messages = self._add_images_to_messages(messages, request.images)
 
-        # Prepare payload
+        # Prepare payload — use max_completion_tokens for newer models (gpt-5-*)
+        model = config.model_name
+        token_key = "max_completion_tokens" if model.startswith(("gpt-5", "o1", "o3", "o4")) else "max_tokens"
         payload = {
-            "model": config.model_name,
+            "model": model,
             "messages": messages,
             "temperature": config.temperature,
-            "max_tokens": config.max_tokens,
+            token_key: config.max_tokens,
         }
 
         if config.top_p is not None:
@@ -112,7 +115,8 @@ class OpenAIProvider(ServerInterface):
             "Content-Type": "application/json",
         }
 
-        response = requests.post(self.api_url, headers=headers, json=payload, timeout=timeout)
+        url = self.base_url.rstrip("/") + "/chat/completions"
+        response = requests.post(url, headers=headers, json=payload, timeout=timeout)
         response.raise_for_status()
         return response.json()
 
@@ -127,7 +131,11 @@ class OpenAIProvider(ServerInterface):
 
                 # Add images
                 for image in images:
-                    if isinstance(image, str):
+                    if isinstance(image, Image.Image):
+                        # PIL Image object
+                        base64_image = encode_image_to_base64(image, image_format="JPEG", convert_rgb=True, quality=85)
+                        messages[i]["content"].append({"type": "image_url", "image_url": {"url": f"data:image/jpeg;base64,{base64_image}"}})
+                    elif isinstance(image, str):
                         # File path
                         base64_image = self._encode_image(image)
                         messages[i]["content"].append({"type": "image_url", "image_url": {"url": f"data:image/jpeg;base64,{base64_image}"}})

--- a/lmms_eval/llm_judge/providers/openai.py
+++ b/lmms_eval/llm_judge/providers/openai.py
@@ -1,6 +1,6 @@
 import os
 import time
-from typing import Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 import requests
 from loguru import logger as eval_logger
@@ -11,6 +11,22 @@ from lmms_eval.models.model_utils.usage_metrics import log_usage
 
 from ..base import ServerInterface
 from ..protocol import Request, Response, ServerConfig
+
+
+def _is_reasoning_model(model_name: str) -> bool:
+    """Reasoning models (gpt-5*, o1/o3/o4*) require max_completion_tokens and reject an explicit temperature."""
+    return model_name.startswith(("gpt-5", "o1", "o3", "o4"))
+
+
+def build_sampling_kwargs(config: ServerConfig) -> Dict[str, Any]:
+    """Token-limit and temperature kwargs for a chat.completions payload.
+
+    Reasoning models use max_completion_tokens and reject a non-default temperature
+    (the API returns 400), so temperature is omitted for them.
+    """
+    if _is_reasoning_model(config.model_name):
+        return {"max_completion_tokens": config.max_tokens}
+    return {"max_tokens": config.max_tokens, "temperature": config.temperature}
 
 
 class OpenAIProvider(ServerInterface):
@@ -46,14 +62,11 @@ class OpenAIProvider(ServerInterface):
         if request.images:
             messages = self._add_images_to_messages(messages, request.images)
 
-        # Prepare payload — use max_completion_tokens for newer models (gpt-5-*)
-        model = config.model_name
-        token_key = "max_completion_tokens" if model.startswith(("gpt-5", "o1", "o3", "o4")) else "max_tokens"
+        # Prepare payload
         payload = {
-            "model": model,
+            "model": config.model_name,
             "messages": messages,
-            "temperature": config.temperature,
-            token_key: config.max_tokens,
+            **build_sampling_kwargs(config),
         }
 
         if config.top_p is not None:
@@ -120,7 +133,7 @@ class OpenAIProvider(ServerInterface):
         response.raise_for_status()
         return response.json()
 
-    def _add_images_to_messages(self, messages: List[Dict], images: List[Union[str, bytes]]) -> List[Dict]:
+    def _add_images_to_messages(self, messages: List[Dict], images: List[Union[str, bytes, Image.Image]]) -> List[Dict]:
         """Add images to the last user message"""
         # Find the last user message
         for i in range(len(messages) - 1, -1, -1):


### PR DESCRIPTION
## Summary
- Fix a malformed `OPENAI_API_URL` default (`.../v1/chat/completions/v1`) that was being passed straight into the `OpenAI(base_url=...)` client; now stores a clean base URL (default `https://api.openai.com/v1`) and appends `/chat/completions` only for the raw-`requests` fallback path.
- Apply the same base-URL fix to the async provider, and additionally pass `base_url` into the `AsyncOpenAI(...)` client construction -- previously a custom `OPENAI_API_URL` override was silently ignored by the async client (only the `aiohttp` fallback respected it).
- Use `max_completion_tokens` instead of `max_tokens` for `gpt-5*`/`o1*`/`o3*`/`o4*` models in **both the sync and async providers**, via a shared `build_sampling_kwargs` helper (single source of truth so the two can't drift). For those reasoning models the helper also **omits `temperature`**, which they reject at non-default values.
- Accept `PIL.Image.Image` objects directly in `OpenAIProvider._add_images_to_messages` (in addition to file-path strings and pre-encoded bytes), reusing the existing `encode_image_to_base64` helper which already supports `Union[Image.Image, str]`.

## Compatibility note
`OPENAI_API_URL` now means a **base URL** (e.g. `https://api.openai.com/v1` or your proxy's base). If you previously set it to a full `.../chat/completions` endpoint, drop that suffix — the SDK client appends the route itself.

## Test plan
- [x] `python3 -m py_compile` on changed files
- [x] `uvx ruff check` -- clean
- [x] Ephemeral env import + runtime check: default/custom `OPENAI_API_URL` resolves correctly for both sync and async clients and fallback paths; PIL image branch produces a correct `data:image/jpeg;base64,...` URL; existing bytes-branch behavior unchanged
- [x] Payload matrix: `gpt-4o` -> `max_tokens` + `temperature`; `gpt-5-mini` / `o3` -> `max_completion_tokens` only (no `temperature`, no `max_tokens`); sync and async providers verified to share the same helper object

### Review pass (2026-07-06)
Self-review caught that the original commit applied the `max_completion_tokens` switch to the sync provider only — the async provider (the default concurrent path) still sent `max_tokens`, and both providers always sent `temperature`. Follow-up commit centralizes the logic in `build_sampling_kwargs` (used by both) and fixes stale `images` type hints.

Follow-up candidate (out of scope here): `azure_openai.py` / `async_azure_openai.py` have the same latent issue (always send `temperature` + `max_tokens`); the shared helper is import-ready for them.
