### PR TITLE
fix(rvos, mmou): parse truncated tracks + switch MMOU to self-contained repo

### DIFF
--- a/lmms_eval/tasks/mmou/_default_template_yaml
+++ b/lmms_eval/tasks/mmou/_default_template_yaml
@@ -1,4 +1,4 @@
-dataset_path: nvidia/MMOU
+dataset_path: kcz358/MMOU
 dataset_kwargs:
   token: True
   cache_dir: mmou
@@ -19,4 +19,3 @@ lmms_eval_specific_kwargs:
     post_prompt: "\nAnswer with the option's letter from the given choices directly."
 metadata:
   - version: 0.0
-    video_repo_id: sonalkum/MMOU-Videos

--- a/lmms_eval/tasks/mmou/mmou_test_mini.yaml
+++ b/lmms_eval/tasks/mmou/mmou_test_mini.yaml
@@ -1,6 +1,5 @@
 task: mmou_test_mini
 include: _default_template_yaml
-dataset_name: test
 test_split: test
 doc_to_target: "correct_option_letter"
 process_results: !function utils.mmou_process_results_scored

--- a/lmms_eval/tasks/mmou/utils.py
+++ b/lmms_eval/tasks/mmou/utils.py
@@ -1,24 +1,23 @@
 """MMOU: Massive Multi-Task Omni Understanding benchmark.
 
-Annotations: ``nvidia/MMOU`` (HF dataset).
-Videos: ``sonalkum/MMOU-Videos`` (flat ``<video_id>.mp4`` files at repo root).
+Repackaged self-contained dataset: ``kcz358/MMOU``
+  data/{train,test}-*.parquet                  annotations for available videos
+  data_missing/{train,test}_missing-*.parquet  annotations whose upstream video is missing
+  videos_chunked_*.zip                          videos/<video_id>.mp4 for main split and
+                                                videos/test/<video_id>.mp4 for Test Mini
 
-Videos are fetched lazily via ``huggingface_hub.hf_hub_download`` and cached
-under the standard HF cache, so only videos referenced by the evaluation split
-(e.g. Test Mini) are downloaded on first use.
+``dataset_kwargs.video=True`` in the yaml lets lmms-eval auto-extract every
+zip into ``$HF_HOME/mmou/`` on first run, so runtime just does a path lookup.
 """
 
 import json
 import os
 import re
-from functools import lru_cache
 from pathlib import Path
 from urllib.parse import parse_qs, urlparse
 
 import yaml
 from loguru import logger as eval_logger
