### PR TITLE
feat(models): add diffusers-based world-model generation backends (Wan 2.1/2.2, Cosmos, LTX-Video, MAGI-1, fal.ai)

### DIFF
--- a/lmms_eval/models/__init__.py
+++ b/lmms_eval/models/__init__.py
@@ -17,6 +17,14 @@ logger.add(sys.stdout, level="WARNING", format=log_format)
 
 AVAILABLE_SIMPLE_MODELS = {
     "aero": "Aero",
+    "generation_api": "GenerationApi",
+    "cosmos_wm": "CosmosWorldModel",
+    "wan2_1_t2i": "Wan2_1_T2I",
+    "wan2_1_t2v": "Wan2_1_T2V",
+    "wan2_2": "Wan2_2",
+    "wan2_2_t2v": "Wan2_2_T2V",
+    "ltx_video": "LTXVideo",
+    "magi1_wm": "Magi1WorldModel",
     "aria": "Aria",
     "audio_flamingo_3": "AudioFlamingo3",
     "glm4v": "GLM4V",

--- a/lmms_eval/models/simple/cosmos_wm.py
+++ b/lmms_eval/models/simple/cosmos_wm.py
@@ -1,0 +1,1439 @@
+"""Cosmos World Model backend for evaluating next-state simulation quality.
+
+Supports NVIDIA Cosmos-Predict2, Cosmos-Predict2.5, and Cosmos3 (omnimodal)
+for image-conditioned and video-conditioned video generation (I2V and V2V).
+
+Usage:
+  # Cosmos Predict2 (I2V only)
+  python -m lmms_eval \
+    --model cosmos_wm \
+    --model_args "backend=nim,output_dir=./logs/cosmos_wm" \
+    --tasks physics_iq_i2v \
+    --batch_size 1 \
+    --log_samples
+
+  # Cosmos Predict2.5-2B (I2V and V2V)
+  python -m lmms_eval \
+    --model cosmos_wm \
+    --model_args "backend=local,nim_model=nvidia/Cosmos-Predict2.5-2B,output_dir=./logs/cosmos25" \
+    --tasks physics_iq_i2v \
+    --batch_size 1 \
+    --log_samples
+
+Backends:
+  nim         NVIDIA NIM API (requires NVIDIA_API_KEY)
+  local       Local diffusers pipeline (Predict2, Predict2.5, or Cosmos3)
+  vllm_omni   Remote Cosmos3 served by a vLLM-Omni OpenAI-compatible video server
+  transformers_reasoner
+              Local Transformers Cosmos3 Reasoner for text-answer VQA tasks
+  passthrough Returns input image as static video (for baseline comparison)
+
+Environment:
+  NVIDIA_API_KEY  Required for nim backend.
+"""
+
+import base64
+import io
+import json
+import os
+import threading
+import time
+import traceback
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+import requests as http_requests
+from loguru import logger as eval_logger
+from PIL import Image, UnidentifiedImageError
+from tqdm import tqdm
+
+from lmms_eval.api.instance import Instance
+from lmms_eval.api.model import lmms
+from lmms_eval.api.registry import register_model
+
+_WORLD_MODEL_TASK_PREFIXES = ("physics_iq_",)
+
+
+def _is_world_model_task(task: str) -> bool:
+    return task.startswith(_WORLD_MODEL_TASK_PREFIXES)
+
+
+def _image_to_base64(image: Any, fmt: str = "JPEG") -> str:
+    """Convert a PIL Image or file path to base64 data URI."""
+    if isinstance(image, str):
+        image = Image.open(image)
+    if isinstance(image, Image.Image):
+        if image.mode == "RGBA":
+            image = image.convert("RGB")
+        buf = io.BytesIO()
+        image.save(buf, format=fmt)
+        b64 = base64.b64encode(buf.getvalue()).decode()
+        mime = "image/jpeg" if fmt.upper() == "JPEG" else f"image/{fmt.lower()}"
+        return f"data:{mime};base64,{b64}"
+    raise TypeError(f"Cannot convert {type(image)} to base64")
+
+
+def _file_to_data_uri(path: str, mime: str) -> str:
+    with open(path, "rb") as f:
+        encoded = base64.b64encode(f.read()).decode()
+    return f"data:{mime};base64,{encoded}"
+
+
+def _extract_last_frame(video_path: str) -> Image.Image:
+    """Extract the last frame from a video file as a PIL Image."""
+    import av
+
+    with av.open(video_path) as container:
+        stream = container.streams.video[0]
+        # Seek near end and decode last frame
+        last_frame = None
+        for frame in container.decode(stream):
+            last_frame = frame
+        if last_frame is None:
+            raise ValueError(f"No frames in video: {video_path}")
+        return last_frame.to_image()
+
+
+@register_model("cosmos_wm")
+class CosmosWorldModel(lmms):
+    """World model for next-state video simulation.
+
+    Evaluates world model quality by generating videos from image+instruction
+    and measuring simulation fidelity via downstream metrics.
+    """
+
+    is_simple = True
+
+    def __init__(
+        self,
+        # Backend selection
+        backend: str = "local",
+        # Model ID (for local backend: HF model ID; for NIM: API model path)
+        nim_model: str = "nvidia/Cosmos-Predict2-2B-Video2World",
+        nim_base_url: str = "https://ai.api.nvidia.com/v1/cv",
+        # Model revision (required for Cosmos 2.5 branches)
+        revision: str = "diffusers/base/post-trained",
+        # Local backend params
+        device: str = "cuda",
+        torch_dtype: str = "bfloat16",
+        num_inference_steps: int = 30,
+        # Cosmos 3 safety checker (loads cosmos_guardrail when True). Default
+        # False so the cosmos_guardrail package is not required.
+        enable_safety_checker: bool = False,
+        # Scheduler flow_shift override (Cosmos 3 uses 10.0 per the model card).
+        flow_shift: Optional[float] = None,
+        # Generation params (default 81 = 5s at 16fps + 1 for PhysicsIQ compat)
+        num_frames: int = 81,
+        fps: int = 16,
+        width: int = 1280,
+        height: int = 704,
+        seed: Optional[int] = None,
+        guidance_scale: float = 7.0,
+        negative_prompt: str = "The video captures a series of frames showing ugly scenes, static with no motion, motion blur, over-saturation, shaky footage, low resolution, grainy texture, poor lighting, washed-out colors, lack of detail, blurry backgrounds, monotonous scenery, cluttered composition, unnatural colors, pixelated images, repetitive patterns, flat visuals, poor framing, overexposed highlights, underexposed shadows, choppy transitions, artifacts, lens flare, distracting elements, inconsistent focus.",
+        # Infrastructure
+        output_dir: str = "./logs/cosmos_wm_videos",
+        num_concurrent: int = 2,
+        batch_size: Union[int, str] = 1,
+        poll_interval: int = 5,
+        max_polls: int = 240,
+        max_retries: int = 2,
+        # vllm_omni backend params (Cosmos3 served via vLLM-Omni OpenAI-compatible API)
+        server_url: str = "http://localhost:8000",
+        server_endpoint: str = "/v1/videos/sync",
+        reasoner_server_url: Optional[str] = None,
+        reasoner_endpoint: str = "/v1/chat/completions",
+        reasoner_model: Optional[str] = None,
+        reasoner_api_key_env: Optional[str] = None,
+        request_timeout: int = 1800,
+        max_sequence_length: int = 4096,
+        send_cond_video: bool = True,
+        cond_fps: int = 16,
+        strip_cond_seconds: float = 0.0,
+        # Local Transformers Reasoner params (Cosmos3 text-output tasks)
+        reasoner_min_pixels: int = 256 * 28 * 28,
+        reasoner_max_pixels: int = 1605632,
+        reasoner_max_num_frames: int = 32,
+        reasoner_video_fps: float = 4.0,
+        reasoner_attn_implementation: Optional[str] = None,
+        **kwargs,
+    ) -> None:
+        super().__init__()
+        self.backend = backend
+        self.nim_model = nim_model
+        self.nim_base_url = nim_base_url.rstrip("/")
+        self.revision = revision
+        self.device = device
+        self.enable_safety_checker = bool(enable_safety_checker)
+        self.flow_shift = float(flow_shift) if flow_shift is not None else None
+        self.num_inference_steps = int(num_inference_steps)
+        self.num_frames = int(num_frames)
+        self.fps = int(fps)
+        self.width = int(width)
+        self.height = int(height)
+        self.seed = int(seed) if seed is not None else None
+        self.guidance_scale = float(guidance_scale)
+        self.negative_prompt = negative_prompt
+        self.output_dir = str(output_dir)
+        self.num_concurrent = max(1, int(num_concurrent))
+        self.batch_size_per_gpu = int(batch_size)
+        self.poll_interval = max(1, int(poll_interval))
+        self.max_polls = max(1, int(max_polls))
+        self.max_retries = max(1, int(max_retries))
+        # vllm_omni — multiple replicas (one per GPU/node) for throughput;
+        # requests are round-robined across them. The replica list is read from
+        # the COSMOS3_SERVER_URLS env var when set (so the comma-separated list
+        # does NOT collide with lmms-eval's comma-delimited model_args parsing);
+        # otherwise from the server_url arg. Entries may be ";"/","/space
+        # separated and bare "host:port" (http:// is prepended).
+        import re as _re
+
+        _raw = os.environ.get("COSMOS3_SERVER_URLS", "") or str(server_url)
+
+        def _norm(u: str) -> str:
+            u = u.strip().rstrip("/")
+            if u and not u.startswith("http"):
+                u = "http://" + u
+            return u
+
+        def _split_urls(raw: str) -> List[str]:
+            return [_norm(u) for u in _re.split(r"[;,\s]+", raw) if u.strip()]
+
+        self.server_urls = _split_urls(_raw)
+        self.server_url = self.server_urls[0] if self.server_urls else _norm(str(server_url))
+        reasoner_raw = os.environ.get("COSMOS3_REASONER_SERVER_URLS", "")
+        if not reasoner_raw and reasoner_server_url is not None:
+            reasoner_raw = str(reasoner_server_url)
+        self.reasoner_server_urls = _split_urls(reasoner_raw) if reasoner_raw else list(self.server_urls)
+        self._url_counter = 0
+        self._reasoner_url_counter = 0
+        self._url_lock = threading.Lock()
+        self.server_endpoint = "/" + str(server_endpoint).lstrip("/")
+        self.reasoner_endpoint = "/" + str(reasoner_endpoint).lstrip("/")
+        self.reasoner_model = reasoner_model or self._default_reasoner_model(str(nim_model))
+        self._reasoner_headers: Dict[str, str] = {"Accept": "application/json", "Content-Type": "application/json"}
+        if reasoner_api_key_env:
+            reasoner_api_key = os.environ.get(str(reasoner_api_key_env), "")
+            if reasoner_api_key:
+                self._reasoner_headers["Authorization"] = f"Bearer {reasoner_api_key}"
+        self.request_timeout = int(request_timeout)
+        self.max_sequence_length = int(max_sequence_length)
+        self.send_cond_video = str(send_cond_video).lower() in ("1", "true", "yes")
+        self.cond_fps = int(cond_fps)
+        self.strip_cond_seconds = float(strip_cond_seconds)
+        self.reasoner_min_pixels = int(reasoner_min_pixels)
+        self.reasoner_max_pixels = int(reasoner_max_pixels)
+        self.reasoner_max_num_frames = int(reasoner_max_num_frames)
+        self.reasoner_video_fps = float(reasoner_video_fps)
+        self.reasoner_attn_implementation = reasoner_attn_implementation
+
+        # Resolve torch dtype
+        _dtype_map = {"bfloat16": "bfloat16", "bf16": "bfloat16", "float16": "float16", "fp16": "float16"}
+        self._torch_dtype_str = _dtype_map.get(torch_dtype, torch_dtype)
+
+        # Cache version detection
+        self._is_v2_5 = self._is_cosmos_2_5()
+        self._is_v3 = self._is_cosmos_3()
+        if self._is_v3:
+            # Cosmos 3 and 2.5 are mutually exclusive; v3 wins.
+            self._is_v2_5 = False
+
+        # Backend-specific init
+        self._pipe = None  # Lazy-loaded for local backend
+        self._transformers_reasoner_model = None
+        self._transformers_reasoner_processor = None
+        self._transformers_reasoner_device = device
+        self._pipe_lock = threading.Lock()  # diffusers pipelines are NOT thread-safe
+
+        # Force sequential generation for in-process model backends to avoid
+        # racing a single loaded model from multiple Python threads.
+        if backend in ("local", "transformers_reasoner") and self.num_concurrent > 1:
+            eval_logger.info(f"{backend} backend: overriding num_concurrent={self.num_concurrent}->1 " f"(in-process generation is not thread-safe)")
+            self.num_concurrent = 1
+
+        if backend == "nim":
+            self.api_key = os.environ.get("NVIDIA_API_KEY", "")
+            if not self.api_key:
+                raise EnvironmentError("NVIDIA_API_KEY environment variable is required for cosmos_wm nim backend.")
+            self._session = http_requests.Session()
+            self._session.headers.update(
+                {
+                    "Authorization": f"Bearer {self.api_key}",
+                    "Content-Type": "application/json",
+                    "Accept": "application/json",
+                }
+            )
+        elif backend == "local":
+            variant = "Cosmos3" if self._is_v3 else ("Cosmos-Predict2.5" if self._is_v2_5 else "Cosmos-Predict2")
+            eval_logger.info(f"Local backend selected ({variant}). Model {nim_model} will be loaded on first use.")
+        elif backend == "vllm_omni":
+            # Cosmos3 served via vLLM-Omni OpenAI-compatible video API. The model
+            # lives on the remote server; this backend is a thin HTTP client, so
+            # concurrent requests are fine (the server batches them).
+            self._session = http_requests.Session()
+            eval_logger.info(
+                f"vLLM-Omni backend selected. {len(self.server_urls)} replica(s)={self.server_urls}, "
+                f"endpoint={self.server_endpoint}, timeout={self.request_timeout}s, "
+                f"send_cond_video={self.send_cond_video}, strip_cond_seconds={self.strip_cond_seconds}, "
+                f"reasoner_model={self.reasoner_model}, reasoner_replicas={self.reasoner_server_urls}, "
+                f"reasoner_endpoint={self.reasoner_endpoint}"
+            )
+        elif backend == "transformers_reasoner":
+            eval_logger.info(f"Transformers Reasoner backend selected. model={self.nim_model}, " f"video_fps={self.reasoner_video_fps}, max_num_frames={self.reasoner_max_num_frames}, " f"max_pixels={self.reasoner_max_pixels}")
+
+        Path(self.output_dir).mkdir(parents=True, exist_ok=True)
+        eval_logger.info(f"CosmosWM initialized: backend={backend}, model={nim_model}, " f"v2_5={self._is_v2_5}, v3={self._is_v3}, output_dir={self.output_dir}")
+
+    # ------------------------------------------------------------------
+    # Version detection
+    # ------------------------------------------------------------------
+
+    def _is_cosmos_2_5(self) -> bool:
+        """Check if the configured model is a Cosmos Predict2.5 variant."""
+        return "2.5" in self.nim_model or "Predict2.5" in self.nim_model
+
+    def _is_cosmos_3(self) -> bool:
+        """Check if the configured model is a Cosmos 3 (omnimodal) variant.
+
+        Matches nvidia/Cosmos3-Nano, Cosmos3-Super, and future Cosmos-Predict3
+        checkpoints. Case-insensitive.
+        """
+        name = self.nim_model.lower()
+        return "cosmos3" in name or "predict3" in name
+
+    @staticmethod
+    def _default_reasoner_model(nim_model: str) -> str:
+        name = nim_model.lower()
+        if "cosmos3" in name and "nano" in name:
+            return "nvidia/cosmos3-nano-reasoner"
+        if "cosmos3" in name and "super" in name:
+            return "nvidia/cosmos3-super-reasoner"
+        return str(nim_model).rstrip("/").split("/")[-1]
+
+    # ------------------------------------------------------------------
+    # NIM API helpers
+    # ------------------------------------------------------------------
+
+    def _nim_submit(self, image_b64: str, prompt: str) -> str:
+        """Submit image-to-video generation to NIM. Returns request_id."""
+        url = f"{self.nim_base_url}/{self.nim_model}"
+        payload = {
+            "image": image_b64,
+            "prompt": prompt,
+            "cfg_scale": self.guidance_scale,
+            "seed": self.seed if self.seed is not None else 42,
+        }
+
+        resp = self._session.post(url, json=payload, timeout=120)
+        resp.raise_for_status()
+        data = resp.json()
+
+        request_id = data.get("reqId") or data.get("request_id", "")
+        if not request_id:
+            # Synchronous response — video returned directly
+            return data
+
+        return {"request_id": request_id, "data": data}
+
+    def _nim_poll(self, request_id: str) -> Dict:
+        """Poll NIM for job completion."""
+        url = f"{self.nim_base_url}/status/{request_id}"
+        for i in range(1, self.max_polls + 1):
+            resp = self._session.get(url, timeout=30)
+            resp.raise_for_status()
+            data = resp.json()
+            status = data.get("status", "").upper()
+
+            if status in ("COMPLETED", "FULFILLED"):
+                return data
+            if status in ("FAILED", "ERROR"):
+                raise RuntimeError(f"NIM job failed: {json.dumps(data)[:500]}")
+
+            if i % 10 == 0:
+                eval_logger.debug(f"NIM poll {i}/{self.max_polls}: status={status}")
+            time.sleep(self.poll_interval)
+
+        raise TimeoutError(f"NIM job did not complete in {self.max_polls * self.poll_interval}s")
+
+    def _nim_download(self, result_data: Dict, output_path: str) -> str:
+        """Download video from NIM result."""
+        video_url = None
+        # Try common response fields
+        for key in ("video_url", "videoUrl", "output", "url"):
+            if key in result_data and isinstance(result_data[key], str):
+                video_url = result_data[key]
+                break
+        # Handle nested data
+        if video_url is None and "video" in result_data:
+            vid = result_data["video"]
+            if isinstance(vid, str):
+                video_url = vid
+            elif isinstance(vid, dict) and "url" in vid:
+                video_url = vid["url"]
+
+        if not video_url:
+            # Result may contain base64-encoded video
+            b64_video = result_data.get("video_b64") or result_data.get("video")
+            if isinstance(b64_video, str) and not b64_video.startswith("http"):
+                Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+                with open(output_path, "wb") as f:
+                    f.write(base64.b64decode(b64_video))
+                return output_path
+            raise ValueError(f"No video in NIM result: {json.dumps(result_data)[:500]}")
+
+        # Download from URL
+        resp = self._session.get(video_url, stream=True, timeout=300)
+        resp.raise_for_status()
+        Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+        with open(output_path, "wb") as f:
+            for chunk in resp.iter_content(chunk_size=65536):
+                f.write(chunk)
+        return output_path
+
+    # ------------------------------------------------------------------
+    # Local inference via diffusers
+    # ------------------------------------------------------------------
+
+    def _ensure_local_pipeline(self):
+        """Lazy-load the Cosmos diffusers pipeline on first use."""
+        if self._pipe is not None:
+            return
+
+        import sys
+        import types
+
+        import torch
+
+        # Stub cosmos_guardrail so diffusers' Cosmos pipeline can init
+        # without installing the heavy (and numpy-incompatible) package.
+        # diffusers does `from cosmos_guardrail import CosmosSafetyChecker`
+        # at module level in pipeline_cosmos2_video2world.py.
+        if "cosmos_guardrail" not in sys.modules:
+            _stub = types.ModuleType("cosmos_guardrail")
+
+            class _NoopGuardrail:
+                """Catch-all stub that passes any safety check.
+
+                - __call__: returns (first_arg, False) for result unpacking
+                - __iter__: empty, so `for name, p in comp.named_parameters()` skips
+                - __getattr__: returns no-op callable for any method
+                """
+
+                def __init__(self, *a, **kw):
+                    pass
+
+                def __call__(self, *a, **kw):
+                    return (a[0] if a else None, False)
+
+                def __iter__(self):
+                    return iter([])
+
+                def __bool__(self):
+                    return True
+
+                def __getattr__(self, name):
+                    # Return first positional arg (the content being checked)
+                    # so check_video_safety(vid) returns vid, not self.
+                    return lambda *a, **kw: a[0] if a else self
+
+            _stub.CosmosSafetyChecker = _NoopGuardrail
+            _stub.CosmosGuardrail = _NoopGuardrail
+            sys.modules["cosmos_guardrail"] = _stub
+
+        if self._is_v3:
+            # Cosmos3OmniPipeline lives in diffusers git-main (not in any
+            # released diffusers as of 0.38.0). Import lazily so the class
+            # import does not require diffusers at module import time.
+            from diffusers import Cosmos3OmniPipeline as PipeClass
+        elif self._is_v2_5:
+            from diffusers import Cosmos2_5_PredictBasePipeline as PipeClass
+        else:
+            from diffusers import Cosmos2VideoToWorldPipeline as PipeClass
+
+        # MPS (Apple Silicon) does not support bfloat16 → fall back to float16
+        dtype = getattr(torch, self._torch_dtype_str, torch.bfloat16)
+        actual_device = self.device
+        # Under `accelerate launch --multi_gpu`, every rank starts with
+        # self.device="cuda" (the default) and would race onto cuda:0,
+        # colliding into an NCCL/OOM crash. Pin each rank to its own GPU
+        # via LOCAL_RANK so DP works. (Same fix as wan2_2.py:107-109.)
+        if actual_device == "cuda" and torch.cuda.is_available():
+            local_rank = int(os.environ.get("LOCAL_RANK", 0))
+            actual_device = f"cuda:{local_rank}"
+            torch.cuda.set_device(local_rank)
+        if actual_device == "cuda" and not torch.cuda.is_available():
+            if torch.backends.mps.is_available():
+                actual_device = "mps"
+                dtype = torch.float16  # MPS doesn't support bfloat16
+                eval_logger.info("CUDA not available, using MPS with float16")
+            else:
+                actual_device = "cpu"
+                dtype = torch.float32
+                eval_logger.warning("No GPU available, falling back to CPU (very slow)")
+        elif actual_device == "mps":
+            dtype = torch.float16
+
+        self._actual_device = actual_device
+        hf_token = os.environ.get("HF_TOKEN") or os.environ.get("HUGGING_FACE_HUB_TOKEN")
+
+        # Build extra kwargs for from_pretrained
+        if self._is_v3:
+            # Cosmos3OmniPipeline takes `enable_safety_checker` (loads the
+            # cosmos_guardrail CosmosSafetyChecker when True) instead of the
+            # 2.x-style `safety_checker=None`. No subfolder revision for v3.
+            load_kwargs: Dict[str, Any] = {"enable_safety_checker": self.enable_safety_checker}
+        else:
+            load_kwargs = {"safety_checker": None}
+            if self._is_v2_5 and self.revision:
+                load_kwargs["revision"] = self.revision
+
+        variant_name = "Cosmos3" if self._is_v3 else ("Cosmos-Predict2.5" if self._is_v2_5 else "Cosmos-Predict2")
+        eval_logger.info(
+            f"Loading {variant_name} pipeline: {self.nim_model} " f"(dtype={dtype}, device={actual_device}, " f"token={'set' if hf_token else 'NOT SET'}" f"{', revision=' + self.revision if load_kwargs.get('revision') else ''})"
+        )
+        # Resolve local snapshot path to bypass Xet CDN 403 in containers.
+        local_snapshot = self._find_local_snapshot(self.nim_model)
+
+        if local_snapshot:
+            eval_logger.info(f"Loading from local snapshot: {local_snapshot}")
+            try:
+                self._pipe = PipeClass.from_pretrained(
+                    local_snapshot,
+                    torch_dtype=dtype,
+                    local_files_only=True,
+                    **load_kwargs,
+                )
+            except Exception as e:
+                eval_logger.warning(f"Local snapshot load failed ({e}), falling back to hub download")
+                local_snapshot = None  # Fall through to hub download
+
+        if not local_snapshot:
+            eval_logger.info("Downloading from HuggingFace Hub...")
+            self._pipe = PipeClass.from_pretrained(
+                self.nim_model,
+                torch_dtype=dtype,
+                token=hf_token,
+                **load_kwargs,
+            )
+
+        self._pipe.to(actual_device)
+
+        # Verify no parameters stuck on meta device (can happen with
+        # interrupted downloads or keep_in_fp32_modules edge cases).
+        # Diffusers pipelines don't have named_parameters() directly,
+        # so iterate over .components sub-models.
+        meta_params = []
+        for comp_name, comp in self._pipe.components.items():
+            if hasattr(comp, "named_parameters"):
+                for pname, p in comp.named_parameters():
+                    if p.device.type == "meta":
+                        meta_params.append(f"{comp_name}.{pname}")
+        if meta_params:
+            eval_logger.error(f"{len(meta_params)} parameters still on meta device after .to({actual_device}). " f"First 5: {meta_params[:5]}. Retrying with device_map...")
+            del self._pipe
+            import gc
+
+            gc.collect()
+            torch.cuda.empty_cache()
+            self._pipe = PipeClass.from_pretrained(
+                local_snapshot or self.nim_model,
+                torch_dtype=dtype,
+                token=hf_token if not local_snapshot else None,
+                local_files_only=bool(local_snapshot),
+                device_map=actual_device,
+                **load_kwargs,
+            )
+
+        eval_logger.info(f"{variant_name} pipeline loaded on {actual_device}")
+
+        # Cosmos 3: apply the UniPCMultistepScheduler flow_shift tweak from the
+        # official model card. flow_shift defaults to 10.0 for v3 when unset.
+        # Guarded so a scheduler-config mismatch logs a warning instead of
+        # hard-failing the run.
+        if self._is_v3:
+            v3_flow_shift = self.flow_shift if self.flow_shift is not None else 10.0
+            try:
+                from diffusers import UniPCMultistepScheduler
+
+                self._pipe.scheduler = UniPCMultistepScheduler.from_config(self._pipe.scheduler.config, flow_shift=v3_flow_shift)
+                eval_logger.info(f"Cosmos3: set UniPCMultistepScheduler flow_shift={v3_flow_shift}")
+            except Exception as e:
+                eval_logger.warning(f"Cosmos3: failed to apply UniPCMultistepScheduler flow_shift={v3_flow_shift} ({e}); using default scheduler")
+
+        # Fix numpy 2.x + PIL incompatibility: np.asanyarray(pil_img) fails
+        # with "invalid __array_struct__" in diffusers post-processing.
+        # numpy 2.x checks __array_struct__ (C-level) before __array__,
+        # and PIL's deprecated C interface triggers ValueError.
+        # Patch np.asanyarray + its local ref in shape_base (used by np.stack).
+        try:
+            import numpy as _np
+
+            if int(_np.__version__.split(".")[0]) >= 2 and not getattr(_np, "_cosmos_pil_patched", False):
+                _orig_asanyarray = _np.asanyarray
+
+                def _safe_asanyarray(a, dtype=None, order=None, **kw):
+                    # Duck-type check: avoids isinstance failures from
+                    # multiple PIL installs in containers
+                    if hasattr(a, "tobytes") and hasattr(a, "size") and hasattr(a, "getbands"):
+                        arr = _np.frombuffer(a.tobytes(), dtype=_np.uint8)
+                        w, h = a.size
+                        ch = len(a.getbands())
+                        arr = arr.reshape((h, w, ch) if ch > 1 else (h, w))
+                        return arr.astype(dtype) if dtype is not None else arr
+                    try:
+                        return _orig_asanyarray(a, dtype=dtype, order=order, **kw)
+                    except ValueError:
+                        # Last resort: if __array_struct__ fails on any object
+                        if hasattr(a, "tobytes") and hasattr(a, "size"):
+                            return _np.array(a)
+                        raise
+
+                _np.asanyarray = _safe_asanyarray
+                # Patch local imports in shape_base (used by np.stack)
+                import numpy._core.shape_base as _sb
+
+                _sb.asanyarray = _safe_asanyarray
+                _np._core.asanyarray = _safe_asanyarray
+                try:
+                    import numpy.core.shape_base as _sb2
+
+                    _sb2.asanyarray = _safe_asanyarray
+                    _np.core.asanyarray = _safe_asanyarray
+                except (ImportError, AttributeError):
+                    pass
+                _np._cosmos_pil_patched = True
+                eval_logger.info("Patched np.asanyarray for numpy 2.x + PIL compat")
+        except Exception:
+            pass
+
+    @staticmethod
+    def _find_local_snapshot(model_id: str) -> Optional[str]:
+        """Find a locally cached snapshot directory for a HF model.
+
+        Searches HF_HOME, HF_HUB_CACHE, and common paths to find a
+        pre-downloaded snapshot, returning the full path or None.
+        """
+        # model_id like "nvidia/Cosmos-Predict2-2B-Video2World"
+        safe_name = f"models--{model_id.replace('/', '--')}"
+        search_dirs = []
+        for env_var in ("HF_HUB_CACHE", "HF_HOME", "TRANSFORMERS_CACHE"):
+            val = os.environ.get(env_var, "")
+            if val:
+                search_dirs.append(val)
+                search_dirs.append(os.path.join(val, "hub"))
+        # Common locations (including /root for containers with HOME override)
+        search_dirs.extend(
+            [
+                os.path.expanduser("~/.cache/huggingface/hub"),
+                "/root/.cache/huggingface/hub",
+            ]
+        )
+        for cache_dir in search_dirs:
+            model_dir = os.path.join(cache_dir, safe_name)
+            refs_main = os.path.join(model_dir, "refs", "main")
+            if os.path.exists(refs_main):
+                with open(refs_main) as f:
+                    commit = f.read().strip()
+                snapshot = os.path.join(model_dir, "snapshots", commit)
+                index_file = os.path.join(snapshot, "model_index.json")
+                if os.path.exists(index_file):
+                    return snapshot
+        return None
+
+    @staticmethod
+    def _find_local_transformers_snapshot(model_id: str) -> Optional[str]:
+        """Find a locally cached Transformers snapshot directory for a HF model."""
+
+        def has_transformers_weights(snapshot: Path) -> bool:
+            patterns = (
+                "model.safetensors",
+                "model-*.safetensors",
+                "pytorch_model.bin",
+                "pytorch_model-*.bin",
+                "model.safetensors.index.json",
+                "pytorch_model.bin.index.json",
+            )
+            return any(next(snapshot.glob(pattern), None) is not None for pattern in patterns)
+
+        safe_name = f"models--{model_id.replace('/', '--')}"
+        search_dirs = []
+        for env_var in ("HF_HUB_CACHE", "HF_HOME", "TRANSFORMERS_CACHE"):
+            val = os.environ.get(env_var, "")
+            if val:
+                search_dirs.append(val)
+                search_dirs.append(os.path.join(val, "hub"))
+        search_dirs.extend(
+            [
+                os.path.expanduser("~/.cache/huggingface/hub"),
+                "/root/.cache/huggingface/hub",
+            ]
+        )
+        for cache_dir in search_dirs:
+            model_dir = Path(cache_dir) / safe_name
+            refs_main = model_dir / "refs" / "main"
+            if refs_main.exists():
+                commit = refs_main.read_text().strip()
+                snapshot = model_dir / "snapshots" / commit
+                if (snapshot / "config.json").exists() and has_transformers_weights(snapshot):
+                    return str(snapshot)
+            snapshots_dir = model_dir / "snapshots"
+            if snapshots_dir.exists():
+                snapshots = [p for p in snapshots_dir.iterdir() if (p / "config.json").exists() and has_transformers_weights(p)]
+                if snapshots:
+                    snapshots.sort(key=lambda p: p.stat().st_mtime, reverse=True)
+                    return str(snapshots[0])
+        return None
+
+    def _local_generate(self, image: Image.Image, prompt: str, output_path: str) -> str:
+        """Generate video using local diffusers pipeline (I2V mode)."""
+        import torch
+        from diffusers.utils import export_to_video
+
+        # Cosmos guardrail rejects empty prompts; use a neutral default.
+        if not prompt or not prompt.strip():
+            prompt = "Generate a natural video continuation."
+
+        self._ensure_local_pipeline()
+        actual_device = getattr(self, "_actual_device", self.device)
+
+        # Ensure correct resolution and mode for Cosmos
+        if image.mode != "RGB":
+            image = image.convert("RGB")
+        if image.size != (self.width, self.height):
+            image = image.resize((self.width, self.height), Image.LANCZOS)
+
+        # MPS generator must be on CPU
+        gen_device = "cpu" if actual_device == "mps" else actual_device
+        generator = torch.Generator(device=gen_device)
+        if self.seed is not None:
+            generator.manual_seed(self.seed)
+        else:
+            generator.manual_seed(42)
+
+        call_kwargs: Dict[str, Any] = dict(
+            image=image,
+            prompt=prompt,
+            negative_prompt=self.negative_prompt,
+            guidance_scale=self.guidance_scale,
+            num_inference_steps=self.num_inference_steps,
+            num_frames=self.num_frames,
+            generator=generator,
+            output_type="np",
+        )
+
+        with self._pipe_lock:
+            output = self._pipe(**call_kwargs)
+
+        # output.frames[0] is already numpy with output_type="np"
+        frames_out = output.frames[0]
+
+        Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+        export_to_video(frames_out, output_path, fps=self.fps)
+        eval_logger.info(f"Local I2V generation saved: {output_path}")
+        return output_path
+
+    def _local_generate_v2v(self, video_frames: List[Image.Image], prompt: str, output_path: str) -> str:
+        """Generate continuation video from conditioning video frames (V2V mode).
+
+        Only Cosmos Predict2.5 supports native V2V. For Predict2, falls back
+        to I2V using the last conditioning frame.
+        """
+        import torch
+        from diffusers.utils import export_to_video
+
+        if not self._is_v2_5:
+            # Fallback: use last frame as I2V conditioning
+            eval_logger.info("V2V requested but model is Predict2; falling back to I2V with last frame")
+            return self._local_generate(video_frames[-1], prompt, output_path)
+
+        # Cosmos guardrail rejects empty prompts; use a neutral default.
+        if not prompt or not prompt.strip():
+            prompt = "Generate a natural video continuation."
+
+        self._ensure_local_pipeline()
+        actual_device = getattr(self, "_actual_device", self.device)
+
+        # Resize all conditioning frames to expected resolution.
+        # Keep as PIL Images — the diffusers pipeline's video_processor
+        # handles PIL→tensor conversion. The __array_struct__ bug is
+        # patched in the pipeline's output path via np.frombuffer.
+        resized_frames = []
+        for frame in video_frames:
+            if not isinstance(frame, Image.Image):
+                frame = Image.fromarray(frame)
+            if frame.mode != "RGB":
+                frame = frame.convert("RGB")
+            if frame.size != (self.width, self.height):
+                frame = frame.resize((self.width, self.height), Image.LANCZOS)
+            resized_frames.append(frame)
+
+        # MPS generator must be on CPU
+        gen_device = "cpu" if actual_device == "mps" else actual_device
+        generator = torch.Generator(device=gen_device)
+        if self.seed is not None:
+            generator.manual_seed(self.seed)
+        else:
+            generator.manual_seed(42)
+
+        with self._pipe_lock:
+            output = self._pipe(
+                video=resized_frames,
+                prompt=prompt,
+                negative_prompt=self.negative_prompt,
+                guidance_scale=self.guidance_scale,
+                num_inference_steps=self.num_inference_steps,
+                num_frames=self.num_frames,
+                generator=generator,
+                output_type="np",
+            )
+
+        # output.frames[0] is already numpy array (T, H, W, C) with output_type="np"
+        frames_out = output.frames[0]
+
+        Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+        export_to_video(frames_out, output_path, fps=self.fps)
+        eval_logger.info(f"Local V2V generation saved: {output_path}")
+        return output_path
+
+    def _local_generate_v3(
+        self,
+        prompt: str,
+        image: Optional[Image.Image] = None,
+        video: Optional[List[Image.Image]] = None,
+        output_path: str = "",
+    ) -> str:
+        """Generate video with the Cosmos 3 omnimodal pipeline (Cosmos3OmniPipeline).
+
+        Pass EITHER ``image`` (I2V) OR ``video`` (V2V) — they are mutually
+        exclusive in the Cosmos3 ``__call__``. Conditioning frames are passed as
+        PIL Images: the pipeline's VideoProcessor handles PIL→tensor conversion
+        and resizing to (width, height), so we only normalize mode here and let
+        the pipeline downscale (it never upscales).
+        """
+        import torch
+        from diffusers.utils import export_to_video
+
+        if image is not None and video is not None:
+            raise ValueError("Cosmos3 generation accepts either image (I2V) or video (V2V), not both.")
+
+        # Cosmos guardrail (when enabled) rejects empty prompts; use a neutral
+        # default. Harmless when the safety checker is disabled.
+        if not prompt or not prompt.strip():
+            prompt = "Generate a natural video continuation."
+
+        self._ensure_local_pipeline()
+        actual_device = getattr(self, "_actual_device", self.device)
+
+        # Normalize conditioning visuals to RGB PIL. We deliberately do NOT
+        # resize here: the Cosmos3 VideoProcessor resizes to (height, width).
+        cond_image: Optional[Image.Image] = None
+        cond_video: Optional[List[Image.Image]] = None
+        if image is not None:
+            cond_image = image if image.mode == "RGB" else image.convert("RGB")
+        elif video is not None:
+            cond_video = []
+            for frame in video:
+                if not isinstance(frame, Image.Image):
+                    frame = Image.fromarray(frame)
+                if frame.mode != "RGB":
+                    frame = frame.convert("RGB")
+                cond_video.append(frame)
+
+        # MPS generator must be on CPU
+        gen_device = "cpu" if actual_device == "mps" else actual_device
+        generator = torch.Generator(device=gen_device)
+        if self.seed is not None:
+            generator.manual_seed(self.seed)
+        else:
+            generator.manual_seed(42)
+
+        # Only forward kwargs that exist in the Cosmos3OmniPipeline.__call__
+        # signature (no Predict2-specific kwargs). Output is read via .video.
+        call_kwargs: Dict[str, Any] = dict(
+            prompt=prompt,
+            negative_prompt=self.negative_prompt,
+            num_frames=self.num_frames,
+            height=self.height,
+            width=self.width,
+            fps=float(self.fps),
+            num_inference_steps=self.num_inference_steps,
+            guidance_scale=self.guidance_scale,
+            generator=generator,
+            enable_safety_check=self.enable_safety_checker,
+            output_type="pil",
+        )
+        if cond_image is not None:
+            call_kwargs["image"] = cond_image
+        elif cond_video is not None:
+            call_kwargs["video"] = cond_video
+
+        with self._pipe_lock:
+            result = self._pipe(**call_kwargs)
+
+        # Cosmos3OmniPipelineOutput exposes .video (list of PIL frames for
+        # output_type="pil"), NOT .frames.
+        frames_out = result.video
+
+        Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+        export_to_video(frames_out, output_path, fps=self.fps)
+        mode = "I2V" if cond_image is not None else "V2V"
+        eval_logger.info(f"Local Cosmos3 {mode} generation saved: {output_path}")
+        return output_path
+
+    # ------------------------------------------------------------------
+    # vLLM-Omni server backend (Cosmos3)
+    # ------------------------------------------------------------------
+
+    def _encode_frames_to_mp4(self, frames: List[Image.Image], path: str, fps: int) -> None:
+        """Encode a list of PIL frames to an H.264 mp4 at the given fps."""
+        import imageio.v3 as iio
+        import numpy as np
+
+        arr = []
+        for f in frames:
+            if not isinstance(f, Image.Image):
+                f = Image.fromarray(f)
+            if f.mode != "RGB":
+                f = f.convert("RGB")
+            arr.append(np.asarray(f))
+        iio.imwrite(path, np.stack(arr), fps=fps, codec="libx264")
+
+    def _strip_leading_seconds(self, path: str, seconds: float) -> None:
+        """Drop the first `seconds` of a video in-place (re-encode via ffmpeg)."""
+        import subprocess
+
+        tmp = path + ".strip.mp4"
+        cmd = ["ffmpeg", "-y", "-loglevel", "error", "-ss", f"{seconds}", "-i", path, "-c:v", "libx264", "-an", tmp]
+        subprocess.run(cmd, check=True)
+        os.replace(tmp, path)
+
+    def _vllm_omni_generate(self, image: Image.Image, prompt: str, output_path: str, video_frames: Optional[List[Image.Image]] = None) -> str:
+        """Generate a video by POSTing to a vLLM-Omni Cosmos3 server.
+
+        Conditioning:
+          - V2V (multiframe): send the conditioning frames as an mp4 in
+            ``input_reference`` (mime video/mp4) when ``send_cond_video`` is set,
+            else fall back to the last frame as a single image.
+          - I2V: send ``image`` as a single ``input_reference`` image.
+          - T2V: no ``input_reference`` file.
+
+        The server returns mp4 bytes (``/v1/videos/sync``). If
+        ``strip_cond_seconds`` > 0, the leading conditioning window is dropped so
+        the saved video is the prediction window only (Physics-IQ scoring compares
+        the generated video directly against the 5s test clip).
+        """
+        if not prompt or not prompt.strip():
+            prompt = "Generate a natural, physically plausible video continuation."
+
+        # flow_shift is nullable on the shared __init__; vllm_omni still
+        # defaults to 10.0 (unchanged behavior) when it is unset.
+        _fs = self.flow_shift if self.flow_shift is not None else 10.0
+        data = {
+            "prompt": prompt,
+            "negative_prompt": self.negative_prompt,
+            "size": f"{self.width}x{self.height}",
+            "num_frames": str(self.num_frames),
+            "fps": str(self.fps),
+            "num_inference_steps": str(self.num_inference_steps),
+            "guidance_scale": str(self.guidance_scale),
+            "max_sequence_length": str(self.max_sequence_length),
+            "flow_shift": str(_fs),
+            "extra_params": json.dumps(
+                {
+                    "use_resolution_template": False,
+                    "use_duration_template": False,
+                    "guardrails": self.enable_safety_checker,
+                }
+            ),
+            "seed": str(self.seed if self.seed is not None else 0),
+        }
+
+        # Round-robin across replicas for throughput.
+        with self._url_lock:
+            base = self.server_urls[self._url_counter % len(self.server_urls)]
+            self._url_counter += 1
+        url = f"{base}{self.server_endpoint}"
+        Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+
+        tmp_cond = None
+        files = None
+        cond_file = None
+        try:
+            if video_frames and self.send_cond_video:
+                tmp_cond = output_path + ".cond.mp4"
+                self._encode_frames_to_mp4(video_frames, tmp_cond, self.cond_fps)
+                cond_file = open(tmp_cond, "rb")
+                files = {"input_reference": ("conditioning.mp4", cond_file, "video/mp4")}
+            elif image is not None:
+                buf = io.BytesIO()
+                img = image.convert("RGB") if image.mode != "RGB" else image
+                img.save(buf, format="JPEG", quality=95)
+                buf.seek(0)
+                files = {"input_reference": ("input.jpg", buf, "image/jpeg")}
+
+            resp = self._session.post(url, data=data, files=files, headers={"Accept": "video/mp4"}, timeout=self.request_timeout)
+            resp.raise_for_status()
+            ctype = resp.headers.get("Content-Type", "")
+            if "application/json" in ctype:
+                raise RuntimeError(f"Server returned JSON (not video): {resp.text[:500]}")
+            with open(output_path, "wb") as f:
+                f.write(resp.content)
+        finally:
+            if cond_file is not None:
+                cond_file.close()
+            if tmp_cond and os.path.exists(tmp_cond):
+                os.remove(tmp_cond)
+
+        if self.strip_cond_seconds > 0:
+            self._strip_leading_seconds(output_path, self.strip_cond_seconds)
+
+        eval_logger.info(f"vLLM-Omni generation saved: {output_path}")
+        return output_path
+
+    def _visual_to_openai_content(self, visual: Any) -> Optional[Dict[str, Any]]:
+        if isinstance(visual, Image.Image):
+            return {"type": "image_url", "image_url": {"url": _image_to_base64(visual)}}
+
+        if isinstance(visual, str):
+            video_exts = (".mp4", ".mov", ".webm", ".mkv")
+            lower = visual.lower().split("?", 1)[0]
+            if lower.startswith(("http://", "https://", "file://")):
+                if lower.endswith(video_exts):
+                    return {"type": "video_url", "video_url": {"url": visual}}
+                return {"type": "image_url", "image_url": {"url": visual}}
+
+            if os.path.exists(visual):
+                if lower.endswith(video_exts):
+                    return {"type": "video_url", "video_url": {"url": _file_to_data_uri(visual, "video/mp4")}}
+                try:
+                    return {"type": "image_url", "image_url": {"url": _image_to_base64(visual)}}
+                except (UnidentifiedImageError, OSError):
+                    return {"type": "video_url", "video_url": {"url": _file_to_data_uri(visual, "video/mp4")}}
+
+        return None
+
+    def _vllm_omni_reason(self, prompt: str, gen_kwargs: Dict[str, Any], visuals: List[Any]) -> str:
+        """Answer text tasks through the Cosmos3 Reasoner OpenAI-compatible API."""
+        if self.backend != "vllm_omni" or not self._is_v3:
+            raise ValueError("Cosmos text-answer tasks require Cosmos3 with backend='vllm_omni'.")
+        if not self.reasoner_server_urls:
+            raise ValueError("Cosmos text-answer tasks require reasoner_server_url or COSMOS3_REASONER_SERVER_URLS.")
+
+        content: List[Dict[str, Any]] = [{"type": "text", "text": prompt}]
+        for visual in visuals:
+            media = self._visual_to_openai_content(visual)
+            if media is not None:
+                content.append(media)
+
+        with self._url_lock:
+            base = self.reasoner_server_urls[self._reasoner_url_counter % len(self.reasoner_server_urls)]
+            self._reasoner_url_counter += 1
+        url = f"{base}{self.reasoner_endpoint}"
+
+        payload: Dict[str, Any] = {
+            "model": self.reasoner_model,
+            "messages": [{"role": "user", "content": content}],
+            "modalities": ["text"],
+            "max_tokens": int(gen_kwargs.get("max_new_tokens", 4096)),
+            "temperature": float(gen_kwargs.get("temperature", 0)),
+        }
+        top_p = gen_kwargs.get("top_p")
+        if top_p is not None:
+            payload["top_p"] = float(top_p)
+        if self.seed is not None:
+            payload["seed"] = self.seed
+
+        resp = self._session.post(url, json=payload, headers=self._reasoner_headers, timeout=self.request_timeout)
+        resp.raise_for_status()
+        data = resp.json()
+        try:
+            message = data["choices"][0]["message"]
+            answer = message["content"]
+        except (KeyError, IndexError, TypeError) as exc:
+            raise RuntimeError(f"Cosmos Reasoner returned an unexpected response: {str(data)[:500]}") from exc
+
+        if isinstance(answer, str):
+            return answer
+        if isinstance(answer, list):
+            text = "".join(part.get("text", "") for part in answer if isinstance(part, dict))
+            if text:
+                return text
+            content_types = [str(part.get("type", type(part).__name__)) for part in answer if isinstance(part, dict)]
+            raise RuntimeError(
+                "Cosmos Reasoner returned non-text content "
+                f"types={content_types or [type(answer).__name__]} from {url}. "
+                "This usually means reasoner_server_url points at a Cosmos3 generator/vLLM-Omni endpoint. "
+                "Use NVIDIA Cosmos3 Reasoner NIM, e.g. model nvidia/cosmos3-nano-reasoner."
+            )
+        return str(answer)
+
+    def _ensure_transformers_reasoner(self) -> None:
+        """Lazy-load the local Transformers Cosmos3 Reasoner."""
+        if self._transformers_reasoner_model is not None:
+            return
+        if self.backend != "transformers_reasoner" or not self._is_v3:
+            raise ValueError("Cosmos text-answer tasks require Cosmos3 with backend='transformers_reasoner'.")
+
+        import torch
+
+        try:
+            from transformers import AutoProcessor, Cosmos3OmniForConditionalGeneration
+        except ImportError as exc:
+            raise ImportError("backend='transformers_reasoner' requires transformers>=5.11.0, " "where Cosmos3OmniForConditionalGeneration is available.") from exc
+
+        dtype = getattr(torch, self._torch_dtype_str, torch.bfloat16)
+        actual_device = self.device
+        if actual_device == "cuda" and torch.cuda.is_available():
+            local_rank = int(os.environ.get("LOCAL_RANK", 0))
+            actual_device = f"cuda:{local_rank}"
+            torch.cuda.set_device(local_rank)
+        elif actual_device == "cuda" and not torch.cuda.is_available():
+            actual_device = "cpu"
+            dtype = torch.float32
+            eval_logger.warning("CUDA not available, loading Cosmos3 Reasoner on CPU (very slow)")
+
+        self._transformers_reasoner_device = actual_device
+        hf_token = os.environ.get("HF_TOKEN") or os.environ.get("HUGGING_FACE_HUB_TOKEN")
+        local_snapshot = self._find_local_transformers_snapshot(self.nim_model)
+        model_source = local_snapshot or self.nim_model
+        local_only = bool(local_snapshot)
+
+        eval_logger.info(f"Loading Cosmos3 Reasoner with Transformers: {model_source} " f"(dtype={dtype}, device={actual_device}, token={'set' if hf_token else 'NOT SET'})")
+        self._transformers_reasoner_processor = AutoProcessor.from_pretrained(
+            model_source,
+            trust_remote_code=True,
+            token=None if local_only else hf_token,
+            local_files_only=local_only,
+            min_pixels=self.reasoner_min_pixels,
+            max_pixels=self.reasoner_max_pixels,
+        )
+
+        load_kwargs: Dict[str, Any] = {
+            "dtype": dtype,
+            "device_map": actual_device,
+            "trust_remote_code": True,
+            "token": None if local_only else hf_token,
+            "local_files_only": local_only,
+        }
+        if self.reasoner_attn_implementation:
+            load_kwargs["attn_implementation"] = self.reasoner_attn_implementation
+        try:
+            model = Cosmos3OmniForConditionalGeneration.from_pretrained(model_source, **load_kwargs)
+        except TypeError:
+            load_kwargs["torch_dtype"] = load_kwargs.pop("dtype")
+            model = Cosmos3OmniForConditionalGeneration.from_pretrained(model_source, **load_kwargs)
+
+        self._transformers_reasoner_model = model.eval()
+        eval_logger.info(f"Cosmos3 Reasoner loaded on {actual_device}")
+
+    def _visual_to_hf_content(self, visual: Any) -> Optional[Dict[str, Any]]:
+        if isinstance(visual, Image.Image):
+            return {
+                "type": "image",
+                "image": visual,
+            }
+
+        if isinstance(visual, str):
+            lower = visual.lower().split("?", 1)[0]
+            video_exts = (".mp4", ".mov", ".webm", ".mkv", ".avi")
+            if lower.endswith(video_exts):
+                return {
+                    "type": "video",
+                    "path": visual,
+                }
+            if lower.startswith(("http://", "https://")) or os.path.exists(visual):
+                return {
+                    "type": "image",
+                    "path": visual,
+                }
+
+        return None
+
+    def _build_transformers_generate_kwargs(self, gen_kwargs: Dict[str, Any]) -> Dict[str, Any]:
+        max_new_tokens = int(gen_kwargs.get("max_new_tokens", 4096))
+        temperature = float(gen_kwargs.get("temperature", 0) or 0)
+        do_sample = bool(gen_kwargs.get("do_sample", temperature > 0))
+        generate_kwargs: Dict[str, Any] = {
+            "max_new_tokens": max_new_tokens,
+            "do_sample": do_sample,
+        }
+        if do_sample:
+            generate_kwargs["temperature"] = temperature
+            top_p = gen_kwargs.get("top_p")
+            if top_p is not None:
+                generate_kwargs["top_p"] = float(top_p)
+        num_beams = gen_kwargs.get("num_beams")
+        if num_beams is not None:
+            generate_kwargs["num_beams"] = int(num_beams)
+        return generate_kwargs
+
+    def _transformers_reason(self, prompt: str, gen_kwargs: Dict[str, Any], visuals: List[Any]) -> str:
+        """Answer text tasks by loading Cosmos3 Reasoner in-process."""
+        self._ensure_transformers_reasoner()
+        import torch
+
+        processor = self._transformers_reasoner_processor
+        model = self._transformers_reasoner_model
+        if processor is None or model is None:
+            raise RuntimeError("Cosmos3 Transformers Reasoner failed to initialize.")
+
+        content: List[Dict[str, Any]] = []
+        has_video = False
+        for visual in visuals:
+            media = self._visual_to_hf_content(visual)
+            if media is not None:
+                content.append(media)
+                has_video = has_video or media["type"] == "video"
+        content.append({"type": "text", "text": prompt})
+        messages = [{"role": "user", "content": content}]
+        template_kwargs: Dict[str, Any] = {
+            "tokenize": True,
+            "add_generation_prompt": True,
+            "return_dict": True,
+            "return_tensors": "pt",
+        }
+        if has_video:
+            template_kwargs["processor_kwargs"] = {"num_frames": max(1, self.reasoner_max_num_frames)}
+
+        dtype = getattr(torch, self._torch_dtype_str, torch.bfloat16)
+        if str(self._transformers_reasoner_device).startswith("cpu"):
+            dtype = torch.float32
+
+        inputs = processor.apply_chat_template(messages, **template_kwargs).to(self._transformers_reasoner_device, dtype)
+
+        with torch.inference_mode():
+            output_ids = model.generate(**inputs, **self._build_transformers_generate_kwargs(gen_kwargs))
+
+        generated_ids = [out_ids[len(in_ids) :] for in_ids, out_ids in zip(inputs.input_ids, output_ids, strict=True)]
+        answer = processor.batch_decode(generated_ids, skip_special_tokens=True, clean_up_tokenization_spaces=False)[0]
+
+        until = gen_kwargs.get("until")
+        if isinstance(until, str):
+            until = [until]
+        if isinstance(until, list):
+            for term in until:
+                if term:
+                    answer = answer.split(term)[0]
+        return answer
+
+    # ------------------------------------------------------------------
+    # Passthrough (baseline)
+    # ------------------------------------------------------------------
+
+    def _passthrough_generate(self, image: Image.Image, output_path: str) -> str:
+        """Return input image as a static 1-second video (baseline)."""
+        import av
+
+        Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+        container = av.open(output_path, mode="w")
+        stream = container.add_stream("libx264", rate=self.fps)
+        stream.width = image.width
+        stream.height = image.height
+        stream.pix_fmt = "yuv420p"
+
+        frame = av.VideoFrame.from_image(image)
+        for _ in range(self.fps):  # 1 second of static frames
+            for packet in stream.encode(frame):
+                container.mux(packet)
+
+        for packet in stream.encode():
+            container.mux(packet)
+        container.close()
+        return output_path
+
+    # ------------------------------------------------------------------
+    # Core generation pipeline
+    # ------------------------------------------------------------------
+
+    def _generate_video(
+        self,
+        image: Image.Image,
+        prompt: str,
+        task: str,
+        doc_id: Union[str, int],
+        video_frames: Optional[List[Image.Image]] = None,
+    ) -> str:
+        """Full pipeline: image + prompt → video path.
+
+        Args:
+            image: Conditioning image (used for I2V and as fallback for V2V).
+            prompt: Text instruction describing the desired video.
+            task: Task name for output path organization.
+            doc_id: Document ID for output path naming.
+            video_frames: Optional list of conditioning frames for V2V mode.
+                When provided and backend is "local", uses V2V generation.
+        """
+        import hashlib
+
+        safe_task = str(task).replace("/", "_").replace(" ", "_")
+        # Cache key includes all generation params to avoid serving stale outputs
+        # when seed, guidance_scale, num_frames, revision, or V2V input changes.
+        v2v_tag = ""
+        if video_frames:
+            # Hash first+last frame content for V2V cache isolation
+            frame_bytes = video_frames[0].tobytes()[:512] + video_frames[-1].tobytes()[:512]
+            v2v_tag = f":v2v:{len(video_frames)}:{hashlib.sha256(frame_bytes).hexdigest()[:8]}"
+        content_hash = hashlib.sha256(
+            f"{self.backend}:{self.nim_model}:{self.revision}:{self.seed}:" f"{self.guidance_scale}:{self.num_frames}:{self.num_inference_steps}:" f"{prompt}:{image.size}:{image.tobytes()[:1024]}{v2v_tag}".encode()
+        ).hexdigest()[:12]
+        output_path = os.path.join(self.output_dir, safe_task, f"{safe_task}_{doc_id}_{content_hash}.mp4")
+
+        # Check cache
+        if os.path.exists(output_path):
+            eval_logger.debug(f"Cache hit: {output_path}")
+            return output_path
+
+        last_error = None
+        for attempt in range(1, self.max_retries + 1):
+            try:
+                if self.backend == "passthrough":
+                    return self._passthrough_generate(image, output_path)
+
+                if self.backend == "local":
+                    if self._is_v3:
+                        # Cosmos 3: route multi-frame conditioning to V2V (video=)
+                        # and single-image conditioning to I2V (image=).
+                        if video_frames is not None:
+                            return self._local_generate_v3(prompt, video=video_frames, output_path=output_path)
+                        return self._local_generate_v3(prompt, image=image, output_path=output_path)
+                    if video_frames is not None:
+                        return self._local_generate_v2v(video_frames, prompt, output_path)
+                    return self._local_generate(image, prompt, output_path)
+
+                if self.backend == "vllm_omni":
+                    return self._vllm_omni_generate(image, prompt, output_path, video_frames=video_frames)
+
+                if self.backend == "nim":
+                    if video_frames is not None:
+                        raise NotImplementedError("NIM backend does not support V2V (video conditioning). " "Use backend='local' for V2V tasks like physics_iq_v2v.")
+                    image_b64 = _image_to_base64(image)
+                    result = self._nim_submit(image_b64, prompt)
+
+                    if isinstance(result, dict) and "request_id" in result:
+                        poll_result = self._nim_poll(result["request_id"])
+                        return self._nim_download(poll_result, output_path)
+                    else:
+                        # Synchronous result
+                        return self._nim_download(result, output_path)
+
+                raise ValueError(f"Unknown backend: {self.backend}")
+
+            except Exception as exc:
+                last_error = exc
+                tb = traceback.format_exc()
+                eval_logger.warning(f"Attempt {attempt}/{self.max_retries} failed: " f"task={task} doc_id={doc_id}: {exc}\n{tb}")
+                if attempt < self.max_retries:
+                    time.sleep(min(attempt * 5, 30))
+
+        error_msg = f"[GENERATION_FAILED] {last_error}"
+        eval_logger.error(f"All retries exhausted: task={task} doc_id={doc_id}: {last_error}")
+        return error_msg
+
+    # ------------------------------------------------------------------
+    # Public: extract last frame (for agentic use)
+    # ------------------------------------------------------------------
+
+    def simulate(
+        self,
+        image: Image.Image,
+        prompt: str,
+        task: str = "sim",
+        doc_id: int = 0,
+        video_frames: Optional[List[Image.Image]] = None,
+    ) -> Tuple[str, Image.Image]:
+        """Generate video and extract last frame. Returns (video_path, last_frame).
+
+        Args:
+            image: Conditioning image for I2V (also used as fallback for V2V).
+            prompt: Text instruction describing the desired video.
+            task: Task name for output organization.
+            doc_id: Document ID.
+            video_frames: Optional list of conditioning frames for V2V mode.
+        """
+        video_path = self._generate_video(image, prompt, task, doc_id, video_frames=video_frames)
+        if video_path.startswith("["):
+            raise RuntimeError(video_path)
+        last_frame = _extract_last_frame(video_path)
+        return video_path, last_frame
+
+    # ------------------------------------------------------------------
+    # lmms interface
+    # ------------------------------------------------------------------
+
+    def generate_until(self, requests: List[Instance]) -> List[str]:
+        """Generate videos for world-model tasks or text answers via Cosmos3 Reasoner."""
+        results: List[Optional[str]] = [None] * len(requests)
+        pbar = tqdm(
+            total=len(requests),
+            disable=(self.rank != 0),
+            desc="Cosmos WM/Reasoner",
+        )
+
+        def _process(index: int) -> Tuple[int, str]:
+            req = requests[index]
+            ctx, gen_kwargs, doc_to_visual, doc_id, task, split = req.args
+            prompt = str(ctx).strip()
+            gen_kwargs = dict(gen_kwargs or {})
+
+            visuals = []
+            if doc_to_visual is not None:
+                try:
+                    doc = self.task_dict[task][split][doc_id]
+                    visuals = doc_to_visual(doc) or []
+                except Exception as e:
+                    eval_logger.warning(f"Failed to extract visual: {e}")
+
+            if not _is_world_model_task(str(task)):
+                if self.backend == "vllm_omni":
+                    return index, self._vllm_omni_reason(prompt, gen_kwargs, visuals)
+                if self.backend == "transformers_reasoner":
+                    return index, self._transformers_reason(prompt, gen_kwargs, visuals)
+                raise ValueError("Cosmos text-answer tasks require backend='vllm_omni' or backend='transformers_reasoner'.")
+
+            image = None
+            video_frames: Optional[List[Image.Image]] = None
+            if visuals:
+                if len(visuals) > 1:
+                    # Multiple frames = V2V conditioning
+                    video_frames = []
+                    for v in visuals:
+                        if isinstance(v, Image.Image):
+                            video_frames.append(v)
+                        elif isinstance(v, str) and os.path.exists(v):
+                            video_frames.append(Image.open(v))
+                    # Use last frame as fallback image for cache key / non-V2V paths
+                    image = video_frames[-1] if video_frames else None
+                else:
+                    v = visuals[0]
+                    if isinstance(v, Image.Image):
+                        image = v
+                    elif isinstance(v, str) and os.path.exists(v):
+                        image = Image.open(v)
+
+            if image is None:
+                # Create blank image if no conditioning provided
+                image = Image.new("RGB", (self.width, self.height), (128, 128, 128))
+                eval_logger.warning(f"No conditioning image for task={task} doc_id={doc_id}")
+
+            return index, self._generate_video(image, prompt, task, doc_id, video_frames=video_frames)
+
+        with ThreadPoolExecutor(max_workers=self.num_concurrent) as pool:
+            futures = {pool.submit(_process, i): i for i in range(len(requests))}
+            for future in as_completed(futures):
+                idx, result = future.result()
+                results[idx] = result
+                pbar.update(1)
+
+        pbar.close()
+
+        generated = sum(1 for r in results if r and not r.startswith("["))
+        failed = len(results) - generated
+        eval_logger.info(f"Cosmos WM complete: {generated} succeeded, {failed} failed, " f"output_dir={self.output_dir}")
+
+        return [r if r is not None else "[ERROR] Unknown" for r in results]
+
+    def loglikelihood(self, requests: List[Instance]) -> List[Tuple[float, bool]]:
+        raise NotImplementedError("CosmosWM does not support loglikelihood")
+
+    def generate_until_multi_round(self, requests: List[Instance]) -> List[str]:
+        raise NotImplementedError("CosmosWM does not support multi-round generation")

--- a/lmms_eval/models/simple/cosmos_wm.py
+++ b/lmms_eval/models/simple/cosmos_wm.py
@@ -59,6 +59,15 @@ def _is_world_model_task(task: str) -> bool:
     return task.startswith(_WORLD_MODEL_TASK_PREFIXES)
 
 
+def _lazy_export_to_video():
+    """Import diffusers' export_to_video, with an actionable error if missing."""
+    try:
+        from diffusers.utils import export_to_video
+    except ImportError as exc:
+        raise ImportError("Cosmos local backend requires diffusers: `pip install diffusers imageio imageio-ffmpeg`") from exc
+    return export_to_video
+
+
 def _image_to_base64(image: Any, fmt: str = "JPEG") -> str:
     """Convert a PIL Image or file path to base64 data URI."""
     if isinstance(image, str):
@@ -163,6 +172,21 @@ class CosmosWorldModel(lmms):
         self.nim_model = nim_model
         self.nim_base_url = nim_base_url.rstrip("/")
         self.revision = revision
+        self._rank = int(os.environ.get("RANK", 0))
+        self._world_size = int(os.environ.get("WORLD_SIZE", 1))
+        # Pin each rank to its own GPU. The evaluator reads lm.device to place
+        # cross-rank sync tensors *before* _load_pipeline runs, so a bare "cuda"
+        # (the default) would put every rank's tensor on cuda:0 and collide.
+        # Mirror DiffusersWMBase: cuda:{LOCAL_RANK} when available, else mps/cpu.
+        if device == "cuda":
+            import torch
+
+            if torch.cuda.is_available():
+                device = f"cuda:{int(os.environ.get('LOCAL_RANK', 0))}"
+            elif torch.backends.mps.is_available():
+                device = "mps"
+            else:
+                device = "cpu"
         self.device = device
         self.enable_safety_checker = bool(enable_safety_checker)
         self.flow_shift = float(flow_shift) if flow_shift is not None else None
@@ -314,8 +338,12 @@ class CosmosWorldModel(lmms):
     # NIM API helpers
     # ------------------------------------------------------------------
 
-    def _nim_submit(self, image_b64: str, prompt: str) -> str:
-        """Submit image-to-video generation to NIM. Returns request_id."""
+    def _nim_submit(self, image_b64: str, prompt: str) -> Dict:
+        """Submit image-to-video generation to NIM.
+
+        Returns the synchronous result dict when the video is returned directly,
+        otherwise ``{"request_id": ..., "data": ...}`` for async polling.
+        """
         url = f"{self.nim_base_url}/{self.nim_model}"
         payload = {
             "image": image_b64,
@@ -440,38 +468,32 @@ class CosmosWorldModel(lmms):
             _stub.CosmosGuardrail = _NoopGuardrail
             sys.modules["cosmos_guardrail"] = _stub
 
-        if self._is_v3:
-            # Cosmos3OmniPipeline lives in diffusers git-main (not in any
-            # released diffusers as of 0.38.0). Import lazily so the class
-            # import does not require diffusers at module import time.
-            from diffusers import Cosmos3OmniPipeline as PipeClass
-        elif self._is_v2_5:
-            from diffusers import Cosmos2_5_PredictBasePipeline as PipeClass
-        else:
-            from diffusers import Cosmos2VideoToWorldPipeline as PipeClass
+        try:
+            if self._is_v3:
+                # Cosmos3OmniPipeline lives in diffusers git-main (not in any
+                # released diffusers as of 0.38.0). Import lazily so the class
+                # import does not require diffusers at module import time.
+                from diffusers import Cosmos3OmniPipeline as PipeClass
+            elif self._is_v2_5:
+                from diffusers import Cosmos2_5_PredictBasePipeline as PipeClass
+            else:
+                from diffusers import Cosmos2VideoToWorldPipeline as PipeClass
+        except ImportError as exc:
+            raise ImportError("Cosmos local backend requires diffusers: `pip install diffusers imageio imageio-ffmpeg`") from exc
 
         # MPS (Apple Silicon) does not support bfloat16 → fall back to float16
         dtype = getattr(torch, self._torch_dtype_str, torch.bfloat16)
         actual_device = self.device
-        # Under `accelerate launch --multi_gpu`, every rank starts with
-        # self.device="cuda" (the default) and would race onto cuda:0,
-        # colliding into an NCCL/OOM crash. Pin each rank to its own GPU
-        # via LOCAL_RANK so DP works. (Same fix as wan2_2.py:107-109.)
-        if actual_device == "cuda" and torch.cuda.is_available():
-            local_rank = int(os.environ.get("LOCAL_RANK", 0))
-            actual_device = f"cuda:{local_rank}"
-            torch.cuda.set_device(local_rank)
-        if actual_device == "cuda" and not torch.cuda.is_available():
-            if torch.backends.mps.is_available():
-                actual_device = "mps"
-                dtype = torch.float16  # MPS doesn't support bfloat16
-                eval_logger.info("CUDA not available, using MPS with float16")
-            else:
-                actual_device = "cpu"
-                dtype = torch.float32
-                eval_logger.warning("No GPU available, falling back to CPU (very slow)")
+        # Each rank is pinned to cuda:{LOCAL_RANK} in __init__; set the current
+        # CUDA device on the loading thread so implicitly-placed tensors don't
+        # default to cuda:0 and collide under multi-GPU DP. MPS/CPU adjust dtype.
+        if actual_device.startswith("cuda"):
+            torch.cuda.set_device(torch.device(actual_device))
         elif actual_device == "mps":
-            dtype = torch.float16
+            dtype = torch.float16  # MPS doesn't support bfloat16
+        elif actual_device == "cpu":
+            dtype = torch.float32
+            eval_logger.warning("No GPU available, running Cosmos on CPU (very slow)")
 
         self._actual_device = actual_device
         hf_token = os.environ.get("HF_TOKEN") or os.environ.get("HUGGING_FACE_HUB_TOKEN")
@@ -687,7 +709,8 @@ class CosmosWorldModel(lmms):
     def _local_generate(self, image: Image.Image, prompt: str, output_path: str) -> str:
         """Generate video using local diffusers pipeline (I2V mode)."""
         import torch
-        from diffusers.utils import export_to_video
+
+        export_to_video = _lazy_export_to_video()
 
         # Cosmos guardrail rejects empty prompts; use a neutral default.
         if not prompt or not prompt.strip():
@@ -739,7 +762,8 @@ class CosmosWorldModel(lmms):
         to I2V using the last conditioning frame.
         """
         import torch
-        from diffusers.utils import export_to_video
+
+        export_to_video = _lazy_export_to_video()
 
         if not self._is_v2_5:
             # Fallback: use last frame as I2V conditioning
@@ -811,7 +835,8 @@ class CosmosWorldModel(lmms):
         the pipeline downscale (it never upscales).
         """
         import torch
-        from diffusers.utils import export_to_video
+
+        export_to_video = _lazy_export_to_video()
 
         if image is not None and video is not None:
             raise ValueError("Cosmos3 generation accepts either image (I2V) or video (V2V), not both.")
@@ -886,7 +911,10 @@ class CosmosWorldModel(lmms):
 
     def _encode_frames_to_mp4(self, frames: List[Image.Image], path: str, fps: int) -> None:
         """Encode a list of PIL frames to an H.264 mp4 at the given fps."""
-        import imageio.v3 as iio
+        try:
+            import imageio.v3 as iio
+        except ImportError as exc:
+            raise ImportError("Cosmos frame encoding requires imageio: `pip install imageio imageio-ffmpeg`") from exc
         import numpy as np
 
         arr = []
@@ -945,7 +973,7 @@ class CosmosWorldModel(lmms):
                     "guardrails": self.enable_safety_checker,
                 }
             ),
