### PR TITLE
feat: add Kaleidoscope multilingual exam benchmark

### DIFF
--- a/docs/advanced/current_tasks.md
+++ b/docs/advanced/current_tasks.md
@@ -143,6 +143,12 @@ python -m lmms_eval --tasks list_with_num
   - Benign split (safety_jailbreakbench_benign)
 
 ### Multilingual Benchmarks
+- [Kaleidoscope](https://arxiv.org/abs/2504.07072) (kaleidoscope)
+  - Kaleidoscope multimodal, direct prompting (kaleidoscope_multimodal)
+  - Kaleidoscope text-only, direct prompting (kaleidoscope_text_only)
+  - Kaleidoscope all questions, direct prompting (kaleidoscope_direct)
+  - Kaleidoscope multimodal, zero-shot CoT (kaleidoscope_multimodal_cot)
+  - Kaleidoscope all questions, zero-shot CoT (kaleidoscope_cot)
 - [Multilingual LLaVA Bench](https://huggingface.co/datasets/gagan3012/multilingual-llava-bench)
   - llava_in_the_wild_arabic
   - llava_in_the_wild_bengali

--- a/lmms_eval/tasks/kaleidoscope/README.md
+++ b/lmms_eval/tasks/kaleidoscope/README.md
@@ -1,0 +1,137 @@
+# Kaleidoscope
+
+**In-language exams for massively multilingual vision evaluation.**
+
+| | |
+|---|---|
+| Paper | [arXiv:2504.07072](https://arxiv.org/abs/2504.07072) (ICLR 2026) |
+| Reference code | https://github.com/israfelsr/kaleidoscope |
+| Dataset | [`CohereLabs/kaleidoscope`](https://huggingface.co/datasets/CohereLabs/kaleidoscope) |
+
+Kaleidoscope is a multiple-choice exam benchmark built by an open-science
+collaboration rather than by translating an English dataset: every question is
+sourced from a real exam written in the language it is asked in. It covers
+**20,911 questions**, **18 languages** and **14 subjects**; **11,457 questions
+(54.8%)** carry an image that is needed to answer them.
+
+Languages: Arabic, Bengali, Croatian, Dutch, English, French, German, Hindi,
+Hungarian, Lithuanian, Nepali, Persian, Portuguese, Russian, Serbian, Spanish,
+Telugu, Ukrainian.
+
+## Tasks
+
+| Task | Questions | Prompt regime | Paper setting |
+|---|---|---|---|
+| `kaleidoscope` | 20,911 | direct | group: multimodal + text-only |
+| `kaleidoscope_multimodal` | 11,457 | direct | headline multimodal results (Table 2, Fig. 4) |
+| `kaleidoscope_text_only` | 9,454 | direct | text-only column of Fig. 3a |
+| `kaleidoscope_direct` | 20,911 | direct | all questions in one task |
+| `kaleidoscope_multimodal_cot` | 11,457 | zero-shot CoT | closed-model multimodal setting |
+| `kaleidoscope_cot` | 20,911 | zero-shot CoT | closed-model setting, all questions |
+
+Both prompting regimes from the paper are implemented:
+
+- **`direct`** — an English system message asking for `{"choice": "A"}` JSON,
+  plus in-language `Question:` / `Options:` keywords and an `ANSWER:` cue. The
+  paper uses this for open-weight models, which could not reliably follow the
+  CoT format at ≤32B.
+- **`cot`** — the zero-shot chain-of-thought system message, translated into all
+  18 languages, asking the model to think step by step and close with
+  `<ANSWER> X </ANSWER>`. The paper uses this for the closed models.
+
+## Metrics
+
+Matching `get_score.py` in the reference repo, three numbers are reported:
+
+| Metric | Definition |
+|---|---|
+| `kaleidoscope_acc` | Accuracy over **all** samples; unparseable answers count as wrong. Macro-averaged over the 18 languages (equal weight per language). |
+| `kaleidoscope_valid_acc` | Accuracy over samples whose answer could be extracted. Also macro-averaged over languages. |
+| `kaleidoscope_format_error` | Share of samples (micro, over all) whose answer could not be extracted. Lower is better. |
+
+The aggregation logs per-language, per-subject and — for multimodal tasks —
+per-image-type breakdowns, so the tables in the paper's appendix can be
+reproduced from one run.
+
+## Usage
+
+```bash
+python -m lmms_eval \
+    --model qwen2_vl \
+    --model_args pretrained=Qwen/Qwen2-VL-2B-Instruct \
+    --tasks kaleidoscope_multimodal \
+    --batch_size 1 \
+    --log_samples \
+    --output_path ./logs/
+```
+
+### Images
+
+The Hub release stores question metadata in parquet and the pixels in a
+companion `data.zip` (~1 GB); the `image` column holds relative paths such as
+`data/GATE_2022_Multimodal/images/xl_question_11.png`. Three resolution modes
+are supported, all handled lazily inside `doc_to_visual`:
+
+| Mode | How |
+|---|---|
+| Archive via HF cache (default) | Downloads `data.zip` once through `huggingface_hub` and reads members in place — no extraction, no second copy on disk. |
+| Pre-extracted directory | `KALEIDOSCOPE_DATA_ROOT=/path/to/final_data` — the directory that directly contains `data/`. |
+| Range-streamed archive | `KALEIDOSCOPE_STREAM_ZIP=1` — reads individual members over HTTP range requests without downloading the whole archive. Best for `--limit`ed smoke tests, too slow for a full run. |
+
+### Environment overrides
+
+| Variable | Default | Effect |
+|---|---|---|
+| `KALEIDOSCOPE_DATA_ROOT` | unset | Read images from a pre-extracted directory. |
+| `KALEIDOSCOPE_STREAM_ZIP` | `0` | Stream archive members instead of downloading. |
+| `KALEIDOSCOPE_IMAGE_SIZE` | `512` | Square edge length images are resized to; `0` feeds native resolution. |
+| `KALEIDOSCOPE_LENIENT_EXTRACTION` | `0` | Fall back to the shared loose MCQ extractor when strict parsing fails. |
+
+## Fidelity notes
+
+Deliberate deviations from the reference implementation, all of them
+side-effects of running inside lmms-eval rather than the paper's own harness:
+
+1. **Inference backend.** The paper runs the Qwen models through vLLM; lmms-eval
+   drives them through the HF `transformers` wrappers. Sampled decoding on a
+   different backend produces different token sequences, so per-run numbers move
+   even with identical prompts.
+2. **System-message typo dropped.** The reference `SYS_MESSAGE` contains
+   `\n\ONLY` — a Python escape-sequence slip that puts a literal backslash in
+   front of `ONLY`, visible in the `prompt_used` field of its published outputs.
+   The paper's appendix shows the intended text, which is what ships here.
+3. **Sampling is non-deterministic by default.** `temperature=0.7`, `top_p=0.9`,
+   `do_sample=true`, `max_new_tokens=1024` reproduce the reference sampling
+   parameters. Add `--gen_kwargs temperature=0,do_sample=False` for repeatable
+   runs.
+4. **Answer extraction is marginally more forgiving.** `extract_choice` agrees
+   with the reference `format_answer.py` on 199/200 of the published sample
+   outputs. The single difference: the reference regex is line-bound and misses
+   `{"choice": "C", "reasoning": "..."}` spread over several lines, which is
+   counted here as a valid answer rather than a format error.
+5. **Image options are shown as images.** Exactly 2 of the 20,911 questions have
+   options that are themselves PNG paths. The reference open-model path renders
+   those as the literal filename; here they are interleaved as images, matching
+   the reference's own closed-model path.
+6. **Model-side system prompt.** Chat wrappers (`is_simple = False`, the default
+   resolution for e.g. `qwen2_5_vl`) receive the benchmark system message as a
+   real `system` message through `doc_to_messages`. Legacy simple wrappers
+   substitute their own system prompt, so for those the message is folded into
+   the user turn by `doc_to_text` instead.
+7. **`level`, `country` and few-shot splits** are carried in the records for
+   breakdowns but no few-shot task is provided; the paper's headline results are
+   zero-shot.
+
+## Citation
+
+```bibtex
+@misc{salazar2025kaleidoscopeinlanguageexamsmassively,
+      title={Kaleidoscope: In-language Exams for Massively Multilingual Vision Evaluation},
+      author={Israfel Salazar and Manuel Fernández Burda and Shayekh Bin Islam and Arshia Soltani Moakhar and Shivalika Singh and Fabian Farestam and Angelika Romanou and Danylo Boiko and Dipika Khullar and Mike Zhang and Dominik Krzemiński and Jekaterina Novikova and Luísa Shimabucoro and Joseph Marvin Imperial and Rishabh Maheshwary and Sharad Duwal and Alfonso Amayuelas and Swati Rajwal and Jebish Purbey and Ahmed Ruby and Nicholas Popovič and Marek Suppa and Azmine Toushik Wasi and Ram Mohan Rao Kadiyala and Olga Tsymboi and Maksim Kostritsya and Bardia Soltani Moakhar and Gabriel da Costa Merlin and Otávio Ferracioli Coletti and Maral Jabbari Shiviari and MohammadAmin farahani fard and Silvia Fernandez and María Grandury and Dmitry Abulkhanov and Drishti Sharma and Andre Guarnier De Mitri and Leticia Bossatto Marchezi and Johan Obando-Ceron and Nazar Kohut and Beyza Ermis and Desmond Elliott and Enzo Ferrante and Sara Hooker and Marzieh Fadaee},
+      year={2025},
+      eprint={2504.07072},
+      archivePrefix={arXiv},
+      primaryClass={cs.CL},
+      url={https://arxiv.org/abs/2504.07072},
+}
+```

--- a/lmms_eval/tasks/kaleidoscope/RESULTS.md
+++ b/lmms_eval/tasks/kaleidoscope/RESULTS.md
@@ -1,0 +1,92 @@
+# Kaleidoscope — reproduction notes
+
+## 1. Answer extraction vs. the reference implementation
+
+The reference repo publishes raw and post-processed model outputs for two models
+under `sample_outputs/zero-shot/` (100 questions each). Running this task's
+`extract_choice` over the raw `reasoning` field and comparing against the
+reference `format_answer.py` output in `results_format.json`:
+
+| Model | Agreement |
+|---|--:|
+| Qwen2.5-VL-3B | **100 / 100** |
+| Aya-Vision | **99 / 100** |
+
+The single Aya-Vision difference is the reference's line-bound `{"choice": ...}`
+regex failing on
+
+```json
+{
+  "choice": "C",
+  "reasoning": "The traffic interchange depicted in the image is ..."
+}
+```
+
+which the reference counts as a format error and this task counts as a valid
+answer. See fidelity note 4 in `README.md`.
+
+## 2. End-to-end reproduction on the reference's 100-question slice
+
+The reference's published sample is the **first 100 rows** of
+`CohereLabs/kaleidoscope` (all English, all multimodal, GATE 2022). Those rows
+are order-identical to `--tasks kaleidoscope_multimodal --limit 100`, so the two
+runs score exactly the same questions.
+
+| Run | Decoding | acc | valid_acc | format_error |
+|---|---|--:|--:|--:|
+| **Reference** (`sample_outputs/model_qwen2.5-3b`, vLLM) | T=0.7, top_p=0.9 | **30.00** | 30.00 | 0.00 |
+| lmms-eval, this task (HF transformers) | greedy | **31.00** | 31.00 | 0.00 |
+| lmms-eval, this task | T=0.7, seed 1234 | 37.00 | 38.14 | 3.00 |
+| lmms-eval, this task | T=0.7, seed 7 | 32.00 | 33.33 | 4.00 |
+| lmms-eval, this task | T=0.7, seed 99 | 35.00 | 35.71 | 2.00 |
+
+Greedy decoding lands within **one question** of the reference (31 vs 30). The
+sampled runs scatter over 32–37, which is what `temperature=0.7` on `n=100`
+buys you (binomial s.e. ≈ 4.6 pp) — the paper's sampling parameters are kept as
+the task default for fidelity, but `--gen_kwargs temperature=0,do_sample=False`
+is the reproducible setting.
+
+Commands:
+
+```bash
+python -m lmms_eval --model qwen2_5_vl \
+    --model_args pretrained=Qwen/Qwen2.5-VL-3B-Instruct \
+    --tasks kaleidoscope_multimodal --batch_size 1 --limit 100 \
+    --gen_kwargs temperature=0,do_sample=False
+```
+
+## 3. Paper comparison target (full multimodal split)
+
+The paper's appendix table (`tables/complete_lang_acc.tex`, multimodal split)
+reports the following for **Qwen2.5-VL-3B** — the numbers a full
+`kaleidoscope_multimodal` run should be compared against. This task's
+`kaleidoscope_acc` aggregation prints the same breakdown, so one run reproduces
+the whole table.
+
+| | en | fr | de | nl | pt | es | ar | bn | hr | hi | hu | lt | ne | fa | ru | sr | te | uk |
+|---|--:|--:|--:|--:|--:|--:|--:|--:|--:|--:|--:|--:|--:|--:|--:|--:|--:|--:|
+| Total Acc. | 35.0 | 32.3 | 21.1 | 41.8 | 52.2 | 53.3 | 33.5 | 32.8 | 25.9 | 31.3 | 28.2 | 35.6 | 23.8 | 30.3 | 29.0 | 27.8 | 31.8 | 40.1 |
+| Valid Acc. | 35.0 | 32.4 | 21.1 | 41.8 | 52.3 | 53.3 | 33.7 | 32.8 | 26.4 | 31.3 | 29.2 | 35.6 | 23.8 | 30.4 | 29.0 | 28.1 | 31.8 | 40.1 |
+| FE | 0.0 | 0.3 | 0.0 | 0.0 | 0.1 | 0.0 | 0.5 | 0.2 | 1.9 | 0.0 | 3.2 | 0.0 | 0.0 | 0.2 | 0.0 | 1.1 | 0.0 | 0.0 |
+
+Macro-average over the 18 languages: **Total Acc. 33.7**, **Valid Acc. 33.8**.
+
+```bash
+python -m lmms_eval --model qwen2_5_vl \
+    --model_args pretrained=Qwen/Qwen2.5-VL-3B-Instruct \
+    --tasks kaleidoscope_multimodal --batch_size 1 \
+    --log_samples --output_path ./logs/
+```
+
+## 4. Environment used
+
+| | |
+|---|---|
+| GPU | 1× RTX 3060 (12 GB) |
+| Python | 3.10 (conda) |
+| torch | 2.13.0+cu126 |
+| transformers | 5.14.1 |
+| datasets | 5.0.0 |
+| lmms-eval | 0.7.2 (`v0.6-167-g6619ef61`) |
+
+Unit tests: `pytest test/eval/test_kaleidoscope.py` — 44 passed.

--- a/lmms_eval/tasks/kaleidoscope/_default_template_yaml
+++ b/lmms_eval/tasks/kaleidoscope/_default_template_yaml
@@ -1,0 +1,37 @@
+dataset_path: CohereLabs/kaleidoscope
+# The Hub release ships every one of the 20,911 questions in a single `train`
+# split; the paper evaluates on all of it, so it doubles as the test split.
+test_split: train
+output_type: generate_until
+
+doc_to_visual: !function utils.kaleidoscope_doc_to_visual
+doc_to_text: !function utils.kaleidoscope_doc_to_text
+doc_to_messages: !function utils.kaleidoscope_doc_to_messages
+doc_to_target: "answer"
+
+# Sampling parameters from the reference implementation (model_utils.py).
+# Override with e.g. `--gen_kwargs temperature=0,do_sample=False` for greedy runs.
+generation_kwargs:
+  max_new_tokens: 1024
+  temperature: 0.7
+  top_p: 0.9
+  do_sample: true
+
+metric_list:
+  - metric: kaleidoscope_acc
+    aggregation: !function utils.kaleidoscope_aggregate_accuracy
+    higher_is_better: true
+  - metric: kaleidoscope_valid_acc
+    aggregation: !function utils.kaleidoscope_aggregate_valid_accuracy
+    higher_is_better: true
+  - metric: kaleidoscope_format_error
+    aggregation: !function utils.kaleidoscope_aggregate_format_error
+    higher_is_better: false
+
+metadata:
+  version: 0.0
+  # Edge length images are resized to, matching the reference pipeline.
+  # Set to `none` (or KALEIDOSCOPE_IMAGE_SIZE=0) to feed native resolution.
+  image_size: 512
+  # Keep strict paper-style parsing so the format-error rate stays meaningful.
+  lenient_extraction: false

--- a/lmms_eval/tasks/kaleidoscope/kaleidoscope.yaml
+++ b/lmms_eval/tasks/kaleidoscope/kaleidoscope.yaml
@@ -1,0 +1,4 @@
+group: kaleidoscope
+task:
+  - kaleidoscope_multimodal
+  - kaleidoscope_text_only

--- a/lmms_eval/tasks/kaleidoscope/kaleidoscope_cot.yaml
+++ b/lmms_eval/tasks/kaleidoscope/kaleidoscope_cot.yaml
@@ -1,0 +1,9 @@
+task: "kaleidoscope_cot"
+task_alias: "Kaleidoscope (zero-shot CoT, all)"
+process_results: !function utils.kaleidoscope_process_results_cot
+
+lmms_eval_specific_kwargs:
+  default:
+    prompt_type: "cot"
+
+include: _default_template_yaml

--- a/lmms_eval/tasks/kaleidoscope/kaleidoscope_direct.yaml
+++ b/lmms_eval/tasks/kaleidoscope/kaleidoscope_direct.yaml
@@ -1,0 +1,9 @@
+task: "kaleidoscope_direct"
+task_alias: "Kaleidoscope (direct, all)"
+process_results: !function utils.kaleidoscope_process_results
+
+lmms_eval_specific_kwargs:
+  default:
+    prompt_type: "direct"
+
+include: _default_template_yaml

--- a/lmms_eval/tasks/kaleidoscope/kaleidoscope_multimodal.yaml
+++ b/lmms_eval/tasks/kaleidoscope/kaleidoscope_multimodal.yaml
@@ -1,0 +1,10 @@
+task: "kaleidoscope_multimodal"
+task_alias: "Kaleidoscope (direct, multimodal)"
+process_docs: !function utils.kaleidoscope_filter_multimodal
+process_results: !function utils.kaleidoscope_process_results
+
+lmms_eval_specific_kwargs:
+  default:
+    prompt_type: "direct"
+
+include: _default_template_yaml

--- a/lmms_eval/tasks/kaleidoscope/kaleidoscope_multimodal_cot.yaml
+++ b/lmms_eval/tasks/kaleidoscope/kaleidoscope_multimodal_cot.yaml
@@ -1,0 +1,10 @@
+task: "kaleidoscope_multimodal_cot"
+task_alias: "Kaleidoscope (zero-shot CoT, multimodal)"
+process_docs: !function utils.kaleidoscope_filter_multimodal
+process_results: !function utils.kaleidoscope_process_results_cot
+
+lmms_eval_specific_kwargs:
+  default:
+    prompt_type: "cot"
+
+include: _default_template_yaml

--- a/lmms_eval/tasks/kaleidoscope/kaleidoscope_text_only.yaml
+++ b/lmms_eval/tasks/kaleidoscope/kaleidoscope_text_only.yaml
@@ -1,0 +1,10 @@
+task: "kaleidoscope_text_only"
+task_alias: "Kaleidoscope (direct, text-only)"
+process_docs: !function utils.kaleidoscope_filter_text_only
+process_results: !function utils.kaleidoscope_process_results
+
+lmms_eval_specific_kwargs:
+  default:
+    prompt_type: "direct"
+
+include: _default_template_yaml

--- a/lmms_eval/tasks/kaleidoscope/utils.py
+++ b/lmms_eval/tasks/kaleidoscope/utils.py
@@ -1,0 +1,644 @@
+"""Utilities for Kaleidoscope, a massively multilingual multimodal exam benchmark.
+
+Paper: https://arxiv.org/abs/2504.07072
+Code:  https://github.com/israfelsr/kaleidoscope
+Data:  https://huggingface.co/datasets/CohereLabs/kaleidoscope
+
+Prompt construction, answer extraction and metric definitions mirror the
+reference implementation so that scores stay comparable with the paper.  The
+two prompting regimes reported in the paper are both available:
+
+``direct``
+    English JSON-format system message plus in-language ``Question``/``Options``
+    keywords.  Used for the open-weight models in the paper.
+``cot``
+    In-language zero-shot chain-of-thought system message; the answer is read
+    back from ``<ANSWER> X </ANSWER>`` tags.  Used for the closed models.
+
+See ``README.md`` in this directory for the deviations from the reference code.
+"""
+
+import ast
+import io
+import json
+import os
+import re
+import threading
+import zipfile
+from collections import defaultdict
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+import datasets
+import yaml
+from loguru import logger as eval_logger
+from PIL import Image
+
+HF_DATASET_REPO = "CohereLabs/kaleidoscope"
+HF_IMAGE_ARCHIVE = "data.zip"
+# Members inside data.zip are prefixed with the archive's top-level folder,
+# i.e. ``final_data/<value of the "image" column>``.
+ZIP_ROOT_PREFIX = "final_data/"
+
+with open(Path(__file__).parent / "_default_template_yaml", "r", encoding="utf-8") as f:
+    raw_data = f.readlines()
+    safe_data = [line for line in raw_data if "!function" not in line]
+    config = yaml.safe_load("".join(safe_data))
+
+# ---------------------------------------------------------------------------
+# Benchmark constants (kept verbatim from the reference implementation)
+# ---------------------------------------------------------------------------
+
+LANGUAGES: Dict[str, str] = {
+    "ar": "Arabic",
+    "bn": "Bengali",
+    "de": "German",
+    "en": "English",
+    "es": "Spanish",
+    "fa": "Persian",
+    "fr": "French",
+    "hi": "Hindi",
+    "hr": "Croatian",
+    "hu": "Hungarian",
+    "lt": "Lithuanian",
+    "ne": "Nepali",
+    "nl": "Dutch; Flemish",
+    "pt": "Portuguese",
+    "ru": "Russian",
+    "sr": "Serbian",
+    "te": "Telugu",
+    "uk": "Ukrainian",
+}
+
+RESOURCE_LEVEL: Dict[str, str] = {
+    "Arabic": "High",
+    "Croatian": "High",
+    "Dutch; Flemish": "High",
+    "English": "High",
+    "French": "High",
+    "German": "High",
+    "Hindi": "High",
+    "Hungarian": "High",
+    "Persian": "High",
+    "Portuguese": "High",
+    "Russian": "High",
+    "Serbian": "High",
+    "Spanish": "High",
+    "Bengali": "Mid/Low",
+    "Lithuanian": "Mid/Low",
+    "Nepali": "Mid/Low",
+    "Telugu": "Mid/Low",
+    "Ukrainian": "Mid/Low",
+}
+
+LATIN_SCRIPT: Dict[str, str] = {
+    "Croatian": "Latin",
+    "Dutch; Flemish": "Latin",
+    "English": "Latin",
+    "French": "Latin",
+    "German": "Latin",
+    "Hungarian": "Latin",
+    "Lithuanian": "Latin",
+    "Portuguese": "Latin",
+    "Spanish": "Latin",
+    "Arabic": "Non-Latin",
+    "Bengali": "Non-Latin",
+    "Hindi": "Non-Latin",
+    "Nepali": "Non-Latin",
+    "Persian": "Non-Latin",
+    "Russian": "Non-Latin",
+    "Serbian": "Non-Latin",
+    "Telugu": "Non-Latin",
+    "Ukrainian": "Non-Latin",
+}
+
+# In-language words for "Question" / "Options" / "Answer" used to lay out the prompt.
+KEYWORDS: Dict[str, Dict[str, str]] = {
+    "en": {"question": "Question", "options": "Options", "answer": "Answer"},
+    "es": {"question": "Pregunta", "options": "Opciones", "answer": "Respuesta"},
+    "hi": {"question": "प्रश्न", "options": "विकल्प", "answer": "उत्तर"},
+    "hu": {"question": "Kérdés", "options": "Lehetőségek", "answer": "Válasz"},
+    "hr": {"question": "Pitanje", "options": "Opcije", "answer": "Odgovor"},
+    "uk": {"question": "Питання", "options": "Варіанти", "answer": "Відповідь"},
+    "pt": {"question": "Pergunta", "options": "Opções", "answer": "Resposta"},
+    "bn": {"question": "প্রশ্ন", "options": "বিকল্প", "answer": "উত্তর"},
+    "te": {"question": "ప్రశ్న", "options": "ఎంపికలు", "answer": "సమాధానం"},
+    "ne": {"question": "प्रश्न", "options": "विकल्पहरू", "answer": "उत्तर"},
+    "sr": {"question": "Pitanje", "options": "Opcije", "answer": "Odgovor"},
+    "nl": {"question": "Vraag", "options": "Opties", "answer": "Antwoord"},
+    "ar": {"question": "السؤال", "options": "الخيارات", "answer": "الإجابة"},
+    "ru": {"question": "Вопрос", "options": "Варианты", "answer": "Ответ"},
+    "fr": {"question": "Question", "options": "Options", "answer": "Réponse"},
+    "fa": {"question": "سؤال", "options": "گزینه‌ها", "answer": "پاسخ"},
+    "de": {"question": "Frage", "options": "Optionen", "answer": "Antwort"},
+    "lt": {"question": "Klausimas", "options": "Pasirinkimai", "answer": "Atsakymas"},
+}
+
+# Zero-shot chain-of-thought system message, translated into every evaluation language.
+INSTRUCTIONS_COT: Dict[str, str] = {
+    "en": "The following is a multiple-choice question. Think step by step and then provide your FINAL answer between the tags <ANSWER> X </ANSWER> where X is ONLY the correct letter of your choice. Do not write additional text between the tags.",
+    "es": "Lo siguiente es una pregunta de opción múltiple. Piensa paso a paso y luego proporciona tu RESPUESTA FINAL entre las etiquetas <ANSWER> X </ANSWER>, donde X es ÚNICAMENTE la letra correcta de tu elección. No escribas texto adicional entre las etiquetas.",
+    "hi": "निम्नलिखित एक बहुविकल्पीय प्रश्न है। चरणबद्ध सोचें और फिर <ANSWER> X </ANSWER> टैग के बीच अपना अंतिम उत्तर प्रदान करें, जहाँ X केवल आपके चयन का सही अक्षर है। टैग के बीच अतिरिक्त कोई पाठ न लिखें।",
+    "hu": "A következő egy feleletválasztós kérdés. Gondolkodj lépésről lépésre, majd add meg a VÉGSŐ válaszodat a <ANSWER> X </ANSWER> címkék között, ahol X CSAK a választott helyes betű. Ne írj további szöveget a címkék közé.",
+    "hr": "Sljedeće je pitanje s višestrukim izborom. Razmislite korak po korak, a zatim dajte svoj ZAVRŠNI odgovor između oznaka <ANSWER> X </ANSWER> gdje je X SAMO ispravno slovo vašeg izbora. Nemojte pisati dodatni tekst između oznaka.",
+    "uk": "Наступне — це питання з множинним вибором. Думайте крок за кроком, а потім надайте вашу ОСТАННЮ відповідь між тегами <ANSWER> X </ANSWER>, де X — ЛИШЕ правильна літера за вашим вибором. Не пишіть додаткового тексту між тегами.",
+    "pt": "A seguir, temos uma questão de múltipla escolha. Pense passo a passo e depois forneça sua RESPOSTA FINAL entre as tags <ANSWER> X </ANSWER>, onde X é SOMENTE a letra correta da sua escolha. Não escreva texto adicional entre as tags.",
+    "bn": "নিম্নলিখিতটি একটি বহু-বিকল্প প্রশ্ন। ধাপে ধাপে চিন্তা করুন এবং তারপর <ANSWER> X </ANSWER> ট্যাগের মধ্যে আপনার চূড়ান্ত উত্তর প্রদান করুন, যেখানে X শুধুমাত্র আপনার পছন্দের সঠিক অক্ষর। ট্যাগগুলির মধ্যে অতিরিক্ত কোনো লেখা লিখবেন না।",
+    "te": "కింద ఇచ్చినది ఒక బహుళ ఎంపిక ప్రశ్న. దశల వారీగా ఆలోచించి, <ANSWER> X </ANSWER> ట్యాగ్లలో మీ తుది సమాధానాన్ని ఇవ్వండి, ఇక్కడ X మీ ఎంపికలోని సరైన అక్షరం మాత్రమే. ట్యాగ్లలో అదనపు వచనం రాయవద్దు.",
+    "ne": "तलको प्रश्न बहुविकल्पीय छ। चरणबद्ध सोच्नुहोस् र त्यसपछि <ANSWER> X </ANSWER> ट्यागहरूबीच आफ्नो अन्तिम उत्तर प्रदान गर्नुहोस्, जहाँ X केवल तपाईंको रोजाइको सही अक्षर हो। ट्यागहरूबीच अतिरिक्त पाठ नलेख्नुहोस्।",
+    "sr": "Sledeće je pitanje sa višestrukim izborom. Razmislite korak po korak, a zatim dajte svoj KONAČNI odgovor između oznaka <ANSWER> X </ANSWER>, gde je X SAMO tačno slovo vašeg izbora. Nemojte pisati dodatni tekst između oznaka.",
+    "nl": "Het volgende is een meerkeuzevraag. Denk stap voor stap na en geef dan je UITEINDLIJKE antwoord tussen de tags <ANSWER> X </ANSWER>, waarbij X ALLEEN de juiste letter van je keuze is. Schrijf geen extra tekst tussen de tags.",
+    "ar": "التالي هو سؤال اختيار من متعدد. فكر خطوة بخطوة ثم قدم إجابتك النهائية بين الوسوم <ANSWER> X </ANSWER> حيث X هي الحرف الصحيح فقط من اختيارك. لا تكتب نصًا إضافيًا بين الوسوم.",
+    "ru": "Следующее — это вопрос с выбором ответа. Думайте шаг за шагом, а затем предоставьте ваш ОКОНЧАТЕЛЬНЫЙ ответ между тегами <ANSWER> X </ANSWER>, где X — ТОЛЬКО правильная буква вашего выбора. Не пишите дополнительный текст между тегами.",
+    "fr": "Ce qui suit est une question à choix multiple. Réfléchissez étape par étape, puis donnez votre RÉPONSE FINALE entre les balises <ANSWER> X </ANSWER>, où X est UNIQUEMENT la lettre correcte de votre choix. N'écrivez pas de texte supplémentaire entre les balises.",
+    "fa": "متن زیر یک سوال چندگزینه‌ای است. مرحله به مرحله فکر کنید و سپس پاسخ نهایی خود را بین تگ‌های <ANSWER> X </ANSWER> قرار دهید، جایی که X تنها حرف صحیح انتخاب شماست. متن اضافی بین تگ‌ها ننویسید.",
+    "de": "Im Folgenden ist eine Multiple-Choice-Frage. Denken Sie Schritt für Schritt nach und geben Sie dann Ihre ENDGÜLTIGE Antwort zwischen den Tags <ANSWER> X </ANSWER> an, wobei X NUR der korrekte Buchstabe Ihrer Wahl ist. Schreiben Sie keinen zusätzlichen Text zwischen den Tags.",
+    "lt": "Toliau pateikiamas klausimas su keliomis pasirinkimo galimybėmis. Mąstykite žingsnis po žingsnio ir pateikite savo GALUTINĮ atsakymą tarp žymų <ANSWER> X </ANSWER>, kur X yra TIK teisinga jūsų pasirinkta raidė. Nerašykite jokio papildomo teksto tarp žymų.",
+}
+
+# English-only "direct answer" system message, used for the open-weight models.
+# The reference implementation writes ``\n\ONLY`` here; the stray backslash is an
+# escape-sequence typo (see the fidelity notes in README.md) and is dropped.
+SYS_MESSAGE_DIRECT = 'You are a helpful assistant who answers multiple-choice questions. For each question, output your final answer in JSON format with the following structure:\n\n{"choice": "The correct option (e.g., A, B, C, or D)"}\n\nONLY output this format exactly. Do not include any additional text or explanations outside the JSON structure.'
+INSTRUCTION_DIRECT = "Output your choice in the specified JSON format."
+
+# Choice letters that models sometimes emit in the script of the question language.
+MAP_NON_LATIN: Dict[str, str] = {
+    "Б": "B",  # Ukrainian
+    "Ц": "C",  # Ukrainian
+    "Д": "D",  # Ukrainian
+    "Г": "D",
+    "أ": "A",  # Arabic (Alif)
+    "ب": "B",  # Arabic (Ba)
+    "ج": "C",  # Arabic (Jeem)
+    "د": "D",  # Arabic (Dal)
+}
+
+_IMAGE_SUFFIXES = (".png", ".jpg", ".jpeg", ".webp")
+_ANSWER_TAG_RE = re.compile(r"<ANSWER>\s*([^\s<>]+)\s*</ANSWER>", re.IGNORECASE)
+_CHOICE_JSON_RE = re.compile(r"\{\s*\"choice\"\s*:\s*.*?\s*\}", re.DOTALL)
+
+# ---------------------------------------------------------------------------
+# Image resolution
+#
+# The parquet table only stores *relative paths* (e.g.
+# ``data/GATE_2022_Multimodal/images/xl_question_11.png``); the pixels live in a
+# companion ``data.zip`` on the Hub.  Three resolution strategies are supported:
+#
+#   1. ``KALEIDOSCOPE_DATA_ROOT=/path/to/extracted`` - a directory that already
+#      contains ``data/...`` (i.e. the contents of ``final_data/``).
+#   2. default - download ``data.zip`` once through the HF cache and read
+#      members straight out of the archive (no extraction, no second copy).
+#   3. ``KALEIDOSCOPE_STREAM_ZIP=1`` - read members over HTTP range requests
+#      without downloading the ~1 GB archive.  Handy for smoke tests.
+# ---------------------------------------------------------------------------
+
+_zip_lock = threading.Lock()
+_zip_handle: Optional[zipfile.ZipFile] = None
+_zip_names: Optional[frozenset] = None
+
+
+def _data_root() -> Optional[str]:
+    """Return a local directory holding the extracted images, if configured."""
+    root = os.getenv("KALEIDOSCOPE_DATA_ROOT")
+    if not root:
+        return None
+    if not os.path.isdir(root):
+        raise FileNotFoundError(f"KALEIDOSCOPE_DATA_ROOT={root!r} is not a directory")
+    return root
+
+
+def _image_size() -> Optional[int]:
+    """Return the square edge length images are resized to, or ``None`` for native."""
+    raw = os.getenv("KALEIDOSCOPE_IMAGE_SIZE")
+    if raw is None:
+        raw = config.get("metadata", {}).get("image_size", 512)
+    if raw in (None, "", "none", "None", 0, "0"):
+        return None
+    return int(raw)
+
+
+def _get_zip() -> Tuple[zipfile.ZipFile, frozenset]:
+    """Open ``data.zip`` (downloading or streaming it once) and cache the handle."""
+    global _zip_handle, _zip_names
+    if _zip_handle is None:
+        if os.getenv("KALEIDOSCOPE_STREAM_ZIP", "").lower() in ("1", "true", "yes"):
+            from huggingface_hub import HfFileSystem
+
+            eval_logger.info(f"Kaleidoscope: streaming images from {HF_DATASET_REPO}/{HF_IMAGE_ARCHIVE} over range requests")
+            handle = HfFileSystem().open(f"datasets/{HF_DATASET_REPO}/{HF_IMAGE_ARCHIVE}", "rb")
+        else:
+            from huggingface_hub import hf_hub_download
+
+            eval_logger.info(f"Kaleidoscope: resolving images from {HF_DATASET_REPO}/{HF_IMAGE_ARCHIVE} (~1 GB, cached by huggingface_hub)")
+            handle = hf_hub_download(repo_id=HF_DATASET_REPO, filename=HF_IMAGE_ARCHIVE, repo_type="dataset")
+        _zip_handle = zipfile.ZipFile(handle)
+        _zip_names = frozenset(_zip_handle.namelist())
+    return _zip_handle, _zip_names
+
+
+def _read_bytes(relative_path: str) -> bytes:
+    """Read one image from the extracted directory or from ``data.zip``."""
+    root = _data_root()
+    if root is not None:
+        with open(os.path.join(root, relative_path), "rb") as handle:
+            return handle.read()
+
+    with _zip_lock:
+        archive, names = _get_zip()
+        for candidate in (ZIP_ROOT_PREFIX + relative_path, relative_path):
+            if candidate in names:
+                return archive.read(candidate)
+    raise KeyError(f"{relative_path!r} not found in {HF_IMAGE_ARCHIVE}")
+
+
+def _normalize_relative_path(value: str) -> str:
+    """Reject absolute paths and ``..`` segments before touching the filesystem."""
+    cleaned = value.replace("\\", "/")
+    if cleaned.startswith("./"):
+        cleaned = cleaned[2:]
+    if cleaned.startswith("/") or os.path.isabs(cleaned) or ".." in cleaned.split("/"):
+        raise ValueError(f"Kaleidoscope image path must be relative and contain no '..': {value!r}")
+    return cleaned
+
+
+def _load_image(value: str) -> Image.Image:
+    """Load one benchmark image as RGB, resized to the configured edge length."""
+    image = Image.open(io.BytesIO(_read_bytes(_normalize_relative_path(value)))).convert("RGB")
+    size = _image_size()
+    if size is not None:
+        image = image.resize((size, size))
+    return image
+
+
+# ---------------------------------------------------------------------------
+# Document helpers
+# ---------------------------------------------------------------------------
+
+
+def _options(doc: Dict[str, Any]) -> List[str]:
+    """Return the option list, tolerating the stringified form some mirrors use."""
+    options = doc.get("options") or []
+    if isinstance(options, str):
+        options = ast.literal_eval(options)
+    return [str(option) for option in options]
+
+
+def _is_image_option(option: str) -> bool:
+    return option.lower().endswith(_IMAGE_SUFFIXES)
+
+
+def _has_question_image(doc: Dict[str, Any]) -> bool:
+    value = doc.get("image")
+    return bool(value) and str(value).lower() != "none"
+
+
+def _language_name(doc: Dict[str, Any]) -> str:
+    code = doc.get("language", "")
+    return LANGUAGES.get(code, code)
+
+
+def _prompt_type(lmms_eval_specific_kwargs: Optional[Dict[str, Any]]) -> str:
+    if not lmms_eval_specific_kwargs:
+        return "direct"
+    return lmms_eval_specific_kwargs.get("prompt_type", "direct")
+
+
+def _system_message(doc: Dict[str, Any], prompt_type: str) -> str:
+    """Return the system message for this document under the given regime."""
+    if prompt_type == "cot":
+        code = doc.get("language", "en")
+        if code not in INSTRUCTIONS_COT:
+            raise ValueError(f"No chain-of-thought instruction for language {code!r}")
+        return INSTRUCTIONS_COT[code]
+    return SYS_MESSAGE_DIRECT
+
+
+def _question_block(doc: Dict[str, Any], prompt_type: str) -> str:
+    """Render the question stem plus lettered options, following the reference code."""
+    options = _options(doc)
+    if prompt_type == "cot":
+        # Closed-model layout: question, then a plain English "Options:" header.
+        lines = [doc["question"], "Options:"]
+        lines += [f"{chr(65 + index)}. {option}" for index, option in enumerate(options)]
+        return "\n".join(lines)
+
+    keyword = KEYWORDS.get(doc.get("language", "en"), KEYWORDS["en"])
+    block = f"\n{INSTRUCTION_DIRECT}\n\n{keyword['question']}: {doc['question']}\n{keyword['options']}:\n"
+    for index, option in enumerate(options):
+        block += f"{chr(65 + index)}. {option}\n"
+    return block + "\nANSWER:"
+
+
+# ---------------------------------------------------------------------------
+# Task interface
+# ---------------------------------------------------------------------------
+
+
+def kaleidoscope_doc_to_visual(doc: Dict[str, Any]) -> List[Image.Image]:
+    """Return the question image followed by any options that are themselves images."""
+    visuals: List[Image.Image] = []
+    if _has_question_image(doc):
+        visuals.append(_load_image(str(doc["image"])))
+    for option in _options(doc):
+        if _is_image_option(option):
+            visuals.append(_load_image(option))
+    return visuals
+
+
+def kaleidoscope_doc_to_text(doc: Dict[str, Any], lmms_eval_specific_kwargs: Optional[Dict[str, Any]] = None) -> str:
+    """Build the flat prompt used by the simple (non-chat) model interface.
+
+    Simple wrappers substitute their own system prompt, so the benchmark's system
+    message is folded into the user turn here.  Chat wrappers get it as a real
+    ``system`` message via :func:`kaleidoscope_doc_to_messages`.
+    """
+    prompt_type = _prompt_type(lmms_eval_specific_kwargs)
+    return f"{_system_message(doc, prompt_type)}\n{_question_block(doc, prompt_type)}"
+
+
+def kaleidoscope_doc_to_messages(doc: Dict[str, Any], lmms_eval_specific_kwargs: Optional[Dict[str, Any]] = None) -> List[Dict[str, Any]]:
+    """Build interleaved chat messages, placing option images next to their letters."""
+    prompt_type = _prompt_type(lmms_eval_specific_kwargs)
+    options = _options(doc)
+    content: List[Dict[str, Any]] = []
+
+    if prompt_type == "cot":
+        # Closed-model layout: question text, question image, then the options.
+        content.append({"type": "text", "text": doc["question"]})
+        if _has_question_image(doc):
+            content.append({"type": "image", "url": _load_image(str(doc["image"]))})
+        content.append({"type": "text", "text": "Options:"})
+    else:
+        # Open-model layout: the question image leads, then the whole text block.
+        if _has_question_image(doc):
+            content.append({"type": "image", "url": _load_image(str(doc["image"]))})
+        keyword = KEYWORDS.get(doc.get("language", "en"), KEYWORDS["en"])
+        content.append({"type": "text", "text": f"\n{INSTRUCTION_DIRECT}\n\n{keyword['question']}: {doc['question']}\n{keyword['options']}:"})
+
+    for index, option in enumerate(options):
+        letter = chr(65 + index)
+        if _is_image_option(option):
+            content.append({"type": "text", "text": f"{letter}."})
+            content.append({"type": "image", "url": _load_image(option)})
+        else:
+            content.append({"type": "text", "text": f"{letter}. {option}"})
+
+    if prompt_type != "cot":
+        content.append({"type": "text", "text": "\nANSWER:"})
+
+    return [
+        {"role": "system", "content": [{"type": "text", "text": _system_message(doc, prompt_type)}]},
+        {"role": "user", "content": content},
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Answer extraction
+# ---------------------------------------------------------------------------
+
+
+def _letter_to_index(letter: str, num_options: int) -> Optional[int]:
+    letter = MAP_NON_LATIN.get(letter, letter).strip().upper()
+    if len(letter) != 1 or not ("A" <= letter <= "Z"):
+        return None
+    index = ord(letter) - ord("A")
+    return index if 0 <= index < num_options else None
+
+
+def _choice_from_json(response: str, num_options: int) -> Optional[int]:
+    """Extract ``{"choice": "B"}``, mirroring ``format_answer.py`` in the reference code."""
+    payload = response.strip().removeprefix("```json").removeprefix("```").removesuffix("```").strip()
+    candidates: List[str] = []
+
+    try:
+        parsed = json.loads(payload)
+        if isinstance(parsed, dict) and isinstance(parsed.get("choice"), str):
+            candidates.append(parsed["choice"])
+    except (json.JSONDecodeError, TypeError):
+        pass
+
+    if not candidates:
+        match = _CHOICE_JSON_RE.search(payload)
+        if match:
+            try:
+                parsed = ast.literal_eval(match.group())
+            except (ValueError, SyntaxError):
+                parsed = None
+            if isinstance(parsed, dict) and isinstance(parsed.get("choice"), str):
+                candidates.append(parsed["choice"])
+
+    for candidate in candidates:
+        choice = candidate.strip().upper()
+        index = _letter_to_index(choice, num_options)
+        if index is not None:
+            return index
+        # ``{"choice": "B. Ribosome"}`` - split on "." exactly like the reference
+        # ``map_to_choice`` and accept only when a single segment *is* a letter.
+        segments = [segment.strip() for segment in choice.split(".")]
+        valid = [_letter_to_index(segment, num_options) for segment in segments]
+        valid = [index for index in valid if index is not None]
+        if len(valid) == 1:
+            return valid[0]
+    return None
+
+
+def _choice_from_tags(response: str, num_options: int) -> Optional[int]:
+    """Extract ``<ANSWER> X </ANSWER>``, mirroring ``format_answer`` in ``model_zoo.py``."""
+    matches = _ANSWER_TAG_RE.findall(response)
+    for raw in reversed(matches):
+        token = raw.strip().strip(".)(").upper()
+        index = _letter_to_index(token, num_options)
+        if index is not None:
+            return index
+        if token.isdigit() and 1 <= int(token) <= num_options:
+            return int(token) - 1
+    return None
+
+
+def extract_choice(response: str, num_options: int, prompt_type: str = "direct", lenient: bool = False) -> Optional[int]:
+    """Parse a model response into a zero-based option index.
+
+    Both documented output formats are tried regardless of ``prompt_type`` - it
+    only decides which one is attempted first - because models occasionally
+    answer in the other one.  ``None`` means the answer could not be extracted
+    and the sample counts towards the format-error rate.
+
+    Args:
+        response: Raw model output.
+        num_options: Number of options for this question.
+        prompt_type: ``"direct"`` (JSON) or ``"cot"`` (``<ANSWER>`` tags).
+        lenient: Also fall back to the shared loose MCQ extractor.  Off by
+            default because the paper's format-error rate depends on strict
+            parsing.
+
+    Returns:
+        Zero-based option index, or ``None`` when nothing could be extracted.
+    """
+    if not response or not response.strip():
+        return None
+
+    order = (_choice_from_tags, _choice_from_json) if prompt_type == "cot" else (_choice_from_json, _choice_from_tags)
+    for extractor in order:
+        index = extractor(response, num_options)
+        if index is not None:
+            return index
+
+    stripped = response.strip()
+    if len(stripped) == 1:
+        index = _letter_to_index(stripped, num_options)
+        if index is not None:
+            return index
+        if stripped.isdigit() and 1 <= int(stripped) <= num_options:
+            return int(stripped) - 1
+
+    if lenient:
+        from lmms_eval.tasks._task_utils.mcq_extract import extract_mcq_answer
+
+        letter = extract_mcq_answer(response, [chr(65 + i) for i in range(num_options)])
+        if letter:
+            return _letter_to_index(letter, num_options)
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Scoring
+# ---------------------------------------------------------------------------
+
+
+def _lenient_extraction() -> bool:
+    """Whether to fall back to the loose MCQ extractor for unparseable answers."""
+    raw = os.getenv("KALEIDOSCOPE_LENIENT_EXTRACTION")
+    if raw is None:
+        raw = config.get("metadata", {}).get("lenient_extraction", False)
+    return str(raw).lower() in ("1", "true", "yes")
+
+
+def _process_results(doc: Dict[str, Any], results: Sequence[str], prompt_type: str) -> Dict[str, Dict[str, Any]]:
+    """Score one document and emit the record shared by all three metrics."""
+    options = _options(doc)
+    prediction = extract_choice(results[0] if results else "", len(options), prompt_type, _lenient_extraction())
+    valid = prediction is not None
+
+    record = {
+        "language": _language_name(doc),
+        "language_code": doc.get("language", ""),
+        "country": doc.get("country", ""),
+        "level": doc.get("level", ""),
+        "category": doc.get("category_en", ""),
+        "general_category": doc.get("general_category_en", ""),
+        "image_type": doc.get("image_type", ""),
+        "image_information": doc.get("image_information", ""),
+        "is_multimodal": _has_question_image(doc),
+        "answer": doc.get("answer"),
+        "prediction": prediction,
+        "valid": valid,
+        "correct": bool(valid and prediction == doc.get("answer")),
+    }
+    return {
+        "kaleidoscope_acc": record,
+        "kaleidoscope_valid_acc": record,
+        "kaleidoscope_format_error": record,
+    }
+
+
+def kaleidoscope_process_results(doc: Dict[str, Any], results: Sequence[str]) -> Dict[str, Dict[str, Any]]:
+    """Score a ``direct`` (JSON answer format) response."""
+    return _process_results(doc, results, prompt_type="direct")
+
+
+def kaleidoscope_process_results_cot(doc: Dict[str, Any], results: Sequence[str]) -> Dict[str, Dict[str, Any]]:
+    """Score a ``cot`` (``<ANSWER>`` tagged) response."""
+    return _process_results(doc, results, prompt_type="cot")
+
+
+def _macro_average(records: Sequence[Dict[str, Any]], key: str, valid_only: bool) -> float:
+    """Average per-group accuracy with equal weight per group, as the paper does."""
+    groups: Dict[str, List[Dict[str, Any]]] = defaultdict(list)
+    for record in records:
+        groups[record.get(key) or "unknown"].append(record)
+
+    scores = []
+    for group in groups.values():
+        correct = sum(1 for record in group if record["correct"])
+        denominator = sum(1 for record in group if record["valid"]) if valid_only else len(group)
+        if denominator:
+            scores.append(correct / denominator)
+    return 100 * sum(scores) / len(scores) if scores else 0.0
+
+
+def _breakdown(records: Sequence[Dict[str, Any]], key: str) -> List[Dict[str, Any]]:
+    groups: Dict[str, List[Dict[str, Any]]] = defaultdict(list)
+    for record in records:
+        groups[record.get(key) or "unknown"].append(record)
+
+    rows = []
+    for name in sorted(groups):
+        group = groups[name]
+        correct = sum(1 for record in group if record["correct"])
+        valid = sum(1 for record in group if record["valid"])
+        rows.append(
+            {
+                "name": name,
+                "num": len(group),
+                "acc": 100 * correct / len(group),
+                "valid_acc": 100 * correct / valid if valid else 0.0,
+                "format_error": 100 * (len(group) - valid) / len(group),
+            }
+        )
+    return rows
+
+
+def _log_breakdown(title: str, rows: Sequence[Dict[str, Any]]) -> None:
+    lines = [f"{'':2}{title}", f"{'':2}{'group':<24}{'n':>7}{'acc':>9}{'valid_acc':>11}{'fmt_err':>9}"]
+    for row in rows:
+        lines.append(f"{'':2}{row['name'][:24]:<24}{row['num']:>7}{row['acc']:>9.2f}{row['valid_acc']:>11.2f}{row['format_error']:>9.2f}")
+    eval_logger.info("\n".join(lines))
+
+
+def kaleidoscope_aggregate_accuracy(results: List[Dict[str, Any]]) -> float:
+    """Macro-averaged accuracy over languages, counting format errors as wrong."""
+    if not results:
+        return 0.0
+
+    _log_breakdown("Kaleidoscope by language", _breakdown(results, "language"))
+    _log_breakdown("Kaleidoscope by general category", _breakdown(results, "general_category"))
+    if any(record["is_multimodal"] for record in results):
+        multimodal = [record for record in results if record["is_multimodal"]]
+        _log_breakdown("Kaleidoscope by image type (multimodal only)", _breakdown(multimodal, "image_type"))
+
+    valid = sum(1 for record in results if record["valid"])
+    eval_logger.info(
+        f"Kaleidoscope overall: n={len(results)} "
+        f"acc={_macro_average(results, 'language', valid_only=False):.2f} "
+        f"valid_acc={_macro_average(results, 'language', valid_only=True):.2f} "
+        f"format_error={100 * (len(results) - valid) / len(results):.2f}"
+    )
+    return _macro_average(results, "language", valid_only=False)
+
+
+def kaleidoscope_aggregate_valid_accuracy(results: List[Dict[str, Any]]) -> float:
+    """Macro-averaged accuracy over languages, ignoring unparseable responses."""
+    return _macro_average(results, "language", valid_only=True) if results else 0.0
+
+
+def kaleidoscope_aggregate_format_error(results: List[Dict[str, Any]]) -> float:
+    """Share of responses (over all samples) whose answer could not be extracted."""
+    if not results:
+        return 0.0
+    return 100 * sum(1 for record in results if not record["valid"]) / len(results)
+
+
+# ---------------------------------------------------------------------------
+# Split filters
+# ---------------------------------------------------------------------------
+
+
+def kaleidoscope_filter_multimodal(dataset: datasets.Dataset) -> datasets.Dataset:
+    """Keep only questions that carry an image."""
+    return dataset.filter(_has_question_image)
+
+
+def kaleidoscope_filter_text_only(dataset: datasets.Dataset) -> datasets.Dataset:
+    """Keep only questions that have no image."""
+    return dataset.filter(lambda doc: not _has_question_image(doc))

--- a/test/eval/test_kaleidoscope.py
+++ b/test/eval/test_kaleidoscope.py
@@ -1,0 +1,323 @@
+import pytest
+from PIL import Image
+
+from lmms_eval.tasks import TaskManager
+from lmms_eval.tasks.kaleidoscope import utils
+
+
+def _doc(language="en", answer=1, image="data/exam/images/q1.png", options=None):
+    return {
+        "language": language,
+        "country": "India",
+        "file_name": "xl_2022.pdf",
+        "source": "GATE",
+        "license": "cc-by",
+        "level": "university",
+        "category_en": "Biology",
+        "category_original_lang": "Biology",
+        "general_category_en": "STEM",
+        "original_question_num": "11",
+        "question": "Which structure is labelled X?",
+        "options": options if options is not None else ["Nucleus", "Ribosome", "Golgi", "Vacuole"],
+        "answer": answer,
+        "image_png": "q1.png",
+        "image_information": "essential",
+        "image_type": "diagram",
+        "parallel_question_id": "",
+        "image": image,
+    }
+
+
+def _write_png(root, relative_path, size=(8, 6), color=(10, 20, 30)):
+    path = root / relative_path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    Image.new("RGB", size, color).save(path)
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "task",
+    [
+        "kaleidoscope_direct",
+        "kaleidoscope_multimodal",
+        "kaleidoscope_text_only",
+        "kaleidoscope_cot",
+        "kaleidoscope_multimodal_cot",
+    ],
+)
+def test_tasks_are_registered(task):
+    assert task in TaskManager("WARNING").all_subtasks
+
+
+# ---------------------------------------------------------------------------
+# Prompt construction
+# ---------------------------------------------------------------------------
+
+
+def test_direct_prompt_uses_in_language_keywords_and_json_system_message():
+    prompt = utils.kaleidoscope_doc_to_text(_doc(language="bn"), {"prompt_type": "direct"})
+
+    assert '{"choice": "The correct option (e.g., A, B, C, or D)"}' in prompt
+    assert "\\ONLY" not in prompt  # reference escape-sequence typo must not leak through
+    assert "প্রশ্ন: Which structure is labelled X?" in prompt
+    assert "বিকল্প:" in prompt
+    assert "A. Nucleus" in prompt
+    assert "D. Vacuole" in prompt
+    assert prompt.endswith("\nANSWER:")
+
+
+def test_cot_prompt_uses_in_language_system_message_and_no_answer_cue():
+    prompt = utils.kaleidoscope_doc_to_text(_doc(language="es"), {"prompt_type": "cot"})
+
+    assert prompt.startswith(utils.INSTRUCTIONS_COT["es"])
+    assert "<ANSWER> X </ANSWER>" in prompt
+    assert "Options:" in prompt
+    assert not prompt.endswith("ANSWER:")
+
+
+def test_cot_prompt_rejects_unknown_language():
+    with pytest.raises(ValueError, match="chain-of-thought instruction"):
+        utils.kaleidoscope_doc_to_text(_doc(language="zz"), {"prompt_type": "cot"})
+
+
+def test_every_language_has_keywords_and_cot_instruction():
+    assert set(utils.KEYWORDS) == set(utils.LANGUAGES)
+    assert set(utils.INSTRUCTIONS_COT) == set(utils.LANGUAGES)
+
+
+def test_doc_to_messages_puts_question_image_first_for_direct(monkeypatch, tmp_path):
+    monkeypatch.setenv("KALEIDOSCOPE_DATA_ROOT", str(tmp_path))
+    _write_png(tmp_path, "data/exam/images/q1.png")
+
+    messages = utils.kaleidoscope_doc_to_messages(_doc(), {"prompt_type": "direct"})
+
+    assert messages[0]["role"] == "system"
+    assert messages[1]["role"] == "user"
+    assert messages[1]["content"][0]["type"] == "image"
+    assert messages[1]["content"][-1]["text"] == "\nANSWER:"
+
+
+def test_doc_to_messages_puts_question_text_first_for_cot(monkeypatch, tmp_path):
+    monkeypatch.setenv("KALEIDOSCOPE_DATA_ROOT", str(tmp_path))
+    _write_png(tmp_path, "data/exam/images/q1.png")
+
+    messages = utils.kaleidoscope_doc_to_messages(_doc(), {"prompt_type": "cot"})
+
+    assert messages[1]["content"][0] == {"type": "text", "text": "Which structure is labelled X?"}
+    assert messages[1]["content"][1]["type"] == "image"
+
+
+def test_doc_to_messages_interleaves_image_options(monkeypatch, tmp_path):
+    monkeypatch.setenv("KALEIDOSCOPE_DATA_ROOT", str(tmp_path))
+    _write_png(tmp_path, "data/exam/images/q1.png")
+    _write_png(tmp_path, "data/exam/images/opt_a.png")
+
+    doc = _doc(options=["data/exam/images/opt_a.png", "Ribosome"])
+    content = utils.kaleidoscope_doc_to_messages(doc, {"prompt_type": "direct"})[1]["content"]
+    images = [item for item in content if item["type"] == "image"]
+
+    assert len(images) == 2  # question image + one option image
+    assert {"type": "text", "text": "A."} in content
+    assert {"type": "text", "text": "B. Ribosome"} in content
+
+
+# ---------------------------------------------------------------------------
+# Visuals
+# ---------------------------------------------------------------------------
+
+
+def test_doc_to_visual_resizes_to_configured_edge_length(monkeypatch, tmp_path):
+    monkeypatch.setenv("KALEIDOSCOPE_DATA_ROOT", str(tmp_path))
+    monkeypatch.setenv("KALEIDOSCOPE_IMAGE_SIZE", "512")
+    _write_png(tmp_path, "data/exam/images/q1.png", size=(40, 10))
+
+    visuals = utils.kaleidoscope_doc_to_visual(_doc())
+
+    assert len(visuals) == 1
+    assert visuals[0].size == (512, 512)
+    assert visuals[0].mode == "RGB"
+
+
+def test_doc_to_visual_can_keep_native_resolution(monkeypatch, tmp_path):
+    monkeypatch.setenv("KALEIDOSCOPE_DATA_ROOT", str(tmp_path))
+    monkeypatch.setenv("KALEIDOSCOPE_IMAGE_SIZE", "0")
+    _write_png(tmp_path, "data/exam/images/q1.png", size=(40, 10))
+
+    assert utils.kaleidoscope_doc_to_visual(_doc())[0].size == (40, 10)
+
+
+def test_doc_to_visual_is_empty_for_text_only_questions(monkeypatch, tmp_path):
+    monkeypatch.setenv("KALEIDOSCOPE_DATA_ROOT", str(tmp_path))
+
+    assert utils.kaleidoscope_doc_to_visual(_doc(image=None)) == []
+
+
+def test_doc_to_visual_rejects_path_traversal(monkeypatch, tmp_path):
+    monkeypatch.setenv("KALEIDOSCOPE_DATA_ROOT", str(tmp_path))
+
+    with pytest.raises(ValueError, match="must be relative"):
+        utils.kaleidoscope_doc_to_visual(_doc(image="../../secret.png"))
+
+
+# ---------------------------------------------------------------------------
+# Answer extraction
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "response,expected",
+    [
+        ('{"choice": "B"}', 1),
+        ('```json\n{"choice": "C"}\n```', 2),
+        ('Sure!\n{"choice": "D"}', 3),
+        ('{"choice": "B. Ribosome"}', 1),
+        ('{"choice": "b"}', 1),
+        ("B", 1),
+        ("2", 1),
+    ],
+)
+def test_direct_extraction(response, expected):
+    assert utils.extract_choice(response, 4, "direct") == expected
+
+
+@pytest.mark.parametrize(
+    "response,expected",
+    [
+        ("Step one... <ANSWER> C </ANSWER>", 2),
+        ("<ANSWER>A</ANSWER>", 0),
+        ("<ANSWER> b </ANSWER>", 1),
+        ("first <ANSWER> A </ANSWER> then <ANSWER> D </ANSWER>", 3),
+    ],
+)
+def test_cot_extraction(response, expected):
+    assert utils.extract_choice(response, 4, "cot") == expected
+
+
+def test_non_latin_choice_letters_are_mapped():
+    assert utils.extract_choice('{"choice": "Б"}', 4, "direct") == 1
+    assert utils.extract_choice("<ANSWER> د </ANSWER>", 4, "cot") == 3
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        "",
+        "   ",
+        "I cannot answer this question.",
+        "<ANSWER></ANSWER>",
+        '{"choice": "A or B"}',
+        '{"answer": "B"}',
+    ],
+)
+def test_unparseable_responses_return_none(response):
+    assert utils.extract_choice(response, 4, "direct") is None
+
+
+def test_out_of_range_letters_are_rejected():
+    assert utils.extract_choice('{"choice": "D"}', 2, "direct") is None
+
+
+def test_lenient_extraction_is_opt_in():
+    response = "The correct answer is (C) because the diagram shows a Golgi body."
+
+    assert utils.extract_choice(response, 4, "direct") is None
+    assert utils.extract_choice(response, 4, "direct", lenient=True) == 2
+
+
+# ---------------------------------------------------------------------------
+# Scoring
+# ---------------------------------------------------------------------------
+
+
+def test_process_results_emits_all_three_metrics():
+    scored = utils.kaleidoscope_process_results(_doc(answer=1), ['{"choice": "B"}'])
+
+    assert set(scored) == {"kaleidoscope_acc", "kaleidoscope_valid_acc", "kaleidoscope_format_error"}
+    record = scored["kaleidoscope_acc"]
+    assert record["language"] == "English"
+    assert record["general_category"] == "STEM"
+    assert record["is_multimodal"] is True
+    assert record["prediction"] == 1
+    assert record["valid"] is True
+    assert record["correct"] is True
+
+
+def test_format_error_counts_as_wrong_but_not_as_valid():
+    record = utils.kaleidoscope_process_results(_doc(answer=1), ["no idea"])["kaleidoscope_acc"]
+
+    assert record["prediction"] is None
+    assert record["valid"] is False
+    assert record["correct"] is False
+
+
+def test_cot_process_results_reads_answer_tags():
+    record = utils.kaleidoscope_process_results_cot(_doc(answer=2), ["reasoning <ANSWER> C </ANSWER>"])["kaleidoscope_acc"]
+
+    assert record["prediction"] == 2
+    assert record["correct"] is True
+
+
+def _records(*specs):
+    """Build metric records from (language, gold, response) triples."""
+    return [utils.kaleidoscope_process_results(_doc(language=language, answer=answer), [response])["kaleidoscope_acc"] for language, answer, response in specs]
+
+
+def test_accuracy_is_macro_averaged_over_languages():
+    # English: 2/2 correct.  Bengali: 0/4 correct.  Micro would be 33.3%.
+    records = _records(
+        ("en", 0, '{"choice": "A"}'),
+        ("en", 1, '{"choice": "B"}'),
+        ("bn", 0, '{"choice": "B"}'),
+        ("bn", 0, '{"choice": "B"}'),
+        ("bn", 0, '{"choice": "B"}'),
+        ("bn", 0, '{"choice": "B"}'),
+    )
+
+    assert utils.kaleidoscope_aggregate_accuracy(records) == pytest.approx(50.0)
+
+
+def test_valid_accuracy_excludes_format_errors():
+    records = _records(
+        ("en", 0, '{"choice": "A"}'),
+        ("en", 0, "I refuse to answer"),
+    )
+
+    assert utils.kaleidoscope_aggregate_accuracy(records) == pytest.approx(50.0)
+    assert utils.kaleidoscope_aggregate_valid_accuracy(records) == pytest.approx(100.0)
+    assert utils.kaleidoscope_aggregate_format_error(records) == pytest.approx(50.0)
+
+
+def test_format_error_is_micro_averaged_over_all_samples():
+    records = _records(
+        ("en", 0, "no"),
+        ("bn", 0, '{"choice": "A"}'),
+        ("bn", 0, '{"choice": "A"}'),
+        ("bn", 0, '{"choice": "A"}'),
+    )
+
+    assert utils.kaleidoscope_aggregate_format_error(records) == pytest.approx(25.0)
+
+
+def test_aggregations_handle_empty_results():
+    assert utils.kaleidoscope_aggregate_accuracy([]) == 0.0
+    assert utils.kaleidoscope_aggregate_valid_accuracy([]) == 0.0
+    assert utils.kaleidoscope_aggregate_format_error([]) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Split filters
+# ---------------------------------------------------------------------------
+
+
+def test_split_filters_partition_the_dataset():
+    import datasets
+
+    dataset = datasets.Dataset.from_list([_doc(), _doc(image=None), _doc(image="")])
+
+    assert len(utils.kaleidoscope_filter_multimodal(dataset)) == 1
+    assert len(utils.kaleidoscope_filter_text_only(dataset)) == 2


### PR DESCRIPTION
Adds Kaleidoscope (arXiv:2504.07072), an in-language multiple-choice exam benchmark spanning 20,911 questions, 18 languages and 14 subjects, 11,457 of which require reading an image. Implements both prompting regimes from the paper (English JSON direct-answer and in-language zero-shot CoT with <ANSWER> tags) and all three reported metrics, macro-averaged over languages as upstream get_score.py does. Images are resolved lazily out of the dataset's companion data.zip. Validated against the reference implementation: answer extraction agrees 199/200 on its published outputs, and a greedy run scores 31.00 vs the reference 30.00 on the identical 100-question slice. I am one of the lead author's of this benchmark.

## Summary
- Adds **Kaleidoscope** ([arXiv:2504.07072](https://arxiv.org/abs/2504.07072), ICLR 2026) — an in-language multiple-choice exam benchmark of **20,911 questions across 18 languages and 14 subjects**, **11,457 (54.8%)** of which require reading an image. Unlike most multilingual suites it is not translated from English: every question comes from a real exam written in the language it is asked in.
- Implements **both prompting regimes from the paper** (English JSON "direct answer" for open-weight models; in-language zero-shot CoT with `<ANSWER>` tags for closed models) and all three reported metrics — accuracy, valid accuracy, format-error rate — macro-averaged over languages exactly as the reference `get_score.py` does.
- Validated against the reference implementation's own published outputs: answer extraction agrees **199/200**, and a greedy end-to-end run scores **31.00 vs the reference's 30.00** on an order-identical 100-question slice.

## In scope
- `lmms_eval/tasks/kaleidoscope/` — `utils.py`, `_default_template_yaml`, six task configs (`kaleidoscope` group, `kaleidoscope_multimodal`, `kaleidoscope_text_only`, `kaleidoscope_direct`, `kaleidoscope_multimodal_cot`, `kaleidoscope_cot`), plus `README.md` and `RESULTS.md`.
- Lazy image resolution for the dataset's split layout: the Hub release keeps question rows in parquet and pixels in a companion `data.zip`, so `doc_to_visual` reads members straight out of the HF-cached archive — no extraction, no second copy on disk. `KALEIDOSCOPE_DATA_ROOT` points at a pre-extracted directory; `KALEIDOSCOPE_STREAM_ZIP=1` range-streams individual members so a `--limit`ed smoke test needs no ~1 GB download.
- Per-language, per-subject and per-image-type breakdowns printed by the aggregation, so one run reproduces the paper's appendix tables without needing 18 per-language subtasks.
- `test/eval/test_kaleidoscope.py` — 44 fully offline tests covering registration, both prompt regimes, image/option interleaving, resizing, path-traversal rejection, every documented answer format, and the macro-average / format-error aggregations.
- One entry under **Multilingual Benchmarks** in `docs/advanced/current_tasks.md`.

## Out of scope
- No new model wrappers and no changes to shared framework code — runs on the existing `qwen2_vl` / `qwen2_5_vl` (and any other) wrappers unchanged.
- No few-shot task; the paper's headline results are zero-shot.
- The paper's ablations (Random Image / No-Image, caption+OCR augmentation) are not ported.
- No per-language subtasks — the language breakdown comes out of a single run's aggregation instead.

## Validation
- `pytest test/eval/test_kaleidoscope.py` | sample size: `N=44 tests` | key metrics: `44 passed` | result: `pass`
- `python -m lmms_eval --model qwen2_5_vl --model_args pretrained=Qwen/Qwen2.5-VL-3B-Instruct --tasks kaleidoscope_multimodal --limit 100 --gen_kwargs temperature=0,do_sample=False` | sample size: `N=100`, order-identical to the reference repo's published `sample_outputs/model_qwen2.5-3b` slice | key metrics: `acc=31.00, valid_acc=31.00, format_error=0.00` vs reference `30.00 / 30.00 / 0.00` | result: `pass` (Δ = 1 question)
- `extract_choice` replayed over the reference's published raw outputs and compared against its `format_answer.py` | sample size: `N=200` (Qwen2.5-VL-3B + Aya-Vision) | key metrics: `199/200 agreement` | result: `pass` (the single difference is the reference's line-bound regex missing a multi-line `{"choice": ...}`, documented as fidelity note 4)

Sampled decoding at the paper's `temperature=0.7` scatters over `acc` 32–37 on those same 100 questions (binomial s.e. ≈ 4.6 pp at `n=100`), which is why greedy is used as the reproduction anchor. Full commands, the environment used, and the paper's per-language comparison table are in `lmms_eval/tasks/kaleidoscope/RESULTS.md`.

## Risk / Compatibility
- Additive only — one new task directory, one new test file, one docs entry. No existing task, model, or shared utility is touched, so there is no migration impact.
- Task defaults reproduce the paper's sampling parameters (`temperature=0.7`, `top_p=0.9`, `do_sample=true`, `max_new_tokens=1024`), so runs are non-deterministic unless overridden with `--gen_kwargs temperature=0,do_sample=False`. This is a deliberate fidelity choice, called out in the task README — happy to flip the default to greedy if you'd prefer reproducibility over paper parity.
- First run downloads the ~1 GB `data.zip` once into the HF cache; `KALEIDOSCOPE_STREAM_ZIP=1` avoids it entirely for smoke tests.

## Type of Change
- [ ] Bug fix (non-breaking change)
- [ ] New feature
- [x] New benchmark/task
- [ ] New model integration
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring (no functional changes)