### PR TITLE
fix: normalize fullwidth ASCII in OCRBench scoring

### DIFF
--- a/lmms_eval/tasks/ocrbench/utils.py
+++ b/lmms_eval/tasks/ocrbench/utils.py
@@ -17,6 +17,20 @@ OCRBench_score = {
 }
 
 
+def _fold_fullwidth_ascii(text: str) -> str:
+    """Fold fullwidth ASCII and ideographic space without broader NFKC changes."""
+    folded = []
+    for char in text:
+        codepoint = ord(char)
+        if 0xFF01 <= codepoint <= 0xFF5E:
+            folded.append(chr(codepoint - 0xFEE0))
+        elif codepoint == 0x3000:
+            folded.append(" ")
+        else:
+            folded.append(char)
+    return "".join(folded)
+
+
 def ocrbench_doc_to_visual(doc):
     # Assuming the 'doc' dictionary has a key 'image' with image data
     return [doc["image"].convert("RGB")]
@@ -51,13 +65,13 @@ def ocrbench_process_results(doc, results):
     else:
         if type(gt_ans) == list:
             for j in range(len(gt_ans)):
-                answer = gt_ans[j].lower().strip().replace("\n", " ")
-                predict = pred.lower().strip().replace("\n", " ")
+                answer = _fold_fullwidth_ascii(gt_ans[j]).lower().strip().replace("\n", " ")
+                predict = _fold_fullwidth_ascii(pred).lower().strip().replace("\n", " ")
                 if answer in predict:
                     score = 1
         else:
-            answer = gt_ans.lower().strip().replace("\n", " ")
-            predict = pred.lower().strip().replace("\n", " ")
+            answer = _fold_fullwidth_ascii(gt_ans).lower().strip().replace("\n", " ")
+            predict = _fold_fullwidth_ascii(pred).lower().strip().replace("\n", " ")
             if answer in predict:
                 score = 1
     return {

--- a/test/eval/test_ocrbench.py
+++ b/test/eval/test_ocrbench.py
@@ -1,0 +1,30 @@
+from lmms_eval.tasks.ocrbench.utils import ocrbench_process_results
+
+
+def _score(answer: str, prediction: str, dataset: str = "IIIT5K") -> int:
+    result = ocrbench_process_results(
+        {
+            "answer": [answer],
+            "dataset": dataset,
+            "question_type": "Regular Text Recognition",
+        },
+        [prediction],
+    )
+    return result["ocrbench_accuracy"]["score"]
+
+
+def test_ocrbench_treats_fullwidth_ascii_as_equivalent():
+    assert _score("2590", "２５９０") == 1
+    assert _score("２５９０", "2590") == 1
+    assert _score("both sides", "ｂｏｔｈ　ｓｉｄｅｓ") == 1
+
+
+def test_ocrbench_does_not_fold_other_compatibility_characters():
+    assert _score("1", "①") == 0
+    assert _score("2", "²") == 0
+    assert _score("IV", "Ⅳ") == 0
+    assert _score("kg", "㎏") == 0
+
+
+def test_ocrbench_keeps_hme_width_sensitive():
+    assert _score("x+1", "ｘ＋１", dataset="HME100k") == 0


### PR DESCRIPTION
## Summary
- Treat fullwidth ASCII characters as equivalent to their ASCII counterparts in OCRBench's existing accuracy metric.
- Avoid broad NFKC normalization so circled numbers, superscripts, Roman numerals, and unit symbols remain distinct.
- Add focused regression tests for width equivalence, non-width compatibility characters, and HME behavior.

## In scope
- Fold U+FF01-U+FF5E and U+3000 symmetrically in non-HME OCRBench predictions and ground truths.
- Keep the existing `ocrbench_accuracy` metric name and aggregation.
- Add OCRBench scorer regression tests.

## Out of scope
- No global NFKC normalization.
- No changes to prompts, generation parameters, task YAML, or HME100k's width-sensitive scoring.

## Validation
- `python -m pytest -q test/eval/test_ocrbench.py` | sample size: `N=3 tests` | key metrics: width equivalence and negative controls | result: `3 passed`
- Historical Qwen3.5-9B vLLM replay | sample size: `N=1000` | key metrics: `844 -> 874`, HME `77 -> 77` | result: `pass`
- Qwen3.5-9B vLLM, 8xA100, thinking disabled | sample size: `N=1000` | key metrics: legacy scorer `846`, patched scorer `876`, 30 corrected false negatives, 0 regressions | result: `pass`

## Risk / Compatibility
- This intentionally changes OCRBench scores for outputs containing fullwidth ASCII; comparisons with unpatched scorer runs should record the scorer version.
- Compatibility folding is deliberately narrow and excludes HME100k to avoid erasing potentially meaningful OCR distinctions.

## Type of Change
- [x] Bug fix (non-breaking change)
- [ ] New feature
- [ ] New benchmark/task
- [ ] New model integration
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring (no functional changes)