### PR TITLE
Add Qwen-native JSON coordinate variants for pointing tasks

### DIFF
--- a/lmms_eval/tasks/_task_utils/point_format.py
+++ b/lmms_eval/tasks/_task_utils/point_format.py
@@ -1,0 +1,31 @@
+"""Shared helper for Qwen-native point parsing.
+
+Qwen-VL grounding models emit points as a JSON list of
+``{"point_2d": [x, y], ...}`` entries on a 0-1000 normalized grid. The pointing
+tasks (where2place / refspatial / pointbench) ship ``*_json`` variants that
+prompt for this format and parse it with :func:`parse_point2d` below.
+"""
+
+import re
+
+import numpy as np
+
+
+def parse_point2d(text: str, width: int, height: int) -> np.ndarray:
+    """Parse ``[x, y]`` / ``(x, y)`` coordinate pairs into pixel points.
+
+    Integers are interpreted on a 0-1000 grid (divided by 1000, then scaled to
+    the image); floats are treated as already-normalized in [0, 1]. This covers
+    Qwen's native ``"point_2d": [x, y]`` JSON output as well as bare tuples.
+    """
+    pattern = r"[\[\(]\s*([-+]?\d+\.?\d*)\s*,\s*([-+]?\d+\.?\d*)\s*[\]\)]"
+    points = []
+    for xs, ys in re.findall(pattern, text):
+        xf, yf = float(xs), float(ys)
+        is_float = ("." in xs) or ("." in ys)
+        if is_float:
+            x, y = int(xf * width), int(yf * height)
+        else:
+            x, y = int(xf / 1000 * width), int(yf / 1000 * height)
+        points.append((x, y))
+    return np.array(points)

--- a/lmms_eval/tasks/pointbench/pointbench_json.yaml
+++ b/lmms_eval/tasks/pointbench/pointbench_json.yaml
@@ -1,0 +1,5 @@
+task: pointbench_json
+test_split: train
+include: _default_template_yaml
+doc_to_text: !function utils.pointbench_doc_to_text_json
+process_results: !function utils.pointbench_process_results_json

--- a/lmms_eval/tasks/pointbench/utils.py
+++ b/lmms_eval/tasks/pointbench/utils.py
@@ -3,13 +3,14 @@ import unicodedata
 import zipfile
 from functools import lru_cache
 from io import BytesIO
-from typing import Any, Dict, List
+from typing import Any, Callable, Dict, List
 
 import datasets
 import numpy as np
 from PIL import Image
 
 from lmms_eval.tasks._task_utils.default_template_yaml import load_default_template_yaml
+from lmms_eval.tasks._task_utils.point_format import parse_point2d
 from lmms_eval.utils import eval_logger
 
 POINTARENA_REPO = "PointArena/pointarena-data"
