### PR TITLE
Add MMOU and RVOS tracking benchmarks

### DIFF
--- a/lmms_eval/tasks/mmou/_default_template_yaml
+++ b/lmms_eval/tasks/mmou/_default_template_yaml
@@ -1,0 +1,22 @@
+dataset_path: nvidia/MMOU
+dataset_kwargs:
+  token: True
+  cache_dir: mmou
+  video: True
+output_type: generate_until
+doc_to_visual: !function utils.mmou_doc_to_visual
+doc_to_text: !function utils.mmou_doc_to_text
+doc_to_messages: !function utils.mmou_doc_to_messages
+doc_to_target: "question"
+generation_kwargs:
+  max_new_tokens: 64
+  temperature: 0
+  top_p: 1.0
+  do_sample: false
+lmms_eval_specific_kwargs:
+  default:
+    pre_prompt: ""
+    post_prompt: "\nAnswer with the option's letter from the given choices directly."
+metadata:
+  - version: 0.0
+    video_repo_id: sonalkum/MMOU-Videos

--- a/lmms_eval/tasks/mmou/mmou.yaml
+++ b/lmms_eval/tasks/mmou/mmou.yaml
@@ -1,0 +1,8 @@
+task: mmou
+include: _default_template_yaml
+test_split: train
+process_results: !function utils.mmou_process_results_submission
+metric_list:
+  - metric: mmou_submission
+    aggregation: !function utils.mmou_aggregate_submission
+    higher_is_better: true

--- a/lmms_eval/tasks/mmou/mmou_test_mini.yaml
+++ b/lmms_eval/tasks/mmou/mmou_test_mini.yaml
@@ -1,0 +1,10 @@
+task: mmou_test_mini
+include: _default_template_yaml
+dataset_name: test
+test_split: test
+doc_to_target: "correct_option_letter"
+process_results: !function utils.mmou_process_results_scored
+metric_list:
+  - metric: mmou_accuracy
+    aggregation: !function utils.mmou_aggregate_accuracy
+    higher_is_better: true

--- a/lmms_eval/tasks/mmou/utils.py
+++ b/lmms_eval/tasks/mmou/utils.py
@@ -1,0 +1,295 @@
+"""MMOU: Massive Multi-Task Omni Understanding benchmark.
+
+Annotations: ``nvidia/MMOU`` (HF dataset).
+Videos: ``sonalkum/MMOU-Videos`` (flat ``<video_id>.mp4`` files at repo root).
+
+Videos are fetched lazily via ``huggingface_hub.hf_hub_download`` and cached
+under the standard HF cache, so only videos referenced by the evaluation split
+(e.g. Test Mini) are downloaded on first use.
+"""
+
+import json
+import os
+import re
+from functools import lru_cache
+from pathlib import Path
+from urllib.parse import parse_qs, urlparse
+
+import yaml
+from loguru import logger as eval_logger
+
+VIDEO_REPO_ID = "sonalkum/MMOU-Videos"
+
+DOMAINS = [
+    "Sports",
+    "Travel",
+    "Video Games",
+    "Daily Life",
+    "Academic Lectures",
+    "Film",
+    "Pranks",
+    "Music",
+    "Animation",
+    "News",
+]
+
+DURATION_BUCKETS = ["< 5", "5-10", "10-20", "20-30", "> 30"]
+
+hf_home = os.getenv("HF_HOME", "~/.cache/huggingface/")
+base_cache_dir = os.path.expanduser(hf_home)
+
+with open(Path(__file__).parent / "_default_template_yaml", "r") as f:
+    raw_data = f.readlines()
+    safe_data = [line for line in raw_data if "!function" not in line]
+_config = yaml.safe_load("".join(safe_data))
+cache_name = _config["dataset_kwargs"]["cache_dir"]
+video_cache_dir = os.path.join(base_cache_dir, cache_name, "videos")
+
+
+def extract_youtube_id(url: str) -> str:
+    """Extract YouTube video ID from various URL formats."""
+    parsed = urlparse(url)
+    if parsed.hostname == "youtu.be":
+        return parsed.path.lstrip("/")
+    if parsed.hostname in ("www.youtube.com", "youtube.com"):
+        if parsed.path == "/watch":
+            return parse_qs(parsed.query).get("v", [""])[0]
+        if parsed.path.startswith("/embed/") or parsed.path.startswith("/v/"):
+            return parsed.path.split("/")[2]
+    match = re.search(r"(?:v=|/)([a-zA-Z0-9_-]{11})", url)
+    if match:
+        return match.group(1)
+    return url
+
+
+def duration_bucket(seconds: float) -> str:
+    minutes = seconds / 60.0
+    if minutes < 5:
+        return "< 5"
+    if minutes < 10:
+        return "5-10"
+    if minutes < 20:
+        return "10-20"
+    if minutes < 30:
+        return "20-30"
+    return "> 30"
+
+
+# Videos live either at the repo root (main split) or under ``test/`` (Test Mini).
+_VIDEO_PREFIXES = ("", "test/")
+_VIDEO_EXTS = ("mp4", "MP4", "mkv", "webm")
+
+
+@lru_cache(maxsize=None)
+def _fetch_video(video_id: str) -> str:
+    """Download a single MMOU video from the HF hub and return its local path.
+
+    Uses ``hf_hub_download`` with ``local_dir=video_cache_dir`` so files land in
+    a predictable location and are only fetched once.
+    """
+    from huggingface_hub import hf_hub_download
+    from huggingface_hub.errors import EntryNotFoundError
+
+    os.makedirs(video_cache_dir, exist_ok=True)
+    for prefix in _VIDEO_PREFIXES:
+        for ext in _VIDEO_EXTS:
+            local_path = os.path.join(video_cache_dir, prefix, f"{video_id}.{ext}")
+            if os.path.exists(local_path):
+                return local_path
+    for prefix in _VIDEO_PREFIXES:
+        for ext in _VIDEO_EXTS:
+            try:
+                return hf_hub_download(
+                    repo_id=VIDEO_REPO_ID,
+                    filename=f"{prefix}{video_id}.{ext}",
+                    repo_type="dataset",
+                    local_dir=video_cache_dir,
+                )
+            except EntryNotFoundError:
+                continue
+            except Exception as e:
+                eval_logger.warning(f"[mmou] hf_hub_download failed for {prefix}{video_id}.{ext}: {e}")
+                continue
+    return ""
+
+
+def mmou_doc_to_visual(doc):
+    video_id = extract_youtube_id(doc["video_url"])
+    path = _fetch_video(video_id)
+    if path and os.path.exists(path):
+        return [path]
+    eval_logger.warning(f"[mmou] Video not found for {video_id} ({doc['video_url']}).")
+    return []
+
+
+def _format_options(options) -> str:
+    if isinstance(options, str):
+        options = json.loads(options)
+    lines = [f"{k}. {options[k]}" for k in sorted(options.keys())]
+    return "\n".join(lines)
+
+
+def mmou_doc_to_text(doc, lmms_eval_specific_kwargs=None):
+    lmms_eval_specific_kwargs = lmms_eval_specific_kwargs or {}
+    pre_prompt = lmms_eval_specific_kwargs.get("pre_prompt", "")
+    post_prompt = lmms_eval_specific_kwargs.get(
+        "post_prompt",
+        "\nAnswer with the option's letter from the given choices directly.",
+    )
+    question = doc["question"]
+    option_text = _format_options(doc.get("options", {}))
+    return f"{pre_prompt}{question}\n{option_text}{post_prompt}"
+
+
+def mmou_doc_to_messages(doc, lmms_eval_specific_kwargs=None):
+    prompt = mmou_doc_to_text(doc, lmms_eval_specific_kwargs)
+    content = []
+    for video_path in mmou_doc_to_visual(doc):
+        content.append({"type": "video", "url": video_path})
+    content.append({"type": "text", "text": prompt})
+    return [{"role": "user", "content": content}]
+
+
+_VALID_LETTERS = "ABCDEFGHIJ"
+
+
+def _extract_answer(response: str) -> str:
+    """Extract answer letter (A-J) from model response."""
+    if not response:
+        return ""
+    text = response.strip()
+    for pattern in ("the answer is", "answer:", "the option is", "final answer:"):
+        idx = text.lower().rfind(pattern)
+        if idx >= 0:
+            text = text[idx + len(pattern):].strip()
+            break
+    m = re.search(r"\(([A-J])\)", text)
+    if m:
+        return m.group(1)
+    m = re.search(r"\b([A-J])\b", text)
+    if m:
+        return m.group(1)
+    for ch in text:
+        if ch.upper() in _VALID_LETTERS:
+            return ch.upper()
+    return ""
+
+
+def _build_result_dict(doc, pred: str, pred_ans: str) -> dict:
+    video_id = extract_youtube_id(doc["video_url"])
+    dur = doc.get("video_duration", 0) or 0
+    qtypes = doc.get("question_type", [])
+    if isinstance(qtypes, str):
+        try:
+            qtypes = json.loads(qtypes)
+        except Exception:
+            qtypes = [qtypes]
+    return {
+        "question_id": doc["question_id"],
+        "question": doc["question"],
+        "answer": pred_ans,
+        "raw_answer": pred,
+        "domain": doc.get("domain", "Unknown"),
+        "subdomain": doc.get("subdomain", "Unknown"),
+        "question_type": qtypes,
+        "video_url": doc.get("video_url", ""),
+        "video_id": video_id,
+        "video_duration": dur,
+        "duration_bucket": duration_bucket(dur) if dur else "Unknown",
+        "start_time": doc.get("start_time", ""),
+        "end_time": doc.get("end_time", ""),
+    }
+
+
+def mmou_process_results_submission(doc, results):
+    """Process results for the main (unlabeled) MMOU split.
+
+    Ground truth is not available; results are aggregated into a submission
+    file for the MMOU-Eval HuggingFace Space.
+    """
+    pred = results[0]
+    pred_ans = _extract_answer(pred)
+    return {"mmou_submission": _build_result_dict(doc, pred, pred_ans)}
+
+
+def mmou_process_results_scored(doc, results):
+    """Process results for the labeled MMOU Test Mini split."""
+    pred = results[0]
+    pred_ans = _extract_answer(pred)
+    gt = str(doc.get("correct_option_letter", "")).strip().upper()
+    data = _build_result_dict(doc, pred, pred_ans)
+    data["gt"] = gt
+    data["score"] = int(pred_ans == gt and gt != "")
+    return {"mmou_accuracy": data}
+
+
+def _write_submission(results, filename: str) -> str:
+    output_dir = os.environ.get("MMOU_OUTPUT_DIR", "mmou_output")
+    os.makedirs(output_dir, exist_ok=True)
+    path = os.path.join(output_dir, filename)
+    submission = [{"question_id": r["question_id"], "answer": r["answer"]} for r in results]
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(submission, f, indent=2, ensure_ascii=False)
+    return path
+
+
+def _log_breakdown(results):
+    domain_counts, duration_counts, skill_counts = {}, {}, {}
+    for r in results:
+        domain_counts[r.get("domain", "Unknown")] = domain_counts.get(r.get("domain", "Unknown"), 0) + 1
+        bucket = r.get("duration_bucket", "Unknown")
+        duration_counts[bucket] = duration_counts.get(bucket, 0) + 1
+        for skill in r.get("question_type", []) or []:
+            skill_counts[skill] = skill_counts.get(skill, 0) + 1
+    eval_logger.info("=== MMOU Domain Breakdown ===")
+    for k, v in sorted(domain_counts.items()):
+        eval_logger.info(f"  {k}: {v}")
+    eval_logger.info("=== MMOU Duration Breakdown ===")
+    for k in DURATION_BUCKETS:
+        eval_logger.info(f"  {k} min: {duration_counts.get(k, 0)}")
+    eval_logger.info("=== MMOU Skill Breakdown ===")
+    for k, v in sorted(skill_counts.items()):
+        eval_logger.info(f"  {k}: {v}")
+
+
+def mmou_aggregate_submission(results):
+    path = _write_submission(results, "mmou_submission.json")
+    eval_logger.info(
+        f"MMOU submission saved to {path} ({len(results)} predictions). "
+        "Upload to https://huggingface.co/spaces/nvidia/MMOU-Eval for scoring."
+    )
+    _log_breakdown(results)
+    return len(results)
+
+
+def mmou_aggregate_accuracy(results):
+    path = _write_submission(results, "mmou_test_mini_submission.json")
+    total = len(results)
+    if total == 0:
+        return 0.0
+    correct = sum(r["score"] for r in results)
+    acc = correct / total * 100
+    eval_logger.info(f"MMOU Test Mini Accuracy: {acc:.2f}% [{correct}/{total}]")
+    eval_logger.info(f"MMOU predictions saved to {path}")
+
+    per_skill = {}
+    for r in results:
+        for skill in r.get("question_type", []) or []:
+            per_skill.setdefault(skill, []).append(r["score"])
+    if per_skill:
+        eval_logger.info("=== MMOU Per-Skill Accuracy ===")
+        for skill, scores in sorted(per_skill.items()):
+            skill_acc = sum(scores) / len(scores) * 100
+            eval_logger.info(f"  {skill}: {skill_acc:.2f}% [{len(scores)} samples]")
+
+    per_bucket = {}
+    for r in results:
+        per_bucket.setdefault(r.get("duration_bucket", "Unknown"), []).append(r["score"])
+    if per_bucket:
+        eval_logger.info("=== MMOU Per-Duration Accuracy ===")
+        for k in DURATION_BUCKETS + ["Unknown"]:
+            scores = per_bucket.get(k, [])
+            if scores:
+                eval_logger.info(f"  {k} min: {sum(scores)/len(scores)*100:.2f}% [{len(scores)}]")
+
+    return acc