-            "seed": str(self.seed if self.seed is not None else 0),
+            "seed": str(self.seed if self.seed is not None else 42),
         }
 
         # Round-robin across replicas for throughput.
@@ -1083,12 +1111,11 @@ class CosmosWorldModel(lmms):
 
         dtype = getattr(torch, self._torch_dtype_str, torch.bfloat16)
         actual_device = self.device
-        if actual_device == "cuda" and torch.cuda.is_available():
-            local_rank = int(os.environ.get("LOCAL_RANK", 0))
-            actual_device = f"cuda:{local_rank}"
-            torch.cuda.set_device(local_rank)
-        elif actual_device == "cuda" and not torch.cuda.is_available():
-            actual_device = "cpu"
+        if actual_device.startswith("cuda"):
+            torch.cuda.set_device(torch.device(actual_device))
+        elif actual_device == "mps":
+            dtype = torch.float16  # MPS doesn't support bfloat16
+        elif actual_device == "cpu":
             dtype = torch.float32
             eval_logger.warning("CUDA not available, loading Cosmos3 Reasoner on CPU (very slow)")
 
@@ -1420,8 +1447,13 @@ class CosmosWorldModel(lmms):
         with ThreadPoolExecutor(max_workers=self.num_concurrent) as pool:
             futures = {pool.submit(_process, i): i for i in range(len(requests))}
             for future in as_completed(futures):