@@ -34,6 +35,23 @@ def pointbench_doc_to_text(doc: Dict[str, Any], lmms_eval_specific_kwargs: Dict[
     post_prompt = kwargs.get("post_prompt", "")
     user_input = str(doc.get("user_input", "")).strip()
     return f"{pre_prompt}{user_input} {suffix} {FORMAT}{post_prompt}".strip()
+
+
+def pointbench_doc_to_text_json(doc: Dict[str, Any], lmms_eval_specific_kwargs: Dict[str, Any] | None = None) -> str:
+    """Qwen-native variant: 'pointing:' framing + JSON point_2d on a 0-1000 grid.
+
+    A bare coordinate suffix makes the model decline with "There are none"; the
+    "pointing:" framing elicits its native point_2d JSON.
+    """
+    kwargs = lmms_eval_specific_kwargs or {}
+    pre_prompt = kwargs.get("pre_prompt", "")
+    post_prompt = kwargs.get("post_prompt", "")
+    user_input = str(doc.get("user_input", "")).strip()
+    if doc.get("category", "") == "counting":
+        question = f"pointing: {user_input}, You should point to all the objects in the image that are mentioned in the question."
+    else:
+        question = f"pointing: {user_input}"
+    return f"{pre_prompt}{question}\nReturn points in JSON format and normalized to the range [0, 1000].{post_prompt}".strip()
 
 
 def _zip_basename_key(name: str) -> str:
@@ -175,7 +193,9 @@ def _binary_score(points: np.ndarray, mask: np.ndarray, category: str, expected_
     return 1
 
 
-def pointbench_process_results(doc: Dict[str, Any], result: List[str]) -> Dict[str, Dict[str, Any]]:
+def _pointbench_eval(doc: Dict[str, Any], result: List[str], parser: Callable[[str, int, int], np.ndarray]) -> Dict[str, Dict[str, Any]]:
+    """Score one example with ``parser`` (tuples for the default task, JSON for
+    the ``_json`` variant). Emits both the fraction and the binary metric."""
     mask_filename = str(doc.get("mask_filename", ""))
     mask = _load_mask(mask_filename)
     response = result[0] if result else ""
@@ -188,7 +208,7 @@ def pointbench_process_results(doc: Dict[str, Any], result: List[str]) -> Dict[s
         binary = {"id": sample_id, "score": 0, "category": category}
         return {"pointbench_acc": frac, "pointbench_binary_acc": binary}
 
-    points = _text_to_points(response, mask.shape[1], mask.shape[0])
+    points = parser(response, mask.shape[1], mask.shape[0])
 
     # Fraction metric (OSS native): mean mask value over all predicted points.
     acc = 0.0
@@ -209,6 +229,15 @@ def pointbench_process_results(doc: Dict[str, Any], result: List[str]) -> Dict[s
     }
     binary_submission = {"id": sample_id, "score": int(binary), "category": category}
     return {"pointbench_acc": frac_submission, "pointbench_binary_acc": binary_submission}
+
+
+def pointbench_process_results(doc: Dict[str, Any], result: List[str]) -> Dict[str, Dict[str, Any]]:
+    return _pointbench_eval(doc, result, _text_to_points)
+
+
+def pointbench_process_results_json(doc: Dict[str, Any], result: List[str]) -> Dict[str, Dict[str, Any]]:
+    """Qwen-native variant: parse JSON point_2d; identical fraction + binary scoring."""
+    return _pointbench_eval(doc, result, parse_point2d)
 
 
 def pointbench_aggregate_results(results: List[Dict[str, Any]]) -> float:

--- a/lmms_eval/tasks/pointbench/utils.py
+++ b/lmms_eval/tasks/pointbench/utils.py
@@ -9,7 +9,8 @@ import datasets
 import numpy as np
 from PIL import Image
 
-from lmms_eval.tasks._task_utils.default_template_yaml import load_default_template_yaml
+from lmms_eval.tasks._task_utils.default_template_yaml import \
+    load_default_template_yaml
 from lmms_eval.tasks._task_utils.point_format import parse_point2d
 from lmms_eval.utils import eval_logger
 

--- a/lmms_eval/tasks/refspatial/refspatial_location_json.yaml
+++ b/lmms_eval/tasks/refspatial/refspatial_location_json.yaml
@@ -1,0 +1,5 @@
+test_split: location
+task: "refspatial_location_json"
+include: _default_template_yaml
+doc_to_text: !function utils.refspatial_doc_to_text_json
+process_results: !function utils.refspatial_process_results_json

--- a/lmms_eval/tasks/refspatial/refspatial_placement_json.yaml
+++ b/lmms_eval/tasks/refspatial/refspatial_placement_json.yaml
@@ -1,0 +1,5 @@
+test_split: placement
+task: "refspatial_placement_json"
+include: _default_template_yaml
+doc_to_text: !function utils.refspatial_doc_to_text_json
+process_results: !function utils.refspatial_process_results_json

--- a/lmms_eval/tasks/refspatial/refspatial_unseen_json.yaml
+++ b/lmms_eval/tasks/refspatial/refspatial_unseen_json.yaml
@@ -1,0 +1,5 @@
+test_split: unseen
+task: "refspatial_unseen_json"
+include: _default_template_yaml
+doc_to_text: !function utils.refspatial_doc_to_text_json
+process_results: !function utils.refspatial_process_results_json

--- a/lmms_eval/tasks/refspatial/utils.py
+++ b/lmms_eval/tasks/refspatial/utils.py
@@ -5,6 +5,8 @@ from typing import Any, Dict, List
 import numpy as np
 import yaml
 
+from lmms_eval.tasks._task_utils.point_format import parse_point2d
+
 PROMPT_SUFFIX_0_999 = (
     "Your answer should be formatted as a list of tuples, i.e. [(x1, y1)], "
     "where each tuple contains the x and y coordinates of a point satisfying the conditions above. "
@@ -12,6 +14,17 @@ PROMPT_SUFFIX_0_999 = (
 )
 
 FORMAT = "Return only list of tuples, don't add anything else."
+
+# JSON ("json") variant: replace the dataset's default tuple-format suffix with a
+# Qwen-native single-point JSON instruction on a 0-1000 grid. Any task-specific
+# clarification suffix is kept.
+_SUFFIX_TO_STRIP = "Your answer should be formatted as a list of tuples, i.e. [(x1, y1)], where each tuple contains the x and y coordinates of a point satisfying the conditions above. The coordinates should be between 0 and 1, indicating the normalized pixel locations of the points in the image."
+
+_JSON_POST_PROMPT = """Pinpoint the SINGLE best 2D point that satisfies the description. Output exactly one coordinate pair in JSON, normalized to [0, 1000]:
+```json
+[{"point_2d": [x, y], "label": "target"}]
+```
+Do not output more than one point. Do not include additional text after the JSON block."""
 
 with open(Path(__file__).parent / "_default_template_yaml", "r") as f:
     raw_data = f.readlines()
@@ -29,6 +42,15 @@ def refspatial_doc_to_text(doc: dict[str, Any]) -> str:
         print(config)
         return f"{doc['prompt']} {PROMPT_SUFFIX_0_999} {FORMAT}"
     return f"{doc['prompt']} {doc['suffix']} {FORMAT}"
+
+
+def refspatial_doc_to_text_json(doc: dict[str, Any]) -> str:
+    """Qwen-native variant: ask for a single point_2d in JSON on a 0-1000 grid."""
+    prompt = doc["prompt"]
+    suffix = doc.get("suffix", "")
+    if suffix and suffix.strip() != _SUFFIX_TO_STRIP.strip():
+        prompt = f"{prompt} {suffix}"
+    return f"{prompt}\n{_JSON_POST_PROMPT}"
 
 
 def refspatial_doc_to_visual(doc: dict) -> list:
@@ -53,6 +75,14 @@ def _text2pts(text: str, width: int = 640, height: int = 480, normalization_cons
     return np.array(points)
 
 
+def _refspatial_acc(mask: np.ndarray, points: np.ndarray) -> float:
+    acc = 0.0
+    if len(points) > 0:
+        in_range = (points[:, 0] >= 0) & (points[:, 0] < mask.shape[1]) & (points[:, 1] >= 0) & (points[:, 1] < mask.shape[0])
+        acc = np.concatenate([mask[points[in_range, 1], points[in_range, 0]], np.zeros(points.shape[0] - in_range.sum())]).mean()
+    return acc
+
+
 # inspired by original work: https://github.com/Zhoues/RoboRefer/blob/main/Evaluation/summarize_acc.py
 def refspatial_process_results(doc: Dict, result: List[str]) -> Dict[str, Dict]:
     key_name = "refspatial_acc"
@@ -73,15 +103,24 @@ def refspatial_process_results(doc: Dict, result: List[str]) -> Dict[str, Dict]:
     normalization_constant = 1000 if prompt_suffix_type == "0_999" else 1
     points = _text2pts(response, mask.shape[1], mask.shape[0], normalization_constant)
 
-    # process the answer
-    acc = 0.0
-    if len(points) > 0:
-        in_range = (points[:, 0] >= 0) & (points[:, 0] < mask.shape[1]) & (points[:, 1] >= 0) & (points[:, 1] < mask.shape[0])
-        acc = np.concatenate([mask[points[in_range, 1], points[in_range, 0]], np.zeros(points.shape[0] - in_range.sum())]).mean()
-
+    acc = _refspatial_acc(mask, points)
     query = refspatial_doc_to_text(doc)
     omnispatial_submission = {"id": doc["id"], "query": query, "pred": response, "parsed_points": list(map(tuple, points)), "accuracy": acc}
     return {key_name: omnispatial_submission}
+
+
+def refspatial_process_results_json(doc: Dict, result: List[str]) -> Dict[str, Dict]:
+    """Qwen-native variant: parse JSON point_2d; identical mask scoring."""
+    mask = np.array(doc["mask"]) / 255.0
+    mask = np.round(mask, 0).astype(int)
+    if mask.ndim == 3:
+        mask = mask[:, :, 0]
+
+    response = result[0]
+    points = parse_point2d(response, mask.shape[1], mask.shape[0])
+    acc = _refspatial_acc(mask, points)
+    submission = {"id": doc["id"], "query": refspatial_doc_to_text_json(doc), "pred": response, "parsed_points": list(map(tuple, points)), "accuracy": acc}
+    return {"refspatial_acc": submission}
 
 
 def refspatial_aggregate_results(results: List[Dict]) -> float:

--- a/lmms_eval/tasks/refspatial/utils.py
+++ b/lmms_eval/tasks/refspatial/utils.py
@@ -15,17 +15,6 @@ PROMPT_SUFFIX_0_999 = (
 
 FORMAT = "Return only list of tuples, don't add anything else."
 
-# JSON ("json") variant: replace the dataset's default tuple-format suffix with a
-# Qwen-native single-point JSON instruction on a 0-1000 grid. Any task-specific
-# clarification suffix is kept.
-_SUFFIX_TO_STRIP = "Your answer should be formatted as a list of tuples, i.e. [(x1, y1)], where each tuple contains the x and y coordinates of a point satisfying the conditions above. The coordinates should be between 0 and 1, indicating the normalized pixel locations of the points in the image."
-
-_JSON_POST_PROMPT = """Pinpoint the SINGLE best 2D point that satisfies the description. Output exactly one coordinate pair in JSON, normalized to [0, 1000]:
-```json
-[{"point_2d": [x, y], "label": "target"}]
-```
-Do not output more than one point. Do not include additional text after the JSON block."""
-
 with open(Path(__file__).parent / "_default_template_yaml", "r") as f:
     raw_data = f.readlines()
     safe_data = []
@@ -45,12 +34,8 @@ def refspatial_doc_to_text(doc: dict[str, Any]) -> str:
 
 
 def refspatial_doc_to_text_json(doc: dict[str, Any]) -> str:
-    """Qwen-native variant: ask for a single point_2d in JSON on a 0-1000 grid."""
-    prompt = doc["prompt"]
-    suffix = doc.get("suffix", "")
-    if suffix and suffix.strip() != _SUFFIX_TO_STRIP.strip():
-        prompt = f"{prompt} {suffix}"
-    return f"{prompt}\n{_JSON_POST_PROMPT}"
+    """Use RoboRefer's Qwen prompt, which elicits native ``point_2d`` JSON."""
+    return f"Locate {doc['object']} in this image and output the point coordinates in JSON format."
 
 
 def refspatial_doc_to_visual(doc: dict) -> list:

--- a/lmms_eval/tasks/where2place/utils.py
+++ b/lmms_eval/tasks/where2place/utils.py
@@ -4,9 +4,12 @@ from typing import Any, Dict, List
 import numpy as np
 
 from lmms_eval.tasks._task_utils.default_template_yaml import load_default_template_yaml
+from lmms_eval.tasks._task_utils.point_format import parse_point2d
 
 PROMPT_SUFFIX_0_999 = "Your answer should be formatted as a list of tuples, i.e. [(x1, y1), (x2, y2), ...], where each tuple contains the x and y coordinates of a point satisfying the conditions above. The coordinates should be integers between 0 and 999, representing the pixel locations scaled to a 1000×1000 grid."
 PROMPT_SUFFIX_ORIGINAL = "Your answer should be formatted as a list of tuples, i.e. [(x1, y1), (x2, y2), ...], where each tuple contains the x and y coordinates of a point satisfying the conditions above. The coordinates should be between 0 and 1, indicating the normalized pixel locations of the points in the image."
+# Qwen-native grounding prompt: a JSON list of point_2d entries on a 0-1000 grid.
+PROMPT_SUFFIX_JSON = "Your answer should be JSON format. The coordinates should be between 0 and 1000, indicating the normalized pixel locations of the points in the image."
 FORMAT = "Return only list of tuples, don't add anything else."
 
 
@@ -17,6 +20,11 @@ def where2place_doc_to_text(doc: dict[str, Any]) -> str:
     if config.get("metadata", {}).get("prompt_suffix_type", {}) == "0_999":
         return f"{doc['question']} {PROMPT_SUFFIX_0_999} {FORMAT}"
     return f"{doc['question']} {PROMPT_SUFFIX_ORIGINAL} {FORMAT}"
+
+
+def where2place_doc_to_text_json(doc: dict[str, Any]) -> str:
+    """Qwen-native variant: ask for a JSON list of point_2d on a 0-1000 grid."""
+    return f"{doc['question']} {PROMPT_SUFFIX_JSON}"
 
 
 def where2place_doc_to_visual(doc: dict) -> list:
@@ -41,6 +49,14 @@ def _text2pts(text: str, width: int = 640, height: int = 480, normalization_cons
     return np.array(points)
 
 
+def _where2place_acc(mask: np.ndarray, points: np.ndarray) -> float:
+    acc = 0.0
+    if len(points) > 0:
+        in_range = (points[:, 0] >= 0) & (points[:, 0] < mask.shape[1]) & (points[:, 1] >= 0) & (points[:, 1] < mask.shape[0])
+        acc = np.concatenate([mask[points[in_range, 1], points[in_range, 0]], np.zeros(points.shape[0] - in_range.sum())]).mean()
+    return acc
+
+
 # inspired by original work: https://github.com/wentaoyuan/RoboPoint/blob/master/robopoint/eval/summarize_vqa.py
 def where2place_process_results(doc: Dict, result: List[str]) -> Dict[str, Dict]:
     key_name = "where2place_acc"
@@ -61,13 +77,23 @@ def where2place_process_results(doc: Dict, result: List[str]) -> Dict[str, Dict]
     normalization_constant = 1000 if prompt_suffix_type == "0_999" else 1
     points = _text2pts(response, mask.shape[1], mask.shape[0], normalization_constant)
 
-    # process the answer
-    acc = 0.0
-    if len(points) > 0:
-        in_range = (points[:, 0] >= 0) & (points[:, 0] < mask.shape[1]) & (points[:, 1] >= 0) & (points[:, 1] < mask.shape[0])
-        acc = np.concatenate([mask[points[in_range, 1], points[in_range, 0]], np.zeros(points.shape[0] - in_range.sum())]).mean()
+    acc = _where2place_acc(mask, points)
     where2place_submission = {"id": doc["question_id"], "pred": response, "parsed_points": list(map(tuple, points)), "accuracy": acc}
     return {key_name: where2place_submission}
+
+
+def where2place_process_results_json(doc: Dict, result: List[str]) -> Dict[str, Dict]:
+    """Qwen-native variant: parse JSON point_2d; identical mask scoring."""
+    mask = np.array(doc["mask"]) / 255.0
+    mask = np.round(mask, 0).astype(int)
+    if mask.ndim == 3:
+        mask = mask[:, :, 0]
+
+    response = result[0]
+    points = parse_point2d(response, mask.shape[1], mask.shape[0])
+    acc = _where2place_acc(mask, points)
+    where2place_submission = {"id": doc["question_id"], "pred": response, "parsed_points": list(map(tuple, points)), "accuracy": acc}
+    return {"where2place_acc": where2place_submission}
 
 
 def where2place_aggregate_results(results: List[Dict]) -> float:

--- a/lmms_eval/tasks/where2place/utils.py
+++ b/lmms_eval/tasks/where2place/utils.py
@@ -3,7 +3,8 @@ from typing import Any, Dict, List
 
 import numpy as np
 
-from lmms_eval.tasks._task_utils.default_template_yaml import load_default_template_yaml
+from lmms_eval.tasks._task_utils.default_template_yaml import \
+    load_default_template_yaml
 from lmms_eval.tasks._task_utils.point_format import parse_point2d
 
 PROMPT_SUFFIX_0_999 = "Your answer should be formatted as a list of tuples, i.e. [(x1, y1), (x2, y2), ...], where each tuple contains the x and y coordinates of a point satisfying the conditions above. The coordinates should be integers between 0 and 999, representing the pixel locations scaled to a 1000×1000 grid."

--- a/lmms_eval/tasks/where2place/where2place_json.yaml
+++ b/lmms_eval/tasks/where2place/where2place_json.yaml
@@ -1,0 +1,5 @@
+task: where2place_json
+test_split: test
+include: _default_template_yaml
+doc_to_text: !function utils.where2place_doc_to_text_json
+process_results: !function utils.where2place_process_results_json

--- a/test/eval/test_point_format.py
+++ b/test/eval/test_point_format.py
@@ -1,0 +1,29 @@
+import numpy as np
+
+from lmms_eval.tasks._task_utils.point_format import parse_point2d
+
+
+def test_parse_point2d_scales_integer_grid_coordinates():
+    points = parse_point2d(
+        '```json\n[{"point_2d": [500, 250], "label": "target"}]\n```',
+        width=200,
+        height=100,
+    )
+
+    np.testing.assert_array_equal(points, np.array([[100, 25]]))
+
+
+def test_parse_point2d_scales_normalized_float_coordinates():
+    points = parse_point2d("[0.5, 0.25]", width=200, height=100)
+
+    np.testing.assert_array_equal(points, np.array([[100, 25]]))
+
+
+def test_parse_point2d_recovers_multiple_pairs():
+    points = parse_point2d(
+        '[{"point_2d": [100, 200]}, {"point_2d": [900, 800]}]',
+        width=100,
+        height=50,
+    )
+
+    np.testing.assert_array_equal(points, np.array([[10, 10], [90, 40]]))

--- a/test/eval/test_refspatial_json.py
+++ b/test/eval/test_refspatial_json.py
@@ -1,0 +1,7 @@
+from lmms_eval.tasks.refspatial.utils import refspatial_doc_to_text_json
+
+
+def test_refspatial_json_uses_roborefer_qwen_prompt():
+    prompt = refspatial_doc_to_text_json({"object": "the red cup"})
+
+    assert prompt == ("Locate the red cup in this image and output the point coordinates " "in JSON format.")


### PR DESCRIPTION
## Summary

This PR rebases and extends #1361 onto the current `main` after its prerequisite PointBench correctness fix #1360 was merged.

Qwen-VL grounding models commonly emit points as JSON entries such as:

```json
[{"point_2d": [x, y], "label": "target"}]
```

Existing pointing tasks prompt for and parse `(x, y)` tuples, so native Qwen output may be dropped or under-scored.

This PR adds separate Qwen-native JSON variants:

- `where2place_json`
- `refspatial_location_json`
- `refspatial_placement_json`
- `refspatial_unseen_json`
- `pointbench_json`

Users must explicitly select the `*_json` task names. The variants share `parse_point2d`, which supports integer coordinates on a 0–1000 grid and normalized floating-point coordinates.

The original implementation commit from #1361 retains its authorship from @njb-nvidia. The rebase, parser tests, RefSpatial prompt correction, and additional end-to-end validation are provided as follow-up changes.

## RefSpatial prompt correction

End-to-end Qwen3-VL-4B evaluation showed that JSON parsing alone was insufficient for RefSpatial: the original JSON instruction obtained `0.4188`.

The JSON variants now use the Qwen prompt from the official RefSpatial-Bench evaluation repository, [Zhoues/RoboRefer](https://github.com/Zhoues/RoboRefer):

`Locate {object} in this image and output the point coordinates in JSON format.`

The integrated task obtains `0.4549`. The dataset, `parse_point2d` parser, mean-in-mask scoring, and size-weighted aggregation remain unchanged. No external RoboRefer dependency is introduced.

## Compatibility

All existing tuple tasks, prompts, metrics, and aggregation remain unchanged. The new behavior is only enabled through the separate `*_json` task names.

## Published reference

For an additional published baseline check, we compare against the Qwen3-VL-4B results in Table 3 of [MolmoAct2: Action Reasoning Models for Real-world Deployment](https://arxiv.org/abs/2605.02881):

- Point-Bench: `0.638`
- RefSpatial: `0.495`
- Where2Place: `0.630`

Our Qwen3-VL-4B-Instruct results are:

- Where2Place JSON: `0.640`
- RefSpatial JSON, size-weighted: `0.4549`
  - Location: `0.470`
  - Placement: `0.525`
  - Unseen: `0.3442`
- PointBench JSON:
  - existing fraction metric: `0.6206`
  - existing binary metric: `0.5784`
  - any-hit eq5 offline rescore of the same logged predictions: `0.6459`

The any-hit eq5 value is reported only as an offline diagnostic; this PR does not change PointBench metrics or aggregation.

## Validation

- `4 passed` in `test/eval/test_point_format.py` and `test/eval/test_refspatial_json.py`
- Confirmed all five JSON task variants register through `TaskManager`
- `isort --check-only` passes for changed Python files
- `black --check` passes for changed Python files
- Full Qwen3-VL-4B-Instruct runs completed for Where2Place, RefSpatial, and PointBench JSON variants

This PR may supersede #1361 if the maintainers and original author prefer.