### PR TITLE
fix: raise RoboSpatial context generation limit

### DIFF
--- a/lmms_eval/tasks/robo_spatial/robo_spatial_context.yaml
+++ b/lmms_eval/tasks/robo_spatial/robo_spatial_context.yaml
@@ -1,3 +1,7 @@
 task: robo_spatial_context
 include: _default_template.yaml
 test_split: context
+generation_kwargs:
+  max_new_tokens: 512
+  temperature: 0
+  do_sample: false


### PR DESCRIPTION
## Summary

Set an explicit 512-token generation limit for `robo_spatial_context`.

The task currently inherits each model adapter's default. For Qwen3-VL that default is 128 output tokens. In a 122-sample checkpoint evaluation, 25 responses reached the cap and ended with incomplete point-list JSON, which makes otherwise parseable predictions score as empty.

This is scoped to the pointing split: the compatibility and configuration splits are short yes/no responses and remain unchanged. A 512-token cap provides 4x the current Qwen3-VL headroom without allowing the unusually long generations observed with a 2048-token cap.

This changes output generation only; prompt/image input lengths are unaffected.

## Test

- Parsed the task YAML and verified the resolved `generation_kwargs` values and types.
