### PR TITLE
feat: add SlideVQA benchmark

### DIFF
--- a/lmms_eval/tasks/slidevqa/_default_template_slidevqa_yaml
+++ b/lmms_eval/tasks/slidevqa/_default_template_slidevqa_yaml
@@ -1,0 +1,19 @@
+dataset_path: NTT-hil-insight/SlideVQA
+dataset_kwargs:
+  token: True
+output_type: generate_until
+doc_to_visual: !function utils.slidevqa_doc_to_visual
+doc_to_text: !function utils.slidevqa_doc_to_text
+doc_to_target: answer
+doc_to_messages: !function utils.slidevqa_doc_to_messages
+process_results: !function utils.slidevqa_process_results
+generation_kwargs:
+  max_new_tokens: 128
+  temperature: 0
+  do_sample: false
+lmms_eval_specific_kwargs:
+  default:
+    pre_prompt: ""
+    post_prompt: "\nAnswer using only the short answer, without explanation."
+metadata:
+  version: 0.0

--- a/lmms_eval/tasks/slidevqa/slidevqa.yaml
+++ b/lmms_eval/tasks/slidevqa/slidevqa.yaml
@@ -1,0 +1,3 @@
+group: slidevqa
+task:
+- slidevqa_val

--- a/lmms_eval/tasks/slidevqa/slidevqa_val.yaml
+++ b/lmms_eval/tasks/slidevqa/slidevqa_val.yaml
@@ -1,0 +1,13 @@
+task: slidevqa_val
+test_split: val
+metric_list:
+  - metric: anls
+    aggregation: mean
+    higher_is_better: true
+  - metric: em
+    aggregation: mean
+    higher_is_better: true
+  - metric: f1
+    aggregation: mean
+    higher_is_better: true
+include: _default_template_slidevqa_yaml

