### PR TITLE
feat(loggers): add SwanLab logger as a wandb alternative (--swanlab_args)

### DIFF
--- a/docs/getting-started/commands.md
+++ b/docs/getting-started/commands.md
@@ -57,6 +57,8 @@ This mode supports a number of command-line arguments, the details of which can 
 
 * `--wandb_args`:  Tracks logging to Weights and Biases for evaluation runs and includes args passed to `wandb.init`, such as `project` and `job_type`. Full list [here](https://docs.wandb.ai/ref/python/init). e.g., ```--wandb_args project=test-project,name=test-run```
 
+* `--swanlab_args`:  Tracks logging to [SwanLab](https://swanlab.cn) for evaluation runs (a Weights and Biases alternative) and includes args passed to `swanlab.init`, such as `project`, `exp_name`, and `mode`. Requires `pip install swanlab`; authenticate via the `SWANLAB_API_KEY` env var (and optional `SWANLAB_HOST` for a self-hosted instance). e.g., ```--swanlab_args project=lmms-eval,exp_name=test-run```
+
 ## Command Examples
 
 ### Basic Evaluation

--- a/lmms_eval/__main__.py
+++ b/lmms_eval/__main__.py
@@ -34,7 +34,7 @@ from lmms_eval.api.metrics import power_analysis
 from lmms_eval.api.registry import ALL_TASKS
 from lmms_eval.cli.power_utils import collect_task_sizes
 from lmms_eval.evaluator import request_caching_arg_to_dict
-from lmms_eval.loggers import EvaluationTracker, WandbLogger
+from lmms_eval.loggers import EvaluationTracker, SwanLabLogger, WandbLogger
 from lmms_eval.tasks import TaskManager
 from lmms_eval.utils import (
     get_eval_banner,
@@ -260,6 +260,12 @@ def parse_eval_args() -> tuple[argparse.ArgumentParser, argparse.Namespace]:
         help="If True, write out all model outputs and documents for per-sample measurement and post-hoc analysis to Weights and Biases",
     )
     parser.add_argument(
+        "--swanlab_log_samples",
+        action="store_true",
+        default=False,
+        help="If True, write out all model outputs and documents for per-sample measurement and post-hoc analysis to SwanLab",
+    )
+    parser.add_argument(
         "--log_samples_suffix",
         type=str,
         default="model_outputs",
@@ -316,6 +322,11 @@ def parse_eval_args() -> tuple[argparse.ArgumentParser, argparse.Namespace]:
         "--wandb_args",
         default="",
         help="Comma separated string arguments passed to wandb.init, e.g. `project=lmms-eval,job_type=eval",
+    )
+    parser.add_argument(
+        "--swanlab_args",
+        default="",
+        help="Comma separated string arguments passed to swanlab.init, e.g. `project=lmms-eval,exp_name=eval,mode=cloud`",
     )
     parser.add_argument(
         "--timezone",
@@ -467,6 +478,13 @@ def cli_evaluate(args: Union[argparse.Namespace, None] = None) -> None:
             args.wandb_args += f",name={name}"
         wandb_logger = WandbLogger(**simple_parse_args_string(args.wandb_args))
 
+    if args.swanlab_args:
+        if "exp_name" not in args.swanlab_args:
+            name = f"{args.model}_{args.model_args}_{utils.get_datetime_str(timezone=args.timezone)}"
+            name = utils.sanitize_long_string(name)
+            args.swanlab_args += f",exp_name={name}"
+        swanlab_logger = SwanLabLogger(**simple_parse_args_string(args.swanlab_args))
+
     # reset logger
     eval_logger.remove()
     # Configure logger with detailed format including file path, function name, and line number
@@ -556,6 +574,15 @@ def cli_evaluate(args: Union[argparse.Namespace, None] = None) -> None:
                     eval_logger.info(f"Logging to Weights and Biases failed due to {e}")
                 # wandb_logger.finish()
 
+            if is_main_process and args.swanlab_args:
+                try:
+                    swanlab_logger.post_init(results)
+                    swanlab_logger.log_eval_result()
+                    if args.swanlab_log_samples and samples is not None:
+                        swanlab_logger.log_eval_samples(samples)
+                except Exception as e:
+                    eval_logger.info(f"Logging to SwanLab failed due to {e}")
+
         except Exception as e:
             if args.verbosity == "DEBUG":
                 raise e
@@ -575,6 +602,9 @@ def cli_evaluate(args: Union[argparse.Namespace, None] = None) -> None:
 
     if args.wandb_args:
         wandb_logger.run.finish()
+
+    if args.swanlab_args:
+        swanlab_logger.finish()
 
 
 def cli_evaluate_single(args: Union[argparse.Namespace, None] = None) -> None:

--- a/lmms_eval/__main__.py
+++ b/lmms_eval/__main__.py
@@ -478,12 +478,17 @@ def cli_evaluate(args: Union[argparse.Namespace, None] = None) -> None:
             args.wandb_args += f",name={name}"
         wandb_logger = WandbLogger(**simple_parse_args_string(args.wandb_args))
 
+    swanlab_logger = None
     if args.swanlab_args:
         if "exp_name" not in args.swanlab_args:
             name = f"{args.model}_{args.model_args}_{utils.get_datetime_str(timezone=args.timezone)}"
             name = utils.sanitize_long_string(name)
             args.swanlab_args += f",exp_name={name}"
-        swanlab_logger = SwanLabLogger(**simple_parse_args_string(args.swanlab_args))
+        try:
+            swanlab_logger = SwanLabLogger(**simple_parse_args_string(args.swanlab_args))
+        except Exception as e:
+            eval_logger.warning(f"swanlab logger initialization failed; continuing without swanlab: {e}")
+            swanlab_logger = None
 
     # reset logger
     eval_logger.remove()
@@ -574,7 +579,7 @@ def cli_evaluate(args: Union[argparse.Namespace, None] = None) -> None:
                     eval_logger.info(f"Logging to Weights and Biases failed due to {e}")
                 # wandb_logger.finish()
 
-            if is_main_process and args.swanlab_args:
+            if is_main_process and args.swanlab_args and swanlab_logger is not None:
                 try:
                     swanlab_logger.post_init(results)
                     swanlab_logger.log_eval_result()
@@ -603,7 +608,7 @@ def cli_evaluate(args: Union[argparse.Namespace, None] = None) -> None:
     if args.wandb_args:
         wandb_logger.run.finish()
 
-    if args.swanlab_args:
+    if args.swanlab_args and swanlab_logger is not None:
         swanlab_logger.finish()
 
 

--- a/lmms_eval/loggers/__init__.py
+++ b/lmms_eval/loggers/__init__.py
@@ -1,2 +1,3 @@
 from .evaluation_tracker import EvaluationTracker
+from .swanlab_logger import SwanLabLogger
 from .wandb_logger import WandbLogger

--- a/lmms_eval/loggers/swanlab_logger.py
+++ b/lmms_eval/loggers/swanlab_logger.py
@@ -64,11 +64,17 @@ class SwanLabLogger:
                 login_kwargs["host"] = host
             swanlab.login(**login_kwargs)
 
-        # Initialize (or attach to) a SwanLab run.
-        if swanlab.get_run() is None:
+        # Initialize (or attach to) a SwanLab run. swanlab.get_run() returns the
+        # active run (or None) on <0.8, but raises RuntimeError on >=0.8 when no
+        # run is active; treat "no active run" uniformly across both.
+        try:
+            active_run = swanlab.get_run()
+        except Exception:
+            active_run = None
+        if active_run is None:
             self.run = swanlab.init(**self.swanlab_args)
         else:
-            self.run = swanlab.get_run()
+            self.run = active_run
 
     def post_init(self, results: Dict[str, Any]) -> None:
         self.results: Dict[str, Any] = copy.deepcopy(results)

--- a/lmms_eval/loggers/swanlab_logger.py
+++ b/lmms_eval/loggers/swanlab_logger.py
@@ -1,0 +1,179 @@
+"""SwanLab logger for lmms-eval, a drop-in alternative to the wandb logger.
+
+Mirrors the interface of ``lmms_eval.loggers.wandb_logger.WandbLogger`` so it can
+be wired into the same evaluation lifecycle via ``--swanlab_args``:
+
+    swanlab_logger = SwanLabLogger(**simple_parse_args_string(args.swanlab_args))
+    swanlab_logger.post_init(results)
+    swanlab_logger.log_eval_result()
+    swanlab_logger.log_eval_samples(results["samples"])
+    swanlab_logger.finish()
+
+Authentication follows standard SwanLab mechanisms: set ``SWANLAB_API_KEY`` (and
+optionally ``SWANLAB_HOST`` for a self-hosted instance); otherwise SwanLab's own
+login flow / public cloud default applies. The default project is ``lmms-eval``,
+overridable through the args string, e.g.
+``--swanlab_args project=my-proj,exp_name=my-run,mode=cloud``.
+"""
+
+import copy
+import json
+import os
+from typing import Any, Dict, List, Tuple
+
+from lmms_eval.loggers.utils import _handle_non_serializable, remove_none_pattern
+
+# SwanLab (0.7.x) has no Table/Artifact type, so per-task samples are logged as a
+# capped swanlab.Text preview rather than a full browsable table.
+_SAMPLE_PREVIEW_LIMIT = 10
+
+
+class SwanLabLogger:
+    def __init__(self, **kwargs) -> None:
+        """Attaches to the active SwanLab run if one exists, otherwise passes kwargs to swanlab.init().
+
+        Args:
+            kwargs Optional[Any]: Arguments forwarded to ``swanlab.init``. ``exp_name``
+                is accepted as an alias for SwanLab's ``experiment_name``. ``project``
+                defaults to ``lmms-eval`` when not provided.
+
+        Parse and log the results returned from evaluator.simple_evaluate() with:
+            swanlab_logger.post_init(results)
+            swanlab_logger.log_eval_result()
+            swanlab_logger.log_eval_samples(results["samples"])
+        """
+        try:
+            import swanlab
+        except ImportError as e:
+            raise ImportError("To use the SwanLab logging functionality please install swanlab.\n" "Run `pip install swanlab` (or `pip install lmms-eval[swanlab]`).") from e
+
+        # `exp_name` is the user-facing knob (mirrors wandb's `name`); map it to
+        # SwanLab's `experiment_name`.
+        if "exp_name" in kwargs:
+            kwargs["experiment_name"] = kwargs.pop("exp_name")
+        kwargs.setdefault("project", "lmms-eval")
+        self.swanlab_args: Dict[str, Any] = kwargs
+
+        # Standard SwanLab auth: SWANLAB_API_KEY (+ optional SWANLAB_HOST for a
+        # self-hosted instance). Without a key, SwanLab's own login flow applies.
+        api_key = os.environ.get("SWANLAB_API_KEY", "").strip()
+        host = os.environ.get("SWANLAB_HOST", "").strip()
+        if api_key:
+            login_kwargs: Dict[str, Any] = {"api_key": api_key, "save": False}
+            if host:
+                login_kwargs["host"] = host
+            swanlab.login(**login_kwargs)
+
+        # Initialize (or attach to) a SwanLab run.
+        if swanlab.get_run() is None:
+            self.run = swanlab.init(**self.swanlab_args)
+        else:
+            self.run = swanlab.get_run()
+
+    def post_init(self, results: Dict[str, Any]) -> None:
+        self.results: Dict[str, Any] = copy.deepcopy(results)
+        self.task_names: List[str] = list(results.get("results", {}).keys())
+        self.group_names: List[str] = list(results.get("groups", {}).keys())
+
+    def _get_config(self) -> Dict[str, Any]:
+        """Get configuration parameters."""
+        self.task_configs = self.results.get("configs", {})
+        cli_configs = self.results.get("config", {})
+        configs = {
+            "task_configs": self.task_configs,
+            "cli_configs": cli_configs,
+        }
+
+        return configs
+
+    def _sanitize_results_dict(self) -> Tuple[Dict[str, str], Dict[str, Any]]:
+        """Sanitize the results dictionary.
+
+        Returns a tuple of (string-valued metrics, flattened numeric metrics keyed
+        as ``{task}/{metric}``).
+        """
+        _results = copy.deepcopy(self.results.get("results", dict()))
+
+        # Remove None from the metric string name
+        tmp_results = copy.deepcopy(_results)
+        for task_name in self.task_names:
+            task_result = tmp_results.get(task_name, dict())
+            for metric_name, metric_value in task_result.items():
+                _metric_name, removed = remove_none_pattern(metric_name)
+                if removed:
+                    _results[task_name][_metric_name] = metric_value
+                    _results[task_name].pop(metric_name)
+
+        # remove string valued keys from the results dict
+        string_summary = {}
+        for task in self.task_names:
+            task_result = _results.get(task, dict())
+            for metric_name, metric_value in task_result.items():
+                if isinstance(metric_value, str):
+                    string_summary[f"{task}/{metric_name}"] = metric_value
+
+        for summary_metric, summary_value in string_summary.items():
+            _task, _summary_metric = summary_metric.split("/")
+            _results[_task].pop(_summary_metric)
+
+        tmp_results = copy.deepcopy(_results)
+        for task_name, task_results in tmp_results.items():
+            for metric_name, metric_value in task_results.items():
+                _results[f"{task_name}/{metric_name}"] = metric_value
+                _results[task_name].pop(metric_name)
+        for task in self.task_names:
+            _results.pop(task)
+
+        return string_summary, _results
+
+    def log_eval_result(self) -> None:
+        """Log evaluation results to SwanLab."""
+        # Log configs to the run config.
+        configs = self._get_config()
+        self.run.config.update(configs)
+
+        string_summary, swanlab_results = self._sanitize_results_dict()
+        # SwanLab has no run.summary; keep string-valued metrics in the run config
+        # for provenance instead.
+        if string_summary:
+            self.run.config.update(string_summary)
+        # Log the numeric evaluation metrics as SwanLab scalars.
+        if swanlab_results:
+            self.run.log(swanlab_results)
+        # NOTE: wandb's results-as-Table and results-as-JSON-artifact steps have no
+        # SwanLab (0.7.x) equivalent; the scalar metrics above cover the leaderboard
+        # use-case.
+
+    def log_eval_samples(self, samples: Dict[str, List[Dict[str, Any]]]) -> None:
+        """Log evaluation samples to SwanLab.
+
+        SwanLab (0.7.x) has no Table/Artifact type, so each (ungrouped) task's
+        samples are logged as a sample-count scalar plus a capped JSON preview
+        rendered through ``swanlab.Text``.
+
+        Args:
+            samples (Dict[str, List[Dict[str, Any]]]): Evaluation samples for each task.
+        """
+        import swanlab
+
+        task_names: List[str] = [x for x in self.task_names if x not in self.group_names]
+        for task_name in task_names:
+            eval_preds = samples.get(task_name)
+            if not eval_preds:
+                continue
+
+            self.run.log({f"eval_samples/{task_name}/num_samples": len(eval_preds)})
+
+            preview = json.dumps(
+                eval_preds[:_SAMPLE_PREVIEW_LIMIT],
+                indent=2,
+                default=_handle_non_serializable,
+                ensure_ascii=False,
+            )
+            self.run.log({f"eval_samples/{task_name}/preview": swanlab.Text(f"```json\n{preview}\n```")})
+
+    def finish(self) -> None:
+        """Finish the SwanLab run."""
+        import swanlab
+
+        swanlab.finish()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,6 +110,9 @@ gemini = [
 litellm = [
     "litellm",
 ]
+swanlab = [
+    "swanlab",
+]
 reka = [
     "httpx>=0.23.3",
     "reka-api",


### PR DESCRIPTION
## Add SwanLab logger as a Weights & Biases alternative

Adds an optional [SwanLab](https://swanlab.cn) results logger for evaluation runs, wired symmetrically to the existing wandb logger and driven by a new `--swanlab_args` flag. SwanLab is a lightweight, self-hostable experiment tracker many users prefer as a W&B alternative.

### Usage

    python3 -m lmms_eval \
      --model llava --model_args pretrained=... \
      --tasks mme \
      --swanlab_args project=lmms-eval,exp_name=my-run,mode=cloud \
      --swanlab_log_samples

Install the extra: `pip install lmms-eval[swanlab]` (or `pip install swanlab`).

Authenticate with the standard SwanLab mechanism — set `SWANLAB_API_KEY` (and optionally `SWANLAB_HOST` for a self-hosted instance). The default project is `lmms-eval`, overridable via the args string (`project=`, `exp_name=`, `mode=`, and any other `swanlab.init` kwarg).

### What it does

- `SwanLabLogger` (`lmms_eval/loggers/swanlab_logger.py`) mirrors `WandbLogger`'s interface: `post_init(results)`, `log_eval_result()`, `log_eval_samples(samples)`, `finish()`.
- `log_eval_result()` logs task configs to the run config and the flattened per-task numeric metrics as SwanLab scalars.
- `log_eval_samples()` (enabled with `--swanlab_log_samples`) logs a per-task sample count plus a capped JSON preview via `swanlab.Text`.
- Wiring in `lmms_eval/__main__.py` is parallel to wandb: init when `--swanlab_args` is non-empty, log on the main process after each eval (best-effort, wrapped in try/except), finish at the end.

### Notes

- The module imports fine without `swanlab` installed; `swanlab` is imported lazily and raises a clear `ImportError` (`pip install swanlab`) only if the logger is actually used without it.
- SwanLab (0.7.x) has no `Table`/`Artifact` type, so wandb's results-as-table and results-as-JSON-artifact steps are not replicated — the scalar metrics cover the leaderboard use-case.
- No changes to the existing wandb code paths.

### Validation

- `py_compile` on all changed files; module imports cleanly without swanlab installed (lazy import, clear `ImportError` on use)
- Functional smoke test with real swanlab 0.7.15 in `mode=offline`: `init → post_init → log_eval_result → log_eval_samples → finish` all pass on representative results/samples dicts
- ruff clean on the new module; black + isort (pre-commit) pass

### Review pass (2026-07-06)
Two self-review commits:
- **Best-effort init**: `SwanLabLogger(...)` construction in `__main__.py` is now wrapped like the log calls — a bad `SWANLAB_API_KEY`/`SWANLAB_HOST` logs a warning and the eval continues without swanlab, instead of aborting a run at startup (`swanlab.login()` fires during init whenever `SWANLAB_API_KEY` is set, even for offline runs).
- **swanlab >= 0.8 support**: on 0.8.x `swanlab.get_run()` raises when no run is active (0.7.x returned `None`), which would have sent every fresh run into the failure path. Both behaviors are handled; verified against real swanlab 0.8.4 (fresh construction reaches `swanlab.init` exactly once) and 0.7.x semantics are preserved.