--- a/lmms_eval/tasks/rvos/_default_template_yaml
+++ b/lmms_eval/tasks/rvos/_default_template_yaml
@@ -1,0 +1,40 @@
+dataset_kwargs:
+  token: True
+  video: True
+output_type: generate_until
+doc_to_visual: !function utils.rvos_doc_to_visual
+doc_to_text: !function utils.rvos_doc_to_text
+doc_to_messages: !function utils.rvos_doc_to_messages
+doc_to_target: "expression"
+generation_kwargs:
+  max_new_tokens: 2048
+  temperature: 0
+  top_p: 1.0
+  do_sample: false
+process_results: !function utils.rvos_process_results
+metric_list:
+  - metric: rvos_f1
+    aggregation: !function utils.rvos_aggregate_f1
+    higher_is_better: true
+  - metric: rvos_precision
+    aggregation: !function utils.rvos_aggregate_precision
+    higher_is_better: true
+  - metric: rvos_recall
+    aggregation: !function utils.rvos_aggregate_recall
+    higher_is_better: true
+  - metric: rvos_hota
+    aggregation: !function utils.rvos_aggregate_hota
+    higher_is_better: true
+lmms_eval_specific_kwargs:
+  default:
+    prompt_template: "Track the {expression}"
+    prompt_suffix: |2
+
+      Return the answer in XML format:
+      <tracks coords="t0 id0 x0 y0 id1 x1 y1; t1 id0 x2 y2 id1 x3 y3; ...">target objects</tracks>
+      Each semicolon-separated segment is one timestamp.
+      Format of each segment: time object_id x y [object_id x y ...], where time is in seconds, object_id starts from 0, and x and y are integers in [0,1000].
+      If the request refers to multiple objects, track all matching objects.
+      Use one consistent object_id for each physical object across time.
+metadata:
+  - version: 0.0

