### PR TITLE
refactor(mmou, rvos): write submissions under <output_path>/submissions/

### DIFF
--- a/lmms_eval/tasks/mmou/utils.py
+++ b/lmms_eval/tasks/mmou/utils.py
@@ -201,10 +201,14 @@ def mmou_process_results_scored(doc, results):
     return {"mmou_accuracy": data}
 
 
-def _write_submission(results, filename: str) -> str:
-    output_dir = os.environ.get("MMOU_OUTPUT_DIR", "mmou_output")
-    os.makedirs(output_dir, exist_ok=True)
-    path = os.path.join(output_dir, filename)
+def _write_submission(results, filename: str, args) -> str:
+    import datetime
+    from lmms_eval.tasks._task_utils import file_utils
+
+    stem, _, ext = filename.rpartition(".")
+    ts = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+    file_name = f"{stem}_{ts}.{ext}" if stem else f"{filename}_{ts}"
+    path = file_utils.generate_submission_file(file_name, args)
     submission = [{"question_id": r["question_id"], "answer": r["answer"]} for r in results]
     with open(path, "w", encoding="utf-8") as f:
         json.dump(submission, f, indent=2, ensure_ascii=False)
@@ -230,8 +234,8 @@ def _log_breakdown(results):
         eval_logger.info(f"  {k}: {v}")
 
 
-def mmou_aggregate_submission(results):
-    path = _write_submission(results, "mmou_submission.json")
+def mmou_aggregate_submission(results, args):
+    path = _write_submission(results, "mmou_submission.json", args)
     eval_logger.info(
         f"MMOU submission saved to {path} ({len(results)} predictions). "
         "Upload to https://huggingface.co/spaces/nvidia/MMOU-Eval for scoring."
@@ -240,15 +244,13 @@ def mmou_aggregate_submission(results):
     return len(results)
 
 
-def mmou_aggregate_accuracy(results):
-    path = _write_submission(results, "mmou_test_mini_submission.json")
+def mmou_aggregate_accuracy(results, args):
     total = len(results)
     if total == 0:
         return 0.0
     correct = sum(r["score"] for r in results)
     acc = correct / total * 100
     eval_logger.info(f"MMOU Test Mini Accuracy: {acc:.2f}% [{correct}/{total}]")
-    eval_logger.info(f"MMOU predictions saved to {path}")
 
     per_skill = {}
     for r in results:

--- a/lmms_eval/tasks/rvos/utils.py
+++ b/lmms_eval/tasks/rvos/utils.py
@@ -494,17 +494,17 @@ def rvos_process_results(doc, results):
 # ---------------------------------------------------------------------------
 
 
-def _dump_submission(records: List[Dict[str, Any]]) -> str:
+def _dump_submission(records: List[Dict[str, Any]], args) -> str:
+    import datetime
+    from lmms_eval.tasks._task_utils import file_utils
+
     task = records[0]["id"].split("_track_")[0] if records else "rvos"
-    output_dir = os.environ.get("RVOS_OUTPUT_DIR", "rvos_output")
-    os.makedirs(output_dir, exist_ok=True)
-    path = os.path.join(output_dir, f"{task}_submission.json")
+    ts = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+    file_name = f"{task}_submission_{ts}.json"
+    path = file_utils.generate_submission_file(file_name, args)
     with open(path, "w") as f:
         json.dump(records, f)
     return path
-
-
-_MEAN = {"f1": None, "precision": None, "recall": None, "HOTA": None}
 
 
 def _mean_metric(records: List[Dict[str, Any]], key: str) -> float:
@@ -513,20 +513,20 @@ def _mean_metric(records: List[Dict[str, Any]], key: str) -> float:
     return float(np.mean([r.get(key, 0.0) for r in records]))
 
 
-def rvos_aggregate_f1(results):
+def rvos_aggregate_f1(results, args):
     if results:
-        path = _dump_submission(results)
+        path = _dump_submission(results, args)
         eval_logger.info(f"[rvos] Submission saved to {path} ({len(results)} predictions).")
     return _mean_metric(results, "f1")
 
 
-def rvos_aggregate_precision(results):
+def rvos_aggregate_precision(results, args):
     return _mean_metric(results, "precision")
 
 
-def rvos_aggregate_recall(results):
+def rvos_aggregate_recall(results, args):
     return _mean_metric(results, "recall")
 
 
-def rvos_aggregate_hota(results):
+def rvos_aggregate_hota(results, args):
     return _mean_metric(results, "HOTA")


### PR DESCRIPTION
Both tasks used to dump submission JSON to a hard-coded `./mmou_output/` or `./rvos_output/` directory (overridable via env vars), which put them far from the sibling `samples_*.jsonl` produced by the evaluator.

Switch to `lmms_eval.tasks._task_utils.file_utils.generate_submission_file`, same helper that `charades_sta` uses. Result: submissions land in `<output_path>/submissions/<name>_<timestamp>.json` alongside the per-model logs, and repeated runs no longer clobber each other.

Aggregation signatures updated to accept `(results, args)` as required by the helper. The `mmou_test_mini` branch already reports local accuracy so drop its extra submission dump.

## Verification
```
logs/vllm_generate_rvos_ref_davis17_l4/
├── submissions/
│   └── ref-davis17_submission_20260715_004505.json
└── Qwen__Qwen3-VL-4B-Instruct/
    ├── 20260715_154254_results.json
    └── 20260715_154254_samples_rvos_ref_davis17.jsonl
```