### PR TITLE
fix(packaging): include extensionless task template files in pip wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,7 +155,7 @@ all = [
 ]
 
 [tool.setuptools.package-data]
-"lmms_eval" = ["**/*.yaml", "**/*.yml", "**/*.json", "**/*.txt"]
+"lmms_eval" = ["**/*.yaml", "**/*.yml", "**/*.json", "**/*.txt", "tasks/**/*"]
 "lmms_eval.tui.web.dist" = ["**/*"]
 "lmms_eval.tui.web.dist.assets" = ["**/*"]
 


### PR DESCRIPTION
Task template files like _default_template_rec_yaml are referenced via 'include:' directives in .yaml configs but have no file extension, so they were excluded from the pip wheel by the existing glob patterns.

This caused FileNotFoundError for any task using extensionless templates when installed via pip (not git clone). Affected tasks include screenspot, gpqa, mmmu, mmbench, videomme and 170+ others (181 files total).

Fix: add 'tasks/**/*' glob to package-data to include all files under the tasks directory regardless of extension.

Fixes #1350

## Summary
<!-- Max 3 bullets. -->
- 
- 
- 

## In scope
<!-- Explicitly list what this PR changes. -->
- 

## Out of scope
<!-- Explicitly list what this PR does NOT change. -->
- 

## Validation
<!--
Max 3 bullets.
Use this format:
`<command>` | sample size: `N=<...>` | key metrics: `<...>` | result: `pass/fail`
If you ran tests/benchmarks with metrics, include concrete numbers.
-->
- 

## Risk / Compatibility
<!-- 1-2 bullets. Note breaking changes, behavior changes, or migration impact. -->
- 

## Type of Change
- [x] Bug fix (non-breaking change)
- [ ] New feature
- [ ] New benchmark/task
- [ ] New model integration
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
