### PR TITLE
[Model] Add Neo-OV model support and SI benchmark configs

### DIFF
--- a/lmms_eval/models/__init__.py
+++ b/lmms_eval/models/__init__.py
@@ -127,6 +127,7 @@ AVAILABLE_CHAT_TEMPLATE_MODELS = {
     "internvl_hf": "InternVLHf",
     "llava_hf": "LlavaHf",
     "nanovlm": "NanoVLM",
+    "neo_ov": "NeoOV",
     "phi4_multimodal": "Phi4",
     "qwen3_vl": "Qwen3_VL",
     "qwen3_5": "Qwen3_5",

--- a/lmms_eval/models/chat/neo_ov.py
+++ b/lmms_eval/models/chat/neo_ov.py
@@ -113,11 +113,7 @@ def _preprocess_pixel_values(pixel_values: torch.Tensor, patch_size: int = 16) -
     c, h, w = pixel_values.shape
     grid_h = h // patch_size
     grid_w = w // patch_size
-    flat_pixel_values = (
-        pixel_values.view(c, grid_h, patch_size, grid_w, patch_size)
-        .permute(1, 3, 0, 2, 4)
-        .reshape(grid_h * grid_w, c * patch_size**2)
-    )
+    flat_pixel_values = pixel_values.view(c, grid_h, patch_size, grid_w, patch_size).permute(1, 3, 0, 2, 4).reshape(grid_h * grid_w, c * patch_size**2)
     return flat_pixel_values, torch.tensor([[grid_h, grid_w]], device=pixel_values.device)
 
 

--- a/lmms_eval/models/chat/neo_ov.py
+++ b/lmms_eval/models/chat/neo_ov.py
@@ -1,0 +1,395 @@
+import math
+import os
+import re
+import time
+from pathlib import Path
+from typing import Any, List, Optional, Tuple, Union
+
+import torch
+import torchvision.transforms as T
+from accelerate import Accelerator, DistributedType
+from loguru import logger as eval_logger
+from PIL import Image
+from tqdm import tqdm
+from transformers import AutoModel, AutoTokenizer
+
+from lmms_eval.api.instance import GenerationResult, Instance, TokenCounts
+from lmms_eval.api.model import lmms
+from lmms_eval.api.registry import register_model
+from lmms_eval.models.model_utils.gen_metrics import log_metrics
+from lmms_eval.protocol import ChatMessages
+
+IMAGENET_MEAN = (0.485, 0.456, 0.406)
+IMAGENET_STD = (0.229, 0.224, 0.225)
+_NON_GENERATE_KEYS = {
+    "add_special_tokens",
+    "downsample_ratio",
+    "enable_thinking",
+    "max_pixels",
+    "min_pixels",
+    "patch_size",
+    "remove_think",
+    "system_prompt",
+    "until",
+    "upscale",
+}
+
+
+def _as_int(value: Any) -> int:
+    return int(float(value))
+
+
+def _as_float(value: Any) -> float:
+    return float(value)
+
+
+def _round_by_factor(number: int, factor: int) -> int:
+    return round(number / factor) * factor
+
+
+def _ceil_by_factor(number: Union[int, float], factor: int) -> int:
+    return math.ceil(number / factor) * factor
+
+
+def _floor_by_factor(number: Union[int, float], factor: int) -> int:
+    return math.floor(number / factor) * factor
+
+
+def _smart_resize(
+    height: int,
+    width: int,
+    factor: int = 32,
+    min_pixels: int = 65536,
+    max_pixels: int = 4194304,
+) -> Tuple[int, int]:
+    if max(height, width) / min(height, width) > 200:
+        raise ValueError(f"absolute aspect ratio must be smaller than 200, got {max(height, width) / min(height, width)}")
+
+    h_bar = max(factor, _round_by_factor(height, factor))
+    w_bar = max(factor, _round_by_factor(width, factor))
+    if h_bar * w_bar > max_pixels:
+        beta = math.sqrt((height * width) / max_pixels)
+        h_bar = max(factor, _floor_by_factor(height / beta, factor))
+        w_bar = max(factor, _floor_by_factor(width / beta, factor))
+    elif h_bar * w_bar < min_pixels:
+        beta = math.sqrt(min_pixels / (height * width))
+        h_bar = _ceil_by_factor(height * beta, factor)
+        w_bar = _ceil_by_factor(width * beta, factor)
+    return h_bar, w_bar
+
+
+def _contrasting_background(image: Image.Image) -> Optional[Tuple[int, int, int]]:
+    image_alpha = image.getchannel("A")
+    if not image_alpha.getextrema()[0] == 0:
+        return None
+
+    pixels = image.getdata()
+    non_transparent = [pixel[:3] for pixel in pixels if pixel[3] > 0]
+    if not non_transparent:
+        return None
+    pixel_mean = sum(sum(pixel) for pixel in non_transparent) / (len(non_transparent) * 3)
+    return (0, 0, 0) if pixel_mean > 382.5 else (255, 255, 255)
+
+
+def _ensure_rgb(image: Image.Image) -> Image.Image:
+    if image.mode == "RGBA":
+        bg_color = _contrasting_background(image)
+        if bg_color:
+            background = Image.new("RGB", image.size, bg_color)
+            background.paste(image, mask=image.split()[3])
+            return background.convert("RGB")
+    return image.convert("RGB")
+
+
+def _load_image(image_input: Any) -> Image.Image:
+    if isinstance(image_input, Image.Image):
+        return image_input.copy()
+    if isinstance(image_input, (str, Path, os.PathLike)):
+        return Image.open(image_input)
+    raise TypeError(f"Unsupported image type for neo_ov: {type(image_input)}")
+
+
+def _preprocess_pixel_values(pixel_values: torch.Tensor, patch_size: int = 16) -> Tuple[torch.Tensor, torch.Tensor]:
+    c, h, w = pixel_values.shape
+    grid_h = h // patch_size
+    grid_w = w // patch_size
+    flat_pixel_values = (
+        pixel_values.view(c, grid_h, patch_size, grid_w, patch_size)
+        .permute(1, 3, 0, 2, 4)
+        .reshape(grid_h * grid_w, c * patch_size**2)
+    )
+    return flat_pixel_values, torch.tensor([[grid_h, grid_w]], device=pixel_values.device)
+
+
+def _load_image_native(
+    image_input: Any,
+    patch_size: int = 16,
+    downsample_ratio: float = 0.5,
+    min_pixels: int = 65536,
+    max_pixels: int = 4194304,
+    upscale: bool = False,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    image = _ensure_rgb(_load_image(image_input))
+    if upscale:
+        image = image.resize((image.width * 2, image.height * 2), Image.BILINEAR)
+
+    resized_height, resized_width = _smart_resize(
+        image.height,
+        image.width,
+        factor=int(patch_size // downsample_ratio),
+        min_pixels=min_pixels,
+        max_pixels=max_pixels,
+    )
+    image = image.resize((resized_width, resized_height))
+
+    transform = T.Compose(
+        [
+            T.Lambda(lambda img: img.convert("RGB") if img.mode != "RGB" else img),
+            T.ToTensor(),
+            T.Normalize(mean=IMAGENET_MEAN, std=IMAGENET_STD),
+        ],
+    )
+    return _preprocess_pixel_values(transform(image).to(torch.float32), patch_size=patch_size)
+
+
+@register_model("neo_ov")
+class NeoOV(lmms):
+    is_simple = False
+
+    def __init__(
+        self,
+        pretrained: str = "Paranioar/NEO1_5-2B-SFT",
+        device: Optional[str] = "cuda",
+        device_map: Optional[str] = "auto",
+        batch_size: Optional[Union[int, str]] = 1,
+        load_in_8bit: bool = False,
+        trust_remote_code: bool = True,
+        torch_dtype: str = "bfloat16",
+        patch_size: int = 16,
+        min_pixels: int = 65536,
+        max_pixels: int = 4194304,
+        downsample_ratio: float = 0.5,
+        system_prompt: Optional[str] = "Reason step by step.",
+        max_new_tokens: int = 4096,
+        **kwargs,
+    ) -> None:
+        super().__init__()
+        assert kwargs == {}, f"Unexpected kwargs: {kwargs}"
+
+        accelerator = Accelerator()
+        self.accelerator = accelerator
+        if accelerator.num_processes > 1:
+            self._device = torch.device(f"cuda:{accelerator.local_process_index}")
+            self.device_map = f"cuda:{accelerator.local_process_index}"
+        else:
+            self._device = torch.device(device)
+            self.device_map = device_map if device_map else device
+
+        dtype = getattr(torch, torch_dtype) if isinstance(torch_dtype, str) else torch_dtype
+        self._tokenizer = AutoTokenizer.from_pretrained(pretrained, trust_remote_code=trust_remote_code, use_fast=False)
+        self._model = AutoModel.from_pretrained(
+            pretrained,
+            torch_dtype=dtype,
+            load_in_8bit=load_in_8bit,
+            trust_remote_code=trust_remote_code,
+            low_cpu_mem_usage=True,
+            device_map=self.device_map,
+        ).eval()
+
+        self.batch_size_per_gpu = int(batch_size)
+        self.patch_size = _as_int(patch_size)
+        self.min_pixels = _as_int(min_pixels)
+        self.max_pixels = _as_int(max_pixels)
+        self.downsample_ratio = _as_float(downsample_ratio)
+        self.system_prompt = system_prompt
+        self.max_new_tokens = _as_int(max_new_tokens)
+        self._config = self.model.config
+        self._max_length = getattr(self._config, "max_position_embeddings", 2048)
+
+        if accelerator.num_processes > 1:
+            assert accelerator.distributed_type in [
+                DistributedType.FSDP,
+                DistributedType.MULTI_GPU,
+            ], "Unsupported distributed type provided. Only DDP and FSDP are supported."
+            if accelerator.distributed_type == DistributedType.FSDP:
+                self._model = accelerator.prepare(self.model)
+            else:
+                self._model = accelerator.prepare_model(self.model, evaluation_mode=True)
+            if self.accelerator.is_local_main_process:
+                eval_logger.info(f"Using {accelerator.num_processes} devices with data parallelism")
+            self._rank = self.accelerator.local_process_index
+            self._world_size = self.accelerator.num_processes
+        else:
+            self._rank = 0
+            self._world_size = 1
+
+    @property
+    def config(self):
+        return self._config
+
+    @property
+    def tokenizer(self):
+        return self._tokenizer
+
+    @property
+    def model(self):
+        return self.accelerator.unwrap_model(self._model) if hasattr(self, "accelerator") else self._model
+
+    @property
+    def eot_token_id(self):
+        return self.tokenizer.eos_token_id
+
+    @property
+    def max_length(self):
+        return self._max_length
+
+    @property
+    def batch_size(self):
+        return self.batch_size_per_gpu
+
+    @property
+    def device(self):
+        return self._device
+
+    @property
+    def rank(self):
+        return self._rank
+
+    @property
+    def world_size(self):
+        return self._world_size
+
+    def loglikelihood(self, requests: List[Instance]) -> List[Tuple[float, bool]]:
+        raise NotImplementedError("Loglikelihood is not implemented for neo_ov")
+
+    def generate_until_multi_round(self, requests: List[Instance]) -> List[GenerationResult]:
+        raise NotImplementedError("Multi-round generation is not implemented for neo_ov")
+
+    def _serialize_messages(self, messages: ChatMessages) -> Tuple[str, List[Any], Optional[str]]:
+        prompt_parts = []
+        images = []
+        system_prompt = None
+
+        for message in messages.messages:
+            if message.role == "system":
+                system_text = "\n".join(content.text for content in message.content if content.type == "text").strip()
+                if system_text:
+                    system_prompt = system_text
+                continue
+
+            for content in message.content:
+                if content.type == "text":
+                    prompt_parts.append(content.text)
+                elif content.type == "image":
+                    prompt_parts.append("<image>\n")
+                    images.append(content.url)
+                elif content.type in {"video", "audio"}:
+                    raise NotImplementedError(f"neo_ov currently supports image inputs only, got {content.type}")
+
+        return "".join(prompt_parts).strip(), images, system_prompt
+
+    def _build_image_inputs(
+        self,
+        images: List[Any],
+        gen_kwargs: dict,
+    ) -> Tuple[Optional[torch.Tensor], Optional[torch.Tensor]]:
+        if not images:
+            return None, None
+
+        patch_size = _as_int(gen_kwargs.get("patch_size", self.patch_size))
+        min_pixels = _as_int(gen_kwargs.get("min_pixels", self.min_pixels))
+        max_pixels = _as_int(gen_kwargs.get("max_pixels", self.max_pixels))
+        downsample_ratio = _as_float(gen_kwargs.get("downsample_ratio", self.downsample_ratio))
+        upscale_value = gen_kwargs.get("upscale", False)
+        upscale = str(upscale_value).lower() == "true" if isinstance(upscale_value, str) else bool(upscale_value)
+
+        pixel_values_list = []
+        grid_hw_list = []
+        for image in images:
+            pixel_values, grid_hw = _load_image_native(
+                image,
+                patch_size=patch_size,
+                downsample_ratio=downsample_ratio,
+                min_pixels=min_pixels,
+                max_pixels=max_pixels,
+                upscale=upscale,
+            )
+            target_device = "cuda" if self.device_map == "auto" else self.device
+            pixel_values_list.append(pixel_values.to(target_device).to(torch.bfloat16))
+            grid_hw_list.append(grid_hw.to(target_device))
+
+        return torch.cat(pixel_values_list, dim=0), torch.cat(grid_hw_list, dim=0)
+
+    def _build_generation_config(self, gen_kwargs: dict) -> dict:
+        generation_config = {
+            "do_sample": False,
+            "max_new_tokens": self.max_new_tokens,
+            "top_p": None,
+        }
+        generation_config.update({k: v for k, v in gen_kwargs.items() if k not in _NON_GENERATE_KEYS})
+
+        if generation_config.get("do_sample") is False:
+            if generation_config.get("temperature", None) == 0:
+                generation_config["temperature"] = None
+            if generation_config.get("top_p", None) == 1.0:
+                generation_config["top_p"] = None
+        return {k: v for k, v in generation_config.items() if v is not None}
+
+    @staticmethod
+    def _strip_thinking(response: str) -> str:
+        response = re.sub(r"<think>.*?</think>", "", response, flags=re.DOTALL | re.IGNORECASE)
+        response = re.sub(r"<thinking>.*?</thinking>", "", response, flags=re.DOTALL | re.IGNORECASE)
+        return response.strip()
+
+    @torch.no_grad()
+    def generate_until(self, requests: List[Instance]) -> List[GenerationResult]:
+        res = []
+        pbar = tqdm(total=len(requests), disable=(self.rank != 0), desc="Model Responding")
+        total_elapsed_time = 0
+        total_tokens = 0
+
+        for request in requests:
+            ctx, doc_to_messages, gen_kwargs, doc_id, task, split = request.args
+            doc = self.task_dict[task][split][doc_id]
+            messages = ChatMessages(**{"messages": doc_to_messages(doc)})
+            prompt, images, message_system_prompt = self._serialize_messages(messages)
+            request_system_prompt = gen_kwargs.get("system_prompt", message_system_prompt if message_system_prompt is not None else self.system_prompt)
+            if request_system_prompt is not None:
+                self.model.system_message = str(request_system_prompt).replace("\\n", "\n")
+
+            pixel_values, grid_hw = self._build_image_inputs(images, gen_kwargs)
+            generation_config = self._build_generation_config(gen_kwargs)
+
+            start_time = time.time()
+            response = self.model.chat(
+                self.tokenizer,
+                pixel_values=pixel_values,
+                grid_hw=grid_hw,
+                question=prompt,
+                generation_config=generation_config,
+                verbose=self.rank == 0,
+            )
+            end_time = time.time()
+
+            if gen_kwargs.get("remove_think", False):
+                response = self._strip_thinking(response)
+
+            output_tokens = len(self.tokenizer.encode(response, add_special_tokens=False))
+            total_elapsed_time += end_time - start_time
+            total_tokens += output_tokens
+            res.append(GenerationResult(text=response, token_counts=TokenCounts(output_tokens=output_tokens)))
+            self.cache_hook.add_partial("generate_until", (ctx, gen_kwargs), response)
+            eval_logger.debug(f"Question: {prompt}")
+            eval_logger.debug(f"Model Response: {response}")
+            pbar.update(1)
+
+        avg_speed = total_tokens / total_elapsed_time if total_elapsed_time > 0 else 0
+        log_metrics(
+            total_gen_tokens=total_tokens,
+            total_elapsed_time=total_elapsed_time,
+            avg_speed=avg_speed,
+            additional_metrics={"rank": self.rank},
+        )
+
+        pbar.close()
+        return res

--- a/lmms_eval/tasks/3dsrbench/_default_template_yaml
+++ b/lmms_eval/tasks/3dsrbench/_default_template_yaml
@@ -9,6 +9,7 @@ generation_kwargs:
 output_type: generate_until
 doc_to_visual: !function utils.doc_to_visual
 doc_to_text: !function utils.doc_to_text
+doc_to_messages: !function utils.doc_to_messages
 doc_to_target: "answer"
 process_results: !function utils.process_results
 
@@ -16,6 +17,22 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: "Please select the correct answer from the options above. \n"
+  neo_ov:
+    pre_prompt: ""
+    post_prompt: ""
+    prompt_format: neo_ov
+
+model_specific_generation_kwargs:
+  neo_ov:
+    patch_size: 16
+    min_pixels: 691200
+    max_pixels: 691200
+    downsample_ratio: 0.5
+    system_prompt: ""
+    max_new_tokens: 4096
+    temperature: null
+    top_p: null
+    repetition_penalty: null
 
 metadata:
   - version: 0.0

--- a/lmms_eval/tasks/3dsrbench/utils.py
+++ b/lmms_eval/tasks/3dsrbench/utils.py
@@ -101,6 +101,47 @@ def doc_to_text(doc, lmms_eval_specific_kwargs=None):
     return prompt
 
 
+def _format_neo_ov_content(images, prompt):
+    if len(images) == 1:
+        return [{"type": "image", "url": images[0]}, {"type": "text", "text": prompt}]
+
+    content = []
+    for idx, image in enumerate(images, start=1):
+        content.append({"type": "text", "text": f"Image-{idx}: "})
+        content.append({"type": "image", "url": image})
+    content.append({"type": "text", "text": prompt})
+    return content
+
+
+def _doc_to_neo_ov_prompt(doc):
+    question = doc["question"].replace("<image>", "").strip()
+
+    for cand in string.ascii_uppercase:
+        if cand in doc and doc[cand] is not None:
+            val = doc[cand]
+            if isinstance(val, str) and val.lower() == "nan":
+                continue
+            if pd.isna(val):
+                continue
+            question += f"\n{cand}. {val}"
+
+    return question + "\nAnswer with the option's letter from the given choices directly."
+
+
+def doc_to_messages(doc, lmms_eval_specific_kwargs=None):
+    lmms_eval_specific_kwargs = lmms_eval_specific_kwargs or {}
+    images = doc_to_visual(doc)
+
+    if lmms_eval_specific_kwargs.get("prompt_format") == "neo_ov":
+        prompt = _doc_to_neo_ov_prompt(doc)
+        return [{"role": "user", "content": _format_neo_ov_content(images, prompt)}]
+
+    prompt = doc_to_text(doc, lmms_eval_specific_kwargs)
+    content = [{"type": "image", "url": image} for image in images]
+    content.append({"type": "text", "text": prompt})
+    return [{"role": "user", "content": content}]
+
+
 def extract_answer(text: str) -> Optional[str]:
     """Extract the answer letter (A, B, C, D) from the model's response.
 

--- a/lmms_eval/tasks/blink/_default_template_yaml
+++ b/lmms_eval/tasks/blink/_default_template_yaml
@@ -3,6 +3,7 @@ test_split: val
 output_type: generate_until
 doc_to_visual: !function utils.blink_doc_to_visual
 doc_to_text: !function utils.blink_doc_to_text
+doc_to_messages: !function utils.blink_doc_to_messages
 doc_to_target: "answer"
 
 process_results: !function utils.blink_process_results
@@ -16,6 +17,22 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: "Note: You only need to respond with {} without providing any additional information.\n"
     post_prompt: ""
+  neo_ov:
+    pre_prompt: ""
+    post_prompt: ""
+    prompt_format: neo_ov
+
+model_specific_generation_kwargs:
+  neo_ov:
+    patch_size: 16
+    min_pixels: 691200
+    max_pixels: 691200
+    downsample_ratio: 0.5
+    system_prompt: ""
+    max_new_tokens: 4096
+    temperature: null
+    top_p: null
+    repetition_penalty: null
 
 generation_kwargs:
   max_new_tokens: 1024

--- a/lmms_eval/tasks/blink/utils.py
+++ b/lmms_eval/tasks/blink/utils.py
@@ -1,4 +1,5 @@
 import re
+import string
 from typing import Any, Dict, List, Optional
 
 from lmms_eval.tasks._task_utils.default_template_yaml import load_default_template_yaml
@@ -46,6 +47,54 @@ def blink_doc_to_visual(doc: dict) -> list:
         if image is not None:
             image_list.append(image.convert("RGB"))
     return image_list
+
+
+def _format_neo_ov_content(images: list, prompt: str) -> list:
+    if len(images) == 1:
+        return [{"type": "image", "url": images[0]}, {"type": "text", "text": prompt}]
+
+    content = []
+    for idx, image in enumerate(images, start=1):
+        content.append({"type": "text", "text": f"Image-{idx}: "})
+        content.append({"type": "image", "url": image})
+    content.append({"type": "text", "text": prompt})
+    return content
+
+
+def _blink_neo_ov_prompt(doc: dict[str, Any]) -> str:
+    prompt = doc.get("prompt")
+    if prompt:
+        prompt = prompt.replace("<image>", "").strip()
+        return prompt + "\nAnswer with the option's letter from the given choices directly."
+
+    question = doc["question"].replace("<image>", "").strip()
+    hint = doc.get("hint")
+    if hint is not None and hint == hint:
+        question = f"{hint}\n{question}"
+
+    choices = doc.get("choices", [])
+    for idx, item in enumerate(choices):
+        question += f"\n{string.ascii_uppercase[idx]}. {item}"
+
+    if choices:
+        question += "\nAnswer with the option's letter from the given choices directly."
+    else:
+        question += "\nAnswer the question directly."
+    return question
+
+
+def blink_doc_to_messages(doc: dict[str, Any], lmms_eval_specific_kwargs: Optional[dict[str, Any]] = None) -> list:
+    lmms_eval_specific_kwargs = lmms_eval_specific_kwargs or {}
+    images = blink_doc_to_visual(doc)
+
+    if lmms_eval_specific_kwargs.get("prompt_format") == "neo_ov":
+        prompt = _blink_neo_ov_prompt(doc)
+        return [{"role": "user", "content": _format_neo_ov_content(images, prompt)}]
+
+    prompt = blink_doc_to_text(doc, lmms_eval_specific_kwargs)
+    content = [{"type": "image", "url": image} for image in images]
+    content.append({"type": "text", "text": prompt})
+    return [{"role": "user", "content": content}]
 
 
 def blink_process_results(doc: Dict, result: List[str]) -> Dict[str, Dict]:

--- a/lmms_eval/tasks/embspatial/_default_template_yaml
+++ b/lmms_eval/tasks/embspatial/_default_template_yaml
@@ -3,6 +3,7 @@ test_split: test
 output_type: generate_until
 doc_to_visual: !function utils.embspatial_doc_to_visual
 doc_to_text: !function utils.embspatial_doc_to_text
+doc_to_messages: !function utils.embspatial_doc_to_messages
 doc_to_target: "answer"
 
 process_results: !function utils.embspatial_process_results
@@ -25,6 +26,22 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: "Note: You only need to respond with A, B, C, D without providing any additional information.\n"
     post_prompt: ""
+  neo_ov:
+    pre_prompt: ""
+    post_prompt: ""
+    prompt_format: neo_ov
+
+model_specific_generation_kwargs:
+  neo_ov:
+    patch_size: 16
+    min_pixels: 691200
+    max_pixels: 691200
+    downsample_ratio: 0.5
+    system_prompt: ""
+    max_new_tokens: 4096
+    temperature: null
+    top_p: null
+    repetition_penalty: null
 
 generation_kwargs:
   max_new_tokens: 1024

--- a/lmms_eval/tasks/embspatial/utils.py
+++ b/lmms_eval/tasks/embspatial/utils.py
@@ -1,5 +1,6 @@
 import logging
 import re
+import string
 from collections import defaultdict
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -56,6 +57,45 @@ def embspatial_doc_to_text(doc: dict[str, Any], lmms_eval_specific_kwargs: Optio
 
 def embspatial_doc_to_visual(doc: dict) -> list:
     return [doc["image"].convert("RGB")]
+
+
+def _format_neo_ov_content(images: list, prompt: str) -> list:
+    if len(images) == 1:
+        return [{"type": "image", "url": images[0]}, {"type": "text", "text": prompt}]
+
+    content = []
+    for idx, image in enumerate(images, start=1):
+        content.append({"type": "text", "text": f"Image-{idx}: "})
+        content.append({"type": "image", "url": image})
+    content.append({"type": "text", "text": prompt})
+    return content
+
+
+def _embspatial_neo_ov_prompt(doc: dict[str, Any]) -> str:
+    question = doc["question"].replace("<image>", "").strip()
+    hint = doc.get("hint")
+    if hint is not None and hint == hint:
+        question = f"{hint}\n{question}"
+
+    options = doc["answer_options"]
+    for idx, item in enumerate(options):
+        question += f"\n{string.ascii_uppercase[idx]}. {item}"
+
+    return question + "\nAnswer with the option's letter from the given choices directly."
+
+
+def embspatial_doc_to_messages(doc: dict[str, Any], lmms_eval_specific_kwargs: Optional[dict[str, Any]] = None) -> list:
+    lmms_eval_specific_kwargs = lmms_eval_specific_kwargs or {}
+    images = embspatial_doc_to_visual(doc)
+
+    if lmms_eval_specific_kwargs.get("prompt_format") == "neo_ov":
+        prompt = _embspatial_neo_ov_prompt(doc)
+        return [{"role": "user", "content": _format_neo_ov_content(images, prompt)}]
+
+    prompt = embspatial_doc_to_text(doc, lmms_eval_specific_kwargs)
+    content = [{"type": "image", "url": image} for image in images]
+    content.append({"type": "text", "text": prompt})
+    return [{"role": "user", "content": content}]
 
 
 DATA_SOURCES = ["ai2thor", "mp3d", "scannet"]

--- a/lmms_eval/tasks/mindcube/_default_template_yaml
+++ b/lmms_eval/tasks/mindcube/_default_template_yaml
@@ -10,8 +10,26 @@ generation_kwargs:
 output_type: generate_until
 doc_to_visual: !function utils.mindcube_doc_to_visual
 doc_to_text: !function utils.mindcube_doc_to_text
+doc_to_messages: !function utils.mindcube_doc_to_messages
 doc_to_target: "grounded_output"
 process_results: !function utils.mindcube_process_results
+
+lmms_eval_specific_kwargs:
+  neo_ov:
+    pre_prompt: ""
+    post_prompt: ""
+    prompt_format: neo_ov
+
+model_specific_generation_kwargs:
+  neo_ov:
+    patch_size: 16
+    min_pixels: 691200
+    max_pixels: 691200
+    downsample_ratio: 0.5
+    system_prompt: ""
+    temperature: null
+    top_p: null
+    repetition_penalty: null
 
 metric_list:
   - metric: overall_accuracy

--- a/lmms_eval/tasks/mindcube/utils.py
+++ b/lmms_eval/tasks/mindcube/utils.py
@@ -2,7 +2,7 @@ import re
 from typing import Optional
 
 
-def mindcube_doc_to_text(doc):
+def mindcube_doc_to_text(doc, lmms_eval_specific_kwargs=None):
     """Extracts the text prompt from a MindCube dataset sample.
 
     Args:
@@ -27,6 +27,44 @@ def mindcube_doc_to_visual(doc):
         list: A list of visual elements (e.g., PIL Images) converted to 'RGB' format.
     """
     return [visual.convert("RGB") for visual in doc["images"]]
+
+
+def _mindcube_interleaved_messages(prompt, images):
+    content = []
+    prompt_parts = prompt.split("<image>")
+    for idx, part in enumerate(prompt_parts):
+        text = part.strip()
+        if text:
+            content.append({"type": "text", "text": text})
+        if idx != len(prompt_parts) - 1 and idx < len(images):
+            content.append({"type": "image", "url": images[idx]})
+    return [{"role": "user", "content": content}]
+
+
+def _mindcube_neo_ov_messages(doc, images):
+    question = doc["question"].replace("<image>", "").strip()
+    prompt = f"{question}\nAnswer the question directly."
+
+    content = []
+    for idx, image in enumerate(images, start=1):
+        content.append({"type": "text", "text": f"Image-{idx}: "})
+        content.append({"type": "image", "url": image})
+    content.append({"type": "text", "text": prompt})
+    return [{"role": "user", "content": content}]
+
+
+def mindcube_doc_to_messages(doc, lmms_eval_specific_kwargs=None):
+    """Builds an interleaved chat message from MindCube's <image> placeholders."""
+    lmms_eval_specific_kwargs = lmms_eval_specific_kwargs or {}
+    pre_prompt = lmms_eval_specific_kwargs.get("pre_prompt", "")
+    post_prompt = lmms_eval_specific_kwargs.get("post_prompt", "")
+    images = [visual.convert("RGB") for visual in doc["images"]]
+
+    if lmms_eval_specific_kwargs.get("prompt_format") == "neo_ov":
+        return _mindcube_neo_ov_messages(doc, images)
+
+    prompt = f"{pre_prompt}{doc['input_prompt']}{post_prompt}"
+    return _mindcube_interleaved_messages(prompt, images)
 
 
 # This is taken directly from the official mindcube codebase

--- a/lmms_eval/tasks/mmou/utils.py
+++ b/lmms_eval/tasks/mmou/utils.py
@@ -85,7 +85,7 @@ def _resolve_video_path(doc) -> str:
     vid = _video_id(doc)
     is_test = bool(doc.get("is_test"))
     # Test Mini videos land under videos/test/, main split at videos root.
-    for prefix in (("test",) if is_test else ("", "test")):
+    for prefix in ("test",) if is_test else ("", "test"):
         candidate = os.path.join(video_cache_dir, prefix, f"{vid}.mp4") if prefix else os.path.join(video_cache_dir, f"{vid}.mp4")
         if os.path.exists(candidate):
             return candidate
@@ -139,7 +139,7 @@ def _extract_answer(response: str) -> str:
     for pattern in ("the answer is", "answer:", "the option is", "final answer:"):
         idx = text.lower().rfind(pattern)
         if idx >= 0:
-            text = text[idx + len(pattern):].strip()
+            text = text[idx + len(pattern) :].strip()
             break
     m = re.search(r"\(([A-J])\)", text)
     if m:
@@ -203,6 +203,7 @@ def mmou_process_results_scored(doc, results):
 
 def _write_submission(results, filename: str, args) -> str:
     import datetime
+
     from lmms_eval.tasks._task_utils import file_utils
 
     stem, _, ext = filename.rpartition(".")
@@ -236,10 +237,7 @@ def _log_breakdown(results):
 
 def mmou_aggregate_submission(results, args):
     path = _write_submission(results, "mmou_submission.json", args)
-    eval_logger.info(
-        f"MMOU submission saved to {path} ({len(results)} predictions). "
-        "Upload to https://huggingface.co/spaces/nvidia/MMOU-Eval for scoring."
-    )
+    eval_logger.info(f"MMOU submission saved to {path} ({len(results)} predictions). " "Upload to https://huggingface.co/spaces/nvidia/MMOU-Eval for scoring.")
     _log_breakdown(results)
     return len(results)
 

--- a/lmms_eval/tasks/mmsi_bench/msr_bench.yaml
+++ b/lmms_eval/tasks/mmsi_bench/msr_bench.yaml
@@ -7,6 +7,7 @@ test_split: test
 output_type: generate_until
 doc_to_visual: !function utils.msr_doc_to_visual
 doc_to_text: !function utils.msr_doc_to_text
+doc_to_messages: !function utils.msr_doc_to_messages
 doc_to_target: "answer"
 process_results: !function utils.msr_process_results
   
@@ -14,6 +15,22 @@ lmms_eval_specific_kwargs:
   default:
     pre_prompt: ""
     post_prompt: "\nAnswer with the option's letter from the given choices directly. Enclose the option's letter within ``."
+  neo_ov:
+    pre_prompt: ""
+    post_prompt: ""
+    prompt_format: neo_ov
+
+model_specific_generation_kwargs:
+  neo_ov:
+    patch_size: 16
+    min_pixels: 691200
+    max_pixels: 691200
+    downsample_ratio: 0.5
+    system_prompt: ""
+    max_new_tokens: 4096
+    temperature: null
+    top_p: null
+    repetition_penalty: null
 
 
 generation_kwargs:

--- a/lmms_eval/tasks/mmsi_bench/utils.py
+++ b/lmms_eval/tasks/mmsi_bench/utils.py
@@ -7,6 +7,8 @@ from PIL import Image
 
 eval_logger = logging.getLogger("lmms-eval")
 
+MMSI_DIRECT_POST_PROMPT = "\nAnswer with the option's letter from the given choices directly. Enclose the option's letter within ``."
+
 
 CATEGORY_ALIASES = {
     "Positional Relationship (Obj.-Obj.)": "Positional Relationship (Obj.–Obj.)",
@@ -42,6 +44,36 @@ def msr_doc_to_visual(doc):
             image = Image.open(io.BytesIO(img_data)).convert("RGB")
         image_list.append(image)
     return image_list
+
+
+def _format_neo_ov_content(images, prompt):
+    if len(images) == 1:
+        return [{"type": "image", "url": images[0]}, {"type": "text", "text": prompt}]
+
+    content = []
+    for idx, image in enumerate(images, start=1):
+        content.append({"type": "text", "text": f"Image-{idx}: "})
+        content.append({"type": "image", "url": image})
+    content.append({"type": "text", "text": prompt})
+    return content
+
+
+def _msr_neo_ov_prompt(doc):
+    return f"{doc['question'].strip()}{MMSI_DIRECT_POST_PROMPT}"
+
+
+def msr_doc_to_messages(doc, lmms_eval_specific_kwargs=None):
+    lmms_eval_specific_kwargs = lmms_eval_specific_kwargs or {}
+    images = msr_doc_to_visual(doc)
+
+    if lmms_eval_specific_kwargs.get("prompt_format") == "neo_ov":
+        prompt = _msr_neo_ov_prompt(doc)
+        return [{"role": "user", "content": _format_neo_ov_content(images, prompt)}]
+
+    prompt = msr_doc_to_text(doc, lmms_eval_specific_kwargs)
+    content = [{"type": "image", "url": image} for image in images]
+    content.append({"type": "text", "text": prompt})
+    return [{"role": "user", "content": content}]
 
 
 def extract_single_choice_with_word_boundary(pred, gt):

--- a/lmms_eval/tasks/rvos/eval_sam2.py
+++ b/lmms_eval/tasks/rvos/eval_sam2.py
@@ -117,11 +117,7 @@ def run_sam2(predictor, prompt_map: Dict[tuple, List[tuple]], inference_state) -
     prompt_frames = sorted(prompts_by_frame)
 
     if prompt_frames:
-        autocast_ctx = (
-            torch.autocast(device_type="cuda", dtype=torch.bfloat16)
-            if torch.cuda.is_available() and "cuda" in str(inference_state["device"])
-            else nullcontext()
-        )
+        autocast_ctx = torch.autocast(device_type="cuda", dtype=torch.bfloat16) if torch.cuda.is_available() and "cuda" in str(inference_state["device"]) else nullcontext()
         with torch.inference_mode(), autocast_ctx:
             for i, fidx in enumerate(prompt_frames):
                 for obj_id, points in prompts_by_frame[fidx]:
@@ -181,8 +177,7 @@ def build_prompt_map(tracks: List[Dict[str, Any]], W: int, H: int, video_fps: fl
 def extract_frames_ffmpeg(video_path: str, out_dir: str, fps: float) -> None:
     Path(out_dir).mkdir(parents=True, exist_ok=True)
     subprocess.run(
-        ["ffmpeg", "-y", "-loglevel", "error", "-i", video_path, "-vf", f"fps={fps}",
-         os.path.join(out_dir, "%05d.jpg")],
+        ["ffmpeg", "-y", "-loglevel", "error", "-i", video_path, "-vf", f"fps={fps}", os.path.join(out_dir, "%05d.jpg")],
         check=True,
     )
 
@@ -193,8 +188,8 @@ def extract_frames_ffmpeg(video_path: str, out_dir: str, fps: float) -> None:
 
 
 def load_gt_masks(cache_root: str, video: str, mask_ids: List[str], num_frames: int, H: int, W: int) -> np.ndarray:
-    from pycocotools import mask as mask_utils
     import cv2
+    from pycocotools import mask as mask_utils
 
     gt = np.zeros((num_frames, H, W), dtype=np.uint8)
     for mid in mask_ids:
@@ -231,8 +226,8 @@ def _seg2bmap(seg: np.ndarray) -> np.ndarray:
 
 
 def f_measure(fg: np.ndarray, gt: np.ndarray, bound_th: float = 0.008) -> float:
-    from skimage.morphology import disk
     import cv2
+    from skimage.morphology import disk
 
     bound_pix = bound_th if bound_th >= 1 else np.ceil(bound_th * np.linalg.norm(fg.shape))
     fg_b = _seg2bmap(fg)
@@ -314,8 +309,7 @@ def evaluate_masks(gt: np.ndarray, pred: np.ndarray) -> Dict[str, float]:
 # ---------------------------------------------------------------------------
 
 
-def process_query(predictor, record: Dict[str, Any], cache_root: str, tmp_root: Optional[str],
-                  video_fps: float, device: torch.device) -> Optional[Dict[str, Any]]:
+def process_query(predictor, record: Dict[str, Any], cache_root: str, tmp_root: Optional[str], video_fps: float, device: torch.device) -> Optional[Dict[str, Any]]:
     video = record["video"]
     video_path = os.path.join(cache_root, "videos", f"{video}.mp4")
     if not os.path.exists(video_path):
@@ -335,8 +329,7 @@ def process_query(predictor, record: Dict[str, Any], cache_root: str, tmp_root: 
             pred_masks = np.zeros((state["num_frames"], state["video_height"], state["video_width"]), dtype=np.uint8)
         else:
             pred_masks = run_sam2(predictor, prompt_map, state)
-        gt_masks = load_gt_masks(cache_root, video, list(record.get("mask_ids") or []),
-                                 pred_masks.shape[0], pred_masks.shape[1], pred_masks.shape[2])
+        gt_masks = load_gt_masks(cache_root, video, list(record.get("mask_ids") or []), pred_masks.shape[0], pred_masks.shape[1], pred_masks.shape[2])
 
     metrics = evaluate_masks(gt_masks, pred_masks)
     return {
@@ -370,8 +363,7 @@ def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--task", required=True, choices=list(TASK_TO_CACHE.keys()))
     ap.add_argument("--predictions", required=True, help="Path to stage-1 <task>_submission.json")
-    ap.add_argument("--sam2-model", default=DEFAULT_SAM2_MODEL,
-                    help="HF model id (default: facebook/sam2.1-hiera-large)")
+    ap.add_argument("--sam2-model", default=DEFAULT_SAM2_MODEL, help="HF model id (default: facebook/sam2.1-hiera-large)")
     ap.add_argument("--output", default="rvos_sam2_output")
     ap.add_argument("--cache-dir", default=None, help="Override <hf_home>/<task cache dir>")
     ap.add_argument("--video-fps", type=float, default=6.0)

--- a/lmms_eval/tasks/rvos/utils.py
+++ b/lmms_eval/tasks/rvos/utils.py
@@ -119,10 +119,10 @@ def rvos_doc_to_messages(doc, lmms_eval_specific_kwargs=None):
 _COORD_REGEX = re.compile(r'coords\s*=\s*[\'"]([^\'"]*)(?:[\'"]|$)')
 # Match one segment "time obj_id x y [obj_id x y ...]" separated by any of ;, \t, , : (and leading start).
 # Trailing/leading spaces around the delimiter are tolerated.
-_FRAME_REGEX = re.compile(r'(?:^|[\t:,;])\s*([0-9]+(?:\.[0-9]+)?)\s+([0-9.\s]+?)(?=[\t:,;]|$)')
+_FRAME_REGEX = re.compile(r"(?:^|[\t:,;])\s*([0-9]+(?:\.[0-9]+)?)\s+([0-9.\s]+?)(?=[\t:,;]|$)")
 # obj_id / x / y can appear as either ints or floats (e.g. "0.0"). x/y coordinates are
 # in a 0..1000 normalized frame, so cap the integer portion at 4 digits.
-_POINTS_REGEX = re.compile(r'([0-9]+)(?:\.[0-9]+)?\s+([0-9]{1,4})(?:\.[0-9]+)?\s+([0-9]{1,4})(?:\.[0-9]+)?')
+_POINTS_REGEX = re.compile(r"([0-9]+)(?:\.[0-9]+)?\s+([0-9]{1,4})(?:\.[0-9]+)?\s+([0-9]{1,4})(?:\.[0-9]+)?")
 
 
 def parse_xml_tracks(text: str, width: int, height: int, video_fps: float) -> List[Dict[str, Any]]:
@@ -229,8 +229,7 @@ def _load_gt_masks(doc: Dict[str, Any]) -> Dict[str, List[Any]]:
     return out
 
 
-def _load_masks_at_frame(gt_masks: Dict[str, List[Any]], frame_idx: int, height: int, width: int,
-                         return_dict: bool = False):
+def _load_masks_at_frame(gt_masks: Dict[str, List[Any]], frame_idx: int, height: int, width: int, return_dict: bool = False):
     empty = np.zeros((height, width), dtype=bool)
     masks: List[np.ndarray] = []
     masks_by_id: Dict[str, np.ndarray] = {}
@@ -448,10 +447,7 @@ def rvos_process_results(doc, results):
         # Normalize GT points dict-of-obj shape
         for entry in gt_tracks:
             if isinstance(entry.get("points"), list):
-                entry["points"] = {
-                    str(p["id"]): {"point": p["point"], "occluded": p.get("occluded", False)}
-                    for p in entry["points"]
-                }
+                entry["points"] = {str(p["id"]): {"point": p["point"], "occluded": p.get("occluded", False)} for p in entry["points"]}
     except Exception:
         gt_tracks = []
     try:
@@ -496,6 +492,7 @@ def rvos_process_results(doc, results):
 
 def _dump_submission(records: List[Dict[str, Any]], args) -> str:
     import datetime
+
     from lmms_eval.tasks._task_utils import file_utils
 
     task = records[0]["id"].split("_track_")[0] if records else "rvos"

--- a/lmms_eval/tasks/sitebench/multi_image_input/site_video_multiimage.yaml
+++ b/lmms_eval/tasks/sitebench/multi_image_input/site_video_multiimage.yaml
@@ -16,6 +16,7 @@ generation_kwargs:
   do_sample: false
 doc_to_visual: !function utils.spatial_doc_to_visual_video_as_images
 doc_to_text: !function utils.spatial_doc_to_text_video
+doc_to_messages: !function utils.spatial_doc_to_messages_video_as_images
 doc_to_target: "answer"
 process_results: !function utils.spatial_process_results
 metric_list:
@@ -65,5 +66,23 @@ lmms_eval_specific_kwargs:
   default:
     post_prompt: "Give me the answer letter directly. The best answer is:"
     num_frames: 32  # Number of frames to sample from the video
+  neo_ov:
+    pre_prompt: ""
+    post_prompt: "Give me the answer letter directly. The best answer is:"
+    prompt_format: neo_ov
+    num_frames: 32
+
+model_specific_generation_kwargs:
+  neo_ov:
+    patch_size: 16
+    min_pixels: 691200
+    max_pixels: 691200
+    downsample_ratio: 0.5
+    system_prompt: ""
+    max_new_tokens: 4096
+    temperature: null
+    top_p: null
+    num_beams: null
+    repetition_penalty: null
 metadata:
   - version: 0.0

--- a/lmms_eval/tasks/sitebench/multi_image_input/utils.py
+++ b/lmms_eval/tasks/sitebench/multi_image_input/utils.py
@@ -21,6 +21,8 @@ from lmms_eval.tasks.sitebench.utils import (
     aggregate_spatial_relationship_reasoning_caa,
     base_cache_dir,
     cache_name,
+    _format_neo_ov_video_content,
+    _get_specific_kwarg,
     spatial_aggregate_results,
     spatial_doc_to_text_video,
     spatial_process_results,
@@ -46,10 +48,7 @@ def spatial_doc_to_visual_video_as_images(doc, lmms_eval_specific_kwargs=None):
     if not os.path.exists(video_path):
         raise FileNotFoundError(f"Video path: {video_path} does not exist.")
 
-    # Get number of frames from lmms_eval_specific_kwargs or default to 32
-    num_frames = 32
-    if lmms_eval_specific_kwargs:
-        num_frames = lmms_eval_specific_kwargs.get("default", {}).get("num_frames", 32)
+    num_frames = int(_get_specific_kwarg(lmms_eval_specific_kwargs, "num_frames", 32))
 
     # Load video and sample frames uniformly
     vr = VideoReader(video_path, ctx=cpu(0))
@@ -81,6 +80,9 @@ def spatial_doc_to_messages_video_as_images(doc, lmms_eval_specific_kwargs=None)
     """
     question = spatial_doc_to_text_video(doc, lmms_eval_specific_kwargs)
     visuals = spatial_doc_to_visual_video_as_images(doc, lmms_eval_specific_kwargs)
+
+    if lmms_eval_specific_kwargs and lmms_eval_specific_kwargs.get("prompt_format") == "neo_ov":
+        return [{"role": "user", "content": _format_neo_ov_video_content(visuals, question)}]
 
     # Build content as a list with all images first, then text
     content = []

--- a/lmms_eval/tasks/sitebench/multi_image_input/utils.py
+++ b/lmms_eval/tasks/sitebench/multi_image_input/utils.py
@@ -7,6 +7,8 @@ from PIL import Image
 
 from lmms_eval.tasks.sitebench.utils import (
     UpperLetters,
+    _format_neo_ov_video_content,
+    _get_specific_kwarg,
     aggregate_3d_information_understanding_acc,
     aggregate_3d_information_understanding_caa,
     aggregate_counting_and_existence_acc,
@@ -21,8 +23,6 @@ from lmms_eval.tasks.sitebench.utils import (
     aggregate_spatial_relationship_reasoning_caa,
     base_cache_dir,
     cache_name,
-    _format_neo_ov_video_content,
-    _get_specific_kwarg,
     spatial_aggregate_results,
     spatial_doc_to_text_video,
     spatial_process_results,

--- a/lmms_eval/tasks/sitebench/site_image.yaml
+++ b/lmms_eval/tasks/sitebench/site_image.yaml
@@ -66,5 +66,22 @@ lmms_eval_specific_kwargs:
     pre_prompt: ""
     post_prompt: "Give me the answer letter directly. The best answer is:"
     interleave_visuals: true
+  neo_ov:
+    pre_prompt: ""
+    post_prompt: ""
+    prompt_format: neo_ov
+
+model_specific_generation_kwargs:
+  neo_ov:
+    patch_size: 16
+    min_pixels: 691200
+    max_pixels: 691200
+    downsample_ratio: 0.5
+    system_prompt: ""
+    max_new_tokens: 4096
+    temperature: null
+    top_p: null
+    num_beams: null
+    repetition_penalty: null
 metadata:
   - version: 0.0

--- a/lmms_eval/tasks/sitebench/site_video.yaml
+++ b/lmms_eval/tasks/sitebench/site_video.yaml
@@ -66,5 +66,23 @@ lmms_eval_specific_kwargs:
     post_prompt: "Give me the answer letter directly. The best answer is:"
   gemini_api:
     pre_prompt: "<video>"
+  neo_ov:
+    pre_prompt: ""
+    post_prompt: "Give me the answer letter directly. The best answer is:"
+    prompt_format: neo_ov
+    num_frames: 32
+
+model_specific_generation_kwargs:
+  neo_ov:
+    patch_size: 16
+    min_pixels: 691200
+    max_pixels: 691200
+    downsample_ratio: 0.5
+    system_prompt: ""
+    max_new_tokens: 4096
+    temperature: null
+    top_p: null
+    num_beams: null
+    repetition_penalty: null
 metadata:
   - version: 0.0

--- a/lmms_eval/tasks/sitebench/utils.py
+++ b/lmms_eval/tasks/sitebench/utils.py
@@ -128,27 +128,93 @@ def spatial_doc_to_text_image(doc, lmmseval_specific_kwargs=None):
     return prompt
 
 
-def spatial_doc_to_text_video(doc, lmmseval_specific_kwargs=None):
+def _format_neo_ov_content(images, prompt):
+    if len(images) == 1:
+        return [{"type": "image", "url": images[0]}, {"type": "text", "text": prompt}]
+
+    content = []
+    for idx, image in enumerate(images, start=1):
+        content.append({"type": "text", "text": f"Image-{idx}: "})
+        content.append({"type": "image", "url": image})
+    content.append({"type": "text", "text": prompt})
+    return content
+
+
+def _get_specific_kwarg(lmms_eval_specific_kwargs, key, default=None):
+    if not lmms_eval_specific_kwargs:
+        return default
+    if key in lmms_eval_specific_kwargs:
+        return lmms_eval_specific_kwargs[key]
+    nested_default = lmms_eval_specific_kwargs.get("default", {})
+    return nested_default.get(key, default) if isinstance(nested_default, dict) else default
+
+
+def _sitebench_image_neo_ov_prompt(doc):
+    question = doc["question"].strip()
+    options = doc["options"]
+    option_text = "\n".join(f"{UpperLetters[i]}: {options[i]}" for i in range(len(options)))
+
+    raw_prompt = ""
+    if "<image>" not in question and "<image>" not in option_text:
+        raw_prompt += "<image>" * len(doc["visual"]) + "\n"
+
+    raw_prompt += "Question: " + question + "\n"
+    raw_prompt += "Options:\n" + option_text + "\n"
+    raw_prompt += "Give me the answer letter directly. The best answer is:"
+
+    parts = raw_prompt.split("<image>")
+    prompt = ""
+    image_idx = 1
+    for part_idx, part in enumerate(parts):
+        text = part.strip()
+        if text:
+            prompt += text
+        if part_idx != len(parts) - 1 and image_idx <= len(doc["visual"]):
+            prompt += f"<Image-{image_idx}>"
+            image_idx += 1
+
+    images_to_remove = "".join(f"<Image-{idx + 1}>" for idx in range(len(doc["visual"])))
+    return prompt.replace(images_to_remove, "")
+
+
+def sitebench_video_prompt(doc, lmmseval_specific_kwargs=None):
     pre_prompt = "Select the best answer to the following multiple-choice question based on the video. Respond with only the letter of the correct option."
 
     question = doc["question"].strip()
     options = doc["options"]
     option_text = "\n".join(f"{UpperLetters[i]}: {options[i]}" for i in range(len(options)))
+    post_prompt = _get_specific_kwarg(lmmseval_specific_kwargs, "post_prompt", "Give me the answer letter directly. The best answer is:")
 
-    prompt = pre_prompt + "\n"
+    return f"{pre_prompt}\nQuestion: {question}\nOptions:\n{option_text}\n{post_prompt}"
 
-    # check the pre_prompt
-    if lmmseval_specific_kwargs:
-        prompt += lmmseval_specific_kwargs.get("default", {}).get("pre_prompt", "")
 
-    prompt += "Question: " + question + "\n"
-    prompt += "Options:\n" + option_text + "\n"
+def _sitebench_video_frames(doc, lmms_eval_specific_kwargs=None):
+    from decord import VideoReader, cpu
 
-    # Append post prompt if provided
-    if lmmseval_specific_kwargs:
-        prompt += lmmseval_specific_kwargs.get("default", {}).get("post_prompt", "")
+    video_path = os.path.join(cache_dir, doc["visual"][0])
+    if not os.path.exists(video_path):
+        raise FileNotFoundError(f"Video path: {video_path} does not exist.")
 
-    return prompt
+    num_frames = int(_get_specific_kwarg(lmms_eval_specific_kwargs, "num_frames", 32))
+    vr = VideoReader(video_path, ctx=cpu(0))
+    total_frames = len(vr)
+    num_frames = min(num_frames, total_frames)
+    indices = np.linspace(0, total_frames - 1, num_frames, dtype=int)
+    frames = vr.get_batch(indices).asnumpy()
+    return [Image.fromarray(frame) for frame in frames]
+
+
+def _format_neo_ov_video_content(frames, prompt):
+    content = []
+    for idx, frame in enumerate(frames, start=1):
+        content.append({"type": "text", "text": f"Frame-{idx}: "})
+        content.append({"type": "image", "url": frame})
+    content.append({"type": "text", "text": prompt})
+    return content
+
+
+def spatial_doc_to_text_video(doc, lmmseval_specific_kwargs=None):
+    return sitebench_video_prompt(doc, lmmseval_specific_kwargs)
 
 
 def spatial_doc_to_messages_image(doc, lmms_eval_specific_kwargs=None):
@@ -161,6 +227,11 @@ def spatial_doc_to_messages_image(doc, lmms_eval_specific_kwargs=None):
         If 'interleave_visuals' is set to False in the 'default' section,
         the function will generate non-interleaved messages.
     """
+    if lmms_eval_specific_kwargs and lmms_eval_specific_kwargs.get("prompt_format") == "neo_ov":
+        question = _sitebench_image_neo_ov_prompt(doc)
+        visuals = spatial_doc_to_visual_image(doc)
+        return [{"role": "user", "content": _format_neo_ov_content(visuals, question)}]
+
     if lmms_eval_specific_kwargs and lmms_eval_specific_kwargs.get("default", {}).get("interleave_visuals", True) is False:
         # Fallback to non-interleaved format - content must be a list for ChatMessages
         question = spatial_doc_to_text_image(doc, lmms_eval_specific_kwargs)
@@ -204,6 +275,11 @@ def spatial_doc_to_messages_video(doc, lmms_eval_specific_kwargs=None):
     Builds video-text messages for chat-based models.
     """
     question = spatial_doc_to_text_video(doc, lmms_eval_specific_kwargs)
+
+    if lmms_eval_specific_kwargs and lmms_eval_specific_kwargs.get("prompt_format") == "neo_ov":
+        frames = _sitebench_video_frames(doc, lmms_eval_specific_kwargs)
+        return [{"role": "user", "content": _format_neo_ov_video_content(frames, question)}]
+
     visuals = spatial_doc_to_visual_video(doc)
 
     # Video uses a simpler format - video first, then the question text

--- a/lmms_eval/tasks/viewspatial/utils.py
+++ b/lmms_eval/tasks/viewspatial/utils.py
@@ -10,7 +10,7 @@ VIEWSPATIAL_QUESTION_TYPES = {
 }
 
 
-def viewspatial_doc_to_text(doc):
+def viewspatial_doc_to_text(doc, lmms_eval_specific_kwargs=None):
     """Extracts the text prompt from a viewspatial dataset sample.
 
     Args:
@@ -44,6 +44,31 @@ def viewspatial_doc_to_visual(doc):
         list: A list of visual elements (e.g., PIL Images) converted to 'RGB' format.
     """
     return [visual.convert("RGB") for visual in doc["images"]]
+
+
+def _format_neo_ov_content(images, prompt):
+    if len(images) == 1:
+        return [{"type": "image", "url": images[0]}, {"type": "text", "text": prompt}]
+
+    content = []
+    for idx, image in enumerate(images, start=1):
+        content.append({"type": "text", "text": f"Image-{idx}: "})
+        content.append({"type": "image", "url": image})
+    content.append({"type": "text", "text": prompt})
+    return content
+
+
+def viewspatial_doc_to_messages(doc, lmms_eval_specific_kwargs=None):
+    lmms_eval_specific_kwargs = lmms_eval_specific_kwargs or {}
+    images = viewspatial_doc_to_visual(doc)
+    prompt = viewspatial_doc_to_text(doc, lmms_eval_specific_kwargs)
+
+    if lmms_eval_specific_kwargs.get("prompt_format") == "neo_ov":
+        return [{"role": "user", "content": _format_neo_ov_content(images, prompt)}]
+
+    content = [{"type": "image", "url": image} for image in images]
+    content.append({"type": "text", "text": prompt})
+    return [{"role": "user", "content": content}]
 
 
 def extract_option(text):

--- a/lmms_eval/tasks/viewspatial/viewspatial.yaml
+++ b/lmms_eval/tasks/viewspatial/viewspatial.yaml
@@ -13,8 +13,27 @@ generation_kwargs:
 output_type: generate_until
 doc_to_visual: !function utils.viewspatial_doc_to_visual
 doc_to_text: !function utils.viewspatial_doc_to_text
+doc_to_messages: !function utils.viewspatial_doc_to_messages
 doc_to_target: "answer"
 process_results: !function utils.viewspatial_process_results
+
+lmms_eval_specific_kwargs:
+  neo_ov:
+    pre_prompt: ""
+    post_prompt: ""
+    prompt_format: neo_ov
+
+model_specific_generation_kwargs:
+  neo_ov:
+    patch_size: 16
+    min_pixels: 691200
+    max_pixels: 691200
+    downsample_ratio: 0.5
+    system_prompt: ""
+    max_new_tokens: 4096
+    temperature: null
+    top_p: null
+    repetition_penalty: null
 
 metric_list:
   - metric: overall_accuracy

--- a/lmms_eval/tasks/vsibench/_default_template_yaml
+++ b/lmms_eval/tasks/vsibench/_default_template_yaml
@@ -4,6 +4,7 @@ output_type: generate_until
 process_docs: !function utils.process_docs
 doc_to_visual: !function utils.vsibench_doc_to_visual
 doc_to_text: !function utils.vsibench_doc_to_text
+doc_to_messages: !function utils.vsibench_doc_to_messages
 doc_to_target: "ground_truth"
 generation_kwargs:
   max_new_tokens: 16
@@ -54,5 +55,24 @@ lmms_eval_specific_kwargs:
     pre_prompt: ""
     mca_post_prompt: "Answer with the option's letter from the given choices directly."
     na_post_prompt: "Do not response anything other than a single number!"
+  neo_ov:
+    pre_prompt: "These are frames of a video."
+    mca_post_prompt: "Answer with the option's letter from the given choices directly."
+    na_post_prompt: "Answer briefly and directly in one float number."
+    prompt_format: neo_ov
+    num_frames: 32
+
+model_specific_generation_kwargs:
+  neo_ov:
+    patch_size: 16
+    min_pixels: 691200
+    max_pixels: 691200
+    downsample_ratio: 0.5
+    system_prompt: ""
+    max_new_tokens: 4096
+    temperature: null
+    top_p: null
+    num_beams: null
+    repetition_penalty: null
 metadata:
   - version: 0.0

--- a/lmms_eval/tasks/vsibench/multi_image_input/utils.py
+++ b/lmms_eval/tasks/vsibench/multi_image_input/utils.py
@@ -5,10 +5,10 @@ from loguru import logger as eval_logger
 from PIL import Image
 
 from lmms_eval.tasks.vsibench.utils import (
+    _get_specific_kwarg,
     base_cache_dir,
     cache_name,
     format_vsibench_neo_ov_video_content,
-    _get_specific_kwarg,
     sample_vsibench_video_frames,
     vsibench_doc_to_text,
 )

--- a/lmms_eval/tasks/vsibench/multi_image_input/utils.py
+++ b/lmms_eval/tasks/vsibench/multi_image_input/utils.py
@@ -1,13 +1,16 @@
 import os
 
 import numpy as np
-from decord import VideoReader, cpu
 from loguru import logger as eval_logger
 from PIL import Image
 
 from lmms_eval.tasks.vsibench.utils import (
     base_cache_dir,
     cache_name,
+    format_vsibench_neo_ov_video_content,
+    _get_specific_kwarg,
+    sample_vsibench_video_frames,
+    vsibench_doc_to_text,
 )
 
 
@@ -23,6 +26,8 @@ def vsibench_doc_to_visual_as_images(doc, lmms_eval_specific_kwargs=None):
     Returns:
         List of PIL.Image objects sampled uniformly from the video
     """
+    from decord import VideoReader, cpu
+
     cache_dir = os.path.join(base_cache_dir, cache_name)
     video_path = doc["dataset"] + "/" + doc["scene_name"] + ".mp4"
     video_path = os.path.join(cache_dir, video_path)
@@ -30,10 +35,7 @@ def vsibench_doc_to_visual_as_images(doc, lmms_eval_specific_kwargs=None):
     if not os.path.exists(video_path):
         raise FileExistsError(f"video path:{video_path} does not exist.")
 
-    # Get number of frames from lmms_eval_specific_kwargs or default to 32
-    num_frames = 32
-    if lmms_eval_specific_kwargs:
-        num_frames = lmms_eval_specific_kwargs.get("num_frames", 32)
+    num_frames = int(_get_specific_kwarg(lmms_eval_specific_kwargs, "num_frames", 32))
 
     # Load video and sample frames uniformly
     vr = VideoReader(video_path, ctx=cpu(0))
@@ -51,3 +53,17 @@ def vsibench_doc_to_visual_as_images(doc, lmms_eval_specific_kwargs=None):
     eval_logger.info(f"Loaded {len(pil_images)} frames from video as images (total_frames={total_frames})")
 
     return pil_images
+
+
+def vsibench_doc_to_messages_as_images(doc, lmms_eval_specific_kwargs=None):
+    lmms_eval_specific_kwargs = lmms_eval_specific_kwargs or {}
+    prompt = vsibench_doc_to_text(doc, lmms_eval_specific_kwargs)
+
+    if lmms_eval_specific_kwargs.get("prompt_format") == "neo_ov":
+        frames = sample_vsibench_video_frames(doc, lmms_eval_specific_kwargs)
+        content = format_vsibench_neo_ov_video_content(frames, prompt)
+    else:
+        frames = vsibench_doc_to_visual_as_images(doc, lmms_eval_specific_kwargs)
+        content = [{"type": "image", "url": frame} for frame in frames]
+        content.append({"type": "text", "text": prompt})
+    return [{"role": "user", "content": content}]

--- a/lmms_eval/tasks/vsibench/multi_image_input/vsibench_debiased_multiimage.yaml
+++ b/lmms_eval/tasks/vsibench/multi_image_input/vsibench_debiased_multiimage.yaml
@@ -10,6 +10,7 @@ include: ../_default_template_yaml
 
 # Override doc_to_visual to return frames as images instead of video path
 doc_to_visual: !function utils.vsibench_doc_to_visual_as_images
+doc_to_messages: !function utils.vsibench_doc_to_messages_as_images
 
 lmms_eval_specific_kwargs:
   default:
@@ -26,4 +27,10 @@ lmms_eval_specific_kwargs:
     pre_prompt: ""
     mca_post_prompt: "Answer with the option's letter from the given choices directly."
     na_post_prompt: "Do not response anything other than a single number!"
+    num_frames: 32
+  neo_ov:
+    pre_prompt: "These are frames of a video."
+    mca_post_prompt: "Answer with the option's letter from the given choices directly."
+    na_post_prompt: "Answer briefly and directly in one float number."
+    prompt_format: neo_ov
     num_frames: 32

--- a/lmms_eval/tasks/vsibench/multi_image_input/vsibench_multiimage.yaml
+++ b/lmms_eval/tasks/vsibench/multi_image_input/vsibench_multiimage.yaml
@@ -13,6 +13,7 @@ include: ../_default_template_yaml
 
 # Override doc_to_visual to return frames as images instead of video path
 doc_to_visual: !function utils.vsibench_doc_to_visual_as_images
+doc_to_messages: !function utils.vsibench_doc_to_messages_as_images
 
 lmms_eval_specific_kwargs:
   default:
@@ -29,4 +30,10 @@ lmms_eval_specific_kwargs:
     pre_prompt: ""
     mca_post_prompt: "Answer with the option's letter from the given choices directly."
     na_post_prompt: "Do not response anything other than a single number!"
+    num_frames: 32
+  neo_ov:
+    pre_prompt: "These are frames of a video."
+    mca_post_prompt: "Answer with the option's letter from the given choices directly."
+    na_post_prompt: "Answer briefly and directly in one float number."
+    prompt_format: neo_ov
     num_frames: 32

--- a/lmms_eval/tasks/vsibench/utils.py
+++ b/lmms_eval/tasks/vsibench/utils.py
@@ -79,9 +79,7 @@ cache_name = yaml.safe_load("".join(safe_data))["dataset_kwargs"]["cache_dir"]
 
 
 def vsibench_doc_to_visual(doc):
-    cache_dir = os.path.join(base_cache_dir, cache_name)
-    video_path = doc["dataset"] + "/" + doc["scene_name"] + ".mp4"
-    video_path = os.path.join(cache_dir, video_path)
+    video_path = _vsibench_video_path(doc)
     if os.path.exists(video_path):
         video_path = video_path
     else:
@@ -89,7 +87,49 @@ def vsibench_doc_to_visual(doc):
     return [video_path]
 
 
+def _get_specific_kwarg(lmms_eval_specific_kwargs, key, default=None):
+    if not lmms_eval_specific_kwargs:
+        return default
+    if key in lmms_eval_specific_kwargs:
+        return lmms_eval_specific_kwargs[key]
+    nested_default = lmms_eval_specific_kwargs.get("default", {})
+    return nested_default.get(key, default) if isinstance(nested_default, dict) else default
+
+
+def _vsibench_video_path(doc):
+    cache_dir = os.path.join(base_cache_dir, cache_name)
+    video_path = doc["dataset"] + "/" + doc["scene_name"] + ".mp4"
+    return os.path.join(cache_dir, video_path)
+
+
+def sample_vsibench_video_frames(doc, lmms_eval_specific_kwargs=None):
+    from decord import VideoReader, cpu
+    from PIL import Image
+
+    video_path = _vsibench_video_path(doc)
+    if not os.path.exists(video_path):
+        raise FileExistsError(f"video path:{video_path} does not exist.")
+
+    num_frames = int(_get_specific_kwarg(lmms_eval_specific_kwargs, "num_frames", 32))
+    vr = VideoReader(video_path, ctx=cpu(0))
+    total_frames = len(vr)
+    num_frames = min(num_frames, total_frames)
+    indices = np.linspace(0, total_frames - 1, num_frames, dtype=int)
+    frames = vr.get_batch(indices).asnumpy()
+    return [Image.fromarray(frame) for frame in frames]
+
+
+def format_vsibench_neo_ov_video_content(frames, prompt):
+    content = []
+    for idx, frame in enumerate(frames, start=1):
+        content.append({"type": "text", "text": f"Frame-{idx}: "})
+        content.append({"type": "image", "url": frame})
+    content.append({"type": "text", "text": prompt})
+    return content
+
+
 def vsibench_doc_to_text(doc, lmms_eval_specific_kwargs=None):
+    lmms_eval_specific_kwargs = lmms_eval_specific_kwargs or {}
     question = doc["question"]
 
     pre_prompt = lmms_eval_specific_kwargs.get("pre_prompt", "") or "These are frames of a video."
@@ -103,6 +143,19 @@ def vsibench_doc_to_text(doc, lmms_eval_specific_kwargs=None):
         return "\n".join([pre_prompt, question, options, post_prompt])
     else:
         raise ValueError(f"Unknown question type: {doc['question_type']}")
+
+
+def vsibench_doc_to_messages(doc, lmms_eval_specific_kwargs=None):
+    lmms_eval_specific_kwargs = lmms_eval_specific_kwargs or {}
+    prompt = vsibench_doc_to_text(doc, lmms_eval_specific_kwargs)
+
+    if lmms_eval_specific_kwargs.get("prompt_format") == "neo_ov":
+        frames = sample_vsibench_video_frames(doc, lmms_eval_specific_kwargs)
+        content = format_vsibench_neo_ov_video_content(frames, prompt)
+    else:
+        content = [{"type": "video", "url": video_path} for video_path in vsibench_doc_to_visual(doc)]
+        content.append({"type": "text", "text": prompt})
+    return [{"role": "user", "content": content}]
 
 
 def process_docs(dataset: datasets.Dataset) -> datasets.Dataset:


### PR DESCRIPTION
## Summary

This PR adds `neo_ov` as a new lmms-eval chat model backend and aligns benchmark-specific prompting / generation settings for Neo-OV evaluation on 8 spatial intelligence benchmarks.

  Affected benchmarks:

  - MindCube Tiny
  - MMSI-Bench
  - ViewSpatial
  - SiteBench
  - BLINK
  - 3DSRBench
  - EmbSpatial
  - VSI-Bench

  ## Changes

  - Add the `neo_ov` model wrapper and registry entry.
  - Add Neo-OV-specific task YAML settings via `lmms_eval_specific_kwargs` and `model_specific_generation_kwargs`.
  - Keep prompt construction in task-level `doc_to_messages` utilities so the model wrapper remains generic.
  - Align Neo-OV settings with the corresponding SI benchmark evaluation behavior used in [original repo](https://github.com/EvolvingLMMs-Lab/NEO/tree/main/VLMEvalKit_ov) where applicable.

## Validation

  - Reproduced the Neo-OV spatial intelligence benchmark behavior/results against the official NEO VLMEvalKit-ov evaluation setup:
  https://github.com/EvolvingLMMs-Lab/NEO/tree/main/VLMEvalKit_ov
  - Ran `black` and `isort` pre-commit hooks on changed Python files.

## Example
Evaluation of Paranioar/NEO1_5-2B-SFT on vsibench
<img width="1899" height="546" alt="image" src="https://github.com/user-attachments/assets/4c507d97-0c53-4d82-9251-4a45d73ff707" />