--- a/lmms_eval/tasks/slidevqa/utils.py
+++ b/lmms_eval/tasks/slidevqa/utils.py
@@ -1,0 +1,96 @@
+"""SlideVQA task utilities.
+
+The Hugging Face rows contain one question, one answer, and up to 20 slide
+images in page_1 ... page_20. We pack the deck into a few grid images so
+multi-image models can answer with a short, directly scored response.
+Grid packing and scoring follow the public SlideVQA evaluation convention used by VLMEvalKit.
+"""
+
+import math
+import re
+from typing import Any
+
+from PIL import Image
+
+from lmms_eval.api.metrics import levenshtein_distance
+
+PAGE_COLUMNS = tuple(f"page_{index}" for index in range(1, 21))
+
+
+def slidevqa_doc_to_visual(doc: dict[str, Any]) -> list[Image.Image]:
+    """Return SlideVQA pages as up to five grid images."""
+    pages = [doc[column].convert("RGB") for column in PAGE_COLUMNS if doc.get(column) is not None]
+    if not pages:
+        raise ValueError(f"Slide deck {doc.get('deck_name')!r} has no images")
+    return concat_images(pages)
+
+
+def concat_images(images: list[Image.Image], max_concat: int = 5, column_num: int = 2) -> list[Image.Image]:
+    """Concatenate deck pages into grids."""
+    interval = max(math.ceil(len(images) / max_concat), 1)
+    grids = []
+
+    for start in range(0, len(images), interval):
+        batch = images[start : start + interval]
+        rows = math.ceil(len(batch) / column_num)
+        grid = Image.new("RGB", (batch[0].width * column_num, batch[0].height * rows), "white")
+
+        for index, image in enumerate(batch):
+            grid.paste(image, ((index % column_num) * image.width, (index // column_num) * image.height))
+        grids.append(grid)
+
+    return grids
+
+
+def slidevqa_doc_to_text(doc: dict[str, Any], lmms_eval_specific_kwargs: dict[str, str] | None = None) -> str:
+    """Build the short-answer SlideVQA prompt."""
+    kwargs = lmms_eval_specific_kwargs or {}
+    return f"{kwargs.get('pre_prompt', '')}{doc['question']}{kwargs.get('post_prompt', '')}"
+
+
+def slidevqa_doc_to_messages(doc: dict[str, Any], lmms_eval_specific_kwargs: dict[str, str] | None = None) -> list[dict[str, Any]]:
+    """Build interleaved chat messages for multi-image models."""
+    content = [{"type": "image", "url": image} for image in slidevqa_doc_to_visual(doc)]
+    content.append({"type": "text", "text": slidevqa_doc_to_text(doc, lmms_eval_specific_kwargs)})
+    return [{"role": "user", "content": content}]
+
+
+def normalize_answer(answer: Any) -> str:
+    """Normalize a SlideVQA answer."""
+    if answer is None or (isinstance(answer, float) and math.isnan(answer)):
+        return "not answerable"
+    return re.sub("\n", "", str(answer)).lower()
+
+
+def anls_score(answer: str, prediction: str, threshold: float = 0.5) -> float:
+    """Compute thresholded ANLS for one answer/prediction pair."""
+    length = max(len(answer), len(prediction))
+    if length == 0:
+        return 0.0
+    score = 1.0 - levenshtein_distance(answer, prediction) / length
+    return score if score > threshold else 0.0
+
+
+def word_f1(answer: str, prediction: str) -> float:
+    """Compute whitespace-token overlap F1."""
+    answer_words = answer.strip().split()
+    prediction_words = prediction.strip().split()
+    if not answer_words or not prediction_words:
+        return 0.0
+
+    recall = sum(word in answer_words for word in prediction_words) / len(answer_words)
+    precision = sum(word in answer_words for word in prediction_words) / len(prediction_words)
+    if recall + precision <= 1e-4:
+        return 0.0
+    return 2 * recall * precision / (recall + precision)
+
+
+def slidevqa_process_results(doc: dict[str, Any], results: list[str]) -> dict[str, float]:
+    """Score one SlideVQA prediction."""
+    answer = normalize_answer(doc.get("answer"))
+    prediction = str(results[0]).lower()
+    return {
+        "anls": anls_score(answer, prediction),
+        "em": float(answer.strip() == prediction.strip()),
+        "f1": word_f1(answer, prediction),
+    }

--- a/test/eval/test_slidevqa_utils.py
+++ b/test/eval/test_slidevqa_utils.py
@@ -1,0 +1,67 @@
+import math
+
+import pytest
+from PIL import Image
+
+from lmms_eval.tasks.slidevqa import utils
+
+
+def _image(color: tuple[int, int, int] = (0, 0, 0)) -> Image.Image:
+    return Image.new("RGB", (10, 8), color)
+
+
+def _doc(**overrides):
+    doc = {f"page_{index}": None for index in range(1, 21)}
+    doc.update({"deck_name": "demo", "question": "What is shown?", "answer": "chart"})
+    doc.update(overrides)
+    return doc
+
+
+def test_doc_to_visual_packs_twenty_pages_into_five_grids():
+    doc = _doc(**{f"page_{index}": _image() for index in range(1, 21)})
+
+    grids = utils.slidevqa_doc_to_visual(doc)
+
+    assert len(grids) == 5
+    assert all(grid.size == (20, 16) for grid in grids)
+
+
+def test_doc_to_visual_skips_empty_pages_and_errors_on_empty_deck():
+    doc = _doc(page_1=_image((255, 0, 0)), page_3=_image((0, 255, 0)))
+
+    grids = utils.slidevqa_doc_to_visual(doc)
+
+    assert len(grids) == 2
+    assert grids[0].getpixel((0, 0)) == (255, 0, 0)
+    assert grids[1].getpixel((0, 0)) == (0, 255, 0)
+
+    with pytest.raises(ValueError, match="has no images"):
+        utils.slidevqa_doc_to_visual(_doc())
+
+
+def test_doc_to_text_and_messages():
+    doc = _doc(**{f"page_{index}": _image() for index in range(1, 21)})
+    kwargs = {"pre_prompt": "", "post_prompt": "\nAnswer using only the short answer, without explanation."}
+
+    assert utils.slidevqa_doc_to_text(doc, kwargs) == "What is shown?\nAnswer using only the short answer, without explanation."
+
+    messages = utils.slidevqa_doc_to_messages(doc, kwargs)
+    content = messages[0]["content"]
+    assert messages[0]["role"] == "user"
+    assert [item["type"] for item in content] == ["image"] * 5 + ["text"]
+    assert content[-1]["text"].endswith("without explanation.")
+
+
+def test_normalize_answer_handles_missing_and_newlines():
+    assert utils.normalize_answer(None) == "not answerable"
+    assert utils.normalize_answer(float("nan")) == "not answerable"
+    assert utils.normalize_answer("New\nYork") == "newyork"
+
+
+def test_scoring_matches_short_answer_metrics():
+    assert utils.anls_score("newyork", "newyork") == 1.0
+    assert utils.anls_score("abc", "xyz") == 0.0
+    assert math.isclose(utils.word_f1("total revenue", "revenue"), 2 / 3)
+
+    scores = utils.slidevqa_process_results({"answer": "New\nYork"}, ["newyork"])
+    assert scores == {"anls": 1.0, "em": 1.0, "f1": 1.0}


### PR DESCRIPTION
## Summary
- Add SlideVQA task configs for the validation split.
- Implement SlideVQA visual packing, prompt formatting, chat messages, and ANLS/EM/F1 scoring.
- Add unit coverage for SlideVQA utility behavior.

## In scope
- New `slidevqa` task group and `slidevqa_val` task.
- Hugging Face dataset config for `NTT-hil-insight/SlideVQA`.
- Utility tests for page packing, prompts/messages, answer normalization, and scoring.

## Out of scope
- Full benchmark result reporting.
- Model-specific changes or inference optimization.
- Test split submission/export flow.

## Validation
- `uv run --with pytest python -m pytest -q test/eval/test_slidevqa_utils.py` 
  - Sample size: `N/A`
  - Key metrics: `5 utility tests`
  - Result: `pass`

- `python -m lmms_eval eval --model qwen2_5_vl --model_args "pretrained=Qwen/Qwen2.5-VL-3B-Instruct,device_map=auto,attn_implementation=sdpa" --tasks slidevqa_val --batch_size 1 --limit 5 --log_samples --output_path ./logs/slidevqa_smoke`
  - Sample size: `N=5`
  - Key metrics: `anls=0.9500, em=0.8000, f1=0.9333`
  - Result: `pass on A100 SXM4`

## Risk / Compatibility
- SlideVQA requires Hugging Face authentication because the dataset config uses `token: True`.
- Slide decks can be memory-intensive for VLM inference; small GPUs may need reduced visual resolution or smaller limits.

## Type of Change
- [ ] Bug fix (non-breaking change)
- [ ] New feature
- [x] New benchmark/task
- [ ] New model integration
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring (no functional changes)