-                idx, result = future.result()
-                results[idx] = result
+                idx = futures[future]
+                try:
+                    _, result = future.result()
+                    results[idx] = result
+                except Exception as exc:
+                    eval_logger.error(f"Generation failed (idx={idx}): {exc}\n{traceback.format_exc()}")
+                    results[idx] = f"[GENERATION_FAILED] {exc}"
                 pbar.update(1)
 
         pbar.close()

--- a/lmms_eval/models/simple/diffusers_wm_base.py
+++ b/lmms_eval/models/simple/diffusers_wm_base.py
@@ -1,0 +1,345 @@
+"""Diffusers WM Base — shared skeleton for diffusers-backed generation models.
+
+Consolidates per-rank device selection, lazy pipeline load, dual-expert
+device-placement fix, scheduler device patch, cache-path hashing, and the
+DP iteration loop from ``wan2_2``, ``wan2_2_t2v``, ``ltx_video``.
+
+Subclass contract
+-----------------
+Required (set ``_pipeline_cls`` one of two ways):
+    (a) Class attribute — ``_pipeline_cls = SomePipeline``.  Simple, but
+        the ``from diffusers import ...`` must happen at module import time,
+        which breaks in environments that don't have diffusers installed
+        but still want to import the ``lmms_eval`` package.
+    (b) ``_patch_pipeline_cls_before_load`` hook — assign
+        ``type(self)._pipeline_cls`` inside the hook.  Preserves the
+        original "no diffusers at module-import time" contract.
+
+Required (methods):
+    ``_generation_signature(prompt, visuals, extras) -> str``
+    ``_invoke_pipeline(prompt, visuals, generator, **extras)`` -> output object
+
+Optional overrides:
+    ``_patch_pipeline_cls_before_load()``   class-level monkeypatch hook.
+    ``_post_to_device(pipe, device)``       extra per-pipeline device fixups.
+    ``_extract_visuals(req)``               I2V / V2V conditioning extraction.
+    ``_export(output, out_path)``           swap MP4 export for images / other.
+
+Parallelism
+-----------
+Currently DP-only; ``DiffusersWMBase`` enforces ``tp_size == 1`` and will be
+extended in a follow-up PR to mirror ``vllm.py``'s
+``world_size == tp_size * dp_size`` validation.
+"""
+
+from __future__ import annotations
+
+import functools
+import hashlib
+import os
+import threading
+import traceback
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, ClassVar, List, Optional, Tuple, Union
+
+from loguru import logger as eval_logger
+from tqdm import tqdm
+
+from lmms_eval.api.instance import Instance
+from lmms_eval.api.model import lmms
+
+
+@dataclass(frozen=True)
+class ParallelPlan:
+    """Launcher-level topology read from torch.distributed env vars.
+
+    DP-only helper: reads ``RANK`` / ``LOCAL_RANK`` / ``WORLD_SIZE`` and pins
+    each rank to its own CUDA device.
+    """
+
+    global_rank: int
+    local_rank: int
+    world_size: int
+    tp_size: int = 1
+
+    @classmethod
+    def from_env(cls, tp_size: int = 1) -> "ParallelPlan":
+        return cls(
+            global_rank=int(os.environ.get("RANK", 0)),
+            local_rank=int(os.environ.get("LOCAL_RANK", 0)),
+            world_size=int(os.environ.get("WORLD_SIZE", 1)),
+            tp_size=int(tp_size),
+        )
+
+    def device_str(self) -> str:
+        import torch
+
+        if not torch.cuda.is_available():
+            return "cpu"
+        return f"cuda:{self.local_rank}"
+
+
+_DTYPE_ALIASES = {
+    "bfloat16": "bfloat16",
+    "bf16": "bfloat16",
+    "float16": "float16",
+    "fp16": "float16",
+    "half": "float16",
+    "float32": "float32",
+    "fp32": "float32",
+}
+
+
+def _resolve_torch_dtype(name: str):
+    import torch
+
+    key = _DTYPE_ALIASES.get((name or "").lower(), "bfloat16")
+    return getattr(torch, key)
+
+
+def _move_pipeline_to_device(pipe, device: str) -> None:
+    """Pipeline-wide ``.to(device)`` with per-component fallback walk.
+
+    Works around diffusers main's ``Pipeline.to()`` skipping dual-expert
+    components like ``transformer_2`` (observed on Wan2.2-A14B), which would
+    otherwise trigger torch.cat device-mismatch at the first denoising step.
+    """
+    pipe.to(device)
+    components = getattr(pipe, "components", None) or {}
+    for name, mod in components.items():
+        if mod is None or not hasattr(mod, "to") or not callable(mod.to):
+            continue
+        try:
+            mod.to(device)
+        except Exception as exc:
+            eval_logger.debug(f"skip .to on component {name}: {exc}")
+
+
+def _patch_scheduler_keep_device(pipe, device: str) -> None:
+    """Keep scheduler buffers on ``device`` after every ``set_timesteps`` call.
+
+    ``UniPCMultistepScheduler`` pins ``sigmas`` to CPU on purpose (see
+    scheduling_unipc_multistep.py: "to avoid too much CPU/GPU communication"),
+    but that triggers torch.cat mismatch inside ``multistep_uni_p_bh_update``
+    when concatenated with cuda model outputs. This wrapper migrates the
+    known buffers back to ``device`` every time ``set_timesteps`` is called.
+
+    ``functools.wraps`` is load-bearing: LTXPipeline's ``retrieve_timesteps``
+    introspects ``scheduler.set_timesteps`` with ``inspect.signature(...)
+    .parameters`` to decide whether custom ``sigmas`` are accepted. A naked
+    ``def wrapper(*args, **kwargs)`` hides the real signature — Python then
+    reports parameters = {"args", "kwargs"}, the ``"sigmas" in params`` check
+    fails, and LTX aborts with ``ValueError: ... does not support custom
+    sigmas schedules``. ``functools.wraps`` copies the original ``__wrapped__``
+    so ``inspect.signature(..., follow_wrapped=True)`` (the default) sees the
+    real parameters and the pipeline proceeds normally.
+    """
+    import torch
+
+    sched = getattr(pipe, "scheduler", None)
+    if sched is None or not hasattr(sched, "set_timesteps"):
+        return
+    if getattr(sched, "_lmms_eval_device_patched", False):
+        return
+
+    orig = sched.set_timesteps
+    target = torch.device(device)
+
+    @functools.wraps(orig)
+    def wrapper(*args, **kwargs):
+        result = orig(*args, **kwargs)
+        for attr in ("sigmas", "timesteps", "alpha_t", "sigma_t", "lambda_t"):
+            buf = getattr(sched, attr, None)
+            if torch.is_tensor(buf) and buf.device != target:
+                setattr(sched, attr, buf.to(target))
+        return result
+
+    sched.set_timesteps = wrapper
+    sched._lmms_eval_device_patched = True
+
+
+def _cache_path(output_dir: str, task: str, doc_id, signature: str, ext: str = "mp4") -> Path:
+    safe = str(task).replace("/", "_").replace(" ", "_")
+    h = hashlib.sha256(signature.encode()).hexdigest()[:12]
+    return Path(output_dir) / safe / f"{safe}_{doc_id}_{h}.{ext}"
+
+
+class DiffusersWMBase(lmms):
+    """DP-only base class for diffusers-backed video / image generation models."""
+
+    is_simple: ClassVar[bool] = True
+    _pipeline_cls: ClassVar[Optional[type]] = None
+    _output_ext: ClassVar[str] = "mp4"
+
+    def __init__(
+        self,
+        *,
+        pretrained: str,
+        output_dir: str,
+        seed: int = 42,
+        dtype: str = "bfloat16",
+        fps: int = 16,
+        batch_size: Union[int, str] = 1,
+        tp_size: int = 1,
+        **_unused: Any,
+    ) -> None:
+        super().__init__()
+        # _pipeline_cls is checked in _load_pipeline (after the
+        # _patch_pipeline_cls_before_load hook), so subclasses may assign it
+        # lazily to keep diffusers out of the module-import path.
+        self.plan = ParallelPlan.from_env(tp_size=tp_size)
+        if self.plan.tp_size != 1:
+            raise NotImplementedError(f"{type(self).__name__}: tp_size={self.plan.tp_size} not yet supported. " "DiffusersWMBase is DP-only; TP support is planned in a follow-up PR.")
+
+        self.pretrained = str(pretrained)
+        self.output_dir = str(output_dir)
+        self.seed = int(seed)
+        self.dtype_name = str(dtype)
+        self.fps = int(fps)
+        self.batch_size_per_gpu = int(batch_size)
+
+        self._rank = self.plan.global_rank
+        self._world_size = self.plan.world_size
+
+        self._pipe = None
+        self._load_lock = threading.Lock()
+
+        Path(self.output_dir).mkdir(parents=True, exist_ok=True)
+        eval_logger.info(
+            f"{type(self).__name__} init: pretrained={self.pretrained}, "
+            f"rank={self.plan.global_rank}/{self.plan.world_size}, "
+            f"device={self.plan.device_str()}, dtype={self.dtype_name}, "
+            f"seed={self.seed}, output_dir={self.output_dir}"
+        )
+
+    @property
+    def device(self) -> str:
+        """Per-rank device string (e.g. ``"cuda:0"``).
+
+        ``lmms_eval.evaluator.evaluate`` reads ``lm.device`` as a bare
+        attribute to place cross-rank sync tensors; the base's
+        ``self.plan.device_str()`` is the canonical source, so this
+        property just forwards. Lazy — doesn't require the pipeline to
+        be loaded.
+        """
+        return self.plan.device_str()
+
+    # ── Pipeline load + device placement ────────────────────────
+
+    def _ensure_loaded(self) -> None:
+        if self._pipe is not None:
+            return
+        with self._load_lock:
+            if self._pipe is not None:
+                return
+            self._load_pipeline()
+
+    def _load_pipeline(self) -> None:
+        self._patch_pipeline_cls_before_load()
+        if self._pipeline_cls is None:
+            raise TypeError(f"{type(self).__name__} must set _pipeline_cls before _load_pipeline runs " "(either as a class attribute or inside _patch_pipeline_cls_before_load)")
+        device = self.plan.device_str()
+        dtype = _resolve_torch_dtype(self.dtype_name)
+        eval_logger.info(f"Loading {self._pipeline_cls.__name__} from {self.pretrained} on {device}")
+        self._pipe = self._pipeline_cls.from_pretrained(self.pretrained, torch_dtype=dtype)
+        _move_pipeline_to_device(self._pipe, device)
+        _patch_scheduler_keep_device(self._pipe, device)
+        self._post_to_device(self._pipe, device)
+        self._log_component_devices()
+
+    def _log_component_devices(self) -> None:
+        comps = getattr(self._pipe, "components", None) or {}
+        dev_map = {name: str(getattr(mod, "device", "?")) for name, mod in comps.items() if mod is not None and hasattr(mod, "device")}
+        eval_logger.info(f"{type(self).__name__} loaded; components={dev_map}")
+
+    # ── Subclass hooks ──────────────────────────────────────────
+
+    def _patch_pipeline_cls_before_load(self) -> None:
+        """Apply class-level monkeypatches before ``from_pretrained``. No-op by default."""
+        return
+
+    def _post_to_device(self, pipe, device: str) -> None:
+        """Extra per-pipeline device fixups. No-op by default."""
+        return
+
+    def _extract_visuals(self, req: Instance) -> List:
+        """Return conditioning visuals for one request. Empty for T2V / T2I by default.
+
+        I2V subclasses override to pull visuals from ``doc_to_visual``.
+        """
+        return []
+
+    def _generation_signature(self, prompt: str, visuals: List, extras: dict) -> str:
+        """Return a deterministic string used for the cache key."""
+        raise NotImplementedError(f"{type(self).__name__} must implement _generation_signature")
+
+    def _invoke_pipeline(self, prompt: str, visuals: List, generator, **extras):
+        """Call the diffusers pipeline; return the raw output object."""
+        raise NotImplementedError(f"{type(self).__name__} must implement _invoke_pipeline")
+
+    def _export(self, output_obj, out_path: Path) -> None:
+        """Default: export first video frames to MP4. Override for image outputs."""
+        from diffusers.utils import export_to_video
+
+        export_to_video(output_obj.frames[0], str(out_path), fps=self.fps)
+
+    # ── Core generation loop ────────────────────────────────────
+
+    def _generate_one(
+        self,
+        prompt: str,
+        visuals: List,
+        doc_id,
+        task: str,
+        extras: Optional[dict] = None,
+    ) -> str:
+        import torch
+
+        extras = extras or {}
+        self._ensure_loaded()
+
+        sig = self._generation_signature(prompt, visuals, extras)
+        out_path = _cache_path(self.output_dir, task, doc_id, sig, ext=self._output_ext)
+        if out_path.exists():
+            eval_logger.debug(f"Cache hit: {out_path}")
+            return str(out_path)
+
+        try:
+            generator = torch.Generator(device=self.plan.device_str()).manual_seed(self.seed)
+            output = self._invoke_pipeline(prompt, visuals, generator, **extras)
+            out_path.parent.mkdir(parents=True, exist_ok=True)
+            self._export(output, out_path)
+            if out_path.exists():
+                eval_logger.info(f"Generated: {out_path} ({out_path.stat().st_size} bytes)")
+            else:
+                eval_logger.error(f"Output NOT on disk after export: {out_path}")
+            return str(out_path)
+        except Exception as exc:
+            eval_logger.error(f"Generation failed: task={task} doc_id={doc_id}: {exc}\n" f"{traceback.format_exc()}")
+            return f"[GENERATION_FAILED] {exc}"
+
+    def generate_until(self, requests: List[Instance]) -> List[str]:
+        results: List[Optional[str]] = [None] * len(requests)
+        pbar = tqdm(total=len(requests), disable=(self.rank != 0), desc=type(self).__name__)
+        for i, req in enumerate(requests):
+            ctx, gen_kwargs, _doc_to_visual, doc_id, task, _split = req.args
+            prompt = str(ctx).strip()
+            if not prompt:
+                results[i] = "[ERROR] Empty prompt"
+                pbar.update(1)
+                continue
+            visuals = self._extract_visuals(req)
+            results[i] = self._generate_one(prompt, visuals, doc_id, task, extras=gen_kwargs or {})
+            pbar.update(1)
+        pbar.close()
+        ok = sum(1 for r in results if r and not r.startswith("["))
+        failed = len(results) - ok
+        eval_logger.info(f"{type(self).__name__} complete: {ok} succeeded, {failed} failed")
+        return [r if r is not None else "[ERROR] Unknown" for r in results]
+
+    def loglikelihood(self, requests: List[Instance]) -> List[Tuple[float, bool]]:
+        raise NotImplementedError(f"{type(self).__name__} does not support loglikelihood")
+
+    def generate_until_multi_round(self, requests: List[Instance]) -> List[str]:
+        raise NotImplementedError(f"{type(self).__name__} does not support generate_until_multi_round")