-
-VIDEO_REPO_ID = "sonalkum/MMOU-Videos"
 
 DOMAINS = [
     "Sports",
@@ -47,7 +46,7 @@ video_cache_dir = os.path.join(base_cache_dir, cache_name, "videos")
 
 
 def extract_youtube_id(url: str) -> str:
-    """Extract YouTube video ID from various URL formats."""
+    """Extract YouTube video ID from various URL formats (fallback for pre-packed docs)."""
     parsed = urlparse(url)
     if parsed.hostname == "youtu.be":
         return parsed.path.lstrip("/")
@@ -75,50 +74,29 @@ def duration_bucket(seconds: float) -> str:
     return "> 30"
 
 
-# Videos live either at the repo root (main split) or under ``test/`` (Test Mini).
-_VIDEO_PREFIXES = ("", "test/")
-_VIDEO_EXTS = ("mp4", "MP4", "mkv", "webm")
+def _video_id(doc) -> str:
+    vid = doc.get("video_id")
+    if vid:
+        return str(vid)
+    return extract_youtube_id(doc["video_url"])
 
 
-@lru_cache(maxsize=None)
-def _fetch_video(video_id: str) -> str:
-    """Download a single MMOU video from the HF hub and return its local path.
-
-    Uses ``hf_hub_download`` with ``local_dir=video_cache_dir`` so files land in
-    a predictable location and are only fetched once.
-    """
-    from huggingface_hub import hf_hub_download
-    from huggingface_hub.errors import EntryNotFoundError
-
-    os.makedirs(video_cache_dir, exist_ok=True)
-    for prefix in _VIDEO_PREFIXES:
-        for ext in _VIDEO_EXTS:
-            local_path = os.path.join(video_cache_dir, prefix, f"{video_id}.{ext}")
-            if os.path.exists(local_path):
-                return local_path
-    for prefix in _VIDEO_PREFIXES:
-        for ext in _VIDEO_EXTS:
-            try:
-                return hf_hub_download(
-                    repo_id=VIDEO_REPO_ID,
-                    filename=f"{prefix}{video_id}.{ext}",
-                    repo_type="dataset",
-                    local_dir=video_cache_dir,
-                )
-            except EntryNotFoundError:
-                continue
-            except Exception as e:
-                eval_logger.warning(f"[mmou] hf_hub_download failed for {prefix}{video_id}.{ext}: {e}")
-                continue
+def _resolve_video_path(doc) -> str:
+    vid = _video_id(doc)
+    is_test = bool(doc.get("is_test"))
+    # Test Mini videos land under videos/test/, main split at videos root.
+    for prefix in (("test",) if is_test else ("", "test")):
+        candidate = os.path.join(video_cache_dir, prefix, f"{vid}.mp4") if prefix else os.path.join(video_cache_dir, f"{vid}.mp4")
+        if os.path.exists(candidate):
+            return candidate
     return ""
 
 
 def mmou_doc_to_visual(doc):
-    video_id = extract_youtube_id(doc["video_url"])
-    path = _fetch_video(video_id)
-    if path and os.path.exists(path):
+    path = _resolve_video_path(doc)
+    if path:
         return [path]
-    eval_logger.warning(f"[mmou] Video not found for {video_id} ({doc['video_url']}).")
+    eval_logger.warning(f"[mmou] Video not found for {_video_id(doc)} ({doc.get('video_url')}).")
     return []
 
 
@@ -176,7 +154,7 @@ def _extract_answer(response: str) -> str:
 
 
 def _build_result_dict(doc, pred: str, pred_ans: str) -> dict:
-    video_id = extract_youtube_id(doc["video_url"])
+    video_id = _video_id(doc)
     dur = doc.get("video_duration", 0) or 0
     qtypes = doc.get("question_type", [])
     if isinstance(qtypes, str):

--- a/lmms_eval/tasks/rvos/utils.py
+++ b/lmms_eval/tasks/rvos/utils.py
@@ -116,11 +116,13 @@ def rvos_doc_to_messages(doc, lmms_eval_specific_kwargs=None):
 # ---------------------------------------------------------------------------
 
 
-_COORD_REGEX = re.compile(r'coords\s*=\s*[\'"]([^\'"]+)[\'"]')
+_COORD_REGEX = re.compile(r'coords\s*=\s*[\'"]([^\'"]*)(?:[\'"]|$)')
 # Match one segment "time obj_id x y [obj_id x y ...]" separated by any of ;, \t, , : (and leading start).
 # Trailing/leading spaces around the delimiter are tolerated.
 _FRAME_REGEX = re.compile(r'(?:^|[\t:,;])\s*([0-9]+(?:\.[0-9]+)?)\s+([0-9.\s]+?)(?=[\t:,;]|$)')
-_POINTS_REGEX = re.compile(r'([0-9]+)\s+([0-9]{1,4})\s+([0-9]{1,4})')
+# obj_id / x / y can appear as either ints or floats (e.g. "0.0"). x/y coordinates are
+# in a 0..1000 normalized frame, so cap the integer portion at 4 digits.
+_POINTS_REGEX = re.compile(r'([0-9]+)(?:\.[0-9]+)?\s+([0-9]{1,4})(?:\.[0-9]+)?\s+([0-9]{1,4})(?:\.[0-9]+)?')
 
 
 def parse_xml_tracks(text: str, width: int, height: int, video_fps: float) -> List[Dict[str, Any]]:


### PR DESCRIPTION
Follow-up to #1394.

## RVOS fix
Qwen3-VL-4B (and other models bounded by `max_new_tokens`) frequently exhaust the token budget mid-`<tracks>` tag, leaving the coords string unclosed. The previous `_COORD_REGEX` demanded a matching closing quote so those predictions parsed to zero tracks, driving P=R=F1=HOTA=0 across the whole run.

Also tighten `_POINTS_REGEX` so predictions with float-formatted obj_id / coords (e.g. `"0.0 0.0 1000.0 1000.0"`) still parse — the trailing `.NNN` is now optional on all three integer groups.

Verified on the full DAVIS + MeViS_U runs with Qwen3-VL-4B-Instruct (dp=4, fps=1, max_pixels=401408, max_new_tokens=2048):

| Task | P | R | F1 | HOTA |
|---|---|---|---|---|
| rvos_ref_davis17 (244) | 0.0067 | 0.0067 | 0.0067 | 0.0044 |
| rvos_mevis_valid_u (793) | 0.0136 | 0.0131 | 0.0133 | 0.0131 |

Nonzero-score queries: DAVIS 6/244, MeViS 31/793.

## MMOU refactor
Original setup used `nvidia/MMOU` annotations + `sonalkum/MMOU-Videos` for video files, with a runtime `hf_hub_download` fallback per query. That upstream video repo is also missing ~22 videos entirely.

Replace with a single self-contained [kcz358/MMOU](https://huggingface.co/datasets/kcz358/MMOU) dataset:
- `data/train.parquet` / `data/test.parquet`: docs whose upstream YouTube video is available (14983 / 4991)
- `data/train_missing.parquet` / `data/test_missing.parquet`: docs whose upstream video is not available (17 / 9)
- 22 × `videos_chunked_*.zip` auto-extracted to `$HF_HOME/mmou/videos/{,test/}<yid>.mp4` by lmms-eval

utils.py:
- Drop the `hf_hub_download` fetch path entirely.
- Resolve video path directly under the local cache, using the new `video_id` column baked into the parquet (with the URL parser as a fallback).