### PR TITLE
fix: key RoboSpatial mask cache by content

### DIFF
--- a/lmms_eval/tasks/robo_spatial/utils.py
+++ b/lmms_eval/tasks/robo_spatial/utils.py
@@ -66,10 +66,14 @@ def _save_mask(doc):
         except Exception:
             return {"mask_path": ""}
     if isinstance(mask, Image.Image):
-        doc_hash = hashlib.md5(doc.get("question", "").encode()).hexdigest()
-        mask_path = os.path.join(_MASK_CACHE_DIR, f"{doc_hash}.png")
+        buffer = BytesIO()
+        mask.save(buffer, format="PNG")
+        payload = buffer.getvalue()
+        mask_hash = hashlib.md5(payload).hexdigest()
+        mask_path = os.path.join(_MASK_CACHE_DIR, f"{mask_hash}.png")
         if not os.path.exists(mask_path):
-            mask.save(mask_path)
+            with open(mask_path, "wb") as f:
+                f.write(payload)
         return {"mask_path": mask_path}
     return {"mask_path": ""}
 

--- a/test/eval/test_robo_spatial_utils.py
+++ b/test/eval/test_robo_spatial_utils.py
@@ -1,0 +1,18 @@
+import numpy as np
+from PIL import Image
+
+from lmms_eval.tasks.robo_spatial import utils
+
+
+def test_save_mask_keys_cache_by_mask_content(monkeypatch, tmp_path):
+    monkeypatch.setattr(utils, "_MASK_CACHE_DIR", str(tmp_path))
+    question = "Place the object to the left."
+    first_mask = Image.fromarray(np.array([[0, 255], [0, 0]], dtype=np.uint8))
+    second_mask = Image.fromarray(np.array([[0, 0], [255, 0]], dtype=np.uint8))
+
+    first = utils._save_mask({"question": question, "mask": first_mask})
+    second = utils._save_mask({"question": question, "mask": second_mask})
+
+    assert first["mask_path"] != second["mask_path"]
+    np.testing.assert_array_equal(np.array(Image.open(first["mask_path"])), np.array(first_mask))
+    np.testing.assert_array_equal(np.array(Image.open(second["mask_path"])), np.array(second_mask))


### PR DESCRIPTION
## Summary

Key RoboSpatial's temporary mask cache by the serialized mask content instead of the question text.

`RoboSpatial-Home` contains repeated question strings for different images/masks. The current question-only key maps those rows to the same path, and `_save_mask` keeps the first file because it only writes when the path does not exist. Later samples can therefore be scored against a different sample's mask.

This change serializes the decoded mask once, hashes those PNG bytes, and writes the same payload to the cache. No parsing, prompt, generation, or metric behavior is changed.

## Test

- Added a regression test with one question and two different masks; it verifies distinct cache paths and preserved mask contents.
- `python -m pytest -q test/eval/test_robo_spatial_utils.py` (`1 passed`)