--- a/lmms_eval/models/simple/generation_api.py
+++ b/lmms_eval/models/simple/generation_api.py
@@ -1,0 +1,841 @@
+"""Video generation model backend using fal.ai API.
+
+Two modes, selected via ``mode=`` in model_args:
+
+- ``t2v`` (default): text-to-video / text-to-image. Each request submits the
+  doc's text prompt, polls the fal.ai queue, downloads the generated video,
+  and returns the local file path as the generation result.
+- ``v2v``: video-conditioned generation (extend / edit / reference-to-video).
+  Each request uploads the
+  doc's conditioning video to the fal CDN, calls the endpoint, downloads the
+  result, trims the leading conditioning segment when the endpoint returns
+  input++continuation, and returns the local path of the continuation video.
+
+Usage (t2v):
+  python -m lmms_eval \
+    --model generation_api \
+    --model_args "model=wan/v2.6/text-to-video,output_dir=./output_videos" \
+    --tasks videogen_test \
+    --batch_size 1 \
+    --limit 4 \
+    --log_samples
+
+Usage (v2v):
+  python -m lmms_eval \
+    --model generation_api \
+    --model_args "mode=v2v,model=grok_extend,output_dir=./output_videos/grok_extend" \
+    --tasks videogen_v2v_test \
+    --batch_size 1 \
+    --log_samples
+
+Environment:
+  FAL_KEY or FAL_API_KEY must be set for any request that reaches the API.
+  Runs where every request resumes from an existing output file complete
+  without a key (and without billing).
+
+Resume / no-double-billing contract (v2v):
+  The output path for a doc is ``output_dir/<task>/<doc name>.mp4`` (falling
+  back to ``<task>_<doc_id>`` when the doc has no ``name``). If that file
+  already exists the API call is skipped and the path is returned as-is, so
+  re-runs never re-bill completed clips. Externally generated videos can be
+  pre-seeded into that layout to skip regeneration.
+
+Supported t2v endpoints (pass via model= in model_args):
+  Wan:        wan/v2.6/text-to-video
+  LTX:        fal-ai/ltx-video
+  Hunyuan:    fal-ai/hunyuan-video
+  Hunyuan v1.5: fal-ai/hunyuan-video-v1.5/text-to-video
+
+Supported v2v presets (pass via model= in model_args; empirical input
+constraints):
+  grok_extend      xai/grok-imagine-video/extend-video — true extend; 2-15s
+                   input, <=921,600 px^2 (auto-downscaled); output = input ++
+                   continuation
+  gemini_edit      google/gemini-omni-flash/edit — edit-style; output is the
+                   continuation only (same duration as input); flat $1/call
+  seedance_ref     bytedance/seedance-2.0/reference-to-video — re-enacts the
+                   reference from t=0 then continues; video param is an array
+                   referenced as @Video1 in the prompt
+  kling_ref        fal-ai/kling-video/o3/standard/video-to-video/reference —
+                   re-enact + continue; REJECTS inputs < 3.0s (2s conditioning
+                   fails; retiming workarounds distort dynamics,
+                   so the backend fails fast instead of silently retiming)
+  pixverse_extend  fal-ai/pixverse/v6/extend — extend; severe hallucination
+                   observed, baseline only
+Any other value is passed through as a raw fal.ai endpoint path; describe its
+request shape via video_param / video_param_is_array / output_includes_input /
+max_input_area / min_input_seconds model_args.
+"""
+
+import json
+import os
+import re
+import shutil
+import subprocess
+import threading
+import time
+import urllib.parse
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+import requests as http_requests
+from loguru import logger as eval_logger
+from tqdm import tqdm
+
+from lmms_eval.api.instance import Instance
+from lmms_eval.api.model import lmms
+from lmms_eval.api.registry import register_model
+
+# ---------------------------------------------------------------------------
+# Endpoint presets keyed by short alias -> fal.ai endpoint path
+# ---------------------------------------------------------------------------
+ENDPOINT_ALIASES: Dict[str, str] = {
+    "wan_t2v": "wan/v2.6/text-to-video",
+    "wan_i2v": "wan/v2.6/image-to-video",
+    "ltx_t2v": "fal-ai/ltx-video",
+    "hunyuan_t2v": "fal-ai/hunyuan-video",
+    "hunyuan_t2v_v15": "fal-ai/hunyuan-video-v1.5/text-to-video",
+    "hunyuan_i2v_v15": "fal-ai/hunyuan-video-v1.5/image-to-video",
+}
+
+# v2v presets: endpoint + payload shape + empirical input constraints
+# (empirical field notes).
+#   video_param            name of the endpoint's video input field
+#   video_param_is_array   endpoint expects a list of URLs (seedance)
+#   output_includes_input  output = conditioning ++ continuation, so the
+#                          leading cond_seconds are trimmed off the response
+#   max_input_area         max input pixel area; larger inputs are downscaled
+#   min_input_seconds      endpoint rejects shorter conditioning clips
+#   payload                endpoint-specific defaults (types matter: grok
+#                          duration is an int, kling duration a string enum)
+#   prompt                 fixed scene-agnostic prompt (per-scene descriptive
+#                          prompts leak ground-truth information)
+V2V_PRESETS: Dict[str, Dict[str, Any]] = {
+    "grok_extend": {
+        "endpoint": "xai/grok-imagine-video/extend-video",
+        "video_param": "video_url",
+        "output_includes_input": True,
+        "max_input_area": 921_600,
+        # Hard 2.0s minimum server-side; 59.94fps source clips land at 1.985s
+        # and get clone-padded back over the line (see _prepare_input).
+        "min_input_seconds": 2.0,
+        "payload": {"duration": 2},
+        "prompt": "Please continue to generate this video.",
+    },
+    "gemini_edit": {
+        "endpoint": "google/gemini-omni-flash/edit",
+        "video_param": "video_url",
+        "output_includes_input": False,
+        "payload": {},
+        "prompt": "Please continue to generate this video.",
+    },
+    "seedance_ref": {
+        "endpoint": "bytedance/seedance-2.0/reference-to-video",
+        "video_param": "video_urls",
+        "video_param_is_array": True,
+        "output_includes_input": True,
+        # Undocumented: rejects references above ~720p area with a generic
+        # "Invalid input in 'video_urls'" 422 (measured 2026-07-04: every
+        # 1280x720 input passed, every 1920x1080/2560x1440/3840x2160 failed).
+        "max_input_area": 921_600,
+        # Same hard 2.0s stream-duration minimum as grok (422
+        # video_duration_too_short on a 1.9853s clip); enables the clone-pad.
+        "min_input_seconds": 2.0,
+        "payload": {"duration": 4, "generate_audio": False},
+        "prompt": "Please continue to generate the video @Video1.",
+    },
+    "kling_ref": {
+        "endpoint": "fal-ai/kling-video/o3/standard/video-to-video/reference",
+        "video_param": "video_url",
+        "output_includes_input": True,
+        "min_input_seconds": 3.0,
+        "payload": {"duration": "4"},
+        "prompt": "Please continue to generate the video @Video1.",
+    },
+    "pixverse_extend": {
+        "endpoint": "fal-ai/pixverse/v6/extend",
+        "video_param": "video_url",
+        "output_includes_input": True,
+        "payload": {"duration": 2},
+        "prompt": "Please continue to generate this video.",
+    },
+}
+
+VIDEO_EXTENSIONS = (".mp4", ".mov", ".webm", ".mkv", ".avi")
+
+_RESOLUTION_RE = re.compile(r"(\d{2,5})x(\d{2,5})[ ,]")
+_DURATION_RE = re.compile(r"Duration: (\d+):(\d+):(\d+\.?\d*)")
+
+# Inputs missing an endpoint's minimum duration by at most this much are
+# clone-padded on the last frame; anything shorter fails fast (a whole missing
+# second is a protocol mismatch, not encoder rounding).
+_PAD_TOLERANCE_SECONDS = 0.1
+
+
+class MissingApiKeyError(RuntimeError):
+    """No FAL key configured — never heals on retry, so fail requests fast."""
+
+
+def _resolve_endpoint(model: str) -> str:
+    """Resolve a short alias or pass through a full fal.ai endpoint path."""
+    return ENDPOINT_ALIASES.get(model, model)
+
+
+def _ffmpeg_exe() -> str:
+    """ffmpeg binary: PATH first, imageio-ffmpeg's bundled binary as fallback."""
+    exe = shutil.which("ffmpeg")
+    if exe:
+        return exe
+    try:
+        import imageio_ffmpeg
+
+        return imageio_ffmpeg.get_ffmpeg_exe()
+    except ImportError as e:
+        raise RuntimeError("ffmpeg is required for v2v input preparation and output trimming; install ffmpeg or `uv pip install imageio-ffmpeg`") from e
+
+
+def _probe_video(path: str) -> Tuple[int, int, float]:
+    """Return (width, height, duration_seconds) of the VIDEO STREAM.
+
+    fal endpoints validate the stream duration, but the ``Duration:`` line in
+    ``ffmpeg -i`` output is the container duration, which muxers round up
+    (a 1.9853s stream prints as 2.00) — that rounding hid sub-minimum clips
+    from the pad logic. Prefer ffprobe's per-stream numbers; fall back to the
+    ``ffmpeg -i`` parse only when ffprobe is unavailable.
+    """
+    ffprobe = shutil.which("ffprobe")
+    if ffprobe:
+        out = subprocess.run(
+            [ffprobe, "-v", "error", "-select_streams", "v:0", "-show_entries", "stream=width,height,duration", "-of", "csv=p=0", str(path)],
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        parts = out.split(",")
+        if len(parts) >= 3:
+            try:
+                return int(parts[0]), int(parts[1]), float(parts[2])
+            except ValueError:
+                pass  # e.g. duration "N/A" — fall through to the ffmpeg parse
+    out = subprocess.run([_ffmpeg_exe(), "-i", str(path)], capture_output=True, text=True).stderr
+    m = _RESOLUTION_RE.search(out)
+    if not m:
+        raise RuntimeError(f"cannot parse resolution of {path}")
+    w, h = int(m.group(1)), int(m.group(2))
+    d = _DURATION_RE.search(out)
+    duration = (int(d.group(1)) * 3600 + int(d.group(2)) * 60 + float(d.group(3))) if d else 0.0
+    return w, h, duration
+
+
+def _pick_video_url(node: Any) -> Optional[str]:
+    """Recursively extract the first video URL from a fal.ai response dict."""
+    if isinstance(node, dict):
+        # Direct url field
+        if "url" in node and isinstance(node["url"], str):
+            u = node["url"]
+            if u.startswith("http") and any(ext in u.lower() for ext in VIDEO_EXTENSIONS):
+                return u
+        # Priority keys
+        for key in ("video", "videos", "output", "result", "data"):
+            if key in node:
+                found = _pick_video_url(node[key])
+                if found:
+                    return found
+        # Fallback: scan all values
+        for v in node.values():
+            found = _pick_video_url(v)
+            if found:
+                return found
+    elif isinstance(node, list):
+        for item in node:
+            found = _pick_video_url(item)
+            if found:
+                return found
+    elif isinstance(node, str):
+        if node.startswith("http") and any(ext in node.lower() for ext in VIDEO_EXTENSIONS):
+            return node
+    return None
+
+
+@register_model("generation_api")
+class GenerationApi(lmms):
+    """fal.ai queue-based API generation backend."""
+
+    is_simple = True
+
+    def __init__(
+        self,
+        # ── infrastructure ──
+        model: str = "wan/v2.6/text-to-video",
+        mode: str = "t2v",
+        output_dir: str = "./logs/generation_api_videos",
+        num_concurrent: int = 4,
+        batch_size: Union[int, str] = 1,
+        poll_interval: int = 5,
+        max_polls: int = 240,
+        max_retries: int = 2,
+        # ── v2v options (defaults come from the preset when model= matches) ──
+        video_key: str = "conditioning_video",
+        cond_seconds: float = 2.0,
+        prompt: Optional[str] = None,
+        video_param: Optional[str] = None,
+        video_param_is_array: Optional[bool] = None,
+        output_includes_input: Optional[bool] = None,
+        max_input_area: Optional[int] = None,
+        min_input_seconds: Optional[float] = None,
+        # ── shared generation params (None = t2v defaults / absent in v2v) ──
+        duration: Optional[Union[int, str]] = None,
+        resolution: Optional[str] = None,
+        aspect_ratio: Optional[str] = None,
+        negative_prompt: str = "",
+        seed: Optional[int] = None,
+        num_inference_steps: Optional[int] = None,
+        guidance_scale: Optional[float] = None,
+        num_frames: Optional[int] = None,
+        enable_prompt_expansion: Optional[bool] = None,
+        enable_safety_checker: Optional[bool] = None,
+        # ── extra kwargs forwarded to fal.ai as-is ──
+        **kwargs,
+    ) -> None:
+        super().__init__()
+        self.mode = str(mode).lower()
+        if self.mode not in ("t2v", "v2v"):
+            raise ValueError(f"generation_api mode must be 't2v' or 'v2v', got {mode!r}")
+
+        preset = V2V_PRESETS.get(model, {}) if self.mode == "v2v" else {}
+        self.endpoint = preset.get("endpoint") or _resolve_endpoint(model)
+        self.output_dir = str(output_dir)
+        self.num_concurrent = max(1, int(num_concurrent))
+        self.batch_size_per_gpu = int(batch_size)
+        self.poll_interval = max(1, int(poll_interval))
+        self.max_polls = max(1, int(max_polls))
+        self.max_retries = max(1, int(max_retries))
+
+        # v2v request shape: explicit model_args override the preset.
+        self.video_key = str(video_key)
+        self.cond_seconds = float(cond_seconds)
+        self.v2v_prompt = str(prompt) if prompt is not None else str(preset.get("prompt", ""))
+        self.video_param = str(video_param) if video_param is not None else str(preset.get("video_param", "video_url"))
+        self.video_param_is_array = bool(video_param_is_array if video_param_is_array is not None else preset.get("video_param_is_array", False))
+        self.output_includes_input = bool(output_includes_input if output_includes_input is not None else preset.get("output_includes_input", False))
+        self.max_input_area = int(max_input_area if max_input_area is not None else preset.get("max_input_area", 0))
+        self.min_input_seconds = float(min_input_seconds if min_input_seconds is not None else preset.get("min_input_seconds", 0.0))
+        self._v2v_payload_defaults: Dict[str, Any] = dict(preset.get("payload", {}))
+
+        # API auth is checked lazily at the first real network call, so a run
+        # where every request resumes from an existing output file completes
+        # without a key (and without billing).
+        self.api_key = os.environ.get("FAL_KEY") or os.environ.get("FAL_API_KEY", "")
+        if not self.api_key:
+            eval_logger.warning("generation_api: FAL_KEY/FAL_API_KEY not set — resume-only mode; any request that misses an existing output file will fail.")
+
+        # Build the default generation payload template.
+        # t2v keeps its historical defaults (applied when the arg is None).
+        # v2v starts from the preset payload and folds in only the params the
+        # caller explicitly set — unconditional t2v defaults (string duration,
+        # resolution, aspect_ratio, ...) would 422 on extend/edit endpoints.
+        explicit_gen_params: Dict[str, Any] = {
+            k: v
+            for k, v in {
+                "duration": duration,
+                "resolution": resolution,
+                "aspect_ratio": aspect_ratio,
+                "seed": seed,
+                "num_inference_steps": num_inference_steps,
+                "guidance_scale": guidance_scale,
+                "num_frames": num_frames,
+                "enable_prompt_expansion": enable_prompt_expansion,
+                "enable_safety_checker": enable_safety_checker,
+            }.items()
+            if v is not None
+        }
+        if negative_prompt:
+            explicit_gen_params["negative_prompt"] = str(negative_prompt)
+
+        self._gen_defaults: Dict[str, Any] = {}
+        if self.mode == "t2v":
+            self._gen_defaults["duration"] = str(explicit_gen_params.pop("duration", "5"))
+            self._gen_defaults["resolution"] = str(explicit_gen_params.pop("resolution", "720p"))
+            self._gen_defaults["aspect_ratio"] = str(explicit_gen_params.pop("aspect_ratio", "16:9"))
+            self._gen_defaults["enable_prompt_expansion"] = bool(explicit_gen_params.pop("enable_prompt_expansion", True))
+            self._gen_defaults["enable_safety_checker"] = bool(explicit_gen_params.pop("enable_safety_checker", True))
+            for k, caster in (("seed", int), ("num_inference_steps", int), ("guidance_scale", float), ("num_frames", int)):
+                if k in explicit_gen_params:
+                    self._gen_defaults[k] = caster(explicit_gen_params.pop(k))
+            self._gen_defaults.update(explicit_gen_params)
+        else:
+            # Explicit values keep their parsed types: grok wants int duration,
+            # kling a string enum — the preset defaults model the difference.
+            self._v2v_payload_defaults.update(explicit_gen_params)
+
+        # Absorb any extra kwargs the user passes via model_args.
+        # t2v: forwarded with the defaults. v2v: layered over the preset payload
+        # so power users can pass endpoint-specific params directly.
+        _known_infra_keys = {
+            "model",
+            "mode",
+            "output_dir",
+            "num_concurrent",
+            "batch_size",
+            "poll_interval",
+            "max_polls",
+            "max_retries",
+            "device",
+            "max_batch_size",
+            "video_key",
+            "cond_seconds",
+            "prompt",
+            "video_param",
+            "video_param_is_array",
+            "output_includes_input",
+            "max_input_area",
+            "min_input_seconds",
+        }
+        for k, v in kwargs.items():
+            if k in _known_infra_keys:
+                continue
+            if self.mode == "v2v":
+                self._v2v_payload_defaults[k] = v
+            else:
+                self._gen_defaults[k] = v
+
+        Path(self.output_dir).mkdir(parents=True, exist_ok=True)
+        self._session = http_requests.Session()
+        self._session.headers.update({"Content-Type": "application/json"})
+        if self.api_key:
+            self._session.headers.update({"Authorization": f"Key {self.api_key}"})
+        self._upload_cache: Dict[str, str] = {}
+        self._upload_lock = threading.Lock()
+        self._request_log_lock = threading.Lock()
+
+        eval_logger.info(f"GenerationApi initialized: mode={self.mode}, endpoint={self.endpoint}, output_dir={self.output_dir}, concurrency={self.num_concurrent}")
+
+    # ------------------------------------------------------------------
+    # fal.ai queue API helpers
+    # ------------------------------------------------------------------
+
+    def _require_api_key(self) -> None:
+        if not self.api_key:
+            raise MissingApiKeyError("FAL_KEY or FAL_API_KEY environment variable is required for fal.ai calls (this request found no existing output file to resume from). Get an API key at https://fal.ai/dashboard/keys")
+
+    def _upload_video(self, path: str) -> str:
+        """Upload a local video to the fal CDN, memoized per source path."""
+        with self._upload_lock:
+            cached = self._upload_cache.get(path)
+        if cached:
+            return cached
+        self._require_api_key()
+        try:
+            import fal_client
+        except ImportError as e:
+            raise ImportError("fal_client is required for v2v generation_api uploads: `uv pip install fal-client`") from e
+        os.environ.setdefault("FAL_KEY", self.api_key)
+        url = fal_client.upload_file(path)
+        with self._upload_lock:
+            self._upload_cache[path] = url
+        return url
+
+    def _submit_payload(self, payload: Dict[str, Any]) -> Dict[str, str]:
+        """Submit a generation job to the fal.ai queue. Returns job metadata."""
+        self._require_api_key()
+        url = f"https://queue.fal.run/{self.endpoint}"
+
+        resp = self._session.post(url, json=payload, timeout=60)
+        resp.raise_for_status()
+        data = resp.json()
+
+        request_id = data.get("request_id", "")
+        if not request_id:
+            raise ValueError(f"fal.ai submit response missing request_id: {data}")
+
+        return {
+            "request_id": request_id,
+            "status_url": data.get(
+                "status_url",
+                f"{url}/requests/{request_id}/status",
+            ),
+            "response_url": data.get(
+                "response_url",
+                f"{url}/requests/{request_id}",
+            ),
+        }
+
+    def _poll_until_done(self, status_url: str) -> None:
+        """Block until job reaches COMPLETED. Raises on failure/timeout."""
+        for i in range(1, self.max_polls + 1):
+            resp = self._session.get(status_url, timeout=30)
+            resp.raise_for_status()
+            data = resp.json()
+            state = (data.get("status") or data.get("state") or "").upper()
+
+            if state == "COMPLETED":
+                return
+            if state in ("FAILED", "CANCELED"):
+                detail = json.dumps(data, indent=2)[:500]
+                raise RuntimeError(f"fal.ai job {state}: {detail}")
+
+            # Log progress occasionally
+            if i % 10 == 0:
+                eval_logger.debug(f"fal.ai poll {i}/{self.max_polls} state={state}")
+
+            time.sleep(self.poll_interval)
+
+        raise TimeoutError(f"fal.ai job did not complete within {self.max_polls * self.poll_interval}s")
+
+    def _fetch_result(self, response_url: str) -> Tuple[str, Dict]:
+        """Fetch completed result and return (video_url, raw_result_dict)."""
+        resp = self._session.get(response_url, timeout=60)
+        resp.raise_for_status()
+        data = resp.json()
+
+        video_url = _pick_video_url(data)
+        if not video_url:
+            raise ValueError(f"No video URL in fal.ai result: {json.dumps(data)[:500]}")
+
+        return video_url, data
+
+    def _download_video(self, video_url: str, output_path: str) -> str:
+        """Download video from CDN URL to local file."""
+        resp = self._session.get(video_url, stream=True, timeout=300)
+        resp.raise_for_status()
+
+        path = Path(output_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "wb") as f:
+            for chunk in resp.iter_content(chunk_size=65536):
+                f.write(chunk)
+        return str(path)
+
+    def _infer_extension(self, video_url: str) -> str:
+        """Guess file extension from video URL."""
+        parsed_path = urllib.parse.urlparse(video_url).path.lower()
+        for ext in VIDEO_EXTENSIONS:
+            if parsed_path.endswith(ext):
+                return ext
+        return ".mp4"
+
+    def _append_request_log(self, record: Dict[str, Any]) -> None:
+        """Append one line per completed API call to <output_dir>/requests.jsonl.
+
+        Local observability only; the fal.ai dashboard is billing ground truth.
+        """
+        record = {"ts": time.strftime("%Y-%m-%dT%H:%M:%S%z"), **record}
+        log_path = os.path.join(self.output_dir, "requests.jsonl")
+        with self._request_log_lock:
+            with open(log_path, "a", encoding="utf-8") as fh:
+                fh.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+    # ------------------------------------------------------------------
+    # Output naming + resume
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _safe_stem(value: str) -> str:
+        return str(value).replace("/", "_").replace(" ", "_")
+
+    def _final_output_path(self, task: str, doc_id: Union[str, int], doc: Optional[dict], ext: str = ".mp4") -> str:
+        """Canonical per-doc output path: output_dir/<task>/<doc name><ext>.
+
+        Doc ``name`` keys the output layout, so name-keyed outputs stay stable
+        across dataset re-indexing and are directly seedable. Docs without a
+        name fall back to the ``<task>_<doc_id>`` stem.
+        """
+        safe_task = self._safe_stem(task)
+        name = doc.get("name") if isinstance(doc, dict) else None
+        stem = self._safe_stem(name) if name else f"{safe_task}_{doc_id}"
+        return os.path.join(self.output_dir, safe_task, f"{stem}{ext}")
+
+    @staticmethod
+    def _resume_hit(path: str) -> bool:
+        try:
+            return os.path.getsize(path) > 0
+        except OSError:
+            return False
+
+    # ------------------------------------------------------------------
+    # Input preparation (v2v)
+    # ------------------------------------------------------------------
+
+    def _prepare_input(self, src: str, task: str) -> Tuple[str, str]:
+        """Validate + adapt a conditioning clip to the endpoint's limits.
+
+        Two adaptations, both semantics-preserving:
+        - downscale when the pixel area exceeds ``max_input_area`` (spatial
+          only — retiming would invalidate dynamics comparisons);
+        - clone-pad the last frame when the clip misses ``min_input_seconds``
+          by at most ``_PAD_TOLERANCE_SECONDS`` (dataset clips encoded at
+          59.94fps land at 1.985s and trip grok's hard 2.0s minimum). A real
+          protocol mismatch (e.g. 2s conditioning into kling's 3s minimum)
+          still fails fast.
+
+        Returns (prepared_path, prep_note).
+        """
+        w, h, dur = _probe_video(src)
+        short_by = (self.min_input_seconds - dur) if (self.min_input_seconds and dur) else 0.0
+        if short_by > _PAD_TOLERANCE_SECONDS:
+            raise ValueError(f"{self.endpoint} rejects inputs shorter than {self.min_input_seconds}s (got {dur:.2f}s from {src}); retiming workarounds distort dynamics, refusing")
+        need_scale = bool(self.max_input_area) and w * h > self.max_input_area
+        need_pad = short_by > 0
+        if not need_scale and not need_pad:
+            return src, f"{w}x{h}"
+
+        vf_parts = []
+        nw, nh = w, h
+        note = f"{w}x{h}"
+        if need_scale:
+            scale = (self.max_input_area / (w * h)) ** 0.5
+            nw, nh = int(w * scale) // 2 * 2, int(h * scale) // 2 * 2
+            vf_parts.append(f"scale={nw}:{nh}")
+            note = f"{w}x{h}->{nw}x{nh}"
+        if need_pad:
+            # Pad slightly past the minimum so container rounding can't re-trip it.
+            pad_seconds = short_by + 0.02
+            vf_parts.append(f"tpad=stop_mode=clone:stop_duration={pad_seconds:.3f}")
+            note += f"+pad{pad_seconds:.3f}s"
+
+        prepared_dir = os.path.join(self.output_dir, self._safe_stem(task), "prepared_inputs")
+        os.makedirs(prepared_dir, exist_ok=True)
+        suffix = f"_{nw}x{nh}" + ("_pad" if need_pad else "")
+        dst = os.path.join(prepared_dir, f"{Path(src).stem}{suffix}.mp4")
+        if not self._resume_hit(dst):
+            subprocess.run(
+                [_ffmpeg_exe(), "-v", "error", "-i", src, "-vf", ",".join(vf_parts), "-an", "-c:v", "libx264", "-pix_fmt", "yuv420p", "-y", dst],
+                check=True,
+            )
+        return dst, note
+
+    def _trim_leading(self, full_path: str, out_path: str) -> None:
+        """Strip the first cond_seconds so the response is the continuation only."""
+        subprocess.run(
+            [_ffmpeg_exe(), "-v", "error", "-ss", str(self.cond_seconds), "-i", full_path, "-c:v", "libx264", "-pix_fmt", "yuv420p", "-y", out_path],
+            check=True,
+        )
+
+    # ------------------------------------------------------------------
+    # Single-request pipelines
+    # ------------------------------------------------------------------
+
+    def _generate_one(
+        self,
+        prompt: str,
+        task: str,
+        doc_id: Union[str, int],
+    ) -> str:
+        """t2v pipeline for one request: submit -> poll -> download. Returns local path."""
+        # Resume: reruns must not re-bill docs that already have output.
+        safe_task = self._safe_stem(task)
+        for ext in VIDEO_EXTENSIONS:
+            probe_path = os.path.join(self.output_dir, safe_task, f"{safe_task}_{doc_id}{ext}")
+            if self._resume_hit(probe_path):
+                eval_logger.debug(f"Cache hit: {probe_path}")
+                return probe_path
+
+        last_error: Optional[Exception] = None
+        for attempt in range(1, self.max_retries + 1):
+            try:
+                job = self._submit_payload({**self._gen_defaults, "prompt": prompt})
+                eval_logger.debug(f"Submitted fal.ai job: request_id={job['request_id']} task={task} doc_id={doc_id}")
+                self._poll_until_done(job["status_url"])
+                video_url, result_data = self._fetch_result(job["response_url"])
+
+                # Build output path
+                ext = self._infer_extension(video_url)
+                filename = f"{safe_task}_{doc_id}{ext}"
+                output_path = os.path.join(self.output_dir, safe_task, filename)
+                self._download_video(video_url, output_path)
+
+                # Persist metadata alongside video
+                meta_path = output_path.rsplit(".", 1)[0] + ".meta.json"
+                meta = {
+                    "prompt": prompt,
+                    "endpoint": self.endpoint,
+                    "video_url": video_url,
+                    "request_id": job["request_id"],
+                    "seed": result_data.get("seed"),
+                }
+                Path(meta_path).write_text(json.dumps(meta, indent=2))
+                self._append_request_log({"endpoint": self.endpoint, "request_id": job["request_id"], "task": task, "doc_id": doc_id, "output": output_path})
+
+                eval_logger.info(f"Video saved: {output_path}")
+                return output_path
+
+            except MissingApiKeyError as exc:
+                last_error = exc
+                break  # a missing key never heals on retry; fail the doc fast
+            except Exception as exc:
+                last_error = exc
+                eval_logger.warning(f"Attempt {attempt}/{self.max_retries} failed for task={task} doc_id={doc_id}: {exc}")
+                if attempt < self.max_retries:
+                    time.sleep(min(attempt * 5, 30))
+
+        error_msg = f"[GENERATION_FAILED] {last_error}"
+        eval_logger.error(f"All retries exhausted for task={task} doc_id={doc_id}: {last_error}")
+        return error_msg
+
+    def _generate_one_v2v(
+        self,
+        doc: dict,
+        prompt: str,
+        task: str,
+        doc_id: Union[str, int],
+    ) -> str:
+        """v2v pipeline: resume-check -> upload cond video -> call -> trim. Returns local path."""
+        final_path = self._final_output_path(task, doc_id, doc)
+        if self._resume_hit(final_path):
+            eval_logger.debug(f"Cache hit: {final_path}")
+            return final_path
+
+        cond_video = doc.get(self.video_key, "") if isinstance(doc, dict) else ""
+        if not cond_video or not os.path.exists(cond_video):
+            return f"[ERROR] conditioning video not found (doc key {self.video_key!r}): {cond_video!r}"
+
+        # The task's doc_to_text is usually empty for v2v benchmarks; fall back
+        # to the fixed scene-agnostic preset prompt so no GT detail leaks in.
+        effective_prompt = prompt.strip() or self.v2v_prompt
+
+        last_error: Optional[Exception] = None
+        for attempt in range(1, self.max_retries + 1):
+            try:
+                # Key check precedes any input preparation so a missing key
+                # surfaces as itself, not as a downstream ffmpeg/upload error.
+                self._require_api_key()
+                prepared, res_note = self._prepare_input(cond_video, task)
+                video_url = self._upload_video(prepared)
+                payload: Dict[str, Any] = dict(self._v2v_payload_defaults)
+                if effective_prompt:
+                    payload["prompt"] = effective_prompt
+                payload[self.video_param] = [video_url] if self.video_param_is_array else video_url
+
+                job = self._submit_payload(payload)
+                eval_logger.debug(f"Submitted fal.ai job: request_id={job['request_id']} task={task} doc_id={doc_id}")
+                self._poll_until_done(job["status_url"])
+                out_url, result_data = self._fetch_result(job["response_url"])
+
+                Path(final_path).parent.mkdir(parents=True, exist_ok=True)
+                src_ext = self._infer_extension(out_url)
+                if self.output_includes_input:
+                    full_dir = os.path.join(os.path.dirname(final_path), "full")
+                    os.makedirs(full_dir, exist_ok=True)
+                    full_path = os.path.join(full_dir, Path(final_path).stem + src_ext)
+                    self._download_video(out_url, full_path)
+                    self._trim_leading(full_path, final_path)
+                elif src_ext == ".mp4":
+                    self._download_video(out_url, final_path)
+                    full_path = ""
+                else:
+                    # Keep the ".mp4" naming contract honest: transcode foreign
+                    # containers instead of mislabeling their bytes.
+                    eval_logger.warning(f"{self.endpoint} returned {src_ext}; transcoding to mp4 for {final_path}")
+                    tmp_path = final_path + f".src{src_ext}"
+                    self._download_video(out_url, tmp_path)
+                    subprocess.run([_ffmpeg_exe(), "-v", "error", "-i", tmp_path, "-c:v", "libx264", "-pix_fmt", "yuv420p", "-y", final_path], check=True)
+                    os.remove(tmp_path)
+                    full_path = ""
+
+                meta = {
+                    "source": "fal.ai",
+                    "endpoint": self.endpoint,
+                    "request_id": job["request_id"],
+                    "video_url": out_url,
+                    "prompt": effective_prompt,
+                    "payload_keys": sorted(payload.keys()),
+                    "conditioning_video": cond_video,
+                    "input_resolution": res_note,
+                    "cond_seconds_trimmed": self.cond_seconds if self.output_includes_input else 0.0,
+                    "full_output": full_path,
+                    "seed": result_data.get("seed"),
+                }
+                Path(final_path + ".meta.json").write_text(json.dumps(meta, indent=2))
+                self._append_request_log({"endpoint": self.endpoint, "request_id": job["request_id"], "task": task, "doc_id": doc_id, "output": final_path})
+
+                eval_logger.info(f"V2V video saved: {final_path}")
+                return final_path
+
+            except MissingApiKeyError as exc:
+                last_error = exc
+                break  # a missing key never heals on retry; fail the doc fast
+            except Exception as exc:
+                last_error = exc
+                eval_logger.warning(f"Attempt {attempt}/{self.max_retries} failed for task={task} doc_id={doc_id}: {exc}")
+                if attempt < self.max_retries:
+                    time.sleep(min(attempt * 5, 30))
+
+        error_msg = f"[GENERATION_FAILED] {last_error}"
+        eval_logger.error(f"All retries exhausted for task={task} doc_id={doc_id}: {last_error}")
+        return error_msg
+
+    # ------------------------------------------------------------------
+    # lmms interface
+    # ------------------------------------------------------------------
+
+    def _resolve_doc(self, task: str, split: str, doc_id: Union[str, int]) -> Optional[dict]:
+        try:
+            return self.task_dict[task][split][doc_id]
+        except Exception as e:
+            eval_logger.warning(f"Failed to resolve doc task={task} split={split} doc_id={doc_id}: {e}")
+            return None
+
+    def generate_until(self, requests: List[Instance]) -> List[str]:
+        """Generate videos for all requests using concurrent fal.ai calls."""
+        results: List[Optional[str]] = [None] * len(requests)
+        pbar = tqdm(
+            total=len(requests),
+            disable=(self.rank != 0),
+            desc="Generating Videos",
+        )
+
+        # v2v outputs are keyed by doc name; two docs sharing a name would
+        # silently alias to one file, so fail loudly before any API spend.
+        if self.mode == "v2v":
+            path_owner: Dict[str, Any] = {}
+            for req in requests:
+                _, _, _, doc_id, task, split = req.args
+                doc = self._resolve_doc(task, split, doc_id)
+                path = self._final_output_path(task, doc_id, doc)
+                owner = path_owner.setdefault(path, doc_id)
+                if owner != doc_id:
+                    raise ValueError(f"generation_api: output path collision for {path} (doc_ids {owner} and {doc_id}); doc 'name' values must be unique within a task")
+
+        def _process(index: int) -> Tuple[int, str]:
+            req = requests[index]
+            ctx, gen_kwargs, doc_to_visual, doc_id, task, split = req.args
+            prompt = str(ctx).strip()
+            if self.mode == "v2v":
+                doc = self._resolve_doc(task, split, doc_id)
+                if doc is None:
+                    return index, "[ERROR] doc lookup failed"
+                return index, self._generate_one_v2v(doc, prompt, task, doc_id)
+            if not prompt:
+                return index, "[ERROR] Empty prompt"
+            return index, self._generate_one(prompt, task, doc_id)
+
+        with ThreadPoolExecutor(max_workers=self.num_concurrent) as pool:
+            futures = {pool.submit(_process, i): i for i in range(len(requests))}
+            for future in as_completed(futures):
+                idx, result = future.result()
+                results[idx] = result
+                # Cache
+                req = requests[idx]
+                ctx = req.args[0]
+                gen_kwargs = req.args[1]
+                self.cache_hook.add_partial(
+                    "generate_until",
+                    (ctx, gen_kwargs),
+                    result,
+                )
+                pbar.update(1)
+
+        pbar.close()
+
+        # Summary
+        generated = sum(1 for r in results if r and not r.startswith("["))
+        failed = len(results) - generated
+        eval_logger.info(f"Video generation complete: {generated} succeeded, {failed} failed, output_dir={self.output_dir}")
+
+        return [r if r is not None else "[ERROR] Unknown" for r in results]
+
+    def loglikelihood(self, requests: List[Instance]) -> List[Tuple[float, bool]]:
+        raise NotImplementedError("GenerationApi does not support loglikelihood")
+
+    def generate_until_multi_round(self, requests: List[Instance]) -> List[str]:
+        raise NotImplementedError("GenerationApi does not support multi-round generation")

--- a/lmms_eval/models/simple/generation_api.py
+++ b/lmms_eval/models/simple/generation_api.py
@@ -80,6 +80,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import requests as http_requests
+from accelerate import Accelerator, DistributedType
 from loguru import logger as eval_logger
 from tqdm import tqdm
 
@@ -298,6 +299,20 @@ class GenerationApi(lmms):
         **kwargs,
     ) -> None:
         super().__init__()