--- a/lmms_eval/tasks/rvos/eval_sam2.py
+++ b/lmms_eval/tasks/rvos/eval_sam2.py
@@ -1,0 +1,445 @@
+"""Stage-2 evaluation for RVOS tasks: SAM2 mask propagation + J&F metrics.
+
+Consumes the ``<task>_submission.json`` file produced by stage-1 (the
+lmms-eval ``rvos_*`` tasks) and computes mask-level J / F / J&F / HOTA by
+propagating each query's predicted point tracks through a video with a
+SAM2 video predictor from ``facebook/sam2.1-hiera-large``.
+
+Requires:  ``pip install sam2 pycocotools scikit-image opencv-python``
+
+Usage (single GPU)::
+
+    python -m lmms_eval.tasks.rvos.eval_sam2 \\
+        --task rvos_ref_davis17 \\
+        --predictions rvos_output/ref-davis17_submission.json \\
+        --output rvos_sam2_output
+
+Multi-GPU (torchrun)::
+
+    torchrun --nproc-per-node 8 -m lmms_eval.tasks.rvos.eval_sam2 \\
+        --task rvos_ref_davis17 \\
+        --predictions rvos_output/ref-davis17_submission.json
+
+Each rank processes a disjoint slice of the submission; per-query results are
+merged on rank 0 and written to ``<output>/<task>_sam2_metrics.json`` and
+``<output>/<task>_sam2_predictions.json``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import tempfile
+from collections import defaultdict
+from contextlib import nullcontext
+from datetime import timedelta
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import numpy as np
+import torch
+import torch.distributed as dist
+from loguru import logger as eval_logger
+
+TASK_TO_CACHE = {
+    "rvos_ref_davis17": "rvos_ref_davis17",
+    "rvos_mevis_valid_u": "rvos_mevis_valid_u",
+    "rvos_ref_yt_vos": "rvos_ref_yt_vos",
+    "rvos_reasonvos": "rvos_reasonvos",
+}
+
+DEFAULT_SAM2_MODEL = "facebook/sam2.1-hiera-large"
+ALPHA_THRESHOLDS = np.arange(0.05, 1.0, 0.05)
+
+
+# ---------------------------------------------------------------------------
+# Distributed helpers
+# ---------------------------------------------------------------------------
+
+
+def setup_distributed() -> tuple[int, int, torch.device]:
+    if "RANK" in os.environ:
+        dist.init_process_group(backend="nccl", timeout=timedelta(minutes=120))
+        rank = dist.get_rank()
+        world = dist.get_world_size()
+        local_rank = int(os.environ.get("LOCAL_RANK", rank))
+        torch.cuda.set_device(local_rank)
+        return rank, world, torch.device(f"cuda:{local_rank}")
+    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    return 0, 1, device
+
+
+def is_main() -> bool:
+    return not dist.is_initialized() or dist.get_rank() == 0
+
+
+def barrier() -> None:
+    if dist.is_initialized():
+        dist.barrier()
+
+
+# ---------------------------------------------------------------------------
+# SAM2 loading via official API
+# ---------------------------------------------------------------------------
+
+
+def build_sam2_predictor(model_id: str, device: torch.device):
+    from sam2.sam2_video_predictor import SAM2VideoPredictor
+
+    predictor = SAM2VideoPredictor.from_pretrained(model_id)
+    predictor.to(device)
+    predictor.eval()
+    return predictor
+
+
+def _mask_logits_to_uint8(mask_logits: torch.Tensor) -> torch.Tensor:
+    """Reduce per-object mask logits to a single binary uint8 mask (union)."""
+    m = mask_logits.detach()
+    if m.ndim == 4:
+        m = m.squeeze(1)  # (n_obj, 1, H, W) -> (n_obj, H, W)
+    if m.ndim == 3 and m.shape[0] > 0:
+        m, _ = m.max(dim=0)
+    return (m > 0).to(torch.uint8).cpu()
+
+
+def run_sam2(predictor, prompt_map: Dict[tuple, List[tuple]], inference_state) -> np.ndarray:
+    """Propagate points through the video. Returns pred masks (T, H, W) uint8."""
+    num_frames = int(inference_state["num_frames"])
+    video_h = int(inference_state["video_height"])
+    video_w = int(inference_state["video_width"])
+
+    frame_to_mask: Dict[int, torch.Tensor] = {}
+    prompts_by_frame = defaultdict(list)
+    for (frame_idx, obj_id), pts in prompt_map.items():
+        prompts_by_frame[frame_idx].append((obj_id, pts))
+    prompt_frames = sorted(prompts_by_frame)
+
+    if prompt_frames:
+        autocast_ctx = (
+            torch.autocast(device_type="cuda", dtype=torch.bfloat16)
+            if torch.cuda.is_available() and "cuda" in str(inference_state["device"])
+            else nullcontext()
+        )
+        with torch.inference_mode(), autocast_ctx:
+            for i, fidx in enumerate(prompt_frames):
+                for obj_id, points in prompts_by_frame[fidx]:
+                    pts = torch.tensor(points, dtype=torch.float32)
+                    labels = torch.ones((len(points),), dtype=torch.int32)
+                    predictor.add_new_points_or_box(
+                        inference_state=inference_state,
+                        frame_idx=fidx,
+                        obj_id=obj_id,
+                        points=pts,
+                        labels=labels,
+                        clear_old_points=True,
+                        normalize_coords=True,
+                    )
+                next_pf = prompt_frames[i + 1] if i + 1 < len(prompt_frames) else num_frames
+                max_track = max(next_pf - fidx - 1, 0)
+                for out_idx, _, out_logits in predictor.propagate_in_video(
+                    inference_state=inference_state,
+                    start_frame_idx=fidx,
+                    max_frame_num_to_track=max_track,
+                    reverse=False,
+                ):
+                    frame_to_mask[int(out_idx)] = _mask_logits_to_uint8(out_logits)
+            first = prompt_frames[0]
+            if first > 0:
+                for out_idx, _, out_logits in predictor.propagate_in_video(
+                    inference_state=inference_state,
+                    start_frame_idx=first,
+                    max_frame_num_to_track=first,
+                    reverse=True,
+                ):
+                    frame_to_mask[int(out_idx)] = _mask_logits_to_uint8(out_logits)
+
+    empty = torch.zeros((video_h, video_w), dtype=torch.uint8)
+    return np.stack([frame_to_mask.get(i, empty).numpy() for i in range(num_frames)])
+
+
+# ---------------------------------------------------------------------------
+# Prompt map + frame extraction
+# ---------------------------------------------------------------------------
+
+
+def build_prompt_map(tracks: List[Dict[str, Any]], W: int, H: int, video_fps: float, num_frames: int) -> Dict[tuple, List[tuple]]:
+    prompt_map: Dict[tuple, List[tuple]] = defaultdict(list)
+    for entry in tracks:
+        ts = float(entry.get("time", entry.get("frame", 0) / max(video_fps, 1e-6)))
+        frame_idx = int(round(ts * video_fps))
+        frame_idx = max(0, min(frame_idx, num_frames - 1))
+        for oid, p in entry.get("points", {}).items():
+            xy = p["point"] if isinstance(p, dict) else p
+            x = max(0.0, min(float(xy[0]), float(W - 1)))
+            y = max(0.0, min(float(xy[1]), float(H - 1)))
+            prompt_map[(frame_idx, str(oid))].append((x, y))
+    return dict(prompt_map)
+
+
+def extract_frames_ffmpeg(video_path: str, out_dir: str, fps: float) -> None:
+    Path(out_dir).mkdir(parents=True, exist_ok=True)
+    subprocess.run(
+        ["ffmpeg", "-y", "-loglevel", "error", "-i", video_path, "-vf", f"fps={fps}",
+         os.path.join(out_dir, "%05d.jpg")],
+        check=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# GT mask loading + metrics (J / F / J&F / HOTA)
+# ---------------------------------------------------------------------------
+
+
+def load_gt_masks(cache_root: str, video: str, mask_ids: List[str], num_frames: int, H: int, W: int) -> np.ndarray:
+    from pycocotools import mask as mask_utils
+    import cv2
+
+    gt = np.zeros((num_frames, H, W), dtype=np.uint8)
+    for mid in mask_ids:
+        path = os.path.join(cache_root, "masks", video, f"{mid}.json")
+        if not os.path.exists(path):
+            eval_logger.warning(f"GT mask file missing: {path}")
+            continue
+        with open(path, "r") as f:
+            data = json.load(f)
+        for _, rle_list in data.items():
+            for fi, rle in enumerate(rle_list):
+                if fi >= num_frames or rle is None:
+                    continue
+                decoded = mask_utils.decode(rle)
+                if decoded.shape != (H, W):
+                    decoded = cv2.resize(decoded, (W, H), interpolation=cv2.INTER_NEAREST)
+                gt[fi] = np.maximum(gt[fi], decoded)
+    return gt
+
+
+def _seg2bmap(seg: np.ndarray) -> np.ndarray:
+    seg = seg.astype(bool)
+    e = np.zeros_like(seg)
+    s = np.zeros_like(seg)
+    se = np.zeros_like(seg)
+    e[:, :-1] = seg[:, 1:]
+    s[:-1, :] = seg[1:, :]
+    se[:-1, :-1] = seg[1:, 1:]
+    b = seg ^ e | seg ^ s | seg ^ se
+    b[-1, :] = seg[-1, :] ^ e[-1, :]
+    b[:, -1] = seg[:, -1] ^ s[:, -1]
+    b[-1, -1] = 0
+    return b
+
+
+def f_measure(fg: np.ndarray, gt: np.ndarray, bound_th: float = 0.008) -> float:
+    from skimage.morphology import disk
+    import cv2
+
+    bound_pix = bound_th if bound_th >= 1 else np.ceil(bound_th * np.linalg.norm(fg.shape))
+    fg_b = _seg2bmap(fg)
+    gt_b = _seg2bmap(gt)
+    disk_k = disk(bound_pix).astype(np.uint8)
+    fg_dil = cv2.dilate(fg_b.astype(np.uint8), disk_k)
+    gt_dil = cv2.dilate(gt_b.astype(np.uint8), disk_k)
+    gt_match = gt_b * fg_dil
+    fg_match = fg_b * gt_dil
+    n_fg = np.sum(fg_b)
+    n_gt = np.sum(gt_b)
+    if n_fg == 0 and n_gt > 0:
+        p, r = 1.0, 0.0
+    elif n_fg > 0 and n_gt == 0:
+        p, r = 0.0, 1.0
+    elif n_fg == 0 and n_gt == 0:
+        p, r = 1.0, 1.0
+    else:
+        p = float(fg_match.sum()) / float(n_fg)
+        r = float(gt_match.sum()) / float(n_gt)
+    return 0.0 if (p + r) == 0 else float(2 * p * r / (p + r))
+
+
+def db_eval_iou(gt: np.ndarray, pred: np.ndarray) -> np.ndarray:
+    gt = gt.astype(bool)
+    pred = pred.astype(bool)
+    inter = np.sum(gt & pred, axis=(-2, -1))
+    union = np.sum(gt | pred, axis=(-2, -1))
+    j = np.where(union > 0, inter / np.maximum(union, 1), 1.0)
+    return j.astype(float)
+
+
+def db_eval_boundary(gt: np.ndarray, pred: np.ndarray) -> np.ndarray:
+    n = gt.shape[0]
+    out = np.zeros(n)
+    for i in range(n):
+        out[i] = f_measure(pred[i], gt[i])
+    return out
+
+
+def compute_hota_single(gt: np.ndarray, pred: np.ndarray) -> float:
+    n = gt.shape[0]
+    ious = np.zeros(n)
+    for t in range(n):
+        inter = np.logical_and(gt[t] > 0, pred[t] > 0).sum()
+        union = np.logical_or(gt[t] > 0, pred[t] > 0).sum()
+        ious[t] = inter / union if union > 0 else 1.0
+    gt_ex = np.array([gt[t].sum() > 0 for t in range(n)])
+    pd_ex = np.array([pred[t].sum() > 0 for t in range(n)])
+    hs = np.zeros(len(ALPHA_THRESHOLDS))
+    for a, alpha in enumerate(ALPHA_THRESHOLDS):
+        tp = fn = fp = 0
+        for t in range(n):
+            gt_here, pd_here = gt_ex[t], pd_ex[t]
+            if not gt_here and not pd_here:
+                continue
+            if gt_here and pd_here and ious[t] >= alpha:
+                tp += 1
+            else:
+                if gt_here:
+                    fn += 1
+                if pd_here:
+                    fp += 1
+        det_a = tp / (tp + fn + fp) if (tp + fn + fp) > 0 else 1.0
+        hs[a] = np.sqrt(det_a)
+    return float(np.mean(hs))
+
+
+def evaluate_masks(gt: np.ndarray, pred: np.ndarray) -> Dict[str, float]:
+    j_arr = db_eval_iou(gt, pred)
+    f_arr = db_eval_boundary(gt, pred)
+    j = float(j_arr.mean()) if j_arr.size else 0.0
+    f = float(f_arr.mean()) if f_arr.size else 0.0
+    return {"J": j, "F": f, "J&F": (j + f) / 2.0, "HOTA": compute_hota_single(gt, pred)}
+
+
+# ---------------------------------------------------------------------------
+# Per-query processing
+# ---------------------------------------------------------------------------
+
+
+def process_query(predictor, record: Dict[str, Any], cache_root: str, tmp_root: Optional[str],
+                  video_fps: float, device: torch.device) -> Optional[Dict[str, Any]]:
+    video = record["video"]
+    video_path = os.path.join(cache_root, "videos", f"{video}.mp4")
+    if not os.path.exists(video_path):
+        eval_logger.warning(f"[sam2] video not found: {video_path}")
+        return None
+
+    H, W = int(record["height"]), int(record["width"])
+    tracks = record.get("tracks") or []
+
+    with tempfile.TemporaryDirectory(prefix=f"rvos_{video}_", dir=tmp_root) as td:
+        extract_frames_ffmpeg(video_path, td, video_fps)
+        state = predictor.init_state(video_path=td, offload_video_to_cpu=True)
+        state["device"] = device
+
+        prompt_map = build_prompt_map(tracks, W, H, video_fps, state["num_frames"])
+        if not prompt_map:
+            pred_masks = np.zeros((state["num_frames"], state["video_height"], state["video_width"]), dtype=np.uint8)
+        else:
+            pred_masks = run_sam2(predictor, prompt_map, state)
+        gt_masks = load_gt_masks(cache_root, video, list(record.get("mask_ids") or []),
+                                 pred_masks.shape[0], pred_masks.shape[1], pred_masks.shape[2])
+
+    metrics = evaluate_masks(gt_masks, pred_masks)
+    return {
+        "id": record.get("id"),
+        "qid": record.get("qid"),
+        "video": video,
+        "expression": record.get("expression"),
+        "num_prompt_frames": len({fi for fi, _ in prompt_map}),
+        "num_prompt_points": sum(len(v) for v in prompt_map.values()),
+        **metrics,
+    }
+
+
+def gather_records(records: List[Dict[str, Any]], world: int) -> List[Dict[str, Any]]:
+    if world == 1:
+        return records
+    obj_list: List[List[Dict[str, Any]]] = [[] for _ in range(world)]
+    dist.all_gather_object(obj_list, records)
+    merged: List[Dict[str, Any]] = []
+    for lst in obj_list:
+        merged.extend(lst)
+    return merged
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--task", required=True, choices=list(TASK_TO_CACHE.keys()))
+    ap.add_argument("--predictions", required=True, help="Path to stage-1 <task>_submission.json")
+    ap.add_argument("--sam2-model", default=DEFAULT_SAM2_MODEL,
+                    help="HF model id (default: facebook/sam2.1-hiera-large)")
+    ap.add_argument("--output", default="rvos_sam2_output")
+    ap.add_argument("--cache-dir", default=None, help="Override <hf_home>/<task cache dir>")
+    ap.add_argument("--video-fps", type=float, default=6.0)
+    ap.add_argument("--tmp-root", default=None)
+    ap.add_argument("--max-items", type=int, default=-1)
+    args = ap.parse_args()
+
+    rank, world, device = setup_distributed()
+
+    if args.cache_dir is None:
+        hf_home = os.path.expanduser(os.getenv("HF_HOME", "~/.cache/huggingface/"))
+        cache_root = os.path.join(hf_home, TASK_TO_CACHE[args.task])
+    else:
+        cache_root = args.cache_dir
+    if not os.path.isdir(cache_root):
+        raise FileNotFoundError(f"Cache dir missing (run stage 1 first?): {cache_root}")
+
+    with open(args.predictions, "r") as f:
+        records = json.load(f)
+    if args.max_items > 0:
+        records = records[: args.max_items]
+
+    if is_main():
+        eval_logger.info(f"[sam2] task={args.task} world={world} total={len(records)} cache={cache_root} model={args.sam2_model}")
+    barrier()
+
+    predictor = build_sam2_predictor(args.sam2_model, device)
+
+    local_records = records[rank::world]
+    local_results: List[Dict[str, Any]] = []
+    progress_every = max(1, len(local_records) // 20)
+    for i, rec in enumerate(local_records):
+        try:
+            r = process_query(predictor, rec, cache_root, args.tmp_root, args.video_fps, device)
+        except Exception as e:
+            eval_logger.warning(f"[sam2] rank {rank} record {rec.get('id')} failed: {e}")
+            r = None
+        if r is not None:
+            local_results.append(r)
+        if is_main() and (i + 1) % progress_every == 0:
+            eval_logger.info(f"[sam2] rank 0 progress: {i + 1}/{len(local_records)}")
+
+    all_results = gather_records(local_results, world)
+    if not is_main():
+        return
+
+    os.makedirs(args.output, exist_ok=True)
+    per_query_path = os.path.join(args.output, f"{args.task}_sam2_predictions.json")
+    with open(per_query_path, "w") as f:
+        json.dump(all_results, f)
+
+    if all_results:
+        j = float(np.mean([r["J"] for r in all_results]))
+        f_ = float(np.mean([r["F"] for r in all_results]))
+        jf = float(np.mean([r["J&F"] for r in all_results]))
+        hota = float(np.mean([r["HOTA"] for r in all_results]))
+    else:
+        j = f_ = jf = hota = 0.0
+    summary = {"task": args.task, "n": len(all_results), "J": j, "F": f_, "J&F": jf, "HOTA": hota}
+    with open(os.path.join(args.output, f"{args.task}_sam2_metrics.json"), "w") as f:
+        json.dump(summary, f, indent=2)
+
+    eval_logger.info(f"[sam2] === {args.task}  N={summary['n']} ===")
+    eval_logger.info(f"[sam2]   J   = {j:.4f}")
+    eval_logger.info(f"[sam2]   F   = {f_:.4f}")
+    eval_logger.info(f"[sam2]   J&F = {jf:.4f}")
+    eval_logger.info(f"[sam2]   HOTA= {hota:.4f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/lmms_eval/tasks/rvos/rvos_mevis_valid_u.yaml
+++ b/lmms_eval/tasks/rvos/rvos_mevis_valid_u.yaml
@@ -1,0 +1,8 @@
+task: rvos_mevis_valid_u
+dataset_path: kcz358/RVOS-MeViS-ValidU
+dataset_kwargs:
+  token: True
+  video: True
+  cache_dir: rvos_mevis_valid_u
+test_split: valid_u
+include: _default_template_yaml

--- a/lmms_eval/tasks/rvos/rvos_reasonvos.yaml
+++ b/lmms_eval/tasks/rvos/rvos_reasonvos.yaml
@@ -1,0 +1,8 @@
+task: rvos_reasonvos
+dataset_path: kcz358/RVOS-ReasonVOS
+dataset_kwargs:
+  token: True
+  video: True
+  cache_dir: rvos_reasonvos
+test_split: test
+include: _default_template_yaml

--- a/lmms_eval/tasks/rvos/rvos_ref_davis17.yaml
+++ b/lmms_eval/tasks/rvos/rvos_ref_davis17.yaml
@@ -1,0 +1,8 @@
+task: rvos_ref_davis17
+dataset_path: kcz358/RVOS-Ref-DAVIS17
+dataset_kwargs:
+  token: True
+  video: True
+  cache_dir: rvos_ref_davis17
+test_split: valid
+include: _default_template_yaml

--- a/lmms_eval/tasks/rvos/rvos_ref_yt_vos.yaml
+++ b/lmms_eval/tasks/rvos/rvos_ref_yt_vos.yaml
@@ -1,0 +1,8 @@
+task: rvos_ref_yt_vos
+dataset_path: kcz358/RVOS-Ref-YT-VOS
+dataset_kwargs:
+  token: True
+  video: True
+  cache_dir: rvos_ref_yt_vos
+test_split: valid
+include: _default_template_yaml

--- a/lmms_eval/tasks/rvos/utils.py
+++ b/lmms_eval/tasks/rvos/utils.py
@@ -1,0 +1,530 @@
+"""RVOS (Referring Video Object Segmentation) stage-1 evaluation.
+
+Datasets: kcz358/RVOS-{Ref-DAVIS17, MeViS-ValidU, Ref-YT-VOS, ReasonVOS}
+
+For each query, the model receives a video and a referring expression, and is
+expected to output an XML string with object point trajectories:
+
+    <tracks coords="t0 id0 x0 y0 id1 x1 y1; t1 id0 x2 y2 ...">label</tracks>
+
+We parse the tracks and score them against GT masks:
+  - precision / recall / F1 : Hungarian match pred points -> GT points, count
+    a match as correct if the pred point lands inside the matched GT object's
+    mask on that frame.
+  - HOTA (@ alpha=0.5) : mask point-in-mask similarity aggregated with the
+    standard HOTA formulation.
+
+The raw per-query predictions are also written to
+``<output_dir>/<task>_submission.json`` in the same schema used by the
+upstream tracking pipeline, so the accompanying ``eval_sam2.py`` script can
+run stage-2 SAM2 mask propagation on them.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import os
+import re
+from collections import defaultdict
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Dict, List
+
+import numpy as np
+import yaml
+from loguru import logger as eval_logger
+from scipy.optimize import linear_sum_assignment
+from scipy.spatial.distance import cdist
+
+HF_HOME = os.path.expanduser(os.getenv("HF_HOME", "~/.cache/huggingface/"))
+
+
+# ---------------------------------------------------------------------------
+# Config helpers
+# ---------------------------------------------------------------------------
+
+
+@lru_cache(maxsize=None)
+def _load_task_cache_dir(task_name: str) -> str:
+    """Read the task yaml to find its ``dataset_kwargs.cache_dir`` value."""
+    task_yaml = Path(__file__).parent / f"{task_name}.yaml"
+    if not task_yaml.exists():
+        raise FileNotFoundError(task_yaml)
+    with open(task_yaml, "r") as f:
+        raw = [ln for ln in f.readlines() if "!function" not in ln]
+    cfg = yaml.safe_load("".join(raw))
+    return cfg["dataset_kwargs"]["cache_dir"]
+
+
+def _cache_root_for(doc: Dict[str, Any]) -> str:
+    """Resolve <hf_home>/<cache_dir> for the current task."""
+    task = _current_task(doc)
+    return os.path.join(HF_HOME, _load_task_cache_dir(task))
+
+
+def _current_task(doc: Dict[str, Any]) -> str:
+    """Guess task name from doc id prefix.
+
+    Docs carry ``id`` like ``ref-davis17_track_0`` / ``mevis_track_0`` /
+    ``ref-yt-vos_track_0`` / ``reasonvos_track_0``.
+    """
+    pid = str(doc.get("id", ""))
+    if pid.startswith("ref-davis17"):
+        return "rvos_ref_davis17"
+    if pid.startswith("mevis"):
+        return "rvos_mevis_valid_u"
+    if pid.startswith("ref-yt-vos"):
+        return "rvos_ref_yt_vos"
+    if pid.startswith("reasonvos"):
+        return "rvos_reasonvos"
+    raise ValueError(f"Unknown RVOS id prefix: {pid!r}")
+
+
+# ---------------------------------------------------------------------------
+# Visual / prompt
+# ---------------------------------------------------------------------------
+
+
+def rvos_doc_to_visual(doc):
+    root = _cache_root_for(doc)
+    video_path = os.path.join(root, "videos", f"{doc['video']}.mp4")
+    if not os.path.exists(video_path):
+        eval_logger.warning(f"[rvos] Video not found: {video_path}")
+        return []
+    return [video_path]
+
+
+def rvos_doc_to_text(doc, lmms_eval_specific_kwargs=None):
+    lmms_eval_specific_kwargs = lmms_eval_specific_kwargs or {}
+    tmpl = lmms_eval_specific_kwargs.get("prompt_template", "Track the {expression}")
+    suffix = lmms_eval_specific_kwargs.get("prompt_suffix", "")
+    return tmpl.format(expression=doc["expression"]) + suffix
+
+
+def rvos_doc_to_messages(doc, lmms_eval_specific_kwargs=None):
+    prompt = rvos_doc_to_text(doc, lmms_eval_specific_kwargs)
+    content = []
+    for video_path in rvos_doc_to_visual(doc):
+        content.append({"type": "video", "url": video_path})
+    content.append({"type": "text", "text": prompt})
+    return [{"role": "user", "content": content}]
+
+
+# ---------------------------------------------------------------------------
+# XML parsing (ported from Feilong607/lmms-eval-ov2-tracking)
+# ---------------------------------------------------------------------------
+
+
+_COORD_REGEX = re.compile(r'coords\s*=\s*[\'"]([^\'"]+)[\'"]')
+# Match one segment "time obj_id x y [obj_id x y ...]" separated by any of ;, \t, , : (and leading start).
+# Trailing/leading spaces around the delimiter are tolerated.
+_FRAME_REGEX = re.compile(r'(?:^|[\t:,;])\s*([0-9]+(?:\.[0-9]+)?)\s+([0-9.\s]+?)(?=[\t:,;]|$)')
+_POINTS_REGEX = re.compile(r'([0-9]+)\s+([0-9]{1,4})\s+([0-9]{1,4})')
+
+
+def parse_xml_tracks(text: str, width: int, height: int, video_fps: float) -> List[Dict[str, Any]]:
+    grouped = defaultdict(list)
+    for coord_match in _COORD_REGEX.finditer(text):
+        for frame_match in _FRAME_REGEX.finditer(coord_match.group(1)):
+            timestamp = float(frame_match.group(1))
+            point_str = frame_match.group(2)
+            for pt_match in _POINTS_REGEX.finditer(point_str):
+                ix = pt_match.group(1)
+                x = float(pt_match.group(2)) / 1000.0 * width
+                y = float(pt_match.group(3)) / 1000.0 * height
+                if 0 <= x <= width and 0 <= y <= height:
+                    grouped[timestamp].append((ix, x, y))
+    out = []
+    for ts in sorted(grouped):
+        frame = round(ts * video_fps)
+        points = {}
+        for ix, x, y in grouped[ts]:
+            if str(ix) not in points:
+                points[str(ix)] = {"point": [x, y]}
+        out.append({"time": ts, "frame": frame, "points": points})
+    return out
+
+
+def parse_time_dict_tracks(text: str, width: int, height: int, video_fps: float) -> List[Dict[str, Any]]:
+    pattern = r"time\s+(\d+\.?\d*)\s*\n\s*(\{[^}]+\})"
+    result = []
+    for match in re.finditer(pattern, text, re.MULTILINE):
+        seconds = float(match.group(1).strip())
+        try:
+            obj_points = ast.literal_eval(match.group(2).strip())
+        except (ValueError, SyntaxError):
+            continue
+        frame = round(seconds * video_fps)
+        points = {}
+        for oid, coords in obj_points.items():
+            if len(coords) < 2:
+                continue
+            x, y = coords[0], coords[1]
+            if max(x, y) > 100:
+                continue
+            px = float(x) / 100.0 * width
+            py = float(y) / 100.0 * height
+            occ = False
+            if len(coords) == 3:
+                occ = str(coords[2]).strip().lower() in ("yes", "true", "1")
+            points[str(int(oid))] = {"point": [px, py], "occluded": occ}
+        if points:
+            result.append({"time": seconds, "frame": frame, "points": points})
+    return result
+
+
+def extract_tracks(text: str, width: int, height: int, video_fps: float) -> List[Dict[str, Any]]:
+    tracks = parse_xml_tracks(text, width, height, video_fps)
+    if tracks:
+        return tracks
+    return parse_time_dict_tracks(text, width, height, video_fps)
+
+
+# ---------------------------------------------------------------------------
+# GT mask loading (from packed masks.zip -> <cache_root>/masks/<video>/<mid>.json)
+# ---------------------------------------------------------------------------
+
+
+@lru_cache(maxsize=4096)
+def _load_mask_file(cache_root: str, video: str, mask_id: str) -> Any:
+    path = os.path.join(cache_root, "masks", video, f"{mask_id}.json")
+    if not os.path.exists(path):
+        return None
+    with open(path, "r") as f:
+        return json.load(f)
+
+
+def _ann_to_mask(mask_ann):
+    from pycocotools import mask as mask_utils
+
+    if isinstance(mask_ann, np.ndarray):
+        return mask_ann
+    if isinstance(mask_ann, list):
+        h, w = mask_ann[0]["size"]
+        rle = mask_utils.merge(mask_utils.frPyObjects(mask_ann, h, w))
+    elif isinstance(mask_ann["counts"], list):
+        rle = mask_utils.frPyObjects(mask_ann, mask_ann["size"][0], mask_ann["size"][1])
+    else:
+        rle = mask_ann
+    return mask_utils.decode(rle)
+
+
+def _load_gt_masks(doc: Dict[str, Any]) -> Dict[str, List[Any]]:
+    """Return {internal_obj_index_str: [rle_or_none, ...]} aligned with GT tracks."""
+    cache_root = _cache_root_for(doc)
+    video = doc["video"]
+    mask_ids = list(doc["mask_ids"])
+    out: Dict[str, List[Any]] = {}
+    for idx, mid in enumerate(mask_ids):
+        data = _load_mask_file(cache_root, video, mid)
+        if data is None:
+            out[str(idx)] = []
+            continue
+        # File is {"<internal_obj_id>": [rle, rle, ..., null, ...]}
+        key = next(iter(data.keys()))
+        out[str(idx)] = data[key]
+    return out
+
+
+def _load_masks_at_frame(gt_masks: Dict[str, List[Any]], frame_idx: int, height: int, width: int,
+                         return_dict: bool = False):
+    empty = np.zeros((height, width), dtype=bool)
+    masks: List[np.ndarray] = []
+    masks_by_id: Dict[str, np.ndarray] = {}
+    for mid, mask_list in gt_masks.items():
+        binary = empty
+        if frame_idx < len(mask_list) and mask_list[frame_idx] is not None:
+            binary = _ann_to_mask(mask_list[frame_idx]).astype(bool)
+        masks.append(binary)
+        masks_by_id[str(mid)] = binary
+    if return_dict:
+        return masks_by_id
+    return masks
+
+
+def _is_point_in_mask(point, mask) -> bool:
+    h, w = mask.shape
+    x, y = point
+    xi, yi = int(round(x)), int(round(y))
+    return 0 <= xi < w and 0 <= yi < h and bool(mask[yi, xi])
+
+
+# ---------------------------------------------------------------------------
+# Metrics (ported)
+# ---------------------------------------------------------------------------
+
+
+def _evaluate_frame(pred_points, gt_points, masks):
+    ng = len(gt_points)
+    np_ = len(pred_points)
+    if ng == 0:
+        score = float(np_ == 0)
+        return score, score, score
+    if np_ == 0:
+        return 0.0, 0.0, 0.0
+    dist_mat = cdist(np.array(pred_points), np.array(gt_points))
+    ri, ci = linear_sum_assignment(dist_mat)
+    correct = sum(1 for r, c in zip(ri, ci) if c < len(masks) and _is_point_in_mask(pred_points[r], masks[c]))
+    p = correct / np_
+    r = correct / len(masks)
+    f = 2 * p * r / (p + r + 1e-10) if (p + r) > 0 else 0.0
+    return p, r, f
+
+
+def _evaluate_video_tracks_with_masks(pred_tracks, gt_tracks, gt_masks, height, width):
+    pred_by = {e["frame"]: e for e in (pred_tracks or [])}
+    gt_by = {e["frame"]: e for e in (gt_tracks or [])}
+    all_frames = sorted(gt_by.keys())
+    if not all_frames:
+        return {"precision": 1.0, "recall": 1.0, "f1": 1.0}
+    per_frame = []
+    for fidx in all_frames:
+        pf = pred_by.get(fidx)
+        gf = gt_by.get(fidx)
+        pp = [tuple(v["point"]) for v in pf["points"].values()] if pf else []
+        gp = [tuple(v["point"]) for v in gf["points"].values()] if gf else []
+        masks = _load_masks_at_frame(gt_masks, fidx, height, width)
+        p, r, f = _evaluate_frame(pp, gp, masks)
+        per_frame.append((p, r, f))
+    if not per_frame:
+        return {"precision": 1.0, "recall": 1.0, "f1": 1.0}
+    return {
+        "precision": float(np.mean([x[0] for x in per_frame])),
+        "recall": float(np.mean([x[1] for x in per_frame])),
+        "f1": float(np.mean([x[2] for x in per_frame])),
+    }
+
+
+class _HOTAMetric:
+    def __init__(self):
+        self.alpha_thresholds = np.arange(0.05, 1.0, 0.05)
+
+    def prepare_data(self, pred_tracks, gt_tracks, gt_masks, height, width):
+        pred_tracks = pred_tracks or []
+        gt_tracks = gt_tracks or []
+        pred_by = {e["frame"]: e for e in pred_tracks}
+        gt_by = {e["frame"]: e for e in gt_tracks}
+        all_gt_ids, all_pred_ids = set(), set()
+        for e in gt_tracks:
+            all_gt_ids.update(e["points"].keys())
+        for e in pred_tracks:
+            all_pred_ids.update(e["points"].keys())
+        gt_map = {str(oid): i for i, oid in enumerate(sorted(all_gt_ids))}
+        pred_map = {str(oid): i for i, oid in enumerate(sorted(all_pred_ids))}
+        all_frames = sorted(gt_by.keys())
+        data = {
+            "num_gt_ids": len(all_gt_ids),
+            "num_tracker_ids": len(all_pred_ids),
+            "num_timesteps": len(all_frames),
+            "gt_ids": [],
+            "tracker_ids": [],
+            "similarity_scores": [],
+            "num_gt_dets": 0,
+            "num_tracker_dets": 0,
+        }
+        for fidx in all_frames:
+            pf = pred_by.get(fidx)
+            gf = gt_by.get(fidx)
+            gt_ids_l, gt_pts = [], []
+            if gf:
+                for oid, pd in sorted(gf["points"].items()):
+                    gt_ids_l.append(gt_map[str(oid)])
+                    gt_pts.append(pd["point"])
+            pred_ids_l, pred_pts = [], []
+            if pf:
+                for oid, pd in sorted(pf["points"].items()):
+                    pred_ids_l.append(pred_map[str(oid)])
+                    pred_pts.append(pd["point"])
+            gt_arr = np.array(gt_ids_l, dtype=int)
+            pred_arr = np.array(pred_ids_l, dtype=int)
+            data["gt_ids"].append(gt_arr)
+            data["tracker_ids"].append(pred_arr)
+            data["num_gt_dets"] += len(gt_arr)
+            data["num_tracker_dets"] += len(pred_arr)
+            sim = np.zeros((len(gt_pts), len(pred_pts)))
+            if gt_pts and pred_pts:
+                masks_by_id = _load_masks_at_frame(gt_masks, fidx, height, width, return_dict=True)
+                empty_mask = np.zeros((height, width), dtype=bool)
+                gt_oids_ordered = [oid for oid, _ in sorted(gf["points"].items())]
+                for i, oid in enumerate(gt_oids_ordered):
+                    mask = masks_by_id.get(str(oid), empty_mask)
+                    for j, pp in enumerate(pred_pts):
+                        if _is_point_in_mask(pp, mask):
+                            sim[i, j] = 1.0
+            data["similarity_scores"].append(sim)
+        return data
+
+    def compute(self, data):
+        na = len(self.alpha_thresholds)
+        res = {k: np.zeros(na) for k in ["HOTA_TP", "HOTA_FN", "HOTA_FP", "HOTA", "DetA", "AssA", "LocA"]}
+        if data["num_tracker_dets"] == 0 and data["num_gt_dets"] == 0:
+            return {k: np.ones(na) for k in res}
+        if data["num_tracker_dets"] == 0:
+            res["HOTA_FN"] = np.full(na, data["num_gt_dets"])
+            res["LocA"] = np.ones(na)
+            return res
+        if data["num_gt_dets"] == 0:
+            res["HOTA_FP"] = np.full(na, data["num_tracker_dets"])
+            res["LocA"] = np.ones(na)
+            return res
+        pot_matches = np.zeros((data["num_gt_ids"], data["num_tracker_ids"]))
+        gt_count = np.zeros((data["num_gt_ids"], 1))
+        pred_count = np.zeros((1, data["num_tracker_ids"]))
+        for t, (gids, pids) in enumerate(zip(data["gt_ids"], data["tracker_ids"])):
+            sim = data["similarity_scores"][t]
+            denom = sim.sum(0)[None, :] + sim.sum(1)[:, None] - sim
+            iou = np.zeros_like(sim)
+            mask = denom > np.finfo(float).eps
+            iou[mask] = sim[mask] / denom[mask]
+            pot_matches[gids[:, None], pids[None, :]] += iou
+            gt_count[gids] += 1
+            pred_count[0, pids] += 1
+        global_score = pot_matches / (gt_count + pred_count - pot_matches + np.finfo(float).eps)
+        matches_counts = [np.zeros_like(pot_matches) for _ in self.alpha_thresholds]
+        for t, (gids, pids) in enumerate(zip(data["gt_ids"], data["tracker_ids"])):
+            if len(gids) == 0:
+                for a in range(na):
+                    res["HOTA_FP"][a] += len(pids)
+                continue
+            if len(pids) == 0:
+                for a in range(na):
+                    res["HOTA_FN"][a] += len(gids)
+                continue
+            sim = data["similarity_scores"][t]
+            score_mat = global_score[gids[:, None], pids[None, :]] * sim
+            mr, mc = linear_sum_assignment(-score_mat)
+            for a, alpha in enumerate(self.alpha_thresholds):
+                matched = sim[mr, mc] >= alpha - np.finfo(float).eps
+                amr, amc = mr[matched], mc[matched]
+                nm = len(amr)
+                res["HOTA_TP"][a] += nm
+                res["HOTA_FN"][a] += len(gids) - nm
+                res["HOTA_FP"][a] += len(pids) - nm
+                if nm > 0:
+                    res["LocA"][a] += sim[amr, amc].sum()
+                    matches_counts[a][gids[amr], pids[amc]] += 1
+        for a in range(na):
+            mc = matches_counts[a]
+            assA = mc / np.maximum(1, gt_count + pred_count - mc)
+            res["AssA"][a] = np.sum(mc * assA) / np.maximum(1, res["HOTA_TP"][a])
+        res["LocA"] = np.maximum(1e-10, res["LocA"]) / np.maximum(1e-10, res["HOTA_TP"])
+        res["DetA"] = res["HOTA_TP"] / np.maximum(1, res["HOTA_TP"] + res["HOTA_FN"] + res["HOTA_FP"])
+        res["HOTA"] = np.sqrt(res["DetA"] * res["AssA"])
+        return res
+
+
+def _evaluate_video_object_tracking(pred_tracks, gt_tracks, gt_masks, height, width):
+    spatial = _evaluate_video_tracks_with_masks(pred_tracks, gt_tracks, gt_masks, height, width)
+    hota = _HOTAMetric()
+    prep = hota.prepare_data(pred_tracks, gt_tracks, gt_masks, height, width)
+    res = hota.compute(prep)
+    alpha_05_idx = 9  # threshold 0.5
+    return {
+        "precision": spatial["precision"],
+        "recall": spatial["recall"],
+        "f1": spatial["f1"],
+        "HOTA": float(res["HOTA"][alpha_05_idx]),
+    }
+
+
+# ---------------------------------------------------------------------------
+# process_results
+# ---------------------------------------------------------------------------
+
+
+def rvos_process_results(doc, results):
+    """Parse pred tracks, compute per-query metrics, and store submission record."""
+    pred_text = results[0] if results else ""
+    width = int(doc["width"])
+    height = int(doc["height"])
+    video_fps = float(doc["fps"]) if doc["fps"] else 1.0
+
+    pred_tracks = extract_tracks(pred_text, width, height, video_fps)
+    try:
+        gt_tracks = json.loads(doc["frame_trajectories"])
+        # Normalize GT points dict-of-obj shape
+        for entry in gt_tracks:
+            if isinstance(entry.get("points"), list):
+                entry["points"] = {
+                    str(p["id"]): {"point": p["point"], "occluded": p.get("occluded", False)}
+                    for p in entry["points"]
+                }
+    except Exception:
+        gt_tracks = []
+    try:
+        gt_masks = _load_gt_masks(doc)
+    except Exception as e:
+        eval_logger.warning(f"[rvos] Failed to load GT masks for {doc.get('id')}: {e}")
+        gt_masks = {}
+
+    try:
+        metrics = _evaluate_video_object_tracking(pred_tracks, gt_tracks, gt_masks, height, width)
+    except Exception as e:
+        eval_logger.warning(f"[rvos] Metric computation failed for {doc.get('id')}: {e}")
+        metrics = {"precision": 0.0, "recall": 0.0, "f1": 0.0, "HOTA": 0.0}
+
+    record = {
+        "id": doc["id"],
+        "qid": doc.get("qid"),
+        "video": doc["video"],
+        "expression": doc["expression"],
+        "prediction": pred_text,
+        "tracks": pred_tracks,
+        "height": height,
+        "width": width,
+        "fps": int(doc["fps"]),
+        "sampling_fps": int(doc.get("sampling_fps", 1)),
+        "n_frames": int(doc["n_frames"]),
+        "mask_ids": list(doc["mask_ids"]),
+        **metrics,
+    }
+    return {
+        "rvos_f1": record,
+        "rvos_precision": record,
+        "rvos_recall": record,
+        "rvos_hota": record,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Aggregations
+# ---------------------------------------------------------------------------
+
+
+def _dump_submission(records: List[Dict[str, Any]]) -> str:
+    task = records[0]["id"].split("_track_")[0] if records else "rvos"
+    output_dir = os.environ.get("RVOS_OUTPUT_DIR", "rvos_output")
+    os.makedirs(output_dir, exist_ok=True)
+    path = os.path.join(output_dir, f"{task}_submission.json")
+    with open(path, "w") as f:
+        json.dump(records, f)
+    return path
+
+
+_MEAN = {"f1": None, "precision": None, "recall": None, "HOTA": None}
+
+
+def _mean_metric(records: List[Dict[str, Any]], key: str) -> float:
+    if not records:
+        return 0.0
+    return float(np.mean([r.get(key, 0.0) for r in records]))
+
+
+def rvos_aggregate_f1(results):
+    if results:
+        path = _dump_submission(results)
+        eval_logger.info(f"[rvos] Submission saved to {path} ({len(results)} predictions).")
+    return _mean_metric(results, "f1")
+
+
+def rvos_aggregate_precision(results):
+    return _mean_metric(results, "precision")
+
+
+def rvos_aggregate_recall(results):
+    return _mean_metric(results, "recall")
+
+
+def rvos_aggregate_hota(results):
+    return _mean_metric(results, "HOTA")


### PR DESCRIPTION
## Summary

Adds two new video benchmarks to lmms-eval:

### 1. MMOU (`mmou`, `mmou_test_mini`)
[nvidia/MMOU](https://huggingface.co/datasets/nvidia/MMOU) — massive multi-task omni understanding benchmark for long real-world videos, jointly evaluating video + audio + speech.

- Videos are lazily fetched from [sonalkum/MMOU-Videos](https://huggingface.co/datasets/sonalkum/MMOU-Videos) via `hf_hub_download` on first `doc_to_visual` call and cached under `$HF_HOME/mmou/videos/`. Only videos referenced by the evaluated split are downloaded.
- Two configs:
  - `mmou`: unlabeled 15k `train` split — writes a submission JSON compatible with the [MMOU-Eval HF Space](https://huggingface.co/spaces/nvidia/MMOU-Eval).
  - `mmou_test_mini`: labeled 5k `test` split with local accuracy + per-skill / per-duration-bucket breakdowns.
- Verified end-to-end with vLLM Qwen3-VL-4B on `mmou_test_mini` (2 samples → 50% acc, submission JSON produced).

### 2. RVOS tracking (`rvos_ref_davis17`, `rvos_mevis_valid_u`, `rvos_ref_yt_vos`, `rvos_reasonvos`)
4 referring video object segmentation benchmarks, two-stage pipeline.

**Data** (repacked from [FeilongTang/Tracking_Counting_Data](https://huggingface.co/datasets/FeilongTang/Tracking_Counting_Data) into the standard lmms-eval parquet + zip layout):
- [kcz358/RVOS-Ref-DAVIS17](https://huggingface.co/datasets/kcz358/RVOS-Ref-DAVIS17)  (244 queries)
- [kcz358/RVOS-MeViS-ValidU](https://huggingface.co/datasets/kcz358/RVOS-MeViS-ValidU) (793)
- [kcz358/RVOS-Ref-YT-VOS](https://huggingface.co/datasets/kcz358/RVOS-Ref-YT-VOS)   (834)
- [kcz358/RVOS-ReasonVOS](https://huggingface.co/datasets/kcz358/RVOS-ReasonVOS)    (458)

Setting `dataset_kwargs.video: True` auto-extracts `videos.zip` and `masks.zip` to `$HF_HOME/rvos_<task>/{videos,masks}/` on first run.

**Stage 1 (in-process metric)**: the model outputs an XML-formatted point trajectory per object across time. We parse it, load GT masks, and compute per-query **precision / recall / F1 / HOTA** via Hungarian point matching plus point-in-mask checks against pycocotools RLE masks. Predictions are also dumped to `<task>_submission.json`, ready for stage 2.

**Stage 2 (separate CLI, torchrun-friendly)**: `lmms_eval/tasks/rvos/eval_sam2.py` loads `facebook/sam2.1-hiera-large` via the official `SAM2VideoPredictor.from_pretrained(...)`, propagates each query's predicted points through the full video, and computes **J / F / J&F / HOTA** against GT masks. Distributed across ranks by simple slicing; per-query records are all-gathered on rank 0.

Requires `pip install sam2 pycocotools scikit-image opencv-python` for stage 2.

```bash
# Stage 1 (in-process, standard lmms-eval)
bash scripts/run_vllm_generate_eval.sh -t rvos_ref_davis17 -l all
# → rvos_output/ref-davis17_submission.json

# Stage 2 (multi-GPU)
torchrun --nproc-per-node 8 -m lmms_eval.tasks.rvos.eval_sam2 \
  --task rvos_ref_davis17 \
  --predictions rvos_output/ref-davis17_submission.json \
  --output rvos_sam2_output
```

Stage-1 code is adapted from [Feilong607/lmms-eval-ov2-tracking](https://github.com/Feilong607/lmms-eval-ov2-tracking); the `_FRAME_REGEX` pattern is tightened so that segments separated by `"; "` (with spaces) are parsed correctly.

## Verification
- MMOU: vLLM Qwen3-VL-4B on `mmou_test_mini` `--limit 2`, submission JSON + accuracy correct.
- RVOS stage 1: vLLM Qwen3-VL-4B on `rvos_ref_davis17` `--limit 2`; perfect GT-substituted pred → P=R=F1=HOTA=1.0.
- RVOS stage 2: single-GPU and `torchrun --nproc-per-node 2` runs both produce identical J/F/J&F/HOTA, submission → SAM2 propagation → metrics pipeline end-to-end.

## Commits
1. `feat: add MMOU benchmark`
2. `feat: add RVOS tracking benchmarks (Ref-DAVIS17, MeViS, Ref-YT-VOS, ReasonVOS)`