### PR TITLE
feat: add CG-Bench and CG-AV-Counting tasks

### DIFF
--- a/docs/advanced/current_tasks.md
+++ b/docs/advanced/current_tasks.md
@@ -349,6 +349,14 @@ python -m lmms_eval --tasks list_with_num
 
 ### Long Video & Temporal Understanding
 - [Charades-STA](https://github.com/jiyanggao/TALL) (charades_sta)
+- [CG-Bench](https://github.com/CG-Bench/CG-Bench) (cgbench)
+  - Video-only MCQ (cgbench)
+  - Video plus frame-aligned subtitles (cgbench_subtitles)
+  - Both variants (cgbench_all)
+- [CG-AV-Counting](https://av-reasoner.github.io/) (cgav_counting)
+  - Full-video counting (cgav_counting_long): ACC, OBOA, MAE, RMSE
+  - Reference-clip counting (cgav_counting_ref): ACC, OBOA, MAE, RMSE
+  - White-box event/object/attribute clue grounding (cgav_counting_clue): WCS, IFA
 - [FALCON-Bench](https://falcon-bench.github.io/) (FALCONBench) - One-hour-long video understanding
 - [LEMONADE](https://huggingface.co/datasets/amathislab/LEMONADE) (lemonade)
 - [LongTimescope](https://longtimescope.github.io/) (longtimescope)

--- a/lmms_eval/tasks/cgav_counting/README.md
+++ b/lmms_eval/tasks/cgav_counting/README.md
@@ -1,0 +1,23 @@
+# CG-AV-Counting
+
+This directory implements all three protocols from the official
+[CG-AV-Counting implementation](https://github.com/open-compass/VLMEvalKit/tree/main/vlmeval/dataset/CGAVCounting):
+
+- `cgav_counting_long`: full-video count (ACC, OBOA, MAE, RMSE)
+- `cgav_counting_ref`: reference-clip count (ACC, OBOA, MAE, RMSE)
+- `cgav_counting_clue`: white-box clue grounding (WCS, IFA)
+- `cgav_counting`: group that runs all three
+
+The dataset is gated and large. Accept its terms at
+https://huggingface.co/datasets/CG-Bench/CG-AV-Counting and configure a Hugging
+Face token. Normal task execution downloads the dataset, then automatically merges
+and extracts the official split `videos.zip.part*` and `ref_videos.zip.part*`
+archives on first use. The media cache is `$HF_HOME/cgav_counting` by default;
+set `CGAV_COUNTING_ROOT` only to reuse a different existing cache.
+
+```bash
+accelerate launch -m lmms_eval --model <model> --tasks cgav_counting_long --batch_size 1
+```
+
+Audio-dependent query types (`A`, `A2V`, `V2A`, and `AV`) require a model/backend
+that preserves the video's audio track.

--- a/lmms_eval/tasks/cgav_counting/__init__.py
+++ b/lmms_eval/tasks/cgav_counting/__init__.py
@@ -1,0 +1,1 @@
+"""CG-AV-Counting audio-visual counting tasks."""

--- a/lmms_eval/tasks/cgav_counting/_default_template_yaml
+++ b/lmms_eval/tasks/cgav_counting/_default_template_yaml
@@ -1,0 +1,22 @@
+dataset_path: CG-Bench/CG-AV-Counting
+dataset_name: default
+dataset_kwargs:
+  token: true
+  cache_dir: cgav_counting
+  video: true
+  create_link: true
+test_split: test
+output_type: generate_until
+cluster_key: video
+generation_kwargs:
+  max_new_tokens: 1024
+  temperature: 0
+  top_p: 1.0
+  num_beams: 1
+  do_sample: false
+lmms_eval_specific_kwargs:
+  default:
+    pre_prompt: ""
+    post_prompt: ""
+metadata:
+  - version: 1.0

--- a/lmms_eval/tasks/cgav_counting/cgav_counting.yaml
+++ b/lmms_eval/tasks/cgav_counting/cgav_counting.yaml
@@ -1,0 +1,7 @@
+group: cgav_counting
+task:
+  - cgav_counting_long
+  - cgav_counting_ref
+  - cgav_counting_clue
+metadata:
+  - version: 1.0

--- a/lmms_eval/tasks/cgav_counting/cgav_counting_clue.yaml
+++ b/lmms_eval/tasks/cgav_counting/cgav_counting_clue.yaml
@@ -1,0 +1,13 @@
+task: cgav_counting_clue
+include: _default_template_yaml
+doc_to_visual: !function utils.cgav_doc_to_visual_clue
+doc_to_text: !function utils.cgav_doc_to_text_clue
+doc_to_target: clue
+process_results: !function utils.cgav_process_results_clue
+metric_list:
+  - metric: wcs
+    aggregation: !function utils.aggregate_wcs
+    higher_is_better: true
+  - metric: ifa
+    aggregation: !function utils.aggregate_ifa
+    higher_is_better: true

--- a/lmms_eval/tasks/cgav_counting/cgav_counting_long.yaml
+++ b/lmms_eval/tasks/cgav_counting/cgav_counting_long.yaml
@@ -1,0 +1,19 @@
+task: cgav_counting_long
+include: _default_template_yaml
+doc_to_visual: !function utils.cgav_doc_to_visual_long
+doc_to_text: !function utils.cgav_doc_to_text_count
+doc_to_target: answer
+process_results: !function utils.cgav_process_results_long
+metric_list:
+  - metric: acc
+    aggregation: !function utils.aggregate_acc
+    higher_is_better: true
+  - metric: oboa
+    aggregation: !function utils.aggregate_oboa
+    higher_is_better: true
+  - metric: mae
+    aggregation: !function utils.aggregate_mae
+    higher_is_better: false
+  - metric: rmse
+    aggregation: !function utils.aggregate_rmse
+    higher_is_better: false

--- a/lmms_eval/tasks/cgav_counting/cgav_counting_ref.yaml
+++ b/lmms_eval/tasks/cgav_counting/cgav_counting_ref.yaml
@@ -1,0 +1,19 @@
+task: cgav_counting_ref
+include: _default_template_yaml
+doc_to_visual: !function utils.cgav_doc_to_visual_ref
+doc_to_text: !function utils.cgav_doc_to_text_count
+doc_to_target: answer
+process_results: !function utils.cgav_process_results_ref
+metric_list:
+  - metric: acc
+    aggregation: !function utils.aggregate_acc
+    higher_is_better: true
+  - metric: oboa
+    aggregation: !function utils.aggregate_oboa
+    higher_is_better: true
+  - metric: mae
+    aggregation: !function utils.aggregate_mae
+    higher_is_better: false
+  - metric: rmse
+    aggregation: !function utils.aggregate_rmse
+    higher_is_better: false

--- a/lmms_eval/tasks/cgav_counting/utils.py
+++ b/lmms_eval/tasks/cgav_counting/utils.py
@@ -1,0 +1,513 @@
+import json
+import math
+import os
+import re
+import shutil
+import zipfile
+from collections import defaultdict
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+import cv2
+import numpy as np
+from filelock import FileLock
+from PIL import Image
+
+from lmms_eval.tasks._task_utils.media_resolver import resolve_media_reference
+
+Document = Mapping[str, Any]
+TaskKwargs = Mapping[str, Any]
+MetricRecord = dict[str, Any]
+
+_NUMBER_WORDS = {
+    "zero": 0,
+    "one": 1,
+    "two": 2,
+    "three": 3,
+    "four": 4,
+    "five": 5,
+    "six": 6,
+    "seven": 7,
+    "eight": 8,
+    "nine": 9,
+    "ten": 10,
+    "eleven": 11,
+    "twelve": 12,
+    "thirteen": 13,
+    "fourteen": 14,
+    "fifteen": 15,
+    "sixteen": 16,
+    "seventeen": 17,
+    "eighteen": 18,
+    "nineteen": 19,
+    "twenty": 20,
+    "thirty": 30,
+    "forty": 40,
+    "fifty": 50,
+    "sixty": 60,
+    "seventy": 70,
+    "eighty": 80,
+    "ninety": 90,
+}
+
+
+def _parse_clues(doc: Document) -> list[Any]:
+    clues = doc.get("clue", [])
+    if isinstance(clues, str):
+        return json.loads(clues)
+    return clues
+
+
+def _default_media_root() -> Path:
+    """Return the cache directory populated by lmms-eval's video downloader."""
+    hf_home = Path(os.path.expanduser(os.getenv("HF_HOME", "~/.cache/huggingface")))
+    return hf_home / "cgav_counting"
+
+
+def _extract_split_archive(root: Path, archive_prefix: str, destination: Path) -> None:
+    """Merge and extract one official CG-AV-Counting split ZIP archive."""
+    if destination.exists():
+        return
+
+    parts = sorted(root.glob(f"{archive_prefix}.zip.part*"))
+    if not parts:
+        return
+
+    lock = FileLock(str(root / f".{archive_prefix}.extract.lock"), timeout=3600)
+    with lock:
+        if destination.exists():
+            return
+        destination.mkdir(parents=True, exist_ok=True)
+        archive_path = root / f"{archive_prefix}.zip"
+        try:
+            with archive_path.open("wb") as archive:
+                for part in parts:
+                    with part.open("rb") as source:
+                        shutil.copyfileobj(source, archive, length=16 * 1024 * 1024)
+            with zipfile.ZipFile(archive_path) as archive:
+                archive.extractall(destination)
+        finally:
+            archive_path.unlink(missing_ok=True)
+
+
+def _ensure_media_extracted(extra_subdirs: Sequence[str]) -> None:
+    """Extract the required official media archive when only split ZIP parts exist."""
+    root = Path(os.path.expanduser(os.getenv("CGAV_COUNTING_ROOT", ""))) if os.getenv("CGAV_COUNTING_ROOT") else _default_media_root()
+    if "ref_videos" in extra_subdirs:
+        _extract_split_archive(root, "ref_videos", root / "ref_videos")
+    else:
+        _extract_split_archive(root, "videos", root / "cg_videos_720p")
+
+
+def _resolve_video(reference: str, extra_subdirs: Sequence[str] = ()) -> str:
+    _ensure_media_extracted(extra_subdirs)
+    path = resolve_media_reference(
+        reference,
+        media_type="video",
+        cache_dir="cgav_counting",
+        env_vars=("CGAV_COUNTING_ROOT", "CGAV_COUNTING_VIDEO_DIR"),
+        extra_subdirs=extra_subdirs,
+    )
+    if not os.path.exists(path):
+        raise FileNotFoundError(f"CG-AV-Counting media not found: {path}. Set CGAV_COUNTING_ROOT to the extracted dataset root.")
+    return path
+
+
+def _full_video_path(doc: Document) -> str:
+    return _resolve_video(doc["video"], extra_subdirs=("cg_videos_720p", "videos"))
+
+
+def _reference_filename(doc: Document) -> str:
+    start, end = doc["query_interval"]
+    return f"{Path(doc['video']).stem}_{float(start):.2f}_{float(end):.2f}.mp4"
+
+
+def cgav_doc_to_visual_long(doc: Document) -> list[str]:
+    """Return the full video used by the long-video counting protocol."""
+    return [_full_video_path(doc)]
+
+
+def cgav_doc_to_visual_ref(doc: Document) -> list[str]:
+    """Return the official reference clip for a counting question."""
+    return [_resolve_video(_reference_filename(doc), extra_subdirs=("ref_videos",))]
+
+
+def _clue_timestamps(doc: Document) -> list[float]:
+    timestamps = []
+    clues = _parse_clues(doc)
+    flattened = clues if doc["category"] != "attribute" else [item for cluster in clues for item in cluster]
+    for clue in flattened:
+        timestamp = float(clue["timestamp"])
+        if timestamp not in timestamps:
+            timestamps.append(timestamp)
+    return timestamps
+
+
+def _frames_at_timestamps(video_path: str, timestamps: Sequence[float]) -> list[Image.Image]:
+    capture = cv2.VideoCapture(video_path)
+    fps = float(capture.get(cv2.CAP_PROP_FPS))
+    frame_count = int(capture.get(cv2.CAP_PROP_FRAME_COUNT))
+    if frame_count <= 0 or fps <= 0:
+        capture.release()
+        raise ValueError(f"Cannot decode video: {video_path}")
+    frames = []
+    for timestamp in timestamps:
+        index = min(max(int(timestamp * fps), 0), frame_count - 1)
+        capture.set(cv2.CAP_PROP_POS_FRAMES, index)
+        ok, frame = capture.read()
+        if not ok:
+            capture.release()
+            raise ValueError(f"Cannot decode frame {index} from video: {video_path}")
+        frames.append(Image.fromarray(cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)))
+    capture.release()
+    return frames
+
+
+def cgav_doc_to_visual_clue(doc: Document) -> list[str] | list[Image.Image]:
+    """Return a video for event clues or decoded frames for spatial clues."""
+    if doc["category"] == "event":
+        return [_full_video_path(doc)]
+    return _frames_at_timestamps(_full_video_path(doc), _clue_timestamps(doc))
+
+
+def cgav_doc_to_text_count(doc: Document, lmms_eval_specific_kwargs: TaskKwargs | None = None) -> str:
+    """Format the official number-only counting prompt."""
+    kwargs = lmms_eval_specific_kwargs or {}
+    prompt = f"Please answer the question '{doc['question']}' with a number. " "Output only the number and nothing else."
+    return f"{kwargs.get('pre_prompt', '')}{prompt}{kwargs.get('post_prompt', '')}"
+
+
+def cgav_doc_to_text_clue(doc: Document, lmms_eval_specific_kwargs: TaskKwargs | None = None) -> str:
+    """Format the white-box event, object, or attribute clue prompt."""
+    kwargs = lmms_eval_specific_kwargs or {}
+    question = doc["question"]
+    category = doc["category"]
+    if category == "event":
+        prompt = (
+            f"Watch the video and answer the question '{question}' by giving the start and end timestamps for every event. "
+            "Return JSON enclosed in <answer> and </answer> tags, in this form: "
+            '<answer>[["start_time", "end_time"], ...]</answer>. Use seconds (for example, "12.34").'
+        )
+    elif category == "object":
+        frame_count = len(_clue_timestamps(doc))
+        prompt = (
+            f"There are {frame_count} frames, ordered as Frame1 through Frame{frame_count}. "
+            f"Answer the question '{question}' by returning the bounding box for every query object in the first frame where it appears. "
+            "Do not repeat an object in later frames. Return JSON enclosed in <answer> and </answer> tags, in this form: "
+            '<answer>{"Frame1": [[x_min, y_min, x_max, y_max]], "Frame2": []}</answer>. '
+            "Use the same 0-100 coordinate scale as the benchmark."
+        )
+    elif category == "attribute":
+        frame_count = len(_clue_timestamps(doc))
+        prompt = (
+            f"There are {frame_count} frames, ordered as Frame1 through Frame{frame_count}. "
+            f"Answer the question '{question}' by clustering objects according to the requested attribute. "
+            "Give each cluster a stable label and return each object's box only in its first frame. Return JSON enclosed in "
+            '<answer> and </answer> tags, in this form: <answer>{"Frame1": [{"bbox": [x_min, y_min, x_max, y_max], '
+            '"label": "Label 1"}], "Frame2": []}</answer>. Use the same 0-100 coordinate scale as the benchmark.'
+        )
+    else:
+        raise ValueError(f"Unsupported CG-AV-Counting category: {category}")
+    return f"{kwargs.get('pre_prompt', '')}{prompt}{kwargs.get('post_prompt', '')}"
+
+
+def _extract_number(value: Any) -> float:
+    if value is None:
+        return 0.0
+    text = str(value).strip().lower().replace(",", "")
+    if "</think>" in text:
+        text = text.rsplit("</think>", 1)[-1].strip()
+    match = re.search(r"[-+]?\d+(?:\.\d+)?", text)
+    if match:
+        return float(match.group(0))
+    tokens = re.findall(r"[a-z]+", text.replace("-", " "))
+    values = [_NUMBER_WORDS[token] for token in tokens if token in _NUMBER_WORDS]
+    if not values:
+        return 0.0
+    return float(sum(values))
+
+
+def _count_result(doc: Document, results: Sequence[str], task_mode: str) -> dict[str, MetricRecord]:
+    prediction = results[0] if results else ""
+    pred = _extract_number(prediction)
+    target = float(doc["answer"])
+    error = abs(target - pred)
+    capped_error = error if error <= max(2 * target, 100) else abs(2 * target)
+    record = {
+        "index": doc["index"],
+        "task_mode": task_mode,
+        "category": doc["category"],
+        "type": doc["type"],
+        "pred": pred,
+        "answer": target,
+        "acc": float(error <= 1e-5),
+        "oboa": float(error <= 1),
+        "mae": capped_error,
+        "squared_error": capped_error**2,
+    }
+    return {metric: record for metric in ("acc", "oboa", "mae", "rmse")}
+
+
+def cgav_process_results_long(doc: Document, results: Sequence[str]) -> dict[str, MetricRecord]:
+    """Score a full-video count with the official long-accuracy metrics."""
+    return _count_result(doc, results, "long_acc")
+
+
+def cgav_process_results_ref(doc: Document, results: Sequence[str]) -> dict[str, MetricRecord]:
+    """Score a reference-clip count with the official reference metrics."""
+    return _count_result(doc, results, "ref_acc")
+
+
+def aggregate_acc(results: Sequence[MetricRecord]) -> float:
+    """Aggregate exact counting accuracy."""
+    return sum(result["acc"] for result in results) / len(results) if results else 0.0
+
+
+def aggregate_oboa(results: Sequence[MetricRecord]) -> float:
+    """Aggregate off-by-one accuracy."""
+    return sum(result["oboa"] for result in results) / len(results) if results else 0.0
+
+
+def aggregate_mae(results: Sequence[MetricRecord]) -> float:
+    """Aggregate the official capped mean absolute error."""
+    return sum(result["mae"] for result in results) / len(results) if results else 0.0
+
+
+def aggregate_rmse(results: Sequence[MetricRecord]) -> float:
+    """Aggregate root mean squared counting error."""
+    return math.sqrt(sum(result["squared_error"] for result in results) / len(results)) if results else 0.0
+
+
+def _temporal_iou(first: Sequence[float], second: Sequence[float]) -> float:
+    intersection = max(0.0, min(first[1], second[1]) - max(first[0], second[0]))
+    union = max(first[1], second[1]) - min(first[0], second[0])
+    return intersection / union if union > 0 else 0.0
+
+
+def _spatial_iou(first: Sequence[float], second: Sequence[float]) -> float:
+    first = [min(first[0], first[2]), min(first[1], first[3]), max(first[0], first[2]), max(first[1], first[3])]
+    second = [min(second[0], second[2]), min(second[1], second[3]), max(second[0], second[2]), max(second[1], second[3])]
+    intersection = max(0, min(first[2], second[2]) - max(first[0], second[0])) * max(0, min(first[3], second[3]) - max(first[1], second[1]))
+    area_first = (first[2] - first[0]) * (first[3] - first[1])
+    area_second = (second[2] - second[0]) * (second[3] - second[1])
+    union = area_first + area_second - intersection
+    return intersection / union if union > 0 else 0.0
+
+
+def _greedy_spatial_score(gt_instances: Sequence[Sequence[float]], pred_instances: Sequence[Sequence[float]]) -> float:
+    unmatched_gt = set(range(len(gt_instances)))
+    unmatched_pred = set(range(len(pred_instances)))
+    score = 0.0
+    while unmatched_gt and unmatched_pred:
+        best = max(
+            ((_spatial_iou(gt_instances[gt], pred_instances[pred]), gt, pred) for gt in unmatched_gt for pred in unmatched_pred),
+            key=lambda item: item[0],
+        )
+        score += best[0]
+        unmatched_gt.remove(best[1])
+        unmatched_pred.remove(best[2])
+    return score
+
+
+def _cluster_pair_wcs(gt: Sequence[Any], pred: Sequence[Any], iou_type: str) -> float:
+    if iou_type == "temporal":
+        localization = sum(max((_temporal_iou(g, p) for p in pred), default=0.0) for g in gt) / len(gt) if gt else 0.0
+        count_penalty = 1.0 - abs(len(pred) - len(gt)) / max(len(gt), 1)
+        return math.sqrt(localization * max(0.0, count_penalty))
+
+    gt_by_frame = defaultdict(list)
+    pred_by_frame = defaultdict(list)
+    for frame, box in gt:
+        gt_by_frame[frame].append(box)
+    for frame, box in pred:
+        pred_by_frame[frame].append(box)
+    frames = set(gt_by_frame) | set(pred_by_frame)
+    score = 0.0
+    for frame in frames:
+        gt_boxes = gt_by_frame.get(frame, [])
+        pred_boxes = pred_by_frame.get(frame, [])
+        localization = _greedy_spatial_score(gt_boxes, pred_boxes) / len(gt_boxes) if gt_boxes else 0.0
+        count_penalty = 1.0 - abs(len(pred_boxes) - len(gt_boxes)) / max(len(gt_boxes), 1)
+        score += math.sqrt(localization * max(0.0, count_penalty))
+    return score / max(len(frames), 1)
+
+
+def _unlabeled_wcs(gt_clusters: Sequence[Sequence[Any]], pred_clusters: Sequence[Sequence[Any]], iou_type: str) -> float:
+    if not gt_clusters or not pred_clusters:
+        return 0.0
+    scores = np.zeros((len(gt_clusters), len(pred_clusters)))
+    for gt_index, gt in enumerate(gt_clusters):
+        for pred_index, pred in enumerate(pred_clusters):
+            scores[gt_index, pred_index] = _cluster_pair_wcs(gt, pred, iou_type)
+    return _max_assignment_sum(scores) / len(gt_clusters)
+
+
+def _max_assignment_sum(scores: Sequence[Sequence[float]] | np.ndarray) -> float:
+    """Maximum-weight rectangular assignment using the O(n^3) Hungarian algorithm."""
+    matrix = np.asarray(scores, dtype=float)
+    if matrix.size == 0:
+        return 0.0
+    if matrix.shape[0] > matrix.shape[1]:
+        matrix = matrix.T
+
+    rows, columns = matrix.shape
+    max_score = float(matrix.max())
+    costs = max_score - matrix
+    u = np.zeros(rows + 1)
+    v = np.zeros(columns + 1)
+    matching = np.zeros(columns + 1, dtype=int)
+    way = np.zeros(columns + 1, dtype=int)
+
+    for row in range(1, rows + 1):
+        matching[0] = row
+        column0 = 0
+        minimum = np.full(columns + 1, np.inf)
+        used = np.zeros(columns + 1, dtype=bool)
+        while True:
+            used[column0] = True
+            current_row = matching[column0]
+            delta = np.inf
+            column1 = 0
+            for column in range(1, columns + 1):
+                if used[column]:
+                    continue
+                current = costs[current_row - 1, column - 1] - u[current_row] - v[column]
+                if current < minimum[column]:
+                    minimum[column] = current
+                    way[column] = column0
+                if minimum[column] < delta:
+                    delta = minimum[column]
+                    column1 = column
+            for column in range(columns + 1):
+                if used[column]:
+                    u[matching[column]] += delta
+                    v[column] -= delta
+                else:
+                    minimum[column] -= delta
+            column0 = column1
+            if matching[column0] == 0:
+                break
+        while True:
+            column1 = way[column0]
+            matching[column0] = matching[column1]
+            column0 = column1
+            if column0 == 0:
+                break
+
+    total = 0.0
+    for column in range(1, columns + 1):
+        if matching[column]:
+            total += matrix[matching[column] - 1, column - 1]
+    return float(total)
+
+
+def _extract_json(response: str) -> Any | None:
+    match = re.search(r"<answer>(.*?)</answer>", response or "", re.DOTALL | re.IGNORECASE)
+    text = match.group(1).strip() if match else (response or "").strip()
+    try:
+        return json.loads(text)
+    except (TypeError, json.JSONDecodeError):
+        pass
+    for start, char in enumerate(text):
+        if char not in "[{":
+            continue
+        stack = []
+        for end in range(start, len(text)):
+            current = text[end]
+            if current in "[{":
+                stack.append(current)
+            elif current in "]}":
+                if not stack or (stack[-1], current) not in (("[", "]"), ("{", "}")):
+                    break
+                stack.pop()
+                if not stack:
+                    try:
+                        return json.loads(text[start : end + 1])
+                    except json.JSONDecodeError:
+                        break
+    return None
+
+
+def _time_to_seconds(value: str | int | float) -> float:
+    if isinstance(value, (int, float)):
+        return float(value)
+    value = str(value).strip().split()[0]
+    if ":" not in value:
+        return float(value)
+    parts = [float(part) for part in value.split(":")]
+    return sum(part * 60**index for index, part in enumerate(reversed(parts)))
+
+
+def _frame_index(key: Any) -> int | None:
+    match = re.search(r"frame\s*(\d+)", str(key), re.IGNORECASE)
+    return int(match.group(1)) - 1 if match else None
+
+
+def _score_clue(doc: Document, response: str) -> tuple[float, float]:
+    parsed = _extract_json(response)
+    if parsed is None:
+        return 0.0, 0.0
+    clues = _parse_clues(doc)
+    category = doc["category"]
+    try:
+        if category == "event":
+            pred = [[_time_to_seconds(item[0]), _time_to_seconds(item[1])] for item in parsed]
+            gt = [[float(item["start"]), float(item["end"])] for item in clues]
+            return _unlabeled_wcs([gt], [pred], "temporal"), 1.0
+
+        timestamps = _clue_timestamps(doc)
+        if category == "object":
+            gt = [(timestamps.index(float(item["timestamp"])), item["bbox"]) for item in clues]
+            pred = []
+            for key, boxes in parsed.items():
+                frame = _frame_index(key)
+                if frame is None or not isinstance(boxes, list):
+                    continue
+                if boxes and all(isinstance(value, (int, float)) for value in boxes) and len(boxes) == 4:
+                    boxes = [boxes]
+                elif boxes and all(isinstance(point, list) and len(point) == 2 for point in boxes):
+                    boxes = [[boxes[index][0], boxes[index][1], boxes[index + 1][0], boxes[index + 1][1]] for index in range(0, len(boxes) - 1, 2)]
+                for box in boxes:
+                    if isinstance(box, list) and len(box) == 4:
+                        pred.append((frame, box))
+            return _unlabeled_wcs([gt], [pred], "spatial"), 1.0
+
+        gt_clusters = [[(timestamps.index(float(item["timestamp"])), item["bbox"]) for item in cluster] for cluster in clues]
+        pred_clusters = defaultdict(list)
+        for key, objects in parsed.items():
+            frame = _frame_index(key)
+            if frame is None or not isinstance(objects, list):
+                continue
+            for item in objects:
+                if not isinstance(item, dict) or "label" not in item:
+                    continue
+                box = item.get("bbox", item.get("bbox_2d"))
+                if isinstance(box, list) and len(box) == 4:
+                    pred_clusters[str(item["label"])].append((frame, box))
+        return _unlabeled_wcs(gt_clusters, list(pred_clusters.values()), "spatial"), 1.0
+    except (KeyError, TypeError, ValueError, IndexError):
+        return 0.0, 0.0
+
+
+def cgav_process_results_clue(doc: Document, results: Sequence[str]) -> dict[str, MetricRecord]:
+    """Score a white-box clue response with WCS and valid-format accuracy."""
+    response = results[0] if results else ""
+    wcs, ifa = _score_clue(doc, response)
+    record = {
+        "index": doc["index"],
+        "category": doc["category"],
+        "type": doc["type"],
+        "wcs": float(wcs),
+        "ifa": float(ifa),
+    }
+    return {"wcs": record, "ifa": record}
+
+
+def aggregate_wcs(results: Sequence[MetricRecord]) -> float:
+    """Aggregate weighted clue score."""
+    return sum(result["wcs"] for result in results) / len(results) if results else 0.0
+
+
+def aggregate_ifa(results: Sequence[MetricRecord]) -> float:
+    """Aggregate valid-format accuracy for clue responses."""
+    return sum(result["ifa"] for result in results) / len(results) if results else 0.0

--- a/lmms_eval/tasks/cgbench/README.md
+++ b/lmms_eval/tasks/cgbench/README.md
@@ -1,0 +1,18 @@
+# CG-Bench
+
+This task ports the black-box multiple-choice evaluation from the
+[VideoITG lmms-eval integration](https://github.com/NVlabs/VideoITG/tree/main/lmms_eval/tasks/cgbench)
+and the official [CG-Bench](https://github.com/CG-Bench/CG-Bench) protocol.
+`cgbench` evaluates video only;
+`cgbench_subtitles` adds subtitles aligned to the model's uniformly sampled frames;
+`cgbench_all` runs both variants. The default is the official 3,000-question mini split.
+
+The dataset is gated. Accept its terms at
+https://huggingface.co/datasets/CG-Bench/CG-Bench and authenticate with a Hugging
+Face token before running. Media is normally downloaded and extracted under
+`$HF_HOME/cg_videos_720p`. Existing media can instead be exposed through
+`CGBENCH_VIDEO_DIR`; subtitles can be exposed through `CGBENCH_SUBTITLE_DIR`.
+
+```bash
+accelerate launch -m lmms_eval --model <model> --tasks cgbench --batch_size 1
+```

--- a/lmms_eval/tasks/cgbench/__init__.py
+++ b/lmms_eval/tasks/cgbench/__init__.py
@@ -1,0 +1,1 @@
+"""CG-Bench long-video question answering tasks."""

--- a/lmms_eval/tasks/cgbench/_default_template_yaml
+++ b/lmms_eval/tasks/cgbench/_default_template_yaml
@@ -1,0 +1,29 @@
+dataset_path: CG-Bench/CG-Bench
+dataset_name: cg-bench-mini
+dataset_kwargs:
+  token: true
+  cache_dir: cg_videos_720p
+  video: true
+test_split: train
+output_type: generate_until
+cluster_key: video_uid
+doc_to_visual: !function utils.cgbench_doc_to_visual
+doc_to_target: right_answer
+generation_kwargs:
+  max_new_tokens: 16
+  temperature: 0
+  top_p: 1.0
+  num_beams: 1
+  do_sample: false
+process_results: !function utils.cgbench_process_results
+metric_list:
+  - metric: cgbench_accuracy
+    aggregation: !function utils.cgbench_aggregate_results
+    higher_is_better: true
+lmms_eval_specific_kwargs:
+  default:
+    pre_prompt: ""
+    post_prompt: "\nAnswer with the option letter only."
+    frame_num: 32
+metadata:
+  - version: 1.0

--- a/lmms_eval/tasks/cgbench/cgbench.yaml
+++ b/lmms_eval/tasks/cgbench/cgbench.yaml
@@ -1,0 +1,3 @@
+task: cgbench
+include: _default_template_yaml
+doc_to_text: !function utils.cgbench_doc_to_text

--- a/lmms_eval/tasks/cgbench/cgbench_group.yaml
+++ b/lmms_eval/tasks/cgbench/cgbench_group.yaml
@@ -1,0 +1,6 @@
+group: cgbench_all
+task:
+  - cgbench
+  - cgbench_subtitles
+metadata:
+  - version: 1.0

--- a/lmms_eval/tasks/cgbench/cgbench_subtitles.yaml
+++ b/lmms_eval/tasks/cgbench/cgbench_subtitles.yaml
@@ -1,0 +1,3 @@
+task: cgbench_subtitles
+include: _default_template_yaml
+doc_to_text: !function utils.cgbench_doc_to_text_subtitle

--- a/lmms_eval/tasks/cgbench/utils.py
+++ b/lmms_eval/tasks/cgbench/utils.py
@@ -1,0 +1,154 @@
+import os
+import re
+from collections import defaultdict
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+import cv2
+from loguru import logger as eval_logger
+
+from lmms_eval.tasks._task_utils.media_resolver import resolve_media_reference
+
+Document = Mapping[str, Any]
+TaskKwargs = Mapping[str, Any]
+MetricRecord = dict[str, Any]
+
+
+def _video_reference(doc: Document) -> str:
+    return f"{doc['video_uid']}.mp4"
+
+
+def _resolve_video(doc: Document) -> str:
+    return resolve_media_reference(
+        _video_reference(doc),
+        media_type="video",
+        cache_dir="cg_videos_720p",
+        env_vars=("CGBENCH_VIDEO_DIR", "CGBENCH_ROOT"),
+        extra_subdirs=("cg_videos_720p", "videos"),
+    )
+
+
+def cgbench_doc_to_visual(doc: Document) -> list[str]:
+    """Resolve the local video for one CG-Bench example."""
+    video_path = _resolve_video(doc)
+    if not os.path.exists(video_path):
+        raise FileNotFoundError(f"CG-Bench video not found: {video_path}. Accept the dataset terms on Hugging Face " "and set CGBENCH_VIDEO_DIR to the extracted video directory if needed.")
+    return [video_path]
+
+
+def _format_question(doc: Document) -> str:
+    choices = "\n".join(f"{chr(65 + index)}. {choice}" for index, choice in enumerate(doc["choices"]))
+    return f"{doc['question']}\n{choices}"
+
+
+def cgbench_doc_to_text(doc: Document, lmms_eval_specific_kwargs: TaskKwargs | None = None) -> str:
+    """Format the video-only multiple-choice prompt."""
+    kwargs = lmms_eval_specific_kwargs or {}
+    instruction = "Select the best answer to the following multiple-choice question based on the video."
+    return f"{kwargs.get('pre_prompt', '')}{instruction}\n{_format_question(doc)}{kwargs.get('post_prompt', '')}"
+
+
+def _parse_srt_timestamp(value: str) -> float:
+    hours, minutes, seconds = value.strip().replace(".", ",").split(":")
+    seconds, milliseconds = seconds.split(",")
+    return int(hours) * 3600 + int(minutes) * 60 + int(seconds) + int(milliseconds) / 1000
+
+
+def _read_srt(path: str | Path) -> list[tuple[float, float, str]]:
+    entries = []
+    content = Path(path).read_text(encoding="utf-8", errors="replace")
+    for block in re.split(r"\r?\n\r?\n", content.strip()):
+        lines = block.splitlines()
+        time_line = next((line for line in lines if " --> " in line), None)
+        if time_line is None:
+            continue
+        start, end = time_line.split(" --> ", 1)
+        time_index = lines.index(time_line)
+        entries.append((_parse_srt_timestamp(start), _parse_srt_timestamp(end), " ".join(lines[time_index + 1 :])))
+    return entries
+
+
+def _resolve_subtitle(doc: Document) -> str:
+    return resolve_media_reference(
+        f"{doc['video_uid']}.srt",
+        media_type="video",
+        cache_dir="cg_videos_720p",
+        env_vars=("CGBENCH_SUBTITLE_DIR", "CGBENCH_ROOT"),
+        extra_subdirs=("cg_subtitles", "subtitles"),
+    )
+
+
+def _sampled_subtitles(doc: Document, frame_num: int) -> str:
+    subtitle_path = _resolve_subtitle(doc)
+    if not os.path.exists(subtitle_path):
+        return "No subtitles available."
+
+    entries = _read_srt(subtitle_path)
+    if not entries:
+        return "No subtitles available."
+
+    video_path = _resolve_video(doc)
+    capture = cv2.VideoCapture(video_path)
+    fps = capture.get(cv2.CAP_PROP_FPS)
+    frame_count = int(capture.get(cv2.CAP_PROP_FRAME_COUNT))
+    capture.release()
+    if fps <= 0 or frame_count <= 0 or frame_num == -1:
+        return "\n".join(text for _, _, text in entries)
+
+    sample_count = max(1, min(int(frame_num), frame_count))
+    timestamps = [index * (frame_count - 1) / max(sample_count - 1, 1) / fps for index in range(sample_count)]
+    selected = []
+    for start, end, text in entries:
+        if any(start <= timestamp < end for timestamp in timestamps):
+            selected.append(text)
+    return "\n".join(selected) if selected else "No subtitles available."
+
+
+def cgbench_doc_to_text_subtitle(doc: Document, lmms_eval_specific_kwargs: TaskKwargs | None = None) -> str:
+    """Format the multiple-choice prompt with subtitles aligned to sampled frames."""
+    kwargs = lmms_eval_specific_kwargs or {}
+    subtitles = _sampled_subtitles(doc, kwargs.get("frame_num", 32))
+    instruction = "Select the best answer to the following multiple-choice question based on the video and subtitles."
+    return f"{kwargs.get('pre_prompt', '')}This video's subtitles are listed below:\n{subtitles}\n" f"{instruction}\n{_format_question(doc)}{kwargs.get('post_prompt', '')}"
+
+
+def extract_characters_regex(response: str) -> str:
+    """Extract one valid CG-Bench option letter from a model response."""
+    from lmms_eval.tasks._task_utils.mcq_extract import extract_mcq_answer
+
+    return extract_mcq_answer(response or "", choices=[chr(65 + index) for index in range(14)])
+
+
+def cgbench_process_results(doc: Document, results: Sequence[str]) -> dict[str, MetricRecord]:
+    """Parse a prediction and emit the CG-Bench accuracy record."""
+    prediction = results[0] if results else ""
+    parsed_prediction = extract_characters_regex(prediction)
+    answer = str(doc["right_answer"]).strip().upper()
+    return {
+        "cgbench_accuracy": {
+            "question_id": doc["qid"],
+            "video_uid": doc["video_uid"],
+            "duration": doc["duration"],
+            "category": doc["domain"],
+            "sub_category": doc["sub_category"],
+            "pred_answer": parsed_prediction,
+            "answer": answer,
+            "score": float(parsed_prediction == answer),
+        }
+    }
+
+
+def cgbench_aggregate_results(results: Sequence[MetricRecord]) -> float:
+    """Aggregate CG-Bench exact-match accuracy as a percentage."""
+    if not results:
+        return 0.0
+    category_scores = defaultdict(list)
+    subcategory_scores = defaultdict(list)
+    for result in results:
+        category_scores[result["category"]].append(result["score"])
+        subcategory_scores[result["sub_category"]].append(result["score"])
+    for name, scores in sorted(category_scores.items()):
+        eval_logger.info(f"CG-Bench/{name}: {100 * sum(scores) / len(scores):.2f}")
+    for name, scores in sorted(subcategory_scores.items()):
+        eval_logger.debug(f"CG-Bench/{name}: {100 * sum(scores) / len(scores):.2f}")
+    return 100.0 * sum(result["score"] for result in results) / len(results)

--- a/test/eval/test_cgav_counting.py
+++ b/test/eval/test_cgav_counting.py
@@ -1,0 +1,132 @@
+import json
+import zipfile
+
+import cv2
+import numpy as np
+
+from lmms_eval.tasks import TaskManager
+from lmms_eval.tasks.cgav_counting import utils as cgav_utils
+
+
+def _write_test_video(path, frame_count=3, fps=2):
+    writer = cv2.VideoWriter(str(path), cv2.VideoWriter_fourcc(*"mp4v"), fps, (8, 8))
+    assert writer.isOpened(), "OpenCV cannot create the temporary MP4 test fixture"
+    for value in range(frame_count):
+        writer.write(np.full((8, 8, 3), value * 50, dtype=np.uint8))
+    writer.release()
+
+
+def test_cgav_counting_tasks_are_registered():
+    task_manager = TaskManager("ERROR")
+    expected = {"cgav_counting", "cgav_counting_long", "cgav_counting_ref", "cgav_counting_clue"}
+    assert not expected.difference(task_manager.all_tasks)
+
+
+def test_cgav_counting_metrics():
+    doc = {"index": 0, "answer": "18", "category": "object", "type": "A2V"}
+    result = cgav_utils.cgav_process_results_long(doc, ["The answer is 18."])
+
+    assert result["acc"]["acc"] == 1.0
+    assert result["oboa"]["oboa"] == 1.0
+    assert result["mae"]["mae"] == 0.0
+    assert result["rmse"]["squared_error"] == 0.0
+
+
+def test_cgav_counting_caps_outlier_error_like_official_evaluator():
+    doc = {"index": 0, "answer": "18", "category": "object", "type": "A2V"}
+    result = cgav_utils.cgav_process_results_long(doc, ["999"])
+
+    assert result["mae"]["mae"] == 36.0
+    assert result["rmse"]["squared_error"] == 1296.0
+
+
+def test_cgav_counting_aggregations_match_official_definitions():
+    first = cgav_utils.cgav_process_results_long({"index": 0, "answer": "10", "category": "object", "type": "V"}, ["10"])
+    second = cgav_utils.cgav_process_results_long({"index": 1, "answer": "10", "category": "object", "type": "V"}, ["12"])
+
+    assert cgav_utils.aggregate_acc([first["acc"], second["acc"]]) == 0.5
+    assert cgav_utils.aggregate_oboa([first["oboa"], second["oboa"]]) == 0.5
+    assert cgav_utils.aggregate_mae([first["mae"], second["mae"]]) == 1.0
+    assert cgav_utils.aggregate_rmse([first["rmse"], second["rmse"]]) == 2**0.5
+
+
+def test_cgav_reference_filename_uses_official_rounding():
+    doc = {"video": "abc.mp4", "query_interval": [1, 2.345]}
+    assert cgav_utils._reference_filename(doc) == "abc_1.00_2.35.mp4"
+
+
+def test_cgav_clue_frame_extraction_decodes_real_video(tmp_path):
+    video = tmp_path / "video.mp4"
+    _write_test_video(video)
+
+    frames = cgav_utils._frames_at_timestamps(str(video), [0.0, 0.9])
+
+    assert len(frames) == 2
+    assert all(frame.size == (8, 8) for frame in frames)
+    assert np.asarray(frames[1]).mean() > np.asarray(frames[0]).mean()
+
+
+def test_cgav_extracts_official_style_split_archives(monkeypatch, tmp_path):
+    source = tmp_path / "source.mp4"
+    _write_test_video(source)
+    archive = tmp_path / "videos.zip"
+    with zipfile.ZipFile(archive, "w") as handle:
+        handle.write(source, "demo-video.mp4")
+    payload = archive.read_bytes()
+    midpoint = len(payload) // 2
+    (tmp_path / "videos.zip.part000").write_bytes(payload[:midpoint])
+    (tmp_path / "videos.zip.part001").write_bytes(payload[midpoint:])
+    archive.unlink()
+    monkeypatch.setenv("CGAV_COUNTING_ROOT", str(tmp_path))
+
+    cgav_utils._ensure_media_extracted(("cg_videos_720p", "videos"))
+
+    assert (tmp_path / "cg_videos_720p" / "demo-video.mp4").is_file()
+    assert not (tmp_path / "videos.zip").exists()
+
+
+def test_cgav_event_clue_perfect_wcs():
+    doc = {
+        "index": 1,
+        "category": "event",
+        "type": "A",
+        "clue": json.dumps([{"start": 1, "end": 3}]),
+    }
+    result = cgav_utils.cgav_process_results_clue(doc, ['<answer>[["1.00", "3.00"]]</answer>'])
+
+    assert result["wcs"]["wcs"] == 1.0
+    assert result["ifa"]["ifa"] == 1.0
+
+
+def test_cgav_object_and_attribute_clue_perfect_wcs():
+    object_doc = {
+        "index": 2,
+        "category": "object",
+        "type": "V",
+        "clue": json.dumps([{"timestamp": 2, "bbox": [0, 0, 10, 10]}]),
+    }
+    object_result = cgav_utils.cgav_process_results_clue(object_doc, ['<answer>{"Frame1": [[0,0,10,10]]}</answer>'])
+    assert object_result["wcs"]["wcs"] == 1.0
+
+    attribute_doc = {
+        "index": 3,
+        "category": "attribute",
+        "type": "V",
+        "clue": json.dumps([[{"timestamp": 2, "bbox": [0, 0, 10, 10]}]]),
+    }
+    prediction = '<answer>{"Frame 1": [{"bbox": [0,0,10,10], "label": "x"}]}</answer>'
+    attribute_result = cgav_utils.cgav_process_results_clue(attribute_doc, [prediction])
+    assert attribute_result["wcs"]["wcs"] == 1.0
+
+
+def test_cgav_malformed_clue_response_has_zero_wcs_and_ifa():
+    doc = {
+        "index": 4,
+        "category": "event",
+        "type": "A",
+        "clue": json.dumps([{"start": 1, "end": 3}]),
+    }
+    result = cgav_utils.cgav_process_results_clue(doc, ["not valid JSON"])
+
+    assert result["wcs"]["wcs"] == 0.0
+    assert result["ifa"]["ifa"] == 0.0

--- a/test/eval/test_cgbench.py
+++ b/test/eval/test_cgbench.py
@@ -1,0 +1,87 @@
+import cv2
+import numpy as np
+
+from lmms_eval.tasks import TaskManager
+from lmms_eval.tasks.cgbench import utils as cgbench_utils
+
+
+def _doc(answer="A"):
+    return {
+        "qid": 1,
+        "video_uid": "demo-video",
+        "question": "Which option is correct?",
+        "choices": [f"Option {index}" for index in range(14)],
+        "right_answer": answer,
+        "domain": "Knowledge",
+        "sub_category": "Entity Perception",
+        "duration": 600,
+    }
+
+
+def _write_test_video(path, frame_count=4, fps=2):
+    writer = cv2.VideoWriter(str(path), cv2.VideoWriter_fourcc(*"mp4v"), fps, (8, 8))
+    assert writer.isOpened(), "OpenCV cannot create the temporary MP4 test fixture"
+    for value in range(frame_count):
+        writer.write(np.full((8, 8, 3), value * 50, dtype=np.uint8))
+    writer.release()
+
+
+def test_cgbench_tasks_are_registered():
+    task_manager = TaskManager("ERROR")
+    expected = {"cgbench", "cgbench_subtitles", "cgbench_all"}
+    assert not expected.difference(task_manager.all_tasks)
+
+
+def test_cgbench_supports_all_fourteen_choice_letters():
+    assert cgbench_utils.extract_characters_regex("The correct answer is (N).") == "N"
+
+
+def test_cgbench_doc_to_visual_resolves_configured_media_root(monkeypatch, tmp_path):
+    video = tmp_path / "cg_videos_720p" / "demo-video.mp4"
+    video.parent.mkdir()
+    video.touch()
+    monkeypatch.setenv("CGBENCH_VIDEO_DIR", str(tmp_path))
+
+    assert cgbench_utils.cgbench_doc_to_visual(_doc()) == [str(video)]
+
+
+def test_cgbench_prompts_include_all_options_and_subtitle_fallback():
+    doc = _doc()
+    prompt = cgbench_utils.cgbench_doc_to_text(doc, {"pre_prompt": "Video QA:\n", "post_prompt": "\nLetter only."})
+    subtitle_prompt = cgbench_utils.cgbench_doc_to_text_subtitle(doc, {"post_prompt": "\nLetter only."})
+
+    assert prompt.startswith("Video QA:\nSelect the best answer")
+    assert "A. Option 0" in prompt
+    assert "N. Option 13" in prompt
+    assert prompt.endswith("\nLetter only.")
+    assert "No subtitles available." in subtitle_prompt
+    assert "N. Option 13" in subtitle_prompt
+
+
+def test_cgbench_subtitles_are_aligned_to_decoded_video_frames(monkeypatch, tmp_path):
+    video_dir = tmp_path / "cg_videos_720p"
+    subtitle_dir = tmp_path / "cg_subtitles"
+    video_dir.mkdir()
+    subtitle_dir.mkdir()
+    _write_test_video(video_dir / "demo-video.mp4")
+    (subtitle_dir / "demo-video.srt").write_text(
+        "1\n00:00:00,000 --> 00:00:01,000\nFirst caption\n\n" "2\n00:00:01,000 --> 00:00:02,000\nSecond caption\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CGBENCH_ROOT", str(tmp_path))
+
+    prompt = cgbench_utils.cgbench_doc_to_text_subtitle(_doc(), {"frame_num": 1})
+
+    assert "First caption" in prompt
+    assert "Second caption" not in prompt
+
+
+def test_cgbench_process_results_and_aggregate_accuracy():
+    correct = cgbench_utils.cgbench_process_results(_doc("A"), ["The answer is A."])["cgbench_accuracy"]
+    wrong = cgbench_utils.cgbench_process_results(_doc("B"), ["A"])["cgbench_accuracy"]
+
+    assert correct["question_id"] == 1
+    assert correct["pred_answer"] == "A"
+    assert correct["score"] == 1.0
+    assert wrong["score"] == 0.0
+    assert cgbench_utils.cgbench_aggregate_results([correct, wrong]) == 50.0


### PR DESCRIPTION
## Summary

  - Add CG-Bench video-only and subtitle-conditioned multiple-choice tasks.
  - Add CG-AV-Counting long-video, reference-clip, and white-box clue-grounding protocols.
  - Add automated media download/extraction, scoring, and real video-decoding tests.

 ## In scope

  - Add CG-Bench long-video multiple-choice QA:
    - `cgbench`: video-only questions.
    - `cgbench_subtitles`: the same questions with subtitles aligned to uniformly sampled video frames.
    - `cgbench_all`: group that runs both variants.

  - Add CG-AV-Counting long-video protocols:
    - `cgav_counting_long`: count over the complete video; reports ACC, OBOA, MAE, and RMSE.
    - `cgav_counting_ref`: count within the official query-interval reference clip; reports ACC, OBOA, MAE, and RMSE.
    - `cgav_counting_clue`: white-box evidence grounding—event intervals, object boxes, or attribute clusters; reports WCS and IFA.
    - `cgav_counting`: group that runs all three protocols.

  - Automatically download, merge, and extract CG-AV-Counting split media archives during normal task execution.
  - Add task registration, prompt, media resolution, subtitle alignment, real MP4 decoding, and metric tests.


  ## Out of scope

  - Model-specific end-to-end inference baselines.
  - Changes to existing tasks or model backends.

  ## Validation

  - `UV_CACHE_DIR=/tmp/lmms_eval_uv_cache uvx pre-commit run --files lmms_eval/tasks/cgbench/utils.py lmms_eval/tasks/cgav_counting/utils.py test/eval/test_cgbench.py  test/eval/test_cgav_counting.py` | result: pass
  - `pytest -q test/eval/test_cgbench.py test/eval/test_cgav_counting.py` | N=16 | result: 16 passed
  - Real MP4 decoding and CG-Bench subtitle/frame alignment are covered with generated local media fixtures.

  ## Risk / Compatibility

  - No existing task behavior changes.
  - The Hugging Face datasets require users to accept their gated access terms and provide a valid token. Once access is available, task execution downloads and  prepares media automatically.
  - Media is large; first execution requires substantial download time and disk space.

  ## Type of Change

  - [x] New benchmark/task
  - [x] Documentation update