+
+        # DP wiring for accelerate-launched runs: the evaluator reads lm.device,
+        # lm.rank, lm.world_size for cross-rank sync (evaluator.py:950). Mirror
+        # the sibling API backends (gemini_api / gpt4v).
+        accelerator = Accelerator()
+        if accelerator.num_processes > 1:
+            assert accelerator.distributed_type in [DistributedType.FSDP, DistributedType.MULTI_GPU, DistributedType.DEEPSPEED], "Unsupported distributed type provided. Only DDP and FSDP are supported."
+            if accelerator.is_local_main_process:
+                eval_logger.info(f"Using {accelerator.num_processes} devices with data parallelism")
+        self.accelerator = accelerator
+        self._rank = accelerator.local_process_index
+        self._world_size = accelerator.num_processes
+        self.device = accelerator.device
+
         self.mode = str(mode).lower()
         if self.mode not in ("t2v", "v2v"):
             raise ValueError(f"generation_api mode must be 't2v' or 'v2v', got {mode!r}")
@@ -495,15 +510,22 @@ class GenerationApi(lmms):
         return video_url, data
 
     def _download_video(self, video_url: str, output_path: str) -> str:
-        """Download video from CDN URL to local file."""
+        """Download video from CDN URL to local file, atomically.
+
+        Stream into a ``.part`` sidecar and ``os.replace`` into place only on
+        clean completion, so an interrupted download never leaves a truncated
+        file that ``_resume_hit`` would mistake for a finished cache entry.
+        """
         resp = self._session.get(video_url, stream=True, timeout=300)
         resp.raise_for_status()
 
         path = Path(output_path)
         path.parent.mkdir(parents=True, exist_ok=True)
-        with open(path, "wb") as f:
+        part = f"{path}.part"
+        with open(part, "wb") as f:
             for chunk in resp.iter_content(chunk_size=65536):
                 f.write(chunk)
+        os.replace(part, path)
         return str(path)
 
     def _infer_extension(self, video_url: str) -> str:

--- a/lmms_eval/models/simple/ltx_video.py
+++ b/lmms_eval/models/simple/ltx_video.py
@@ -25,7 +25,10 @@ class LTXVideo(DiffusersWMBase):
 
     def _patch_pipeline_cls_before_load(self) -> None:
         if type(self)._pipeline_cls is None:
-            from diffusers import LTXPipeline
+            try:
+                from diffusers import LTXPipeline
+            except ImportError as exc:
+                raise ImportError("ltx_video requires diffusers: `pip install diffusers imageio imageio-ffmpeg`") from exc
 
             type(self)._pipeline_cls = LTXPipeline
 

--- a/lmms_eval/models/simple/ltx_video.py
+++ b/lmms_eval/models/simple/ltx_video.py
@@ -1,0 +1,83 @@
+"""LTX-Video Text-to-Video backend for VBench evaluation.
+
+Uses LTXPipeline (diffusers) for real-time text-to-video generation.  Supports
+``Lightricks/LTX-Video`` and version variants (0.9.5, 0.9.7-dev, 0.9.8-dev).
+
+Usage::
+
+    torchrun --nproc-per-node=8 -m lmms_eval \\
+      --model ltx_video \\
+      --model_args "pretrained=Lightricks/LTX-Video,output_dir=./logs/vbench_ltx" \\
+      --tasks vbench \\
+      --batch_size 1 \\
+      --log_samples
+"""
+
+from typing import Union
+
+from lmms_eval.api.registry import register_model
+from lmms_eval.models.simple.diffusers_wm_base import DiffusersWMBase
+
+
+@register_model("ltx_video")
+class LTXVideo(DiffusersWMBase):
+    """LTX-Video Text-to-Video backend for VBench evaluation."""
+
+    def _patch_pipeline_cls_before_load(self) -> None:
+        if type(self)._pipeline_cls is None:
+            from diffusers import LTXPipeline
+
+            type(self)._pipeline_cls = LTXPipeline
+
+    def __init__(
+        self,
+        pretrained: str = "Lightricks/LTX-Video",
+        num_frames: int = 97,
+        height: int = 512,
+        width: int = 768,
+        num_inference_steps: int = 50,
+        guidance_scale: float = 3.0,
+        decode_timestep: float = 0.03,
+        decode_noise_scale: float = 0.025,
+        negative_prompt: str = "worst quality, inconsistent motion, blurry, jittery, distorted",
+        fps: int = 24,
+        seed: int = 42,
+        dtype: str = "bfloat16",
+        output_dir: str = "./logs/ltx_video",
+        batch_size: Union[int, str] = 1,
+        **kwargs,
+    ) -> None:
+        super().__init__(
+            pretrained=pretrained,
+            output_dir=output_dir,
+            seed=seed,
+            dtype=dtype,
+            fps=fps,
+            batch_size=batch_size,
+            **kwargs,
+        )
+        self.num_frames = int(num_frames)
+        self.height = int(height)
+        self.width = int(width)
+        self.num_inference_steps = int(num_inference_steps)
+        self.guidance_scale = float(guidance_scale)
+        self.decode_timestep = float(decode_timestep)
+        self.decode_noise_scale = float(decode_noise_scale)
+        self.negative_prompt = negative_prompt
+
+    def _generation_signature(self, prompt, visuals, extras):
+        return f"{self.pretrained}:{self.seed}:{self.num_inference_steps}:" f"{self.guidance_scale}:{self.num_frames}:{self.height}x{self.width}:" f"{prompt[:200]}"
+
+    def _invoke_pipeline(self, prompt, visuals, generator, **extras):
+        return self._pipe(
+            prompt=prompt,
+            negative_prompt=self.negative_prompt,
+            num_frames=self.num_frames,
+            height=self.height,
+            width=self.width,
+            num_inference_steps=self.num_inference_steps,
+            guidance_scale=self.guidance_scale,
+            decode_timestep=self.decode_timestep,
+            decode_noise_scale=self.decode_noise_scale,
+            generator=generator,
+        )

--- a/lmms_eval/models/simple/magi1_wm.py
+++ b/lmms_eval/models/simple/magi1_wm.py
@@ -1,0 +1,765 @@
+"""MAGI-1 World Model backend for evaluating video generation quality.
+
+Sand AI's MAGI-1 is an autoregressive video generation model that generates
+video chunk-by-chunk with block-causal attention.  Supports T2V, I2V, and V2V.
+
+For Physics-IQ evaluation the V2V mode is the primary path: a 3-second
+conditioning video is extended into a 5-second continuation for motion-mask
+comparison against ground truth.
+
+Requirements
+    - Clone the MAGI-1 repo (``magi_root`` model arg).
+    - Download weights from HuggingFace ``sand-ai/MAGI-1``.
+    - Provide a config JSON (from ``MAGI-1/example/``).
+    - CUDA-enabled torch.  ffmpeg recommended (for fps resampling).
+    - 4.5B variant: 1× GPU (≥24 GB VRAM).
+      24B variant: 8× H100/H800.
+
+Performance note
+    Pass ``kv_offload=False`` (model arg) to keep the KV cache resident on the
+    GPU.  Leaving offload on idles the GPU near 0% util as KV blocks ping-pong
+    to host RAM every chunk; turning it off pins the GPU near 100%.  Only 24B
+    model-parallel configs that are memory-bound should keep offload on.
+
+Usage (4.5B, single GPU)::
+
+    python -m lmms_eval \\
+        --model magi1_wm \\
+        --model_args "magi_root=/path/to/MAGI-1,config_file=/path/to/4.5B_base_config.json,output_dir=./logs/magi1,kv_offload=False" \\
+        --tasks physics_iq_v2v \\
+        --batch_size 1 --log_samples
+
+Usage (24B, 8 GPUs via torchrun)::
+
+    torchrun --nproc_per_node=8 --rdzv-backend=c10d --rdzv-endpoint=localhost:29400 --nnodes=1 \\
+        -m lmms_eval \\
+        --model magi1_wm \\
+        --model_args "magi_root=/path/to/MAGI-1,config_file=/path/to/24B_base_config.json,output_dir=./logs/magi1" \\
+        --tasks physics_iq_v2v \\
+        --batch_size 1 --log_samples
+"""
+
+import hashlib
+import json
+import os
+import shutil
+import socket
+import subprocess
+import sys
+import threading
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Optional, Tuple, Union
+
+from loguru import logger as eval_logger
+from tqdm import tqdm
+
+from lmms_eval.api.instance import Instance
+from lmms_eval.api.model import lmms
+from lmms_eval.api.registry import register_model
+
+
+def _find_free_port() -> int:
+    """Find a free TCP port for distributed rendezvous."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("", 0))
+        return s.getsockname()[1]
+
+
+@dataclass(frozen=True)
+class _ParallelLayout:
+    global_rank: int
+    local_rank: int
+    world_size: int
+    model_parallel_world_size: int
+    data_parallel_replicas: int
+    replica_rank: int
+
+
+def _read_env_int(name: str, default: int) -> int:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return int(value)
+
+
+def _compute_parallel_layout(
+    *,
+    global_rank: int,
+    local_rank: int,
+    world_size: int,
+    cp_size: int,
+    pp_size: int,
+) -> _ParallelLayout:
+    model_parallel_world_size = max(1, int(cp_size) * int(pp_size))
+    world_size = max(1, int(world_size))
+
+    if world_size % model_parallel_world_size != 0:
+        raise RuntimeError(f"MAGI-1 parallel layout is invalid: world_size={world_size} is not divisible by cp_size*pp_size={model_parallel_world_size}")
+
+    data_parallel_replicas = world_size // model_parallel_world_size
+
+    return _ParallelLayout(
+        global_rank=int(global_rank),
+        local_rank=int(local_rank),
+        world_size=world_size,
+        model_parallel_world_size=model_parallel_world_size,
+        data_parallel_replicas=data_parallel_replicas,
+        replica_rank=int(global_rank) // model_parallel_world_size,
+    )
+
+
+@contextmanager
+def _mask_default_group_to(mp_group):
+    """Temporarily reroute torch.distributed's default group to *mp_group*.
+
+    Inside the context every ``dist.*()`` call without an explicit ``group=``
+    argument operates against *mp_group*.  On exit the original default group
+    is restored so that lmms-eval's evaluator collectives (``gather_object``,
+    ``barrier``, ``broadcast_object_list``) run on the real outer world.
+
+    Used to satisfy MAGI-1's ``world_size == cp_size*pp_size`` assertion
+    during ``MagiPipeline(...)`` construction.  ``mp_group=None`` is a no-op
+    so the single-GPU path is unchanged.
+    """
+    import torch.distributed.distributed_c10d as c10d
+
+    if mp_group is None:
+        yield
+        return
+    orig_pg = c10d._get_default_group()
+    c10d._world.default_pg = mp_group
+    try:
+        yield
+    finally:
+        c10d._world.default_pg = orig_pg
+
+
+@register_model("magi1_wm")
+class Magi1WorldModel(lmms):
+    """MAGI-1 world model backend for video continuation generation.
+
+    Evaluates world-model quality by generating video continuations from
+    conditioning video (V2V) or a single image (I2V) and returning video
+    paths for downstream metric computation (e.g. Physics-IQ).
+    """
+
+    is_simple = True
+
+    def __init__(
+        self,
+        # ── MAGI-1 paths ──
+        magi_root: str = "",
+        config_file: str = "",
+        # ── Generation overrides (applied on top of the JSON config) ──
+        generation_seconds: float = 5.0,
+        num_frames: Optional[int] = None,
+        seed: Optional[int] = None,
+        num_steps: Optional[int] = None,
+        kv_offload: Optional[bool] = None,
+        # ── Output / eval ──
+        eval_fps: int = 16,
+        output_dir: str = "./logs/magi1_wm_videos",
+        # ── Infrastructure ──
+        batch_size: Union[int, str] = 1,
+        **kwargs,
+    ) -> None:
+        super().__init__()
+        import torch
+
+        if not magi_root:
+            raise ValueError("magi_root (path to MAGI-1 repo) is required")
+        if not config_file:
+            raise ValueError("config_file (path to MAGI-1 config JSON) is required")
+        if not os.path.isfile(config_file):
+            raise FileNotFoundError(f"MAGI-1 config not found: {config_file}")
+
+        self.magi_root = os.path.abspath(str(magi_root))
+        self.config_file = os.path.abspath(str(config_file))
+        self.generation_seconds = float(generation_seconds)
+        self._num_frames_override = int(num_frames) if num_frames is not None else None
+        self._seed_override = int(seed) if seed is not None else None
+        self._num_steps_override = int(num_steps) if num_steps is not None else None
+        # Accept "false"/"0"/"no" from the model_args string, not just bool.
+        if isinstance(kv_offload, str):
+            kv_offload = kv_offload.strip().lower() not in ("false", "0", "no", "off", "")
+        self._kv_offload_override = bool(kv_offload) if kv_offload is not None else None
+        self.eval_fps = int(eval_fps)
+        self.output_dir = str(output_dir)
+        self.batch_size_per_gpu = int(batch_size)
+        self._global_rank = _read_env_int("RANK", 0)
+        self._local_rank = _read_env_int("LOCAL_RANK", 0)
+        self._world_size = _read_env_int("WORLD_SIZE", 1)
+        self._rank = self._global_rank
+        if torch.cuda.is_available():
+            self._device = torch.device(f"cuda:{self._local_rank}")
+            torch.cuda.set_device(self._device)
+        else:
+            self._device = torch.device("cpu")
+
+        # Lazy-loaded
+        self._pipeline = None
+        self._native_fps: int = 24
+        self._config_data: Optional[dict] = None
+        self._modified_config_path: Optional[str] = None
+        self._load_lock = threading.Lock()
+        self._mp_group = None  # set in _load_pipeline for DP>1
+
+        # Peek at config to compute parallel layout before build_all_requests.
+        # The evaluator calls build_all_requests with (data_parallel_rank,
+        # data_parallel_world_size) right after __init__ — those properties
+        # read self._parallel_layout, so it must be set here, not lazily in
+        # _load_pipeline.
+        with open(self.config_file) as f:
+            _cfg_peek = json.load(f)
+        _engine = _cfg_peek.get("engine_config", {})
+        _cp = int(_engine.get("cp_size", 1))
+        _pp = int(_engine.get("pp_size", 1))
+        _mp_size = max(1, _cp * _pp)
+        _dp_replicas = self._world_size // _mp_size if self._world_size >= _mp_size else 1
+        _replica_rank = self._global_rank // _mp_size if _mp_size > 0 else 0
+
+        self._parallel_layout = _ParallelLayout(
+            global_rank=self._global_rank,
+            local_rank=self._local_rank,
+            world_size=self._world_size,
+            model_parallel_world_size=_mp_size,
+            data_parallel_replicas=_dp_replicas,
+            replica_rank=_replica_rank,
+        )
+
+        Path(self.output_dir).mkdir(parents=True, exist_ok=True)
+        eval_logger.info(
+            "MAGI-1 WM init: magi_root={}, config={}, eval_fps={}, output_dir={}, rank={}, local_rank={}, world_size={}, device={}",
+            self.magi_root,
+            self.config_file,
+            eval_fps,
+            self.output_dir,
+            self._global_rank,
+            self._local_rank,
+            self._world_size,
+            self._device,
+        )
+
+    @property
+    def device(self):
+        return self._device
+
+    @property
+    def data_parallel_rank(self) -> int:
+        # MAGI-1 ranks within one MP subgroup share input; only replica_rank
+        # distinguishes data shards. For 4.5B (mp_size=1) this equals rank.
+        return self._parallel_layout.replica_rank
+
+    @property
+    def data_parallel_world_size(self) -> int:
+        return self._parallel_layout.data_parallel_replicas
+
+    def _is_mp_leader(self) -> bool:
+        """Return True on the first rank of this replica's MP subgroup.
+
+        Post-process side-effects (shutil.move, os.remove, ffmpeg) are local
+        filesystem operations that must run exactly once per generated video;
+        MP peers would otherwise race on the same path and spurious-log
+        ``V2V failed`` when the losing rank tries to move an already-moved
+        file.
+        """
+        mp_size = self._parallel_layout.model_parallel_world_size
+        return self._global_rank % mp_size == 0
+
+    def _mp_barrier(self):
+        """Barrier across this replica's MP subgroup (no-op if mp_size == 1).
+
+        Uses ``self._mp_group`` when multiple DP replicas are carved out
+        (``data_parallel_replicas > 1``); otherwise the outer world *is* the
+        MP subgroup, so the default group barrier is correct.
+        """
+        import torch.distributed as dist
+
+        if not dist.is_available() or not dist.is_initialized():
+            return
+        if self._parallel_layout.model_parallel_world_size == 1:
+            return
+        if self._mp_group is not None:
+            dist.barrier(group=self._mp_group)
+        else:
+            dist.barrier()
+
+    # ------------------------------------------------------------------
+    # Lazy loading
+    # ------------------------------------------------------------------
+
+    def _ensure_loaded(self):
+        if self._pipeline is not None:
+            return
+        with self._load_lock:
+            if self._pipeline is not None:
+                return
+            self._load_pipeline()
+
+    def _load_pipeline(self):
+        import torch.distributed as dist
+
+        # ── sys.path ──
+        if not os.path.isdir(self.magi_root):
+            raise RuntimeError(f"MAGI-1 repo not found: {self.magi_root}")
+        if self.magi_root not in sys.path:
+            sys.path.insert(0, self.magi_root)
+            eval_logger.info(f"Added {self.magi_root} to sys.path")
+
+        # ── Load & patch config ──
+        with open(self.config_file) as f:
+            cfg = json.load(f)
+        self._config_data = cfg
+
+        runtime = cfg.setdefault("runtime_config", {})
+        engine = cfg.setdefault("engine_config", {})
+
+        self._native_fps = runtime.get("fps", 24)
+
+        # Compute num_frames for target duration
+        if self._num_frames_override is not None:
+            runtime["num_frames"] = self._num_frames_override
+        elif self.generation_seconds > 0:
+            runtime["num_frames"] = int(self.generation_seconds * self._native_fps)
+
+        if self._seed_override is not None:
+            runtime["seed"] = self._seed_override
+        if self._num_steps_override is not None:
+            runtime["num_steps"] = self._num_steps_override
+
+        # kv_offload lives in engine_config. Leaving it on (the MAGI default for
+        # some configs) idles the GPU at ~0% util because KV blocks ping-pong to
+        # host RAM every chunk; kv_offload=False keeps them resident and pins the
+        # GPU near 100%. Override only when explicitly set so memory-bound 24B
+        # model-parallel configs can keep offload on if they need it.
+        if self._kv_offload_override is not None:
+            engine["kv_offload"] = self._kv_offload_override
+
+        num_frames = runtime.get("num_frames", 96)
+        num_steps = runtime.get("num_steps", 64)
+        seed = runtime.get("seed", 1234)
+
+        # ── Distributed setup ──
+        cp_size = engine.get("cp_size", 1)
+        pp_size = engine.get("pp_size", 1)
+        self._parallel_layout = _compute_parallel_layout(
+            global_rank=self._global_rank,
+            local_rank=self._local_rank,
+            world_size=self._world_size,
+            cp_size=cp_size,
+            pp_size=pp_size,
+        )
+        world_needed = self._parallel_layout.model_parallel_world_size
+
+        if not dist.is_initialized():
+            if world_needed == 1:
+                os.environ.setdefault("MASTER_ADDR", "localhost")
+                os.environ.setdefault("MASTER_PORT", str(_find_free_port()))
+                os.environ.setdefault("RANK", "0")
+                os.environ.setdefault("WORLD_SIZE", "1")
+                os.environ.setdefault("LOCAL_RANK", "0")
+            else:
+                raise RuntimeError(f"MAGI-1 config needs {world_needed} GPUs (cp_size={cp_size}, pp_size={pp_size}) but torch.distributed is not initialised.  Launch with:\n  torchrun --nproc_per_node={world_needed} -m lmms_eval …")
+        else:
+            actual = dist.get_world_size()
+            if actual < world_needed:
+                raise RuntimeError(f"MAGI-1 needs {world_needed} GPUs but distributed world_size is {actual}")
+
+        # Prevent double init_process_group (e.g. accelerate already called it)
+        _orig_init_pg = dist.init_process_group
+
+        def _safe_init_pg(*args, **kwargs):
+            if dist.is_initialized():
+                return
+            return _orig_init_pg(*args, **kwargs)
+
+        dist.init_process_group = _safe_init_pg
+
+        # MAGI-1 recommended env vars
+        os.environ.setdefault("PAD_HQ", "1")
+        os.environ.setdefault("PAD_DURATION", "1")
+        os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+
+        # Write modified config to a stable path
+        config_dir = os.path.join(self.output_dir, ".config")
+        os.makedirs(config_dir, exist_ok=True)
+        self._modified_config_path = os.path.join(config_dir, f"magi1_config_rank{self.rank}.json")
+        with open(self._modified_config_path, "w") as f:
+            json.dump(cfg, f, indent=2)
+
+        eval_logger.info(
+            "Loading MAGI-1 pipeline: fps={}, num_frames={}, num_steps={}, seed={}, model_parallel_world_size={}, data_parallel_replicas={}, replica_rank={}",
+            self._native_fps,
+            num_frames,
+            num_steps,
+            seed,
+            self._parallel_layout.model_parallel_world_size,
+            self._parallel_layout.data_parallel_replicas,
+            self._parallel_layout.replica_rank,
+        )
+
+        # ── DP subgroup routing ──
+        # When the outer torchrun world spans multiple DP replicas, carve out
+        # this replica's MP subgroup so MAGI sees world=mp_size inside init.
+        if self._parallel_layout.data_parallel_replicas > 1:
+            self._mp_group, _ = dist.new_subgroups(group_size=self._parallel_layout.model_parallel_world_size)
+            eval_logger.info(
+                "MAGI-1 DP layout: replica {}/{}, mp_size={}",
+                self._parallel_layout.replica_rank,
+                self._parallel_layout.data_parallel_replicas,
+                self._parallel_layout.model_parallel_world_size,
+            )
+
+        # MAGI-1 uses relative paths (e.g. example/assets/special_tokens.npz)
+        # so cwd must be the repo root during pipeline creation.
+        original_cwd = os.getcwd()
+        os.chdir(self.magi_root)
+        try:
+            from inference.pipeline.pipeline import MagiPipeline
+
+            with _mask_default_group_to(self._mp_group):
+                self._pipeline = MagiPipeline(self._modified_config_path)
+        finally:
+            os.chdir(original_cwd)
+            dist.init_process_group = _orig_init_pg
+
+        eval_logger.info("MAGI-1 pipeline loaded successfully")
+
+    # ------------------------------------------------------------------
+    # Path helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _resolve_data_path(doc: dict, field: str) -> str:
+        """Resolve a data path from *doc* using the generic media resolver."""
+        from lmms_eval.tasks._task_utils.media_resolver import resolve_media_reference
+
+        return resolve_media_reference(
+            doc.get(field, ""),
+            media_type="video",
+            env_vars=("PHYSICS_IQ_DATA_DIR",),
+        )
+
+    def _output_path_for(
+        self,
+        input_key: str,
+        prompt: str,
+        task: str,
+        doc_id: Union[str, int],
+    ) -> str:
+        safe_task = str(task).replace("/", "_").replace(" ", "_")
+        runtime = (self._config_data or {}).get("runtime_config", {})
+        cache_hash = hashlib.sha256(f"{self.config_file}:{runtime.get('seed', 1234)}:{runtime.get('num_frames', 96)}:{runtime.get('num_steps', 64)}:{self.eval_fps}:{input_key}:{prompt[:100]}".encode()).hexdigest()[:12]
+        return os.path.join(
+            self.output_dir,
+            safe_task,
+            f"{safe_task}_{doc_id}_{cache_hash}.mp4",
+        )
+
+    # ------------------------------------------------------------------
+    # Video fps resampling
+    # ------------------------------------------------------------------
+
+    def _resample_video(self, src: str, dst: str, target_fps: int) -> str:
+        """Resample *src* to *target_fps*, writing to *dst*.
+
+        Tries ffmpeg first (fast, reliable), then falls back to PyAV.
+        """
+        # ── ffmpeg path ──
+        try:
+            result = subprocess.run(
+                [
+                    "ffmpeg",
+                    "-y",
+                    "-i",
+                    src,
+                    "-filter:v",
+                    f"fps={target_fps}",
+                    "-c:v",
+                    "libx264",
+                    "-pix_fmt",
+                    "yuv420p",
+                    "-loglevel",
+                    "error",
+                    dst,
+                ],
+                capture_output=True,
+                timeout=120,
+            )
+            if result.returncode == 0 and os.path.exists(dst):
+                return dst
+            eval_logger.warning(f"ffmpeg resample failed (rc={result.returncode}): {result.stderr.decode()[:200]}")
+        except FileNotFoundError:
+            eval_logger.debug("ffmpeg not found; falling back to PyAV")
+        except Exception as exc:
+            eval_logger.warning(f"ffmpeg error: {exc}")
+
+        # ── PyAV fallback ──
+        return self._resample_video_av(src, dst, target_fps)
+
+    @staticmethod
+    def _resample_video_av(src: str, dst: str, target_fps: int) -> str:
+        try:
+            import av
+
+            with av.open(src) as inp:
+                stream = inp.streams.video[0]
+                src_fps = float(stream.average_rate or 24)
+                frames = list(inp.decode(video=0))
+
+            if not frames:
+                return src
+
+            duration = len(frames) / src_fps
+            target_n = max(1, int(duration * target_fps))
+            indices = [min(int(i * len(frames) / target_n), len(frames) - 1) for i in range(target_n)]
+
+            with av.open(dst, "w") as out:
+                s = out.add_stream("libx264", rate=target_fps)
+                s.width = frames[0].width
+                s.height = frames[0].height
+                s.pix_fmt = "yuv420p"
+                for idx in indices:
+                    f = frames[idx].reformat(format="yuv420p")
+                    for pkt in s.encode(f):
+                        out.mux(pkt)
+                for pkt in s.encode():
+                    out.mux(pkt)
+
+            return dst
+        except Exception as exc:
+            eval_logger.warning(f"PyAV resample failed ({exc}); using raw video")
+            return src
+
+    # ------------------------------------------------------------------
+    # Generation helpers
+    # ------------------------------------------------------------------
+
+    def _generate_v2v(
+        self,
+        video_path: str,
+        prompt: str,
+        task: str,
+        doc_id: Union[str, int],
+    ) -> str:
+        """V2V: extend a conditioning video into a continuation."""
+        self._ensure_loaded()
+
+        output_path = self._output_path_for(video_path, prompt, task, doc_id)
+        if os.path.exists(output_path):
+            eval_logger.debug(f"Cache hit: {output_path}")
+            return output_path
+
+        Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+
+        try:
+            raw_path = output_path.replace(".mp4", "_raw.mp4")
+            with _mask_default_group_to(self._mp_group):
+                self._pipeline.run_video_to_video(
+                    prompt=prompt,
+                    prefix_video_path=video_path,
+                    output_path=raw_path,
+                )
+
+            # Sync MP peers so every rank sees the committed raw_path, then
+            # let exactly one rank do the post-process (shutil.move / ffmpeg
+            # resample / os.remove). Peers wait at the second barrier and
+            # return by inspecting the deterministic output_path.
+            self._mp_barrier()
+
+            if self._is_mp_leader():
+                if not os.path.exists(raw_path):
+                    eval_logger.error(f"V2V raw missing: task={task} doc_id={doc_id}")
+                else:
+                    if self._native_fps != self.eval_fps:
+                        self._resample_video(raw_path, output_path, self.eval_fps)
+                        if os.path.exists(output_path) and os.path.exists(raw_path):
+                            os.remove(raw_path)
+                    else:
+                        shutil.move(raw_path, output_path)
+                    eval_logger.info(f"V2V generated: {output_path}")
+
+            self._mp_barrier()
+
+            if os.path.exists(output_path):
+                return output_path
+            return "[GENERATION_FAILED] MAGI-1 produced no output"
+
+        except Exception as exc:
+            eval_logger.error(f"V2V failed: task={task} doc_id={doc_id}: {exc}")
+            return f"[GENERATION_FAILED] {exc}"
+
+    def _generate_i2v(
+        self,
+        image_path: str,
+        prompt: str,
+        task: str,
+        doc_id: Union[str, int],
+    ) -> str:
+        """I2V: generate video from a single conditioning image."""
+        self._ensure_loaded()
+
+        output_path = self._output_path_for(image_path, prompt, task, doc_id)
+        if os.path.exists(output_path):
+            eval_logger.debug(f"Cache hit: {output_path}")
+            return output_path
+
+        Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+
+        try:
+            raw_path = output_path.replace(".mp4", "_raw.mp4")
+            with _mask_default_group_to(self._mp_group):
+                self._pipeline.run_image_to_video(
+                    prompt=prompt,
+                    image_path=image_path,
+                    output_path=raw_path,
+                )
+
+            self._mp_barrier()
+
+            if self._is_mp_leader():
+                if not os.path.exists(raw_path):
+                    eval_logger.error(f"I2V raw missing: task={task} doc_id={doc_id}")
+                else:
+                    if self._native_fps != self.eval_fps:
+                        self._resample_video(raw_path, output_path, self.eval_fps)
+                        if os.path.exists(output_path) and os.path.exists(raw_path):
+                            os.remove(raw_path)
+                    else:
+                        shutil.move(raw_path, output_path)
+                    eval_logger.info(f"I2V generated: {output_path}")
+
+            self._mp_barrier()
+
+            if os.path.exists(output_path):
+                return output_path
+            return "[GENERATION_FAILED] MAGI-1 produced no output"
+
+        except Exception as exc:
+            eval_logger.error(f"I2V failed: task={task} doc_id={doc_id}: {exc}")
+            return f"[GENERATION_FAILED] {exc}"
+
+    def _save_frames_as_video(
+        self,
+        frames: list,
+        task: str,
+        doc_id: Union[str, int],
+    ) -> str:
+        """Write PIL frames to a temporary MP4 (fallback when the raw path is unavailable)."""
+        import av
+        from PIL import Image
+
+        safe_task = str(task).replace("/", "_")
+        tmp_dir = os.path.join(self.output_dir, ".tmp_cond")
+        os.makedirs(tmp_dir, exist_ok=True)
+        tmp_path = os.path.join(tmp_dir, f"cond_{safe_task}_{doc_id}.mp4")
+
+        if os.path.exists(tmp_path):
+            return tmp_path
+
+        pil_frames = []
+        for f in frames:
+            if isinstance(f, Image.Image):
+                pil_frames.append(f)
+            elif isinstance(f, str) and os.path.exists(f):
+                pil_frames.append(Image.open(f))
+
+        if not pil_frames:
+            return ""
+
+        with av.open(tmp_path, "w") as container:
+            stream = container.add_stream("libx264", rate=self.eval_fps)
+            stream.width = pil_frames[0].width
+            stream.height = pil_frames[0].height
+            stream.pix_fmt = "yuv420p"
+            for img in pil_frames:
+                frame = av.VideoFrame.from_image(img)
+                for pkt in stream.encode(frame):
+                    container.mux(pkt)
+            for pkt in stream.encode():
+                container.mux(pkt)
+
+        return tmp_path
+
+    # ------------------------------------------------------------------
+    # lmms interface
+    # ------------------------------------------------------------------
+
+    def generate_until(self, requests: List[Instance]) -> List[str]:
+        results: List[Optional[str]] = [None] * len(requests)
+        pbar = tqdm(
+            total=len(requests),
+            disable=(self.rank != 0),
+            desc="MAGI-1 Generation",
+        )
+
+        for i, req in enumerate(requests):
+            ctx, gen_kwargs, doc_to_visual, doc_id, task, split = req.args
+            prompt = str(ctx).strip()
+            doc = self.task_dict[task][split][doc_id]
+
+            # ── Detect mode from doc fields ──
+            cond_video = self._resolve_data_path(doc, "conditioning_video")
+            switch_frame = self._resolve_data_path(doc, "switch_frame")
+
+            if cond_video and os.path.exists(cond_video):
+                # V2V: conditioning video exists → video-to-video
+                results[i] = self._generate_v2v(cond_video, prompt, task, doc_id)
+
+            elif switch_frame and os.path.exists(switch_frame):
+                # I2V: single conditioning image → image-to-video
+                results[i] = self._generate_i2v(switch_frame, prompt, task, doc_id)
+
+            else:
+                # Fallback: try doc_to_visual → save frames as temp video
+                visuals = []
+                if doc_to_visual is not None:
+                    try:
+                        visuals = doc_to_visual(doc) or []
+                    except Exception as exc:
+                        eval_logger.warning(f"doc_to_visual failed: {exc}")
+
+                if not visuals:
+                    results[i] = "[ERROR] No conditioning input"
+                    pbar.update(1)
+                    continue
+
+                if len(visuals) == 1:
+                    # Single frame → save as temp image, run I2V
+                    from PIL import Image
+
+                    img = visuals[0]
+                    if isinstance(img, str):
+                        img = Image.open(img)
+                    tmp_dir = os.path.join(self.output_dir, ".tmp_cond")
+                    os.makedirs(tmp_dir, exist_ok=True)
+                    safe_task = str(task).replace("/", "_")
+                    tmp_img = os.path.join(tmp_dir, f"img_{safe_task}_{doc_id}.jpg")
+                    if not os.path.exists(tmp_img):
+                        img.save(tmp_img)
+                    results[i] = self._generate_i2v(tmp_img, prompt, task, doc_id)
+                else:
+                    # Multiple frames → save as temp video, run V2V
+                    tmp_video = self._save_frames_as_video(visuals, task, doc_id)
+                    if tmp_video:
+                        results[i] = self._generate_v2v(tmp_video, prompt, task, doc_id)
+                    else:
+                        results[i] = "[ERROR] Failed to save conditioning frames"
+
+            pbar.update(1)
+
+        pbar.close()
+
+        generated = sum(1 for r in results if r and not r.startswith("["))
+        failed = len(results) - generated
+        eval_logger.info(f"MAGI-1 complete: {generated} succeeded, {failed} failed, output_dir={self.output_dir}")
+
+        return [r if r is not None else "[ERROR] Unknown" for r in results]
+
+    def loglikelihood(self, requests: List[Instance]) -> List[Tuple[float, bool]]:
+        raise NotImplementedError("MAGI-1 WM does not support loglikelihood")
+
+    def generate_until_multi_round(self, requests: List[Instance]) -> List[str]:
+        raise NotImplementedError("MAGI-1 WM does not support multi-round generation")

--- a/lmms_eval/models/simple/magi1_wm.py
+++ b/lmms_eval/models/simple/magi1_wm.py
@@ -13,7 +13,8 @@ Requirements
     - Provide a config JSON (from ``MAGI-1/example/``).
     - CUDA-enabled torch.  ffmpeg recommended (for fps resampling).
     - 4.5B variant: 1× GPU (≥24 GB VRAM).
-      24B variant: 8× H100/H800.
+      24B variant: 8× H100/H800 (model-parallel — NOT supported under the
+      stock lmms-eval evaluator; see the usage note below).
 
 Performance note
     Pass ``kv_offload=False`` (model arg) to keep the KV cache resident on the
@@ -29,14 +30,13 @@ Usage (4.5B, single GPU)::
         --tasks physics_iq_v2v \\
         --batch_size 1 --log_samples
 
-Usage (24B, 8 GPUs via torchrun)::
-
-    torchrun --nproc_per_node=8 --rdzv-backend=c10d --rdzv-endpoint=localhost:29400 --nnodes=1 \\
-        -m lmms_eval \\
-        --model magi1_wm \\
-        --model_args "magi_root=/path/to/MAGI-1,config_file=/path/to/24B_base_config.json,output_dir=./logs/magi1" \\
-        --tasks physics_iq_v2v \\
-        --batch_size 1 --log_samples
+Model parallelism (24B, ``cp_size * pp_size > 1``) is NOT supported under the
+stock lmms-eval evaluator: it shards docs across all ranks by RANK/WORLD_SIZE,
+which desyncs MAGI-1's model-parallel collectives (each rank would try to
+generate a different doc). Use the single-GPU 4.5B config above, or pure
+data-parallel (``cp_size=pp_size=1``, one full replica per rank via
+``torchrun --nproc_per_node=N``). ``__init__`` raises if model parallel is
+combined with a multi-rank world.
 """
 
 import hashlib
@@ -205,29 +205,26 @@ class Magi1WorldModel(lmms):
         self._modified_config_path: Optional[str] = None
         self._load_lock = threading.Lock()
         self._mp_group = None  # set in _load_pipeline for DP>1
+        self._parallel_layout: Optional[_ParallelLayout] = None  # computed in _load_pipeline
 
-        # Peek at config to compute parallel layout before build_all_requests.
-        # The evaluator calls build_all_requests with (data_parallel_rank,
-        # data_parallel_world_size) right after __init__ — those properties
-        # read self._parallel_layout, so it must be set here, not lazily in
-        # _load_pipeline.
+        # MAGI-1 model parallelism (cp_size * pp_size > 1) needs every MP rank to
+        # co-run each generation, but the stock lmms-eval evaluator shards docs
+        # across all WORLD_SIZE ranks by env RANK/WORLD_SIZE. Under model parallel
+        # the two collide: each MP rank would be handed a different disjoint slice
+        # of docs and desync on MAGI's collectives. Single-GPU 4.5B and pure
+        # data-parallel (cp_size=pp_size=1, one full replica per rank) are fine.
         with open(self.config_file) as f:
-            _cfg_peek = json.load(f)
-        _engine = _cfg_peek.get("engine_config", {})
-        _cp = int(_engine.get("cp_size", 1))
-        _pp = int(_engine.get("pp_size", 1))
-        _mp_size = max(1, _cp * _pp)
-        _dp_replicas = self._world_size // _mp_size if self._world_size >= _mp_size else 1
-        _replica_rank = self._global_rank // _mp_size if _mp_size > 0 else 0
-
-        self._parallel_layout = _ParallelLayout(
-            global_rank=self._global_rank,
-            local_rank=self._local_rank,
-            world_size=self._world_size,
-            model_parallel_world_size=_mp_size,
-            data_parallel_replicas=_dp_replicas,
-            replica_rank=_replica_rank,
-        )
+            _engine = json.load(f).get("engine_config", {})
+        _mp_size = max(1, int(_engine.get("cp_size", 1)) * int(_engine.get("pp_size", 1)))
+        if self._world_size > 1 and _mp_size > 1:
+            raise ValueError(
+                f"Model-parallel MAGI-1 (cp_size*pp_size={_mp_size} with "
+                f"WORLD_SIZE={self._world_size}) is not supported under the stock "
+                "lmms-eval evaluator: it shards docs across all ranks by "
+                "RANK/WORLD_SIZE, which desyncs the model-parallel collectives. "
+                "Use the single-GPU 4.5B config, or pure data-parallel "
+                "(cp_size=pp_size=1, one full replica per rank)."
+            )
 
         Path(self.output_dir).mkdir(parents=True, exist_ok=True)
         eval_logger.info(
@@ -245,16 +242,6 @@ class Magi1WorldModel(lmms):
     @property
     def device(self):
         return self._device
-
-    @property
-    def data_parallel_rank(self) -> int:
-        # MAGI-1 ranks within one MP subgroup share input; only replica_rank
-        # distinguishes data shards. For 4.5B (mp_size=1) this equals rank.
-        return self._parallel_layout.replica_rank
-
-    @property
-    def data_parallel_world_size(self) -> int:
-        return self._parallel_layout.data_parallel_replicas
 
     def _is_mp_leader(self) -> bool:
         """Return True on the first rank of this replica's MP subgroup.
@@ -339,7 +326,7 @@ class Magi1WorldModel(lmms):
 
         num_frames = runtime.get("num_frames", 96)
         num_steps = runtime.get("num_steps", 64)
-        seed = runtime.get("seed", 1234)
+        seed = runtime.get("seed", 42)
 
         # ── Distributed setup ──
         cp_size = engine.get("cp_size", 1)
@@ -451,7 +438,7 @@ class Magi1WorldModel(lmms):
     ) -> str:
         safe_task = str(task).replace("/", "_").replace(" ", "_")
         runtime = (self._config_data or {}).get("runtime_config", {})
-        cache_hash = hashlib.sha256(f"{self.config_file}:{runtime.get('seed', 1234)}:{runtime.get('num_frames', 96)}:{runtime.get('num_steps', 64)}:{self.eval_fps}:{input_key}:{prompt[:100]}".encode()).hexdigest()[:12]
+        cache_hash = hashlib.sha256(f"{self.config_file}:{runtime.get('seed', 42)}:{runtime.get('num_frames', 96)}:{runtime.get('num_steps', 64)}:{self.eval_fps}:{input_key}:{prompt[:100]}".encode()).hexdigest()[:12]
         return os.path.join(
             self.output_dir,
             safe_task,
@@ -726,27 +713,31 @@ class Magi1WorldModel(lmms):
                     pbar.update(1)
                     continue
 
-                if len(visuals) == 1:
-                    # Single frame → save as temp image, run I2V
-                    from PIL import Image
+                try:
+                    if len(visuals) == 1:
+                        # Single frame → save as temp image, run I2V
+                        from PIL import Image
 
-                    img = visuals[0]
-                    if isinstance(img, str):
-                        img = Image.open(img)
-                    tmp_dir = os.path.join(self.output_dir, ".tmp_cond")
-                    os.makedirs(tmp_dir, exist_ok=True)
-                    safe_task = str(task).replace("/", "_")
-                    tmp_img = os.path.join(tmp_dir, f"img_{safe_task}_{doc_id}.jpg")
-                    if not os.path.exists(tmp_img):
-                        img.save(tmp_img)
-                    results[i] = self._generate_i2v(tmp_img, prompt, task, doc_id)
-                else:
-                    # Multiple frames → save as temp video, run V2V
-                    tmp_video = self._save_frames_as_video(visuals, task, doc_id)
-                    if tmp_video:
-                        results[i] = self._generate_v2v(tmp_video, prompt, task, doc_id)
+                        img = visuals[0]
+                        if isinstance(img, str):
+                            img = Image.open(img)
+                        tmp_dir = os.path.join(self.output_dir, ".tmp_cond")
+                        os.makedirs(tmp_dir, exist_ok=True)
+                        safe_task = str(task).replace("/", "_")
+                        tmp_img = os.path.join(tmp_dir, f"img_{safe_task}_{doc_id}.jpg")
+                        if not os.path.exists(tmp_img):
+                            img.save(tmp_img)
+                        results[i] = self._generate_i2v(tmp_img, prompt, task, doc_id)
                     else:
-                        results[i] = "[ERROR] Failed to save conditioning frames"
+                        # Multiple frames → save as temp video, run V2V
+                        tmp_video = self._save_frames_as_video(visuals, task, doc_id)
+                        if tmp_video:
+                            results[i] = self._generate_v2v(tmp_video, prompt, task, doc_id)
+                        else:
+                            results[i] = "[ERROR] Failed to save conditioning frames"
+                except Exception as exc:
+                    eval_logger.error(f"Fallback conditioning failed: task={task} doc_id={doc_id}: {exc}")
+                    results[i] = f"[ERROR] Fallback conditioning failed: {exc}"
 
             pbar.update(1)
 

--- a/lmms_eval/models/simple/wan2_1_t2i.py
+++ b/lmms_eval/models/simple/wan2_1_t2i.py
@@ -20,6 +20,7 @@ Usage::
 
 from __future__ import annotations
 
+import hashlib
 import traceback
 from pathlib import Path
 from typing import List, Union
@@ -40,7 +41,10 @@ class Wan2_1_T2I(DiffusersWMBase):
 
     def _patch_pipeline_cls_before_load(self) -> None:
         if type(self)._pipeline_cls is None:
-            from diffusers import WanPipeline
+            try:
+                from diffusers import WanPipeline
+            except ImportError as exc:
+                raise ImportError("wan2_1_t2i requires diffusers: `pip install diffusers imageio imageio-ffmpeg`") from exc
 
             type(self)._pipeline_cls = WanPipeline
 
@@ -138,7 +142,7 @@ class Wan2_1_T2I(DiffusersWMBase):
                 pbar.update(1)
                 continue
 
-            pid = int(doc_id) if isinstance(doc_id, int) else hash(str(doc_id)) % 100000
+            pid = int(doc_id) if isinstance(doc_id, int) else int(hashlib.sha1(str(doc_id).encode()).hexdigest(), 16) % 100000
             seed_paths = [task_dir / f"{pid:04d}_s{si}.png" for si in range(self.num_images_per_prompt)]
 
             if all(p.exists() and p.stat().st_size > 100 for p in seed_paths):

--- a/lmms_eval/models/simple/wan2_1_t2i.py
+++ b/lmms_eval/models/simple/wan2_1_t2i.py
@@ -1,0 +1,204 @@
+"""Wan2.1-1.3B Text-to-Image backend for GenEval v1/v2 and DPG-Bench.
+
+Wraps ``Wan-AI/Wan2.1-T2V-1.3B-Diffusers`` via ``diffusers.WanPipeline`` with
+``num_frames=1`` and writes the single decoded frame as a PNG. The output
+layout matches the directory convention that the T2I task ``process_results``
+hooks already glob:
+
+    {output_dir}/{task}/{doc_id:04d}_s{seed_idx}.png
+
+Single-DiT variant (no ``transformer_2``); ``DiffusersWMBase``'s component
+walk handles the missing dual-expert gracefully.
+
+Usage::
+
+    python -m lmms_eval \\
+      --model wan2_1_t2i \\
+      --model_args "pretrained=Wan-AI/Wan2.1-T2V-1.3B-Diffusers,output_dir=./logs/wan2_1_t2i" \\
+      --tasks geneval_v2 --batch_size 1 --log_samples
+"""
+
+from __future__ import annotations
+
+import traceback
+from pathlib import Path
+from typing import List, Union
+
+from loguru import logger as eval_logger
+from tqdm import tqdm
+
+from lmms_eval.api.instance import Instance
+from lmms_eval.api.registry import register_model
+from lmms_eval.models.simple.diffusers_wm_base import DiffusersWMBase
+
+
+@register_model("wan2_1_t2i")
+class Wan2_1_T2I(DiffusersWMBase):
+    """Wan2.1-1.3B T2I backend (T2V pipeline pinned to ``num_frames=1``)."""
+
+    _output_ext = "png"
+
+    def _patch_pipeline_cls_before_load(self) -> None:
+        if type(self)._pipeline_cls is None:
+            from diffusers import WanPipeline
+
+            type(self)._pipeline_cls = WanPipeline
+
+    def __init__(
+        self,
+        pretrained: str = "Wan-AI/Wan2.1-T2V-1.3B-Diffusers",
+        height: int = 480,
+        width: int = 832,
+        num_inference_steps: int = 50,
+        guidance_scale: float = 5.0,
+        num_images_per_prompt: int = 1,
+        num_frames: int = 1,
+        seed: int = 42,
+        dtype: str = "bfloat16",
+        output_dir: str = "./logs/wan2_1_t2i",
+        batch_size: Union[int, str] = 1,
+        attn_backend: str = "",
+        **kwargs,
+    ) -> None:
+        super().__init__(
+            pretrained=pretrained,
+            output_dir=output_dir,
+            seed=seed,
+            dtype=dtype,
+            fps=1,
+            batch_size=batch_size,
+            **kwargs,
+        )
+        self.height = int(height)
+        self.width = int(width)
+        self.num_inference_steps = int(num_inference_steps)
+        self.guidance_scale = float(guidance_scale)
+        self.num_images_per_prompt = int(num_images_per_prompt)
+        self.num_frames = int(num_frames)
+        self.attn_backend = str(attn_backend).strip()
+
+    def _invoke_pipeline(self, prompt, visuals, generator, **extras):
+        def _run():
+            return self._pipe(
+                prompt=prompt,
+                num_frames=self.num_frames,
+                height=self.height,
+                width=self.width,
+                num_inference_steps=self.num_inference_steps,
+                guidance_scale=self.guidance_scale,
+                num_videos_per_prompt=1,
+                generator=generator,
+                # Force PIL frames so _save_first_frame can index as
+                # frames[batch][frame_idx]. WanPipeline defaults to "np"
+                # (returns ndarray, breaks truthy checks).
+                output_type="pil",
+            )
+
+        if self.attn_backend:
+            try:
+                from diffusers.models.attention_dispatch import (
+                    attention_backend,
+                )
+
+                with attention_backend(self.attn_backend):
+                    return _run()
+            except Exception as exc:
+                eval_logger.warning(f"attn_backend='{self.attn_backend}' failed ({exc}); falling back to default")
+        return _run()
+
+    def _generation_signature(self, prompt, visuals, extras) -> str:
+        # Unused (we override generate_until and bypass _cache_path), but the
+        # base declares it abstract — keep a sane impl for completeness.
+        return f"{self.pretrained}:{self.seed}:{self.num_inference_steps}:{self.guidance_scale}:{self.height}x{self.width}:{prompt[:200]}"
+
+    def generate_until(self, requests: List[Instance]) -> List[str]:
+        """Per-doc loop that writes the per-seed T2I directory layout.
+
+        T2I tasks (geneval_v1, geneval_v2, dpg_bench) read ``results[0]`` as a
+        directory and glob ``{doc_id:04d}_s{seed}.png`` within it, so we
+        bypass ``DiffusersWMBase._generate_one`` (which produces a single
+        hashed file path) and write per-seed PNGs ourselves.
+        """
+        import torch
+
+        self._ensure_loaded()
+
+        results: List[str] = [""] * len(requests)
+        device = self.plan.device_str()
+        pbar = tqdm(total=len(requests), disable=(self.rank != 0), desc=type(self).__name__)
+
+        for i, req in enumerate(requests):
+            ctx, gen_kwargs, _doc_to_visual, doc_id, task, _split = req.args
+            prompt = str(ctx).strip()
+            task_dir = Path(self.output_dir) / str(task).replace("/", "_")
+            task_dir.mkdir(parents=True, exist_ok=True)
+
+            if not prompt:
+                results[i] = f"[ERROR] Empty prompt: doc_id={doc_id}"
+                pbar.update(1)
+                continue
+
+            pid = int(doc_id) if isinstance(doc_id, int) else hash(str(doc_id)) % 100000
+            seed_paths = [task_dir / f"{pid:04d}_s{si}.png" for si in range(self.num_images_per_prompt)]
+
+            if all(p.exists() and p.stat().st_size > 100 for p in seed_paths):
+                eval_logger.debug(f"Cache hit: {task_dir}/{pid:04d}_s*.png")
+                results[i] = str(task_dir)
+                pbar.update(1)
+                continue
+
+            try:
+                for si, out_path in enumerate(seed_paths):
+                    if out_path.exists() and out_path.stat().st_size > 100:
+                        continue
+                    generator = torch.Generator(device=device).manual_seed(self.seed + si)
+                    output = self._invoke_pipeline(prompt, [], generator, **(gen_kwargs or {}))
+                    self._save_first_frame(output, out_path)
+                results[i] = str(task_dir)
+            except Exception as exc:
+                eval_logger.error(f"Generation failed: task={task} doc_id={doc_id}: {exc}\n{traceback.format_exc()}")
+                results[i] = f"[GENERATION_FAILED] {exc}"
+
+            pbar.update(1)
+
+        pbar.close()
+        ok = sum(1 for r in results if r and not r.startswith("["))
+        failed = len(results) - ok
+        eval_logger.info(f"{type(self).__name__} complete: {ok} succeeded, {failed} failed")
+        return results
+
+    @staticmethod
+    def _save_first_frame(output_obj, out_path: Path) -> None:
+        """Save the first frame of a WanPipeline output as a PNG.
+
+        With ``output_type="pil"``, ``frames`` is ``list[list[PIL.Image]]``
+        keyed as ``frames[batch][frame_idx]``. Numpy / torch fallbacks are
+        kept so this works if a future diffusers release changes the default.
+        """
+        import numpy as np
+        from PIL import Image
+
+        frames = getattr(output_obj, "frames", None)
+        # Don't use ``not frames`` — numpy arrays raise on __bool__.
+        if frames is None:
+            raise RuntimeError("WanPipeline output has no .frames")
+
+        first = frames[0]
+        if isinstance(first, (list, tuple)):
+            img = first[0]
+        elif isinstance(first, Image.Image):
+            img = first
+        else:
+            arr = first
+            if hasattr(arr, "cpu"):  # torch tensor
+                arr = arr.cpu().numpy()
+            arr = np.asarray(arr)
+            if arr.ndim == 4:  # (T, H, W, C)
+                arr = arr[0]
+            if arr.dtype != np.uint8:
+                arr = (np.clip(arr, 0.0, 1.0) * 255).astype(np.uint8)
+            img = Image.fromarray(arr)
+
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        img.save(out_path)
+        eval_logger.debug(f"Saved: {out_path}")

--- a/lmms_eval/models/simple/wan2_1_t2v.py
+++ b/lmms_eval/models/simple/wan2_1_t2v.py
@@ -30,7 +30,10 @@ class Wan2_1_T2V(DiffusersWMBase):
 
     def _patch_pipeline_cls_before_load(self) -> None:
         if type(self)._pipeline_cls is None:
-            from diffusers import WanPipeline
+            try:
+                from diffusers import WanPipeline
+            except ImportError as exc:
+                raise ImportError("wan2_1_t2v requires diffusers: `pip install diffusers imageio imageio-ffmpeg`") from exc
 
             type(self)._pipeline_cls = WanPipeline
 

--- a/lmms_eval/models/simple/wan2_1_t2v.py
+++ b/lmms_eval/models/simple/wan2_1_t2v.py
@@ -1,0 +1,94 @@
+"""Wan2.1-1.3B Text-to-Video (T2V) backend for VBench evaluation.
+
+Wraps ``Wan-AI/Wan2.1-T2V-1.3B-Diffusers`` via ``diffusers.WanPipeline`` for
+text-only video generation. Single-DiT variant (no ``transformer_2``);
+``DiffusersWMBase``'s component walk handles the missing dual-expert
+gracefully. Defaults match Wan2.1's canonical 480x832, 81-frame, 16-fps
+configuration.
+
+Usage::
+
+    torchrun --nproc-per-node=8 -m lmms_eval \\
+      --model wan2_1_t2v \\
+      --model_args "pretrained=Wan-AI/Wan2.1-T2V-1.3B-Diffusers,output_dir=./logs/vbench_wan21" \\
+      --tasks vbench \\
+      --batch_size 1 \\
+      --log_samples
+"""
+
+from typing import Union
+
+from loguru import logger as eval_logger
+
+from lmms_eval.api.registry import register_model
+from lmms_eval.models.simple.diffusers_wm_base import DiffusersWMBase
+
+
+@register_model("wan2_1_t2v")
+class Wan2_1_T2V(DiffusersWMBase):
+    """Wan2.1-1.3B Text-to-Video backend for VBench evaluation."""
+
+    def _patch_pipeline_cls_before_load(self) -> None:
+        if type(self)._pipeline_cls is None:
+            from diffusers import WanPipeline
+
+            type(self)._pipeline_cls = WanPipeline
+
+    def __init__(
+        self,
+        pretrained: str = "Wan-AI/Wan2.1-T2V-1.3B-Diffusers",
+        num_frames: int = 81,
+        height: int = 480,
+        width: int = 832,
+        num_inference_steps: int = 50,
+        guidance_scale: float = 5.0,
+        fps: int = 16,
+        seed: int = 42,
+        dtype: str = "bfloat16",
+        output_dir: str = "./logs/wan2_1_t2v_videos",
+        batch_size: Union[int, str] = 1,
+        attn_backend: str = "",
+        **kwargs,
+    ) -> None:
+        super().__init__(
+            pretrained=pretrained,
+            output_dir=output_dir,
+            seed=seed,
+            dtype=dtype,
+            fps=fps,
+            batch_size=batch_size,
+            **kwargs,
+        )
+        self.num_frames = int(num_frames)
+        self.height = int(height)
+        self.width = int(width)
+        self.num_inference_steps = int(num_inference_steps)
+        self.guidance_scale = float(guidance_scale)
+        self.attn_backend = str(attn_backend).strip()
+
+    def _generation_signature(self, prompt, visuals, extras):
+        return f"{self.pretrained}:{self.seed}:{self.num_inference_steps}:" f"{self.guidance_scale}:{self.num_frames}:{self.height}x{self.width}:" f"{prompt[:200]}"
+
+    def _invoke_pipeline(self, prompt, visuals, generator, **extras):
+        def _run():
+            return self._pipe(
+                prompt=prompt,
+                num_frames=self.num_frames,
+                height=self.height,
+                width=self.width,
+                num_inference_steps=self.num_inference_steps,
+                guidance_scale=self.guidance_scale,
+                generator=generator,
+            )
+
+        if self.attn_backend:
+            try:
+                from diffusers.models.attention_dispatch import (
+                    attention_backend,
+                )
+
+                with attention_backend(self.attn_backend):
+                    return _run()
+            except Exception as exc:
+                eval_logger.warning(f"attn_backend='{self.attn_backend}' failed ({exc}); falling back to default")
+        return _run()

--- a/lmms_eval/models/simple/wan2_2.py
+++ b/lmms_eval/models/simple/wan2_2.py
@@ -1,16 +1,15 @@
 """Wan2.2 Image-to-Video (I2V) backend for evaluating video generation quality.
 
 Uses Wan2.2-I2V-A14B via HuggingFace diffusers to generate video continuations
-from conditioning images.  Supports agentic multi-round rollout (last frame
-chains into the next round).
+from conditioning images.
 
 Dual-expert (``transformer`` + ``transformer_2``) device placement and
 UniPCMultistepScheduler sigma-device patches are inherited from
 ``DiffusersWMBase``.  I2V-specific behavior kept here: conditioning-image
-preprocessing, doc→visual extraction fallback, and the rollout routine.
+preprocessing and doc→visual extraction fallback.
 
 Default generation parameters: resolution=832x480, frames=81, steps=40,
-guidance=3.5, fps=16, seed=114514.
+guidance=3.5, fps=16, seed=42.
 
 Usage::
 
@@ -23,22 +22,20 @@ Usage::
 """
 
 import os
-from typing import List, Optional, Union
+from typing import Union
 
 from loguru import logger as eval_logger
-from tqdm import tqdm
 
 from lmms_eval.api.instance import Instance
 from lmms_eval.api.registry import register_model
-from lmms_eval.models.simple.diffusers_wm_base import DiffusersWMBase, _cache_path
+from lmms_eval.models.simple.diffusers_wm_base import DiffusersWMBase
 
 _DEFAULT_PROMPT = "Generate a natural video continuation of this image."
-_DEFAULT_CONT_PROMPT = "Continue the video naturally."
 
 
 @register_model("wan2_2")
 class Wan2_2(DiffusersWMBase):
-    """Wan2.2 Image-to-Video backend with agentic multi-round rollout support."""
+    """Wan2.2 Image-to-Video backend for evaluating video generation quality."""
 
     def __init__(
         self,
@@ -49,7 +46,7 @@ class Wan2_2(DiffusersWMBase):
         num_inference_steps: int = 40,
         guidance_scale: float = 3.5,
         fps: int = 16,
-        seed: int = 114514,
+        seed: int = 42,
         dtype: str = "bfloat16",
         output_dir: str = "./logs/wan2_2_videos",
         batch_size: Union[int, str] = 1,
@@ -74,7 +71,10 @@ class Wan2_2(DiffusersWMBase):
 
     def _patch_pipeline_cls_before_load(self) -> None:
         if type(self)._pipeline_cls is None:
-            from diffusers import WanImageToVideoPipeline
+            try:
+                from diffusers import WanImageToVideoPipeline
+            except ImportError as exc:
+                raise ImportError("wan2_2 requires diffusers: `pip install diffusers imageio imageio-ffmpeg`") from exc
 
             type(self)._pipeline_cls = WanImageToVideoPipeline
         # Wan2.2-I2V-A14B conditions images through the VAE only, so its
@@ -138,68 +138,3 @@ class Wan2_2(DiffusersWMBase):
         if isinstance(image, Image.Image) and image.mode != "RGB":
             image = image.convert("RGB")
         return image.resize((self.width, self.height))
-
-    # ── Agentic multi-round rollout ─────────────────────────────
-
-    def generate_until_agentic(self, requests: List[Instance]) -> List[str]:
-        """Multi-round rollout: last frame conditions the next round."""
-        self._ensure_loaded()
-        results: List[Optional[str]] = [None] * len(requests)
-        pbar = tqdm(total=len(requests), disable=(self.rank != 0), desc="Wan2.2 Rollout")
-        for i, req in enumerate(requests):
-            ctx, _kw, _dtv, doc_id, task, _split = req.args
-            prompts = [str(p).strip() for p in ctx] if isinstance(ctx, list) else [str(ctx).strip()]
-            visuals = self._extract_visuals(req)
-            if not visuals:
-                results[i] = "[ERROR] No conditioning visuals"
-                pbar.update(1)
-                continue
-            if len(prompts) > 1:
-                results[i] = self._rollout(visuals, prompts, task, doc_id)
-            else:
-                results[i] = self._generate_one(prompts[0], visuals, doc_id, task)
-            pbar.update(1)
-        pbar.close()
-        return [r if r is not None else "[ERROR] Unknown" for r in results]
-
-    def _rollout(self, visuals, prompts, task, doc_id) -> str:
-        import torch
-        from diffusers.utils import export_to_video
-        from PIL import Image
-
-        sig = f"rollout:{self.pretrained}:{self.seed}:{self.num_inference_steps}:" f"{self.guidance_scale}:{self.num_frames}:{len(prompts)}:" f"{len(visuals)}:{'|'.join(p[:50] for p in prompts)}"
-        out_path = _cache_path(self.output_dir, task, doc_id, sig, ext=self._output_ext)
-        if out_path.exists():
-            eval_logger.debug(f"Cache hit (rollout): {out_path}")
-            return str(out_path)
-        try:
-            image = self._prepare_image(visuals[0])
-            all_frames = []
-            device = self.plan.device_str()
-            for step_idx, prompt in enumerate(prompts):
-                if not prompt:
-                    prompt = _DEFAULT_CONT_PROMPT
-                generator = torch.Generator(device=device).manual_seed(self.seed + step_idx)
-                output = self._pipe(
-                    image=image,
-                    prompt=prompt,
-                    num_frames=self.num_frames,
-                    height=self.height,
-                    width=self.width,
-                    num_inference_steps=self.num_inference_steps,
-                    guidance_scale=self.guidance_scale,
-                    generator=generator,
-                )
-                frames = output.frames[0]
-                all_frames.extend(frames if step_idx == 0 else frames[1:])
-                image = frames[-1]
-                if isinstance(image, Image.Image):
-                    image = image.resize((self.width, self.height))
-                eval_logger.info(f"Rollout step {step_idx + 1}/{len(prompts)} done ({len(frames)} frames)")
-            out_path.parent.mkdir(parents=True, exist_ok=True)
-            export_to_video(all_frames, str(out_path), fps=self.fps)
-            eval_logger.info(f"Rollout video saved: {out_path} ({len(all_frames)} total frames)")
-            return str(out_path)
-        except Exception as exc:
-            eval_logger.error(f"Rollout failed: task={task} doc_id={doc_id}: {exc}")
-            return f"[ROLLOUT_FAILED] {exc}"

--- a/lmms_eval/models/simple/wan2_2.py
+++ b/lmms_eval/models/simple/wan2_2.py
@@ -1,0 +1,205 @@
+"""Wan2.2 Image-to-Video (I2V) backend for evaluating video generation quality.
+
+Uses Wan2.2-I2V-A14B via HuggingFace diffusers to generate video continuations
+from conditioning images.  Supports agentic multi-round rollout (last frame
+chains into the next round).
+
+Dual-expert (``transformer`` + ``transformer_2``) device placement and
+UniPCMultistepScheduler sigma-device patches are inherited from
+``DiffusersWMBase``.  I2V-specific behavior kept here: conditioning-image
+preprocessing, doc→visual extraction fallback, and the rollout routine.
+
+Default generation parameters: resolution=832x480, frames=81, steps=40,
+guidance=3.5, fps=16, seed=114514.
+
+Usage::
+
+    python -m lmms_eval \\
+      --model wan2_2 \\
+      --model_args "pretrained=Wan-AI/Wan2.2-I2V-A14B-Diffusers,output_dir=./logs/wan2_2" \\
+      --tasks physics_iq_i2v \\
+      --batch_size 1 \\
+      --log_samples
+"""
+
+import os
+from typing import List, Optional, Union
+
+from loguru import logger as eval_logger
+from tqdm import tqdm
+
+from lmms_eval.api.instance import Instance
+from lmms_eval.api.registry import register_model
+from lmms_eval.models.simple.diffusers_wm_base import DiffusersWMBase, _cache_path
+
+_DEFAULT_PROMPT = "Generate a natural video continuation of this image."
+_DEFAULT_CONT_PROMPT = "Continue the video naturally."
+
+
+@register_model("wan2_2")
+class Wan2_2(DiffusersWMBase):
+    """Wan2.2 Image-to-Video backend with agentic multi-round rollout support."""
+
+    def __init__(
+        self,
+        pretrained: str = "Wan-AI/Wan2.2-I2V-A14B-Diffusers",
+        num_frames: int = 81,
+        height: int = 480,
+        width: int = 832,
+        num_inference_steps: int = 40,
+        guidance_scale: float = 3.5,
+        fps: int = 16,
+        seed: int = 114514,
+        dtype: str = "bfloat16",
+        output_dir: str = "./logs/wan2_2_videos",
+        batch_size: Union[int, str] = 1,
+        **kwargs,
+    ) -> None:
+        super().__init__(
+            pretrained=pretrained,
+            output_dir=output_dir,
+            seed=seed,
+            dtype=dtype,
+            fps=fps,
+            batch_size=batch_size,
+            **kwargs,
+        )
+        self.num_frames = int(num_frames)
+        self.height = int(height)
+        self.width = int(width)
+        self.num_inference_steps = int(num_inference_steps)
+        self.guidance_scale = float(guidance_scale)
+
+    # ── DiffusersWMBase hooks ───────────────────────────────────
+
+    def _patch_pipeline_cls_before_load(self) -> None:
+        if type(self)._pipeline_cls is None:
+            from diffusers import WanImageToVideoPipeline
+
+            type(self)._pipeline_cls = WanImageToVideoPipeline
+        # Wan2.2-I2V-A14B conditions images through the VAE only, so its
+        # model_index.json ships image_encoder / image_processor as [None, None].
+        # Newer diffusers marks both as required at from_pretrained validation
+        # time; widen _optional_components to accept the null-component layout.
+        opts = list(getattr(self._pipeline_cls, "_optional_components", []) or [])
+        for name in ("image_encoder", "image_processor"):
+            if name not in opts:
+                opts.append(name)
+        self._pipeline_cls._optional_components = opts
+
+    def _extract_visuals(self, req: Instance) -> list:
+        _ctx, _kw, doc_to_visual, doc_id, task, split = req.args
+        if doc_to_visual is None:
+            return []
+        # Standard tasks pass a real doc; agentic rollout rounds 2+ pass a
+        # lambda that ignores the doc argument. Try doc first, then None.
+        try:
+            doc = self.task_dict[task][split][doc_id]
+            raw = doc_to_visual(doc)
+            if raw:
+                return list(raw)
+        except Exception as exc:
+            eval_logger.debug(f"doc_to_visual(doc) failed; falling back to doc_to_visual(None): {exc}")
+        try:
+            raw = doc_to_visual(None)
+            if raw:
+                return list(raw)
+        except Exception as exc:
+            eval_logger.warning(f"Failed to extract visuals: {exc}")
+        return []
+
+    def _generation_signature(self, prompt, visuals, extras):
+        return f"{self.pretrained}:{self.seed}:{self.num_inference_steps}:" f"{self.guidance_scale}:{self.num_frames}:{self.height}x{self.width}:" f"{len(visuals)}:{prompt[:100]}"
+
+    def _invoke_pipeline(self, prompt, visuals, generator, **extras):
+        if not visuals:
+            raise RuntimeError("Wan2.2 I2V requires at least one conditioning image")
+        image = self._prepare_image(visuals[0])
+        if not prompt.strip():
+            prompt = _DEFAULT_PROMPT
+        return self._pipe(
+            image=image,
+            prompt=prompt,
+            num_frames=self.num_frames,
+            height=self.height,
+            width=self.width,
+            num_inference_steps=self.num_inference_steps,
+            guidance_scale=self.guidance_scale,
+            generator=generator,
+        )
+
+    # ── I2V helpers ─────────────────────────────────────────────
+
+    def _prepare_image(self, image):
+        from PIL import Image
+
+        if isinstance(image, str) and os.path.exists(image):
+            image = Image.open(image).convert("RGB")
+        if isinstance(image, Image.Image) and image.mode != "RGB":
+            image = image.convert("RGB")
+        return image.resize((self.width, self.height))
+
+    # ── Agentic multi-round rollout ─────────────────────────────
+
+    def generate_until_agentic(self, requests: List[Instance]) -> List[str]:
+        """Multi-round rollout: last frame conditions the next round."""
+        self._ensure_loaded()
+        results: List[Optional[str]] = [None] * len(requests)
+        pbar = tqdm(total=len(requests), disable=(self.rank != 0), desc="Wan2.2 Rollout")
+        for i, req in enumerate(requests):
+            ctx, _kw, _dtv, doc_id, task, _split = req.args
+            prompts = [str(p).strip() for p in ctx] if isinstance(ctx, list) else [str(ctx).strip()]
+            visuals = self._extract_visuals(req)
+            if not visuals:
+                results[i] = "[ERROR] No conditioning visuals"
+                pbar.update(1)
+                continue
+            if len(prompts) > 1:
+                results[i] = self._rollout(visuals, prompts, task, doc_id)
+            else:
+                results[i] = self._generate_one(prompts[0], visuals, doc_id, task)
+            pbar.update(1)
+        pbar.close()
+        return [r if r is not None else "[ERROR] Unknown" for r in results]
+
+    def _rollout(self, visuals, prompts, task, doc_id) -> str:
+        import torch
+        from diffusers.utils import export_to_video
+        from PIL import Image
+
+        sig = f"rollout:{self.pretrained}:{self.seed}:{self.num_inference_steps}:" f"{self.guidance_scale}:{self.num_frames}:{len(prompts)}:" f"{len(visuals)}:{'|'.join(p[:50] for p in prompts)}"
+        out_path = _cache_path(self.output_dir, task, doc_id, sig, ext=self._output_ext)
+        if out_path.exists():
+            eval_logger.debug(f"Cache hit (rollout): {out_path}")
+            return str(out_path)
+        try:
+            image = self._prepare_image(visuals[0])
+            all_frames = []
+            device = self.plan.device_str()
+            for step_idx, prompt in enumerate(prompts):
+                if not prompt:
+                    prompt = _DEFAULT_CONT_PROMPT
+                generator = torch.Generator(device=device).manual_seed(self.seed + step_idx)
+                output = self._pipe(
+                    image=image,
+                    prompt=prompt,
+                    num_frames=self.num_frames,
+                    height=self.height,
+                    width=self.width,
+                    num_inference_steps=self.num_inference_steps,
+                    guidance_scale=self.guidance_scale,
+                    generator=generator,
+                )
+                frames = output.frames[0]
+                all_frames.extend(frames if step_idx == 0 else frames[1:])
+                image = frames[-1]
+                if isinstance(image, Image.Image):
+                    image = image.resize((self.width, self.height))
+                eval_logger.info(f"Rollout step {step_idx + 1}/{len(prompts)} done ({len(frames)} frames)")
+            out_path.parent.mkdir(parents=True, exist_ok=True)
+            export_to_video(all_frames, str(out_path), fps=self.fps)
+            eval_logger.info(f"Rollout video saved: {out_path} ({len(all_frames)} total frames)")
+            return str(out_path)
+        except Exception as exc:
+            eval_logger.error(f"Rollout failed: task={task} doc_id={doc_id}: {exc}")
+            return f"[ROLLOUT_FAILED] {exc}"

--- a/lmms_eval/models/simple/wan2_2_t2v.py
+++ b/lmms_eval/models/simple/wan2_2_t2v.py
@@ -30,7 +30,10 @@ class Wan2_2_T2V(DiffusersWMBase):
 
     def _patch_pipeline_cls_before_load(self) -> None:
         if type(self)._pipeline_cls is None:
-            from diffusers import WanPipeline
+            try:
+                from diffusers import WanPipeline
+            except ImportError as exc:
+                raise ImportError("wan2_2_t2v requires diffusers: `pip install diffusers imageio imageio-ffmpeg`") from exc
 
             type(self)._pipeline_cls = WanPipeline
 
@@ -43,7 +46,7 @@ class Wan2_2_T2V(DiffusersWMBase):
         num_inference_steps: int = 50,
         guidance_scale: float = 5.0,
         fps: int = 16,
-        seed: int = 114514,
+        seed: int = 42,
         dtype: str = "bfloat16",
         output_dir: str = "./logs/wan2_2_t2v_videos",
         batch_size: Union[int, str] = 1,

--- a/lmms_eval/models/simple/wan2_2_t2v.py
+++ b/lmms_eval/models/simple/wan2_2_t2v.py
@@ -1,0 +1,98 @@
+"""Wan2.2 Text-to-Video (T2V) backend for VBench evaluation.
+
+Uses WanPipeline (diffusers) for text-only video generation.  Dual-expert
+device placement (``transformer`` + ``transformer_2``) and the
+UniPCMultistepScheduler sigma-device patch are inherited from
+``DiffusersWMBase``; this subclass only encodes T2V-specific defaults
+and the generation signature / pipeline invocation.
+
+Usage::
+
+    torchrun --nproc-per-node=8 -m lmms_eval \\
+      --model wan2_2_t2v \\
+      --model_args "pretrained=Wan-AI/Wan2.2-T2V-A14B-Diffusers,output_dir=./logs/vbench_wan22" \\
+      --tasks vbench \\
+      --batch_size 1 \\
+      --log_samples
+"""
+
+from typing import Union
+
+from loguru import logger as eval_logger
+
+from lmms_eval.api.registry import register_model
+from lmms_eval.models.simple.diffusers_wm_base import DiffusersWMBase
+
+
+@register_model("wan2_2_t2v")
+class Wan2_2_T2V(DiffusersWMBase):
+    """Wan2.2 Text-to-Video backend for VBench evaluation."""
+
+    def _patch_pipeline_cls_before_load(self) -> None:
+        if type(self)._pipeline_cls is None:
+            from diffusers import WanPipeline
+
+            type(self)._pipeline_cls = WanPipeline
+
+    def __init__(
+        self,
+        pretrained: str = "Wan-AI/Wan2.2-T2V-A14B-Diffusers",
+        num_frames: int = 81,
+        height: int = 480,
+        width: int = 832,
+        num_inference_steps: int = 50,
+        guidance_scale: float = 5.0,
+        fps: int = 16,
+        seed: int = 114514,
+        dtype: str = "bfloat16",
+        output_dir: str = "./logs/wan2_2_t2v_videos",
+        batch_size: Union[int, str] = 1,
+        attn_backend: str = "",
+        **kwargs,
+    ) -> None:
+        super().__init__(
+            pretrained=pretrained,
+            output_dir=output_dir,
+            seed=seed,
+            dtype=dtype,
+            fps=fps,
+            batch_size=batch_size,
+            **kwargs,
+        )
+        self.num_frames = int(num_frames)
+        self.height = int(height)
+        self.width = int(width)
+        self.num_inference_steps = int(num_inference_steps)
+        self.guidance_scale = float(guidance_scale)
+        # Attention kernel override. Empty = default SDPA. Supported values
+        # per diffusers main's attention_dispatch: "flash" (FA2),
+        # "_flash_3"/"_flash_3_hub" (FA3 Hopper-native, requires kernels pkg),
+        # "sage", "xformers", "native". The dispatcher's "is not usable" check
+        # fires on context-enter, not on import, so _invoke_pipeline wraps the
+        # whole call in try/except and falls back to default on failure.
+        self.attn_backend = str(attn_backend).strip()
+
+    def _generation_signature(self, prompt, visuals, extras):
+        return f"{self.pretrained}:{self.seed}:{self.num_inference_steps}:" f"{self.guidance_scale}:{self.num_frames}:{self.height}x{self.width}:" f"{prompt[:200]}"
+
+    def _invoke_pipeline(self, prompt, visuals, generator, **extras):
+        def _run():
+            return self._pipe(
+                prompt=prompt,
+                num_frames=self.num_frames,
+                height=self.height,
+                width=self.width,
+                num_inference_steps=self.num_inference_steps,
+                guidance_scale=self.guidance_scale,
+                generator=generator,
+            )
+
+        if self.attn_backend:
+            try:
+                from diffusers.models.attention_dispatch import attention_backend
+
+                with attention_backend(self.attn_backend):
+                    return _run()
+            except Exception as exc:  # backend unavailable / import miss / runtime failure
+                eval_logger.warning(f"attn_backend='{self.attn_backend}' failed ({exc}); falling back to default")
+        return _run()


### PR DESCRIPTION
## Summary

Adds a family of diffusers/API-based world-model generation backends to lmms-eval, covering text/image-to-video and video-to-video generation.

New model backends (registered in `AVAILABLE_SIMPLE_MODELS`):

| model_id | class | backend |
|---|---|---|
| `wan2_1_t2v` | Wan2_1_T2V | Wan 2.1 text-to-video (diffusers `WanPipeline`) |
| `wan2_1_t2i` | Wan2_1_T2I | Wan 2.1 text-to-image (T2V pipeline, `num_frames=1`) |
| `wan2_2` | Wan2_2 | Wan 2.2 image-to-video |
| `wan2_2_t2v` | Wan2_2_T2V | Wan 2.2 text-to-video |
| `ltx_video` | LTXVideo | LTX-Video text-to-video (diffusers `LTXPipeline`) |
| `cosmos_wm` | CosmosWorldModel | NVIDIA Cosmos Predict2/2.5/3 (nim / local / vllm_omni / transformers_reasoner / passthrough) |
| `magi1_wm` | Magi1WorldModel | Sand-AI MAGI-1 autoregressive T2V/I2V/V2V |
| `generation_api` | GenerationApi | fal.ai queue API (t2v / v2v), `FAL_KEY` env |

A shared `DiffusersWMBase` consolidates per-rank device selection, lazy pipeline load, the dual-expert (`transformer`/`transformer_2`) device-placement fix, the UniPCMultistepScheduler sigma-device patch, cache-path hashing, and the DP generation loop.

## Notes
- Defaults use public HF checkpoint ids (`Wan-AI/*`, `Lightricks/LTX-Video`, `nvidia/Cosmos-*`, `sand-ai/MAGI-1`).
- No new dependencies: `diffusers`, `fal_client`, and `imageio`/`imageio-ffmpeg` are lazy-imported with clear, actionable `ImportError` messages so the package imports fine without them.
- Data-parallel only: `DiffusersWMBase` enforces `tp_size == 1`, and MAGI-1 raises a clear error for model-parallel configs (`cp_size*pp_size > 1`) under the stock evaluator — its sharding is per-rank data-parallel, which would desync model-parallel collectives.
- The generation-eval task YAMLs these backends target (vbench, physics_iq, geneval, ...) ship separately in a follow-up PR series (their datasets are being staged for public HF hosting); the usage docstrings reference those task names ahead of that.

### Review note

`diffusers_wm_base.py` inlines a minimal `ParallelPlan` dataclass. #1382 (gemini SDK) separately ships `model_utils/parallel.py` with the full version — if that lands first, the inline copy here can switch to importing it (one-line follow-up).

### Review pass (2026-07-06)
Self-review follow-up commit, all backends:
- **Per-sample failure isolation**: cosmos's threaded dispatch no longer lets a single failed sample (reasoner HTTP error, corrupt visual) abort the whole run — failures come back as `[GENERATION_FAILED]` sentinels; MAGI-1's fallback image pre-processing likewise returns per-request `[ERROR]` sentinels.
- **Multi-GPU wiring**: cosmos and generation_api now set `_rank`/`_world_size`/`device` (cuda:{LOCAL_RANK} / Accelerator-based respectively) like the sibling backends, fixing pad/gather under `accelerate launch`/torchrun.
- **MAGI-1 model-parallel guard**: removed a dead "data-parallel rank routing" layer built on an evaluator API that doesn't exist, and replaced it with an explicit unsupported error for MP configs (single-GPU 4.5B and pure DP unaffected).
- **Atomic downloads** in generation_api (`.part` + `os.replace`), so an interrupted download can't be resume-hit as a finished video.
- Removed an unreachable `generate_until_agentic` path from wan2_2; unified all seed defaults on 42; stable sha1-based output ids for non-int doc_ids (was `hash()`, PYTHONHASHSEED-dependent); actionable ImportErrors for lazy diffusers/imageio imports; `_nim_submit` annotation corrected.
