### PR TITLE
chore: migrate dataset paths to new orgs

### DIFF
--- a/lmms_eval/models/chat/lfm2_5_vl.py
+++ b/lmms_eval/models/chat/lfm2_5_vl.py
@@ -228,10 +228,7 @@ class LFM2_5_VL(lmms):
                 continue
 
             # Apply chat template to get text prompts for all samples
-            batch_texts = [
-                self.processor.apply_chat_template(msgs, tokenize=False, add_generation_prompt=True)
-                for msgs in batch_hf_messages
-            ]
+            batch_texts = [self.processor.apply_chat_template(msgs, tokenize=False, add_generation_prompt=True) for msgs in batch_hf_messages]
 
             # Filter out samples with no image
             valid_texts = [batch_texts[i] for i in valid_indices if batch_images[i] is not None]

--- a/lmms_eval/tasks/activitynetqa/_default_template_yaml
+++ b/lmms_eval/tasks/activitynetqa/_default_template_yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/ActivityNetQA
+dataset_path: lmms-eval/ActivityNetQA
 dataset_kwargs:
   token: True
   video: True

--- a/lmms_eval/tasks/ai2d/ai2d.yaml
+++ b/lmms_eval/tasks/ai2d/ai2d.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/ai2d
+dataset_path: lmms-lab-encoder/ai2d
 task: "ai2d"
 tag:
   - public_eval_qwen3_5_family

--- a/lmms_eval/tasks/ai2d/ai2d_lite.yaml
+++ b/lmms_eval/tasks/ai2d/ai2d_lite.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/LMMs-Eval-Lite
+dataset_path: lmms-lab-encoder/LMMs-Eval-Lite
 task: "ai2d_lite"
 dataset_kwargs:
   token: True

--- a/lmms_eval/tasks/ai2d/reasoning/ai2d_reasoning.yaml
+++ b/lmms_eval/tasks/ai2d/reasoning/ai2d_reasoning.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/ai2d
+dataset_path: lmms-lab-encoder/ai2d
 task: "ai2d_reasoning"
 dataset_kwargs:
   token: True

--- a/lmms_eval/tasks/ai2d/upload_ai2d.py
+++ b/lmms_eval/tasks/ai2d/upload_ai2d.py
@@ -114,4 +114,4 @@ if __name__ == "__main__":
     data = load_dataset(
         "/path/to/lmms-eval/lmms_eval/tasks/ai2d/upload_ai2d.py",
     )
-    data.push_to_hub("lmms-lab/ai2d", private=True)
+    data.push_to_hub("lmms-lab-encoder/ai2d", private=True)

--- a/lmms_eval/tasks/alpaca_audio/alpaca_audio.yaml
+++ b/lmms_eval/tasks/alpaca_audio/alpaca_audio.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/alpaca_audio
+dataset_path: lmms-lab-audio/alpaca_audio
 dataset_kwargs:
   token: True
 

--- a/lmms_eval/tasks/charades_sta/charades.yaml
+++ b/lmms_eval/tasks/charades_sta/charades.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/charades_sta
+dataset_path: lmms-eval/charades_sta
 dataset_kwargs:
   token: True
   cache_dir: charades_sta

--- a/lmms_eval/tasks/chartqa/chartqa.yaml
+++ b/lmms_eval/tasks/chartqa/chartqa.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/ChartQA
+dataset_path: lmms-lab-encoder/ChartQA
 dataset_kwargs:
   token: True
 task: "chartqa"

--- a/lmms_eval/tasks/chartqa/chartqa_lite.yaml
+++ b/lmms_eval/tasks/chartqa/chartqa_lite.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/LMMs-Eval-Lite
+dataset_path: lmms-lab-encoder/LMMs-Eval-Lite
 dataset_kwargs:
   token: True
 task: "chartqa_lite"

--- a/lmms_eval/tasks/chartqa/reasoning/chartqa_reasoning.yaml
+++ b/lmms_eval/tasks/chartqa/reasoning/chartqa_reasoning.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/ChartQA
+dataset_path: lmms-lab-encoder/ChartQA
 dataset_kwargs:
   token: True
 task: "chartqa_reasoning"

--- a/lmms_eval/tasks/clotho_aqa/_default_template_yaml
+++ b/lmms_eval/tasks/clotho_aqa/_default_template_yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/ClothoAQA
+dataset_path: lmms-lab-audio/ClothoAQA
 dataset_kwargs:
   token: True
 doc_to_target: "answer"

--- a/lmms_eval/tasks/cmmmu/_default_template_cmmmu_yaml
+++ b/lmms_eval/tasks/cmmmu/_default_template_cmmmu_yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/CMMMU
+dataset_path: lmms-lab-encoder/CMMMU
 output_type: generate_until
 doc_to_visual: !function utils.cmmmu_doc_to_visual
 doc_to_text: !function utils.cmmmu_doc_to_text

--- a/lmms_eval/tasks/coco_cap/coco2014_cap_test.yaml
+++ b/lmms_eval/tasks/coco_cap/coco2014_cap_test.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/COCO-Caption
+dataset_path: lmms-lab-encoder/COCO-Caption
 dataset_kwargs:
   token: True
 task : "coco2014_cap_test"

--- a/lmms_eval/tasks/coco_cap/coco2014_cap_val.yaml
+++ b/lmms_eval/tasks/coco_cap/coco2014_cap_val.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/COCO-Caption
+dataset_path: lmms-lab-encoder/COCO-Caption
 dataset_kwargs:
   token: True
 task: "coco2014_cap_val"

--- a/lmms_eval/tasks/coco_cap/coco2017_cap_test.yaml
+++ b/lmms_eval/tasks/coco_cap/coco2017_cap_test.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/COCO-Caption2017
+dataset_path: lmms-lab-encoder/COCO-Caption2017
 dataset_kwargs:
   token: True
 task : "coco2017_cap_test"

--- a/lmms_eval/tasks/coco_cap/coco2017_cap_val.yaml
+++ b/lmms_eval/tasks/coco_cap/coco2017_cap_val.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/COCO-Caption2017
+dataset_path: lmms-lab-encoder/COCO-Caption2017
 dataset_kwargs:
   token: True
 task: "coco2017_cap_val"

--- a/lmms_eval/tasks/coco_cap/coco2017_cap_val_lite.yaml
+++ b/lmms_eval/tasks/coco_cap/coco2017_cap_val_lite.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/LMMs-Eval-Lite
+dataset_path: lmms-lab-encoder/LMMs-Eval-Lite
 dataset_kwargs:
   token: True
 task: "coco2017_cap_val_lite"

--- a/lmms_eval/tasks/common_voice_15/_default_template_yaml
+++ b/lmms_eval/tasks/common_voice_15/_default_template_yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/common_voice_15
+dataset_path: lmms-lab-audio/common_voice_15
 dataset_kwargs:
   token: True
 test_split: test

--- a/lmms_eval/tasks/covost2/_default_template_en_zh_yaml
+++ b/lmms_eval/tasks/covost2/_default_template_en_zh_yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/covost2_en-zh
+dataset_path: lmms-lab-audio/covost2_en-zh
 dataset_name: en_zh
 dataset_kwargs:
   token: True

--- a/lmms_eval/tasks/covost2/_default_template_zh_en_yaml
+++ b/lmms_eval/tasks/covost2/_default_template_zh_en_yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/covost2
+dataset_path: lmms-lab-audio/covost2
 dataset_name: zh_en
 dataset_kwargs:
   token: True

--- a/lmms_eval/tasks/covost2/covost2_en_zh_dev.yaml
+++ b/lmms_eval/tasks/covost2/covost2_en_zh_dev.yaml
@@ -1,6 +1,6 @@
 task: "covost2_en_zh_dev"
 include: _default_template_en_zh_yaml
-dataset_path: lmms-lab/covost2_en-zh
+dataset_path: lmms-lab-audio/covost2_en-zh
 dataset_name: en_zh
 test_split: dev
 lmms_eval_specific_kwargs:

--- a/lmms_eval/tasks/covost2/covost2_en_zh_test.yaml
+++ b/lmms_eval/tasks/covost2/covost2_en_zh_test.yaml
@@ -1,6 +1,6 @@
 task: "covost2_en_zh_test"
 include: _default_template_en_zh_yaml
-dataset_path: lmms-lab/covost2_en-zh
+dataset_path: lmms-lab-audio/covost2_en-zh
 dataset_name: en_zh
 test_split: test
 lmms_eval_specific_kwargs:

--- a/lmms_eval/tasks/csbench/csbench_assertion.yaml
+++ b/lmms_eval/tasks/csbench/csbench_assertion.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/CSBench_Assertion
+dataset_path: lmms-lab-encoder/CSBench_Assertion
 dataset_kwargs:
   token: True
 test_split: assertion

--- a/lmms_eval/tasks/csbench/csbench_mcq.yaml
+++ b/lmms_eval/tasks/csbench/csbench_mcq.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/CSBench_MCQ
+dataset_path: lmms-lab-encoder/CSBench_MCQ
 dataset_kwargs:
   token: True
 test_split: mcq

--- a/lmms_eval/tasks/cvrr/_default_template_yaml
+++ b/lmms_eval/tasks/cvrr/_default_template_yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/CVRR-ES
+dataset_path: lmms-eval/CVRR-ES
 dataset_kwargs:
   token: True
   video: True

--- a/lmms_eval/tasks/docvqa/_default_template_docvqa_yaml
+++ b/lmms_eval/tasks/docvqa/_default_template_docvqa_yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/DocVQA
+dataset_path: lmms-lab-encoder/DocVQA
 dataset_name: DocVQA
 dataset_kwargs:
   token: True

--- a/lmms_eval/tasks/docvqa/docvqa_val_lite.yaml
+++ b/lmms_eval/tasks/docvqa/docvqa_val_lite.yaml
@@ -4,7 +4,7 @@ metric_list:
   - metric: anls
     aggregation: mean
     higher_is_better: true
-dataset_path: lmms-lab/LMMs-Eval-Lite
+dataset_path: lmms-lab-encoder/LMMs-Eval-Lite
 dataset_name: docvqa_val
 dataset_kwargs:
   token: True

--- a/lmms_eval/tasks/egoschema/README.md
+++ b/lmms_eval/tasks/egoschema/README.md
@@ -26,7 +26,7 @@ On a no-egress cluster this submission step (and the upstream Hub data-files loo
 
 #### Offline cache note
 
-`datasets.load_dataset("lmms-lab/egoschema", "Subset")` resolves data files via the Hub even under `HF_HUB_OFFLINE=1`, which fails with `ConnectionError` on a no-egress node *unless the Arrow cache for the `Subset` config has already been built* under `$HF_DATASETS_CACHE` (e.g. `…/datasets/lmms-lab___egoschema/Subset/`). Build it once on a networked host (login node) before the offline run; the videos must also be unzipped under `$HF_HOME/egoschema/videos/`.
+`datasets.load_dataset("lmms-eval/egoschema", "Subset")` resolves data files via the Hub even under `HF_HUB_OFFLINE=1`, which fails with `ConnectionError` on a no-egress node *unless the Arrow cache for the `Subset` config has already been built* under `$HF_DATASETS_CACHE` (e.g. `…/datasets/lmms-lab___egoschema/Subset/`). Build it once on a networked host (login node) before the offline run; the videos must also be unzipped under `$HF_HOME/egoschema/videos/`.
 
 # Tasks
 

--- a/lmms_eval/tasks/egoschema/_default_template_yaml
+++ b/lmms_eval/tasks/egoschema/_default_template_yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/egoschema
+dataset_path: lmms-eval/egoschema
 dataset_kwargs:
   token: True
   video: True

--- a/lmms_eval/tasks/emma/emma_all.yaml
+++ b/lmms_eval/tasks/emma/emma_all.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/EMMA
+dataset_path: lmms-lab-encoder/EMMA
 dataset_name: All  # Options available are: "All" for all data, "Chemistry" for chemistry only, "Physics" for physics only, "Coding" for code only and "Math" for math only
 dataset_kwargs:
   token: True

--- a/lmms_eval/tasks/emma/emma_mini_all.yaml
+++ b/lmms_eval/tasks/emma/emma_mini_all.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/EMMA-mini
+dataset_path: lmms-lab-encoder/EMMA-mini
 dataset_name: All # Options available are: "All" for all data, "Chemistry" for chemistry only, "Physics" for physics only, "Coding" for code only and "Math" for math only
 dataset_kwargs:
   token: True

--- a/lmms_eval/tasks/extremewhenbench/README.md
+++ b/lmms_eval/tasks/extremewhenbench/README.md
@@ -63,9 +63,9 @@ export HF_HOME=/path/to/your/hf-cache   # used by both vLLM and lmms-eval
 
 # 1) Make sure source-corpus videos are cached under $HF_HOME
 #    (skip any corpus you have already downloaded)
-python -c "from datasets import load_dataset; load_dataset('lmms-lab/LVBench')"
+python -c "from datasets import load_dataset; load_dataset('lmms-eval/LVBench')"
 python -c "from datasets import load_dataset; load_dataset('sy1998/MLVU_dev')"
-python -c "from datasets import load_dataset; load_dataset('lmms-lab/Video-MME')"
+python -c "from datasets import load_dataset; load_dataset('lmms-eval/Video-MME')"
 
 # 2) Serve Qwen3.5-9B (Qwen3_5ForConditionalGeneration)
 #    --allowed-local-media-path must cover wherever the videos live.

--- a/lmms_eval/tasks/extremewhenbench/utils.py
+++ b/lmms_eval/tasks/extremewhenbench/utils.py
@@ -61,9 +61,9 @@ def _candidate_paths(corpus: str, vid: str) -> list[str]:
 
 
 _DOWNLOAD_HINT = {
-    "LVBench": "python -c \"from datasets import load_dataset; load_dataset('lmms-lab/LVBench')\"",
+    "LVBench": "python -c \"from datasets import load_dataset; load_dataset('lmms-eval/LVBench')\"",
     "MLVU": "python -c \"from datasets import load_dataset; load_dataset('sy1998/MLVU_dev')\"",
-    "VideoMME": "python -c \"from datasets import load_dataset; load_dataset('lmms-lab/Video-MME')\"",
+    "VideoMME": "python -c \"from datasets import load_dataset; load_dataset('lmms-eval/Video-MME')\"",
 }
 
 

--- a/lmms_eval/tasks/ferret/ferret.yaml
+++ b/lmms_eval/tasks/ferret/ferret.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/Ferret-Bench
+dataset_path: lmms-lab-encoder/Ferret-Bench
 dataset_kwargs:
   token: True
 task: "ferret"

--- a/lmms_eval/tasks/fleurs/_default_template_yaml
+++ b/lmms_eval/tasks/fleurs/_default_template_yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/fleurs
+dataset_path: lmms-lab-audio/fleurs
 dataset_kwargs:
   token: True
 test_split: test

--- a/lmms_eval/tasks/flickr30k/flickr30k_test.yaml
+++ b/lmms_eval/tasks/flickr30k/flickr30k_test.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/flickr30k
+dataset_path: lmms-lab-encoder/flickr30k
 dataset_kwargs:
   token: True
 task : "flickr30k_test"

--- a/lmms_eval/tasks/flickr30k/flickr30k_test_lite.yaml
+++ b/lmms_eval/tasks/flickr30k/flickr30k_test_lite.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/LMMs-Eval-Lite
+dataset_path: lmms-lab-encoder/LMMs-Eval-Lite
 dataset_kwargs:
   token: True
 task : "flickr30k_test_lite"

--- a/lmms_eval/tasks/gigaspeech/gigaspeech_dev.yaml
+++ b/lmms_eval/tasks/gigaspeech/gigaspeech_dev.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/gigaspeech
+dataset_path: lmms-lab-audio/gigaspeech
 dataset_name: dev
 dataset_kwargs:
   token: True

--- a/lmms_eval/tasks/gigaspeech/gigaspeech_l_dev.yaml
+++ b/lmms_eval/tasks/gigaspeech/gigaspeech_l_dev.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/gigaspeech
+dataset_path: lmms-lab-audio/gigaspeech
 dataset_name: l
 dataset_kwargs:
   token: True

--- a/lmms_eval/tasks/gigaspeech/gigaspeech_l_test.yaml
+++ b/lmms_eval/tasks/gigaspeech/gigaspeech_l_test.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/gigaspeech
+dataset_path: lmms-lab-audio/gigaspeech
 dataset_name: l
 dataset_kwargs:
   token: True

--- a/lmms_eval/tasks/gigaspeech/gigaspeech_m_dev.yaml
+++ b/lmms_eval/tasks/gigaspeech/gigaspeech_m_dev.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/gigaspeech
+dataset_path: lmms-lab-audio/gigaspeech
 dataset_name: m
 dataset_kwargs:
   token: True

--- a/lmms_eval/tasks/gigaspeech/gigaspeech_m_test.yaml
+++ b/lmms_eval/tasks/gigaspeech/gigaspeech_m_test.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/gigaspeech
+dataset_path: lmms-lab-audio/gigaspeech
 dataset_name: m
 dataset_kwargs:
   token: True

--- a/lmms_eval/tasks/gigaspeech/gigaspeech_s_dev.yaml
+++ b/lmms_eval/tasks/gigaspeech/gigaspeech_s_dev.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/gigaspeech
+dataset_path: lmms-lab-audio/gigaspeech
 dataset_name: s
 dataset_kwargs:
   token: True

--- a/lmms_eval/tasks/gigaspeech/gigaspeech_s_test.yaml
+++ b/lmms_eval/tasks/gigaspeech/gigaspeech_s_test.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/gigaspeech
+dataset_path: lmms-lab-audio/gigaspeech
 dataset_name: s
 dataset_kwargs:
   token: True

--- a/lmms_eval/tasks/gigaspeech/gigaspeech_test.yaml
+++ b/lmms_eval/tasks/gigaspeech/gigaspeech_test.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/gigaspeech
+dataset_path: lmms-lab-audio/gigaspeech
 dataset_name: test
 dataset_kwargs:
   token: True

--- a/lmms_eval/tasks/gigaspeech/gigaspeech_xl_dev.yaml
+++ b/lmms_eval/tasks/gigaspeech/gigaspeech_xl_dev.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/gigaspeech
+dataset_path: lmms-lab-audio/gigaspeech
 dataset_name: xl
 dataset_kwargs:
   token: True

--- a/lmms_eval/tasks/gigaspeech/gigaspeech_xl_test.yaml
+++ b/lmms_eval/tasks/gigaspeech/gigaspeech_xl_test.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/gigaspeech
+dataset_path: lmms-lab-audio/gigaspeech
 dataset_name: xl
 dataset_kwargs:
   token: True

--- a/lmms_eval/tasks/gigaspeech/gigaspeech_xs_dev.yaml
+++ b/lmms_eval/tasks/gigaspeech/gigaspeech_xs_dev.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/gigaspeech
+dataset_path: lmms-lab-audio/gigaspeech
 dataset_name: xs
 dataset_kwargs:
   token: True

--- a/lmms_eval/tasks/gigaspeech/gigaspeech_xs_test.yaml
+++ b/lmms_eval/tasks/gigaspeech/gigaspeech_xs_test.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/gigaspeech
+dataset_path: lmms-lab-audio/gigaspeech
 dataset_name: xs
 dataset_kwargs:
   token: True

--- a/lmms_eval/tasks/gqa/gqa.yaml
+++ b/lmms_eval/tasks/gqa/gqa.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/GQA
+dataset_path: lmms-lab-encoder/GQA
 dataset_name: testdev_balanced_instructions
 dataset_kwargs:
   token: True

--- a/lmms_eval/tasks/gqa/gqa_lite.yaml
+++ b/lmms_eval/tasks/gqa/gqa_lite.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/LMMs-Eval-Lite
+dataset_path: lmms-lab-encoder/LMMs-Eval-Lite
 dataset_name: gqa
 dataset_kwargs:
   token: True

--- a/lmms_eval/tasks/gqa/utils.py
+++ b/lmms_eval/tasks/gqa/utils.py
@@ -4,7 +4,7 @@ from tqdm import tqdm
 
 
 def gqa_process_docs(dataset: datasets.Dataset) -> datasets.Dataset:
-    gqa_raw_image_dataset = load_dataset("lmms-lab/GQA", "testdev_balanced_images", split="testdev", token=True)
+    gqa_raw_image_dataset = load_dataset("lmms-lab-encoder/GQA", "testdev_balanced_images", split="testdev", token=True)
     gqa_id2image = {}
     for row in tqdm(gqa_raw_image_dataset, desc="Loading GQA images"):
         gqa_id2image[row["id"]] = row["image"].convert("RGB")

--- a/lmms_eval/tasks/hallusion_bench/hallusion_bench_image.yaml
+++ b/lmms_eval/tasks/hallusion_bench/hallusion_bench_image.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/HallusionBench
+dataset_path: lmms-lab-encoder/HallusionBench
 dataset_kwargs:
   token: True
 task: "hallusion_bench_image"

--- a/lmms_eval/tasks/iconqa/_default_template_docvqa_yaml
+++ b/lmms_eval/tasks/iconqa/_default_template_docvqa_yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/ICON-QA
+dataset_path: lmms-lab-encoder/ICON-QA
 dataset_kwargs:
   token: True
 output_type: generate_until

--- a/lmms_eval/tasks/infovqa/_default_template_infovqa_yaml
+++ b/lmms_eval/tasks/infovqa/_default_template_infovqa_yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/DocVQA
+dataset_path: lmms-lab-encoder/DocVQA
 dataset_name: InfographicVQA
 dataset_kwargs:
   token: True

--- a/lmms_eval/tasks/infovqa/infovqa_val_lite.yaml
+++ b/lmms_eval/tasks/infovqa/infovqa_val_lite.yaml
@@ -5,7 +5,7 @@ metric_list:
   - metric: anls
     aggregation: mean
     higher_is_better: true
-dataset_path: lmms-lab/LMMs-Eval-Lite
+dataset_path: lmms-lab-encoder/LMMs-Eval-Lite
 dataset_name: infovqa_val 
 dataset_kwargs:
   token: True

--- a/lmms_eval/tasks/internal_eval/dc100_en.yaml
+++ b/lmms_eval/tasks/internal_eval/dc100_en.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/DC100_EN
+dataset_path: lmms-lab-encoder/DC100_EN
 dataset_kwargs:
   token: True
 task: "dc100_en"

--- a/lmms_eval/tasks/internal_eval/dc200_cn.yaml
+++ b/lmms_eval/tasks/internal_eval/dc200_cn.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/DC200_CN
+dataset_path: lmms-lab-encoder/DC200_CN
 dataset_kwargs:
   token: True
 task: "dc200_cn"

--- a/lmms_eval/tasks/k12/k12.yaml
+++ b/lmms_eval/tasks/k12/k12.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/k12
+dataset_path: lmms-lab-encoder/k12
 dataset_kwargs:
   token: True
 task: "k12"

--- a/lmms_eval/tasks/librispeech/librispeech_dev_clean.yaml
+++ b/lmms_eval/tasks/librispeech/librispeech_dev_clean.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/librispeech
+dataset_path: lmms-lab-audio/librispeech
 dataset_kwargs:
   token: True
 task : "librispeech_dev_clean"

--- a/lmms_eval/tasks/librispeech/librispeech_dev_other.yaml
+++ b/lmms_eval/tasks/librispeech/librispeech_dev_other.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/librispeech
+dataset_path: lmms-lab-audio/librispeech
 dataset_kwargs:
   token: True
 task : "librispeech_dev_other"

--- a/lmms_eval/tasks/librispeech/librispeech_test_clean.yaml
+++ b/lmms_eval/tasks/librispeech/librispeech_test_clean.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/librispeech
+dataset_path: lmms-lab-audio/librispeech
 dataset_kwargs:
   token: True
 task : "librispeech_test_clean"

--- a/lmms_eval/tasks/librispeech/librispeech_test_clean_long.yaml
+++ b/lmms_eval/tasks/librispeech/librispeech_test_clean_long.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/Librispeech-concat
+dataset_path: lmms-lab-audio/Librispeech-concat
 task : "librispeech_test_clean_long"
 test_split: test_clean
 process_results: !function utils.librispeech_long_process_result

--- a/lmms_eval/tasks/librispeech/librispeech_test_other.yaml
+++ b/lmms_eval/tasks/librispeech/librispeech_test_other.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/librispeech
+dataset_path: lmms-lab-audio/librispeech
 dataset_kwargs:
   token: True
 task : "librispeech_test_other"

--- a/lmms_eval/tasks/librispeech/librispeech_test_other_long.yaml
+++ b/lmms_eval/tasks/librispeech/librispeech_test_other_long.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/Librispeech-concat
+dataset_path: lmms-lab-audio/Librispeech-concat
 task : "librispeech_test_other_long"
 test_split: test_other
 process_results: !function utils.librispeech_long_process_result

--- a/lmms_eval/tasks/live_bench/live_bench_template_yaml
+++ b/lmms_eval/tasks/live_bench/live_bench_template_yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/LiveBench
+dataset_path: lmms-eval/LiveBench
 dataset_kwargs:
   token: True
 test_split: test

--- a/lmms_eval/tasks/live_bench/live_bench_template_yaml_v2
+++ b/lmms_eval/tasks/live_bench/live_bench_template_yaml_v2
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/LiveBench
+dataset_path: lmms-eval/LiveBench
 dataset_kwargs:
   token: True
 test_split: test

--- a/lmms_eval/tasks/llava-bench-coco/llava-bench-coco.yaml
+++ b/lmms_eval/tasks/llava-bench-coco/llava-bench-coco.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/llava-bench-coco
+dataset_path: lmms-lab-encoder/llava-bench-coco
 dataset_kwargs:
   token: True
 task: "llava_bench_coco"

--- a/lmms_eval/tasks/llava-in-the-wild/llava-in-the-wild.yaml
+++ b/lmms_eval/tasks/llava-in-the-wild/llava-in-the-wild.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/llava-bench-in-the-wild
+dataset_path: lmms-lab-encoder/llava-bench-in-the-wild
 dataset_kwargs:
   token: True
 task: "llava_in_the_wild"

--- a/lmms_eval/tasks/llava_interleave_bench/in_domain.yaml
+++ b/lmms_eval/tasks/llava_interleave_bench/in_domain.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/LLaVA-NeXT-Interleave-Bench
+dataset_path: lmms-lab-encoder/LLaVA-NeXT-Interleave-Bench
 dataset_name: in_domain
 dataset_kwargs:
   token: True

--- a/lmms_eval/tasks/llava_interleave_bench/multi_view_in_domain.yaml
+++ b/lmms_eval/tasks/llava_interleave_bench/multi_view_in_domain.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/LLaVA-NeXT-Interleave-Bench
+dataset_path: lmms-lab-encoder/LLaVA-NeXT-Interleave-Bench
 dataset_name: multi_view_in_domain
 dataset_kwargs:
   token: True

--- a/lmms_eval/tasks/llava_interleave_bench/out_of_domain.yaml
+++ b/lmms_eval/tasks/llava_interleave_bench/out_of_domain.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/LLaVA-NeXT-Interleave-Bench
+dataset_path: lmms-lab-encoder/LLaVA-NeXT-Interleave-Bench
 dataset_name: out_of_domain
 dataset_kwargs:
   token: True

--- a/lmms_eval/tasks/llava_wilder/llava_wilder_small.yaml
+++ b/lmms_eval/tasks/llava_wilder/llava_wilder_small.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/LLaVA-Bench-Wilder
+dataset_path: lmms-lab-encoder/LLaVA-Bench-Wilder
 dataset_kwargs:
   token: True
 task: "llava_wilder_small"

--- a/lmms_eval/tasks/lvbench/lvbench.yaml
+++ b/lmms_eval/tasks/lvbench/lvbench.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/LVBench
+dataset_path: lmms-eval/LVBench
 dataset_kwargs:
   token: True
   cache_dir: lvbench

--- a/lmms_eval/tasks/lvbench/no_visual/lvbench_no_visual.yaml
+++ b/lmms_eval/tasks/lvbench/no_visual/lvbench_no_visual.yaml
@@ -1,7 +1,7 @@
 # LVBench No Visual Setting
 # Test model ability to answer without video content
 
-dataset_path: lmms-lab/LVBench
+dataset_path: lmms-eval/LVBench
 dataset_kwargs:
   token: True
   cache_dir: lvbench

--- a/lmms_eval/tasks/lvbench/random_choice/lvbench_random_choice.yaml
+++ b/lmms_eval/tasks/lvbench/random_choice/lvbench_random_choice.yaml
@@ -1,7 +1,7 @@
 # LVBench Random Choice Setting
 # Shuffle options to test if model relies on option position bias
 
-dataset_path: lmms-lab/LVBench
+dataset_path: lmms-eval/LVBench
 dataset_kwargs:
   token: True
   cache_dir: lvbench

--- a/lmms_eval/tasks/mdpbench/cdm_metric.py
+++ b/lmms_eval/tasks/mdpbench/cdm_metric.py
@@ -11,13 +11,14 @@ import shutil
 from functools import lru_cache
 
 import numpy as np
+from PIL import Image, ImageDraw
+from skimage.measure import ransac
+
 from lmms_eval.tasks.mdpbench.cdm.modules.latex2bbox_color import latex2bbox_color
 from lmms_eval.tasks.mdpbench.cdm.modules.visual_matcher import (
     HungarianMatcher,
     SimpleAffineTransform,
 )
-from PIL import Image, ImageDraw
-from skimage.measure import ransac
 
 eval_logger = logging.getLogger("lmms-eval")
 

--- a/lmms_eval/tasks/mdpbench/extract.py
+++ b/lmms_eval/tasks/mdpbench/extract.py
@@ -12,15 +12,6 @@ import unicodedata
 from collections import defaultdict
 
 from bs4 import BeautifulSoup
-from lmms_eval.tasks.mdpbench.data_preprocess import (
-    remove_markdown_fences,
-    replace_repeated_chars,
-    textblock2unicode,
-    textblock_with_norm_formula,
-)
-
-# from  modules.table_utils import convert_markdown_to_html #end
-from lmms_eval.tasks.mdpbench.table_utils import convert_markdown_to_html
 from pylatexenc.latex2text import LatexNodes2Text
 from pylatexenc.latexencode import unicode_to_latex
 from pylatexenc.latexwalker import (
@@ -31,6 +22,16 @@ from pylatexenc.latexwalker import (
     LatexSpecialsNode,
     LatexWalker,
 )
+
+from lmms_eval.tasks.mdpbench.data_preprocess import (
+    remove_markdown_fences,
+    replace_repeated_chars,
+    textblock2unicode,
+    textblock_with_norm_formula,
+)
+
+# from  modules.table_utils import convert_markdown_to_html #end
+from lmms_eval.tasks.mdpbench.table_utils import convert_markdown_to_html
 
 
 def extract_tabular(text):

--- a/lmms_eval/tasks/mdpbench/match_quick.py
+++ b/lmms_eval/tasks/mdpbench/match_quick.py
@@ -16,12 +16,13 @@ import evaluate
 import Levenshtein
 import numpy as np
 from Levenshtein import distance as Levenshtein_distance
+from scipy.optimize import linear_sum_assignment
+
 from lmms_eval.tasks.mdpbench.match import (
     compute_edit_distance_matrix_new,
     get_gt_pred_lines,
     get_pred_category_type,
 )
-from scipy.optimize import linear_sum_assignment
 
 # ARRAY_RE = re.compile(
 #     r'\\begin\{array\}\{[^}]*\}(.*?)\\end\{array\}', re.S

--- a/lmms_eval/tasks/mdpbench/utils.py
+++ b/lmms_eval/tasks/mdpbench/utils.py
@@ -1153,6 +1153,7 @@ def mdpbench_process_results(doc, results):
         pred_mix.extend(unmatched_table_pred)
 
     from func_timeout import FunctionTimedOut, func_timeout
+
     from lmms_eval.tasks.mdpbench.match import match_gt2pred_simple
     from lmms_eval.tasks.mdpbench.match_quick import match_gt2pred_quick
 

--- a/lmms_eval/tasks/medqa/medqa.yaml
+++ b/lmms_eval/tasks/medqa/medqa.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/MEDQA
+dataset_path: lmms-lab-encoder/MEDQA
 dataset_kwargs:
   token: True
 

--- a/lmms_eval/tasks/mia_bench/mia_bench.yaml
+++ b/lmms_eval/tasks/mia_bench/mia_bench.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/MIA-Bench
+dataset_path: lmms-lab-encoder/MIA-Bench
 dataset_kwargs:
   token: True
 task: "mia_bench"

--- a/lmms_eval/tasks/mix_evals/audio2text/_default_template_yaml
+++ b/lmms_eval/tasks/mix_evals/audio2text/_default_template_yaml
@@ -1,6 +1,6 @@
 dataset_kwargs:
   token: true
-dataset_path: lmms-lab/MixEval-X-audio2text
+dataset_path: lmms-lab-audio/MixEval-X-audio2text
 lmms_eval_specific_kwargs:
   default:
     post_prompt: ""

--- a/lmms_eval/tasks/mmau/_default_template_yaml
+++ b/lmms_eval/tasks/mmau/_default_template_yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/mmau
+dataset_path: lmms-lab-audio/mmau
 dataset_kwargs:
   token: True
 doc_to_target: "answer"

--- a/lmms_eval/tasks/mmbench/_default_template_mmbench_cn_yaml
+++ b/lmms_eval/tasks/mmbench/_default_template_mmbench_cn_yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/MMBench
+dataset_path: lmms-lab-encoder/MMBench
 dataset_kwargs:
   token: True
 doc_to_target: "answer"

--- a/lmms_eval/tasks/mmbench/_default_template_mmbench_en_yaml
+++ b/lmms_eval/tasks/mmbench/_default_template_mmbench_en_yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/MMBench
+dataset_path: lmms-lab-encoder/MMBench
 dataset_kwargs:
   token: True
 doc_to_target: "answer"

--- a/lmms_eval/tasks/mmbench/en_reasoning/_default_template_mmbench_en_reasoning_yaml
+++ b/lmms_eval/tasks/mmbench/en_reasoning/_default_template_mmbench_en_reasoning_yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/MMBench
+dataset_path: lmms-lab-encoder/MMBench
 dataset_kwargs:
   token: True
 doc_to_target: "answer"

--- a/lmms_eval/tasks/mmbench/mmbench_cc.yaml
+++ b/lmms_eval/tasks/mmbench/mmbench_cc.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/MMBench
+dataset_path: lmms-lab-encoder/MMBench
 dataset_name: cc
 dataset_kwargs:
   token: True

--- a/lmms_eval/tasks/mmbench/mmbench_cn_dev_lite.yaml
+++ b/lmms_eval/tasks/mmbench/mmbench_cn_dev_lite.yaml
@@ -7,7 +7,7 @@ metric_list:
   - metric: submission
     higher_is_better: true
     aggregation: !function cn_utils.mmbench_aggregate_dev_results
-dataset_path: lmms-lab/LMMs-Eval-Lite
+dataset_path: lmms-lab-encoder/LMMs-Eval-Lite
 dataset_name: mmbench_cn_dev
 dataset_kwargs:
   token: True

--- a/lmms_eval/tasks/mmbench/mmbench_en_dev_lite.yaml
+++ b/lmms_eval/tasks/mmbench/mmbench_en_dev_lite.yaml
@@ -1,6 +1,6 @@
 task: "mmbench_en_dev_lite"
 test_split: lite 
-dataset_path: lmms-lab/LMMs-Eval-Lite
+dataset_path: lmms-lab-encoder/LMMs-Eval-Lite
 dataset_name: mmbench_en_dev
 dataset_kwargs:
   token: True

--- a/lmms_eval/tasks/mmbench/reasoning/_default_template_mmbench_reasoning_yaml
+++ b/lmms_eval/tasks/mmbench/reasoning/_default_template_mmbench_reasoning_yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/MMBench
+dataset_path: lmms-lab-encoder/MMBench
 dataset_kwargs:
   token: True
 doc_to_target: "answer"

--- a/lmms_eval/tasks/mme/mme.yaml
+++ b/lmms_eval/tasks/mme/mme.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/MME
+dataset_path: lmms-lab-encoder/MME
 dataset_kwargs:
   token: True
 task: "mme"

--- a/lmms_eval/tasks/mmmu/mmmu_group_img_test.yaml
+++ b/lmms_eval/tasks/mmmu/mmmu_group_img_test.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/MMMU
+dataset_path: lmms-lab-encoder/MMMU
 task: "mmmu_test_group_img"
 test_split: test
 output_type: generate_until

--- a/lmms_eval/tasks/mmmu/mmmu_group_img_val.yaml
+++ b/lmms_eval/tasks/mmmu/mmmu_group_img_val.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/MMMU
+dataset_path: lmms-lab-encoder/MMMU
 task: "mmmu_val_group_img"
 test_split: validation
 output_type: generate_until

--- a/lmms_eval/tasks/mmmu/mmmu_test.yaml
+++ b/lmms_eval/tasks/mmmu/mmmu_test.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/MMMU
+dataset_path: lmms-lab-encoder/MMMU
 task: "mmmu_test"
 test_split: test
 output_type: generate_until

--- a/lmms_eval/tasks/mmmu/mmmu_val.yaml
+++ b/lmms_eval/tasks/mmmu/mmmu_val.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/MMMU
+dataset_path: lmms-lab-encoder/MMMU
 task: "mmmu_val"
 tag:
   - public_eval_qwen3_5_family

--- a/lmms_eval/tasks/mmmu/mmmu_val_pass64.yaml
+++ b/lmms_eval/tasks/mmmu/mmmu_val_pass64.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/MMMU
+dataset_path: lmms-lab-encoder/MMMU
 task: "mmmu_val_pass64"
 test_split: validation
 output_type: generate_until

--- a/lmms_eval/tasks/mmmu/mmmu_val_qwen.yaml
+++ b/lmms_eval/tasks/mmmu/mmmu_val_qwen.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/MMMU
+dataset_path: lmms-lab-encoder/MMMU
 task: "mmmu_val_qwen"
 test_split: validation
 output_type: generate_until

--- a/lmms_eval/tasks/mmmu/mmmu_val_reasoning.yaml
+++ b/lmms_eval/tasks/mmmu/mmmu_val_reasoning.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/MMMU
+dataset_path: lmms-lab-encoder/MMMU
 task: "mmmu_val_reasoning"
 test_split: validation
 output_type: generate_until

--- a/lmms_eval/tasks/mmmu/reasoning/mmmu_val_reasoning.yaml
+++ b/lmms_eval/tasks/mmmu/reasoning/mmmu_val_reasoning.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/MMMU
+dataset_path: lmms-lab-encoder/MMMU
 task: "mmmu_val_reasoning"
 test_split: validation
 output_type: generate_until

--- a/lmms_eval/tasks/mmou/utils.py
+++ b/lmms_eval/tasks/mmou/utils.py
@@ -85,7 +85,7 @@ def _resolve_video_path(doc) -> str:
     vid = _video_id(doc)
     is_test = bool(doc.get("is_test"))
     # Test Mini videos land under videos/test/, main split at videos root.
-    for prefix in (("test",) if is_test else ("", "test")):
+    for prefix in ("test",) if is_test else ("", "test"):
         candidate = os.path.join(video_cache_dir, prefix, f"{vid}.mp4") if prefix else os.path.join(video_cache_dir, f"{vid}.mp4")
         if os.path.exists(candidate):
             return candidate
@@ -139,7 +139,7 @@ def _extract_answer(response: str) -> str:
     for pattern in ("the answer is", "answer:", "the option is", "final answer:"):
         idx = text.lower().rfind(pattern)
         if idx >= 0:
-            text = text[idx + len(pattern):].strip()
+            text = text[idx + len(pattern) :].strip()
             break
     m = re.search(r"\(([A-J])\)", text)
     if m:
@@ -203,6 +203,7 @@ def mmou_process_results_scored(doc, results):
 
 def _write_submission(results, filename: str, args) -> str:
     import datetime
+
     from lmms_eval.tasks._task_utils import file_utils
 
     stem, _, ext = filename.rpartition(".")
@@ -236,10 +237,7 @@ def _log_breakdown(results):
 
 def mmou_aggregate_submission(results, args):
     path = _write_submission(results, "mmou_submission.json", args)
-    eval_logger.info(
-        f"MMOU submission saved to {path} ({len(results)} predictions). "
-        "Upload to https://huggingface.co/spaces/nvidia/MMOU-Eval for scoring."
-    )
+    eval_logger.info(f"MMOU submission saved to {path} ({len(results)} predictions). " "Upload to https://huggingface.co/spaces/nvidia/MMOU-Eval for scoring.")
     _log_breakdown(results)
     return len(results)
 

--- a/lmms_eval/tasks/mmt/mmt_mi_test.yaml
+++ b/lmms_eval/tasks/mmt/mmt_mi_test.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/MMT_MI-Benchmark
+dataset_path: lmms-lab-encoder/MMT_MI-Benchmark
 dataset_kwargs:
   token: True
 task: "mmt_mi_test"

--- a/lmms_eval/tasks/mmt/mmt_mi_val.yaml
+++ b/lmms_eval/tasks/mmt/mmt_mi_val.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/MMT_MI-Benchmark
+dataset_path: lmms-lab-encoder/MMT_MI-Benchmark
 dataset_kwargs:
   token: True
 task: "mmt_mi_val"

--- a/lmms_eval/tasks/mmt/mmt_test.yaml
+++ b/lmms_eval/tasks/mmt/mmt_test.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/MMT-Benchmark
+dataset_path: lmms-lab-encoder/MMT-Benchmark
 dataset_kwargs:
   token: True
 task: "mmt_test"

--- a/lmms_eval/tasks/mmt/mmt_val.yaml
+++ b/lmms_eval/tasks/mmt/mmt_val.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/MMT-Benchmark
+dataset_path: lmms-lab-encoder/MMT-Benchmark
 dataset_kwargs:
   token: True
 task: "mmt_val"

--- a/lmms_eval/tasks/mmvet/mmvet.yaml
+++ b/lmms_eval/tasks/mmvet/mmvet.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/MMVet
+dataset_path: lmms-lab-encoder/MMVet
 dataset_kwargs:
   token: True
 task: "mmvet"

--- a/lmms_eval/tasks/mmvu/mmvu_val.yaml
+++ b/lmms_eval/tasks/mmvu/mmvu_val.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/MMVU
+dataset_path: lmms-eval/MMVU
 dataset_kwargs:
   token: True
   cache_dir: mmvu

--- a/lmms_eval/tasks/mmvu/mmvu_val_cot copy.yaml
+++ b/lmms_eval/tasks/mmvu/mmvu_val_cot copy.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/MMVU
+dataset_path: lmms-eval/MMVU
 dataset_kwargs:
   token: True
   cache_dir: mmvu

--- a/lmms_eval/tasks/muchomusic/muchomusic.yaml
+++ b/lmms_eval/tasks/muchomusic/muchomusic.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/muchomusic
+dataset_path: lmms-lab-audio/muchomusic
 dataset_kwargs:
   token: True
 

--- a/lmms_eval/tasks/multidocvqa/multidocvqa_test.yaml
+++ b/lmms_eval/tasks/multidocvqa/multidocvqa_test.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/MP-DocVQA
+dataset_path: lmms-lab-encoder/MP-DocVQA
 task: "multidocvqa_test"
 test_split: test
 output_type: generate_until

--- a/lmms_eval/tasks/multidocvqa/multidocvqa_val.yaml
+++ b/lmms_eval/tasks/multidocvqa/multidocvqa_val.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/MP-DocVQA
+dataset_path: lmms-lab-encoder/MP-DocVQA
 task: "multidocvqa_val"
 test_split: val
 output_type: generate_until

--- a/lmms_eval/tasks/neptune/README.md
+++ b/lmms_eval/tasks/neptune/README.md
@@ -18,7 +18,7 @@ from pathlib import Path
 from datasets import load_dataset
 from huggingface_hub import hf_hub_download
 
-repo = "lmms-lab/GoogleDeepMind-NEPTUNE"
+repo = "lmms-eval/GoogleDeepMind-NEPTUNE"
 hf_home = Path(os.environ.get("HF_HOME", str(Path.home() / ".cache" / "huggingface")))
 out_dir = hf_home / "neptune"
 out_dir.mkdir(parents=True, exist_ok=True)

--- a/lmms_eval/tasks/neptune/_default_template_yaml
+++ b/lmms_eval/tasks/neptune/_default_template_yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/GoogleDeepMind-NEPTUNE
+dataset_path: lmms-eval/GoogleDeepMind-NEPTUNE
 dataset_kwargs:
   token: True
   cache_dir: neptune

--- a/lmms_eval/tasks/nextqa/_default_template_yaml
+++ b/lmms_eval/tasks/nextqa/_default_template_yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/NExTQA
+dataset_path: lmms-eval/NExTQA
 dataset_kwargs:
   token: True
   video: True

--- a/lmms_eval/tasks/nocaps/nocaps_test.yaml
+++ b/lmms_eval/tasks/nocaps/nocaps_test.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/NoCaps
+dataset_path: lmms-lab-encoder/NoCaps
 dataset_kwargs:
   token: True
 task : "nocaps_test"

--- a/lmms_eval/tasks/nocaps/nocaps_val.yaml
+++ b/lmms_eval/tasks/nocaps/nocaps_val.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/NoCaps
+dataset_path: lmms-lab-encoder/NoCaps
 dataset_kwargs:
   token: True
 task: "nocaps_val"

--- a/lmms_eval/tasks/nocaps/nocaps_val_lite.yaml
+++ b/lmms_eval/tasks/nocaps/nocaps_val_lite.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/LMMs-Eval-Lite
+dataset_path: lmms-lab-encoder/LMMs-Eval-Lite
 dataset_name: nocaps_val
 dataset_kwargs:
   token: True

--- a/lmms_eval/tasks/ok_vqa/_default_template_vqa_yaml
+++ b/lmms_eval/tasks/ok_vqa/_default_template_vqa_yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/OK-VQA
+dataset_path: lmms-lab-encoder/OK-VQA
 output_type: generate_until
 doc_to_visual: !function utils.ok_vqa_doc_to_visual
 doc_to_text: !function utils.ok_vqa_doc_to_text

--- a/lmms_eval/tasks/ok_vqa/ok_vqa_val2014_lite.yaml
+++ b/lmms_eval/tasks/ok_vqa/ok_vqa_val2014_lite.yaml
@@ -1,6 +1,6 @@
 task: ok_vqa_val2014_lite
 test_split: lite 
-dataset_path: lmms-lab/LMMs-Eval-Lite
+dataset_path: lmms-lab-encoder/LMMs-Eval-Lite
 dataset_name: ok_vqa_val2014
 output_type: generate_until
 doc_to_visual: !function utils.ok_vqa_doc_to_visual

--- a/lmms_eval/tasks/omni_bench/_default_template_yaml
+++ b/lmms_eval/tasks/omni_bench/_default_template_yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/Omni_Bench_fix
+dataset_path: lmms-lab-audio/Omni_Bench_fix
 test_split: train
 output_type: generate_until
 

--- a/lmms_eval/tasks/openhermes/openhermes.yaml
+++ b/lmms_eval/tasks/openhermes/openhermes.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/openhermes_instruction
+dataset_path: lmms-lab-audio/openhermes_instruction
 dataset_kwargs:
   token: True
 

--- a/lmms_eval/tasks/people_speech/people_speech_val.yaml
+++ b/lmms_eval/tasks/people_speech/people_speech_val.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/peoples_speech
+dataset_path: lmms-lab-audio/peoples_speech
 dataset_kwargs:
   token: True
 task : "people_speech_val"

--- a/lmms_eval/tasks/perceptiontest/test/_default_template_yaml
+++ b/lmms_eval/tasks/perceptiontest/test/_default_template_yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/PerceptionTest
+dataset_path: lmms-eval/PerceptionTest
 dataset_kwargs:
   token: True
   video: True

--- a/lmms_eval/tasks/perceptiontest/val/_default_template_yaml
+++ b/lmms_eval/tasks/perceptiontest/val/_default_template_yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/PerceptionTest_Val
+dataset_path: lmms-eval/PerceptionTest_Val
 dataset_kwargs:
   token: True
   video: True

--- a/lmms_eval/tasks/pointbench/utils.py
+++ b/lmms_eval/tasks/pointbench/utils.py
@@ -9,8 +9,7 @@ import datasets
 import numpy as np
 from PIL import Image
 
-from lmms_eval.tasks._task_utils.default_template_yaml import \
-    load_default_template_yaml
+from lmms_eval.tasks._task_utils.default_template_yaml import load_default_template_yaml
 from lmms_eval.tasks._task_utils.point_format import parse_point2d
 from lmms_eval.utils import eval_logger
 

--- a/lmms_eval/tasks/pope/pope.yaml
+++ b/lmms_eval/tasks/pope/pope.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/POPE
+dataset_path: lmms-lab-encoder/POPE
 dataset_kwargs:
   token: True
 task: "pope"

--- a/lmms_eval/tasks/pope/pope_adv.yaml
+++ b/lmms_eval/tasks/pope/pope_adv.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/POPE
+dataset_path: lmms-lab-encoder/POPE
 dataset_name: Full
 dataset_kwargs:
   token: True

--- a/lmms_eval/tasks/pope/pope_pop.yaml
+++ b/lmms_eval/tasks/pope/pope_pop.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/POPE
+dataset_path: lmms-lab-encoder/POPE
 dataset_name: Full
 dataset_kwargs:
   token: True

--- a/lmms_eval/tasks/pope/pope_random.yaml
+++ b/lmms_eval/tasks/pope/pope_random.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/POPE
+dataset_path: lmms-lab-encoder/POPE
 dataset_name: Full
 dataset_kwargs:
   token: True

--- a/lmms_eval/tasks/realworldqa/realworldqa.yaml
+++ b/lmms_eval/tasks/realworldqa/realworldqa.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/RealWorldQA
+dataset_path: lmms-lab-encoder/RealWorldQA
 dataset_kwargs:
   token: True
 task: "realworldqa"

--- a/lmms_eval/tasks/realworldqa/reasoning/realworldqa_reasoning.yaml
+++ b/lmms_eval/tasks/realworldqa/reasoning/realworldqa_reasoning.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/RealWorldQA
+dataset_path: lmms-lab-encoder/RealWorldQA
 dataset_kwargs:
   token: True
 task: "realworldqa_reasoning"

--- a/lmms_eval/tasks/refcoco+/_default_template_bbox_rec_yaml
+++ b/lmms_eval/tasks/refcoco+/_default_template_bbox_rec_yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/RefCOCOPlus
+dataset_path: lmms-lab-encoder/RefCOCOplus
 output_type: generate_until
 process_docs: !function utils_rec.refcoco_bbox_rec_preprocess_dataset
 doc_to_visual: !function utils_rec.refcoco_bbox_rec_doc_to_visual

--- a/lmms_eval/tasks/refcoco+/_default_template_bbox_yaml
+++ b/lmms_eval/tasks/refcoco+/_default_template_bbox_yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/RefCOCOplus
+dataset_path: lmms-lab-encoder/RefCOCOplus
 output_type: generate_until
 doc_to_visual: !function utils.refcoco_bbox_doc_to_visual
 doc_to_text: !function utils.refcoco_doc_to_text

--- a/lmms_eval/tasks/refcoco+/_default_template_seg_yaml
+++ b/lmms_eval/tasks/refcoco+/_default_template_seg_yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/RefCOCOplus
+dataset_path: lmms-lab-encoder/RefCOCOplus
 output_type: generate_until
 doc_to_visual: !function utils.refcoco_seg_doc_to_visual
 doc_to_text: !function utils.refcoco_doc_to_text

--- a/lmms_eval/tasks/refcoco/_default_template_bbox_rec_yaml
+++ b/lmms_eval/tasks/refcoco/_default_template_bbox_rec_yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/RefCOCO
+dataset_path: lmms-lab-encoder/RefCOCO
 output_type: generate_until
 process_docs: !function utils_rec.refcoco_bbox_rec_preprocess_dataset
 doc_to_visual: !function utils_rec.refcoco_bbox_rec_doc_to_visual

--- a/lmms_eval/tasks/refcoco/_default_template_bbox_yaml
+++ b/lmms_eval/tasks/refcoco/_default_template_bbox_yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/RefCOCO
+dataset_path: lmms-lab-encoder/RefCOCO
 output_type: generate_until
 doc_to_visual: !function utils.refcoco_bbox_doc_to_visual
 doc_to_text: !function utils.refcoco_doc_to_text

--- a/lmms_eval/tasks/refcoco/_default_template_seg_yaml
+++ b/lmms_eval/tasks/refcoco/_default_template_seg_yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/RefCOCO
+dataset_path: lmms-lab-encoder/RefCOCO
 output_type: generate_until
 doc_to_visual: !function utils.refcoco_seg_doc_to_visual
 doc_to_text: !function utils.refcoco_doc_to_text

--- a/lmms_eval/tasks/refcoco/refcoco_bbox_val_lite.yaml
+++ b/lmms_eval/tasks/refcoco/refcoco_bbox_val_lite.yaml
@@ -1,6 +1,6 @@
 task: refcoco_bbox_val_lite
 test_split: lite
-dataset_path: lmms-lab/LMMs-Eval-Lite
+dataset_path: lmms-lab-encoder/LMMs-Eval-Lite
 dataset_name: refcoco_bbox_val
 output_type: generate_until
 doc_to_visual: !function utils.refcoco_bbox_doc_to_visual

--- a/lmms_eval/tasks/refcoco_grounding/_default_template_yaml
+++ b/lmms_eval/tasks/refcoco_grounding/_default_template_yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/RefCOCO
+dataset_path: lmms-lab-encoder/RefCOCO
 output_type: generate_until
 
 process_results_use_image: true

--- a/lmms_eval/tasks/refcoco_grounding/refcoco_plus_grounding_testA.yaml
+++ b/lmms_eval/tasks/refcoco_grounding/refcoco_plus_grounding_testA.yaml
@@ -1,7 +1,7 @@
 include: _default_template_yaml
 
 task: refcoco_plus_grounding_testA
-dataset_path: lmms-lab/RefCOCOPlus
+dataset_path: lmms-lab-encoder/RefCOCOplus
 test_split: testA
 
 metadata:

--- a/lmms_eval/tasks/refcoco_grounding/refcoco_plus_grounding_testB.yaml
+++ b/lmms_eval/tasks/refcoco_grounding/refcoco_plus_grounding_testB.yaml
@@ -1,7 +1,7 @@
 include: _default_template_yaml
 
 task: refcoco_plus_grounding_testB
-dataset_path: lmms-lab/RefCOCOPlus
+dataset_path: lmms-lab-encoder/RefCOCOplus
 test_split: testB
 
 metadata:

--- a/lmms_eval/tasks/refcoco_grounding/refcocog_grounding_test.yaml
+++ b/lmms_eval/tasks/refcoco_grounding/refcocog_grounding_test.yaml
@@ -1,7 +1,7 @@
 include: _default_template_yaml
 
 task: refcocog_grounding_test
-dataset_path: lmms-lab/RefCOCOg
+dataset_path: lmms-lab-encoder/RefCOCOg
 test_split: test
 
 metadata:

--- a/lmms_eval/tasks/refcocog/_default_template_bbox_rec_yaml
+++ b/lmms_eval/tasks/refcocog/_default_template_bbox_rec_yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/RefCOCOg
+dataset_path: lmms-lab-encoder/RefCOCOg
 output_type: generate_until
 process_docs: !function utils_rec.refcoco_bbox_rec_preprocess_dataset
 doc_to_visual: !function utils_rec.refcoco_bbox_rec_doc_to_visual

--- a/lmms_eval/tasks/refcocog/_default_template_bbox_yaml
+++ b/lmms_eval/tasks/refcocog/_default_template_bbox_yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/RefCOCOg
+dataset_path: lmms-lab-encoder/RefCOCOg
 output_type: generate_until
 doc_to_visual: !function utils.refcoco_bbox_doc_to_visual
 doc_to_text: !function utils.refcoco_doc_to_text

--- a/lmms_eval/tasks/refcocog/_default_template_seg_yaml
+++ b/lmms_eval/tasks/refcocog/_default_template_seg_yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/RefCOCOg
+dataset_path: lmms-lab-encoder/RefCOCOg
 output_type: generate_until
 doc_to_visual: !function utils.refcoco_seg_doc_to_visual
 doc_to_text: !function utils.refcoco_doc_to_text

--- a/lmms_eval/tasks/rvos/eval_sam2.py
+++ b/lmms_eval/tasks/rvos/eval_sam2.py
@@ -117,11 +117,7 @@ def run_sam2(predictor, prompt_map: Dict[tuple, List[tuple]], inference_state) -
     prompt_frames = sorted(prompts_by_frame)
 
     if prompt_frames:
-        autocast_ctx = (
-            torch.autocast(device_type="cuda", dtype=torch.bfloat16)
-            if torch.cuda.is_available() and "cuda" in str(inference_state["device"])
-            else nullcontext()
-        )
+        autocast_ctx = torch.autocast(device_type="cuda", dtype=torch.bfloat16) if torch.cuda.is_available() and "cuda" in str(inference_state["device"]) else nullcontext()
         with torch.inference_mode(), autocast_ctx:
             for i, fidx in enumerate(prompt_frames):
                 for obj_id, points in prompts_by_frame[fidx]:
@@ -181,8 +177,7 @@ def build_prompt_map(tracks: List[Dict[str, Any]], W: int, H: int, video_fps: fl
 def extract_frames_ffmpeg(video_path: str, out_dir: str, fps: float) -> None:
     Path(out_dir).mkdir(parents=True, exist_ok=True)
     subprocess.run(
-        ["ffmpeg", "-y", "-loglevel", "error", "-i", video_path, "-vf", f"fps={fps}",
-         os.path.join(out_dir, "%05d.jpg")],
+        ["ffmpeg", "-y", "-loglevel", "error", "-i", video_path, "-vf", f"fps={fps}", os.path.join(out_dir, "%05d.jpg")],
         check=True,
     )
 
@@ -193,8 +188,8 @@ def extract_frames_ffmpeg(video_path: str, out_dir: str, fps: float) -> None:
 
 
 def load_gt_masks(cache_root: str, video: str, mask_ids: List[str], num_frames: int, H: int, W: int) -> np.ndarray:
-    from pycocotools import mask as mask_utils
     import cv2
+    from pycocotools import mask as mask_utils
 
     gt = np.zeros((num_frames, H, W), dtype=np.uint8)
     for mid in mask_ids:
@@ -231,8 +226,8 @@ def _seg2bmap(seg: np.ndarray) -> np.ndarray:
 
 
 def f_measure(fg: np.ndarray, gt: np.ndarray, bound_th: float = 0.008) -> float:
-    from skimage.morphology import disk
     import cv2
+    from skimage.morphology import disk
 
     bound_pix = bound_th if bound_th >= 1 else np.ceil(bound_th * np.linalg.norm(fg.shape))
     fg_b = _seg2bmap(fg)
@@ -314,8 +309,7 @@ def evaluate_masks(gt: np.ndarray, pred: np.ndarray) -> Dict[str, float]:
 # ---------------------------------------------------------------------------
 
 
-def process_query(predictor, record: Dict[str, Any], cache_root: str, tmp_root: Optional[str],
-                  video_fps: float, device: torch.device) -> Optional[Dict[str, Any]]:
+def process_query(predictor, record: Dict[str, Any], cache_root: str, tmp_root: Optional[str], video_fps: float, device: torch.device) -> Optional[Dict[str, Any]]:
     video = record["video"]
     video_path = os.path.join(cache_root, "videos", f"{video}.mp4")
     if not os.path.exists(video_path):
@@ -335,8 +329,7 @@ def process_query(predictor, record: Dict[str, Any], cache_root: str, tmp_root: 
             pred_masks = np.zeros((state["num_frames"], state["video_height"], state["video_width"]), dtype=np.uint8)
         else:
             pred_masks = run_sam2(predictor, prompt_map, state)
-        gt_masks = load_gt_masks(cache_root, video, list(record.get("mask_ids") or []),
-                                 pred_masks.shape[0], pred_masks.shape[1], pred_masks.shape[2])
+        gt_masks = load_gt_masks(cache_root, video, list(record.get("mask_ids") or []), pred_masks.shape[0], pred_masks.shape[1], pred_masks.shape[2])
 
     metrics = evaluate_masks(gt_masks, pred_masks)
     return {
@@ -370,8 +363,7 @@ def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--task", required=True, choices=list(TASK_TO_CACHE.keys()))
     ap.add_argument("--predictions", required=True, help="Path to stage-1 <task>_submission.json")
-    ap.add_argument("--sam2-model", default=DEFAULT_SAM2_MODEL,
-                    help="HF model id (default: facebook/sam2.1-hiera-large)")
+    ap.add_argument("--sam2-model", default=DEFAULT_SAM2_MODEL, help="HF model id (default: facebook/sam2.1-hiera-large)")
     ap.add_argument("--output", default="rvos_sam2_output")
     ap.add_argument("--cache-dir", default=None, help="Override <hf_home>/<task cache dir>")
     ap.add_argument("--video-fps", type=float, default=6.0)

--- a/lmms_eval/tasks/rvos/utils.py
+++ b/lmms_eval/tasks/rvos/utils.py
@@ -119,10 +119,10 @@ def rvos_doc_to_messages(doc, lmms_eval_specific_kwargs=None):
 _COORD_REGEX = re.compile(r'coords\s*=\s*[\'"]([^\'"]*)(?:[\'"]|$)')
 # Match one segment "time obj_id x y [obj_id x y ...]" separated by any of ;, \t, , : (and leading start).
 # Trailing/leading spaces around the delimiter are tolerated.
-_FRAME_REGEX = re.compile(r'(?:^|[\t:,;])\s*([0-9]+(?:\.[0-9]+)?)\s+([0-9.\s]+?)(?=[\t:,;]|$)')
+_FRAME_REGEX = re.compile(r"(?:^|[\t:,;])\s*([0-9]+(?:\.[0-9]+)?)\s+([0-9.\s]+?)(?=[\t:,;]|$)")
 # obj_id / x / y can appear as either ints or floats (e.g. "0.0"). x/y coordinates are
 # in a 0..1000 normalized frame, so cap the integer portion at 4 digits.
-_POINTS_REGEX = re.compile(r'([0-9]+)(?:\.[0-9]+)?\s+([0-9]{1,4})(?:\.[0-9]+)?\s+([0-9]{1,4})(?:\.[0-9]+)?')
+_POINTS_REGEX = re.compile(r"([0-9]+)(?:\.[0-9]+)?\s+([0-9]{1,4})(?:\.[0-9]+)?\s+([0-9]{1,4})(?:\.[0-9]+)?")
 
 
 def parse_xml_tracks(text: str, width: int, height: int, video_fps: float) -> List[Dict[str, Any]]:
@@ -229,8 +229,7 @@ def _load_gt_masks(doc: Dict[str, Any]) -> Dict[str, List[Any]]:
     return out
 
 
-def _load_masks_at_frame(gt_masks: Dict[str, List[Any]], frame_idx: int, height: int, width: int,
-                         return_dict: bool = False):
+def _load_masks_at_frame(gt_masks: Dict[str, List[Any]], frame_idx: int, height: int, width: int, return_dict: bool = False):
     empty = np.zeros((height, width), dtype=bool)
     masks: List[np.ndarray] = []
     masks_by_id: Dict[str, np.ndarray] = {}
@@ -448,10 +447,7 @@ def rvos_process_results(doc, results):
         # Normalize GT points dict-of-obj shape
         for entry in gt_tracks:
             if isinstance(entry.get("points"), list):
-                entry["points"] = {
-                    str(p["id"]): {"point": p["point"], "occluded": p.get("occluded", False)}
-                    for p in entry["points"]
-                }
+                entry["points"] = {str(p["id"]): {"point": p["point"], "occluded": p.get("occluded", False)} for p in entry["points"]}
     except Exception:
         gt_tracks = []
     try:
@@ -496,6 +492,7 @@ def rvos_process_results(doc, results):
 
 def _dump_submission(records: List[Dict[str, Any]], args) -> str:
     import datetime
+
     from lmms_eval.tasks._task_utils import file_utils
 
     task = records[0]["id"].split("_track_")[0] if records else "rvos"

--- a/lmms_eval/tasks/scibench/scibench_chemistry.yaml
+++ b/lmms_eval/tasks/scibench/scibench_chemistry.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/SciBench_Chemistry
+dataset_path: lmms-lab-encoder/SciBench_Chemistry
 dataset_kwargs:
   token: True
 test_split: test

--- a/lmms_eval/tasks/scibench/scibench_math.yaml
+++ b/lmms_eval/tasks/scibench/scibench_math.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/SciBench_Math
+dataset_path: lmms-lab-encoder/SciBench_Math
 dataset_kwargs:
   token: True
 test_split: train

--- a/lmms_eval/tasks/scibench/scibench_physics.yaml
+++ b/lmms_eval/tasks/scibench/scibench_physics.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/SciBench_Physics
+dataset_path: lmms-lab-encoder/SciBench_Physics
 dataset_kwargs:
   token: True
 test_split: test

--- a/lmms_eval/tasks/scienceqa/scienceqa.yaml
+++ b/lmms_eval/tasks/scienceqa/scienceqa.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/ScienceQA
+dataset_path: lmms-lab-encoder/ScienceQA
 dataset_name: ScienceQA-FULL
 task: "scienceqa"
 dataset_kwargs:

--- a/lmms_eval/tasks/scienceqa/scienceqa_img.yaml
+++ b/lmms_eval/tasks/scienceqa/scienceqa_img.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/ScienceQA
+dataset_path: lmms-lab-encoder/ScienceQA
 dataset_name: ScienceQA-IMG
 task: "scienceqa_img"
 dataset_kwargs:

--- a/lmms_eval/tasks/seedbench/reasoning/seedbench_reasoning.yaml
+++ b/lmms_eval/tasks/seedbench/reasoning/seedbench_reasoning.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/SEED-Bench
+dataset_path: lmms-lab-encoder/SEED-Bench
 dataset_kwargs:
   token: True
 task: "seedbench_reasoning"

--- a/lmms_eval/tasks/seedbench/seedbench.yaml
+++ b/lmms_eval/tasks/seedbench/seedbench.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/SEED-Bench
+dataset_path: lmms-lab-encoder/SEED-Bench
 dataset_kwargs:
   token: True
 task: "seedbench"

--- a/lmms_eval/tasks/seedbench/seedbench_lite.yaml
+++ b/lmms_eval/tasks/seedbench/seedbench_lite.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/LMMs-Eval-Lite
+dataset_path: lmms-lab-encoder/LMMs-Eval-Lite
 dataset_name: seedbench
 dataset_kwargs:
   token: True

--- a/lmms_eval/tasks/seedbench/seedbench_ppl.yaml
+++ b/lmms_eval/tasks/seedbench/seedbench_ppl.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/SEED-Bench
+dataset_path: lmms-lab-encoder/SEED-Bench
 dataset_kwargs:
   token: True
 task: "seedbench_ppl"

--- a/lmms_eval/tasks/seedbench_2/seedbench_2.yaml
+++ b/lmms_eval/tasks/seedbench_2/seedbench_2.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/SEED-Bench-2
+dataset_path: lmms-lab-encoder/SEED-Bench-2
 dataset_kwargs:
   token: True
 task: "seedbench_2"

--- a/lmms_eval/tasks/sis_bench/utils.py
+++ b/lmms_eval/tasks/sis_bench/utils.py
@@ -101,11 +101,7 @@ def sis_bench_process_results(doc, results):
 
 def _aggregate_accuracy(results, dimension=None, task_type=None):
     """Compute question-weighted accuracy, matching the official SIS-Bench scorer."""
-    selected = [
-        result
-        for result in results
-        if (dimension is None or result["dimension"] == dimension) and (task_type is None or result["task_type"] == task_type)
-    ]
+    selected = [result for result in results if (dimension is None or result["dimension"] == dimension) and (task_type is None or result["task_type"] == task_type)]
     if not selected:
         return 0.0
     accuracy = 100.0 * sum(result["score"] for result in selected) / len(selected)

--- a/lmms_eval/tasks/step2_audio_paralinguistic/_default_template_yaml
+++ b/lmms_eval/tasks/step2_audio_paralinguistic/_default_template_yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/StepEval-Audio-Paralinguistic
+dataset_path: lmms-lab-audio/StepEval-Audio-Paralinguistic
 dataset_kwargs:
   token: True
 doc_to_target: !function utils.doc_to_target

--- a/lmms_eval/tasks/stvqa/stvqa.yaml
+++ b/lmms_eval/tasks/stvqa/stvqa.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/ST-VQA
+dataset_path: lmms-lab-encoder/ST-VQA
 task: "stvqa"
 test_split: test
 output_type: generate_until

--- a/lmms_eval/tasks/super_gpqa/super_gpqa.yaml
+++ b/lmms_eval/tasks/super_gpqa/super_gpqa.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/SuperGPQA
+dataset_path: lmms-lab-encoder/SuperGPQA
 dataset_kwargs:
   token: True
 test_split: test

--- a/lmms_eval/tasks/super_gpqa/super_gpqa_multishot.yaml
+++ b/lmms_eval/tasks/super_gpqa/super_gpqa_multishot.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/SuperGPQA
+dataset_path: lmms-lab-encoder/SuperGPQA
 dataset_kwargs:
   token: True
 test_split: test

--- a/lmms_eval/tasks/tedlium/tedlium_dev_test.yaml
+++ b/lmms_eval/tasks/tedlium/tedlium_dev_test.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/tedlium
+dataset_path: lmms-lab-audio/tedlium
 dataset_kwargs:
   token: True
 task : "tedlium_dev_test"

--- a/lmms_eval/tasks/tedlium/tedlium_long_form.yaml
+++ b/lmms_eval/tasks/tedlium/tedlium_long_form.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/tedlium
+dataset_path: lmms-lab-audio/tedlium
 dataset_kwargs:
   token: True
 task : "tedlium_long_form"

--- a/lmms_eval/tasks/tempcompass/_default_template_yaml
+++ b/lmms_eval/tasks/tempcompass/_default_template_yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/TempCompass
+dataset_path: lmms-eval/TempCompass
 dataset_kwargs:
   token: True
   video: True

--- a/lmms_eval/tasks/textcaps/textcaps_test.yaml
+++ b/lmms_eval/tasks/textcaps/textcaps_test.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/TextCaps
+dataset_path: lmms-lab-encoder/TextCaps
 dataset_kwargs:
   token: True
 task : "textcaps_test"

--- a/lmms_eval/tasks/textcaps/textcaps_train.yaml
+++ b/lmms_eval/tasks/textcaps/textcaps_train.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/TextCaps
+dataset_path: lmms-lab-encoder/TextCaps
 dataset_kwargs:
   token: True
 task : "textcaps_train"

--- a/lmms_eval/tasks/textcaps/textcaps_val.yaml
+++ b/lmms_eval/tasks/textcaps/textcaps_val.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/TextCaps
+dataset_path: lmms-lab-encoder/TextCaps
 dataset_kwargs:
   token: True
 task: "textcaps_val"

--- a/lmms_eval/tasks/textcaps/textcaps_val_lite.yaml
+++ b/lmms_eval/tasks/textcaps/textcaps_val_lite.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/LMMs-Eval-Lite
+dataset_path: lmms-lab-encoder/LMMs-Eval-Lite
 dataset_name: textcaps_val
 dataset_kwargs:
   token: True

--- a/lmms_eval/tasks/textvqa/_default_template_textvqa_yaml
+++ b/lmms_eval/tasks/textvqa/_default_template_textvqa_yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/textvqa
+dataset_path: lmms-lab-encoder/textvqa
 output_type: generate_until
 doc_to_visual: !function utils.textvqa_doc_to_visual
 doc_to_text: !function utils.textvqa_doc_to_text

--- a/lmms_eval/tasks/textvqa/textvqa_val_lite.yaml
+++ b/lmms_eval/tasks/textvqa/textvqa_val_lite.yaml
@@ -9,7 +9,7 @@ metric_list:
   - metric: submission
     aggregation: !function utils.textvqa_aggregate_submissions
     higher_is_better: true
-dataset_path: lmms-lab/LMMs-Eval-Lite
+dataset_path: lmms-lab-encoder/LMMs-Eval-Lite
 dataset_name: textvqa_val
 output_type: generate_until
 doc_to_visual: !function utils.textvqa_doc_to_visual

--- a/lmms_eval/tasks/tomato/tomato.yaml
+++ b/lmms_eval/tasks/tomato/tomato.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/TOMATO
+dataset_path: lmms-eval/TOMATO
 dataset_kwargs:
   token: True
   cache_dir: TOMATO

--- a/lmms_eval/tasks/unig2u/chartqa100/chartqa100.yaml
+++ b/lmms_eval/tasks/unig2u/chartqa100/chartqa100.yaml
@@ -29,7 +29,7 @@ metric_list:
 metadata:
   version: 1.0
   description: "ChartQA 100-sample fixed subset (seed=42)"
-  original_dataset: "lmms-lab/ChartQA"
+  original_dataset: "lmms-lab-encoder/ChartQA"
   num_samples: 100
   seed: 42
 lmms_eval_specific_kwargs:

--- a/lmms_eval/tasks/unig2u/chartqa100/chartqa100_visual_cot.yaml
+++ b/lmms_eval/tasks/unig2u/chartqa100/chartqa100_visual_cot.yaml
@@ -52,7 +52,7 @@ lmms_eval_specific_kwargs:
 metadata:
   version: 1.0
   description: "ChartQA 100-sample with Visual CoT"
-  original_dataset: "lmms-lab/ChartQA"
+  original_dataset: "lmms-lab-encoder/ChartQA"
   num_samples: 100
   seed: 42
   prompt_type: visual_cot

--- a/lmms_eval/tasks/vatex/vatex_test.yaml
+++ b/lmms_eval/tasks/vatex/vatex_test.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/VATEX
+dataset_path: lmms-eval/VATEX
 dataset_name: vatex_test
 task: vatex_test
 test_split: test

--- a/lmms_eval/tasks/vatex/vatex_val_zh.yaml
+++ b/lmms_eval/tasks/vatex/vatex_val_zh.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/VATEX_ZH
+dataset_path: lmms-eval/VATEX_ZH
 dataset_name: vatex_val_zh
 task: vatex_val_zh
 test_split: validation

--- a/lmms_eval/tasks/video-tt/_default_template.yaml
+++ b/lmms_eval/tasks/video-tt/_default_template.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/video-tt
+dataset_path: lmms-eval/video-tt
 dataset_kwargs:
   token: True
   cache_dir: video-tt

--- a/lmms_eval/tasks/videochatgpt/_default_template_yaml
+++ b/lmms_eval/tasks/videochatgpt/_default_template_yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/VideoChatGPT
+dataset_path: lmms-eval/VideoChatGPT
 dataset_kwargs:
   token: True
   video: True

--- a/lmms_eval/tasks/videoevalpro/utils.py
+++ b/lmms_eval/tasks/videoevalpro/utils.py
@@ -147,10 +147,7 @@ def videoevalpro_mcq_aggregate_results(results):
         category2score["overall"]["answered"] += 1
         category2score["overall"]["correct"] += int(result["correct"])
 
-    return {
-        task_type: score["correct"] / score["answered"] if score["answered"] else 0.0
-        for task_type, score in category2score.items()
-    }
+    return {task_type: score["correct"] / score["answered"] if score["answered"] else 0.0 for task_type, score in category2score.items()}
 
 
 def videoevalpro_process_results(doc, results):

--- a/lmms_eval/tasks/videomme/_default_template_yaml
+++ b/lmms_eval/tasks/videomme/_default_template_yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/Video-MME
+dataset_path: lmms-eval/Video-MME
 dataset_kwargs:
   token: True
   cache_dir: videomme

--- a/lmms_eval/tasks/videomme/videomme.yaml
+++ b/lmms_eval/tasks/videomme/videomme.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/Video-MME
+dataset_path: lmms-eval/Video-MME
 dataset_kwargs:
   token: True
   cache_dir: videomme

--- a/lmms_eval/tasks/videomme/videomme_w_subtitle.yaml
+++ b/lmms_eval/tasks/videomme/videomme_w_subtitle.yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/Video-MME
+dataset_path: lmms-eval/Video-MME
 dataset_kwargs:
   token: True
   cache_dir: videomme

--- a/lmms_eval/tasks/videommmu/_default_template_yaml
+++ b/lmms_eval/tasks/videommmu/_default_template_yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/VideoMMMU
+dataset_path: lmms-eval/VideoMMMU
 dataset_kwargs:
   token: True
   video: True

--- a/lmms_eval/tasks/videommmu/gt_none_option/_default_template_yaml
+++ b/lmms_eval/tasks/videommmu/gt_none_option/_default_template_yaml
@@ -1,5 +1,5 @@
 # VideoMMMU GT None Option - Default Template
-dataset_path: lmms-lab/VideoMMMU
+dataset_path: lmms-eval/VideoMMMU
 dataset_kwargs:
   token: True
   video: True

--- a/lmms_eval/tasks/videommmu/no_visual/_default_template_yaml
+++ b/lmms_eval/tasks/videommmu/no_visual/_default_template_yaml
@@ -1,7 +1,7 @@
 # VideoMMMU No Visual - Default Template
 # Test model ability to answer without video content
 
-dataset_path: lmms-lab/VideoMMMU
+dataset_path: lmms-eval/VideoMMMU
 dataset_kwargs:
   token: True
   video: True

--- a/lmms_eval/tasks/videommmu/number_option/_default_template_yaml
+++ b/lmms_eval/tasks/videommmu/number_option/_default_template_yaml
@@ -1,5 +1,5 @@
 # VideoMMMU Number Option - Default Template
-dataset_path: lmms-lab/VideoMMMU
+dataset_path: lmms-eval/VideoMMMU
 dataset_kwargs:
   token: True
   video: True

--- a/lmms_eval/tasks/videommmu/random_choice/_default_template_yaml
+++ b/lmms_eval/tasks/videommmu/random_choice/_default_template_yaml
@@ -1,5 +1,5 @@
 # VideoMMMU Random Choice - Default Template
-dataset_path: lmms-lab/VideoMMMU
+dataset_path: lmms-eval/VideoMMMU
 dataset_kwargs:
   token: True
   video: True

--- a/lmms_eval/tasks/visualwebbench/visualwebbench_action_ground.yaml
+++ b/lmms_eval/tasks/visualwebbench/visualwebbench_action_ground.yaml
@@ -1,7 +1,7 @@
 dataset_kwargs:
   token: false
 dataset_name: action_ground
-dataset_path: lmms-lab/VisualWebBench
+dataset_path: lmms-lab-encoder/VisualWebBench
 doc_to_target: !function utils.visualwebbench_doc_to_target
 doc_to_text: !function utils.visualwebbench_doc_to_text
 doc_to_visual: !function utils.visualwebbench_doc_to_visual

--- a/lmms_eval/tasks/visualwebbench/visualwebbench_action_prediction.yaml
+++ b/lmms_eval/tasks/visualwebbench/visualwebbench_action_prediction.yaml
@@ -1,7 +1,7 @@
 dataset_kwargs:
   token: false
 dataset_name: action_prediction
-dataset_path: lmms-lab/VisualWebBench
+dataset_path: lmms-lab-encoder/VisualWebBench
 doc_to_target: !function utils.visualwebbench_doc_to_target
 doc_to_text: !function utils.visualwebbench_doc_to_text
 doc_to_visual: !function utils.visualwebbench_doc_to_visual

--- a/lmms_eval/tasks/visualwebbench/visualwebbench_element_ground.yaml
+++ b/lmms_eval/tasks/visualwebbench/visualwebbench_element_ground.yaml
@@ -1,7 +1,7 @@
 dataset_kwargs:
   token: false
 dataset_name: element_ground
-dataset_path: lmms-lab/VisualWebBench
+dataset_path: lmms-lab-encoder/VisualWebBench
 doc_to_target: !function utils.visualwebbench_doc_to_target
 doc_to_text: !function utils.visualwebbench_doc_to_text
 doc_to_visual: !function utils.visualwebbench_doc_to_visual

--- a/lmms_eval/tasks/visualwebbench/visualwebbench_element_ocr.yaml
+++ b/lmms_eval/tasks/visualwebbench/visualwebbench_element_ocr.yaml
@@ -1,7 +1,7 @@
 dataset_kwargs:
   token: false
 dataset_name: element_ocr
-dataset_path: lmms-lab/VisualWebBench
+dataset_path: lmms-lab-encoder/VisualWebBench
 doc_to_target: !function utils.visualwebbench_doc_to_target
 doc_to_text: !function utils.visualwebbench_doc_to_text
 doc_to_visual: !function utils.visualwebbench_doc_to_visual

--- a/lmms_eval/tasks/visualwebbench/visualwebbench_heading_ocr.yaml
+++ b/lmms_eval/tasks/visualwebbench/visualwebbench_heading_ocr.yaml
@@ -1,7 +1,7 @@
 dataset_kwargs:
   token: false
 dataset_name: heading_ocr
-dataset_path: lmms-lab/VisualWebBench
+dataset_path: lmms-lab-encoder/VisualWebBench
 doc_to_target: !function utils.visualwebbench_doc_to_target
 doc_to_text: !function utils.visualwebbench_doc_to_text
 doc_to_visual: !function utils.visualwebbench_doc_to_visual

--- a/lmms_eval/tasks/visualwebbench/visualwebbench_web_caption.yaml
+++ b/lmms_eval/tasks/visualwebbench/visualwebbench_web_caption.yaml
@@ -1,7 +1,7 @@
 dataset_kwargs:
   token: false
 dataset_name: web_caption
-dataset_path: lmms-lab/VisualWebBench
+dataset_path: lmms-lab-encoder/VisualWebBench
 doc_to_target: !function utils.visualwebbench_doc_to_target
 doc_to_text: !function utils.visualwebbench_doc_to_text
 doc_to_visual: !function utils.visualwebbench_doc_to_visual

--- a/lmms_eval/tasks/visualwebbench/visualwebbench_webqa.yaml
+++ b/lmms_eval/tasks/visualwebbench/visualwebbench_webqa.yaml
@@ -1,7 +1,7 @@
 dataset_kwargs:
   token: false
 dataset_name: webqa
-dataset_path: lmms-lab/VisualWebBench
+dataset_path: lmms-lab-encoder/VisualWebBench
 doc_to_target: !function utils.visualwebbench_doc_to_target
 doc_to_text: !function utils.visualwebbench_doc_to_text
 doc_to_visual: !function utils.visualwebbench_doc_to_visual

--- a/lmms_eval/tasks/vizwiz_vqa/_default_template_vqa_yaml
+++ b/lmms_eval/tasks/vizwiz_vqa/_default_template_vqa_yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/VizWiz-VQA
+dataset_path: lmms-lab-encoder/VizWiz-VQA
 output_type: generate_until
 doc_to_visual: !function utils.vizwiz_vqa_doc_to_visual
 doc_to_text: !function utils.vizwiz_vqa_doc_to_text

--- a/lmms_eval/tasks/vizwiz_vqa/vizwiz_vqa_val_lite.yaml
+++ b/lmms_eval/tasks/vizwiz_vqa/vizwiz_vqa_val_lite.yaml
@@ -1,6 +1,6 @@
 task: vizwiz_vqa_val_lite
 test_split: lite 
-dataset_path: lmms-lab/LMMs-Eval-Lite
+dataset_path: lmms-lab-encoder/LMMs-Eval-Lite
 dataset_name: vizwiz_vqa_val
 output_type: generate_until
 doc_to_visual: !function utils.vizwiz_vqa_doc_to_visual

--- a/lmms_eval/tasks/vocalsound/_default_template_yaml
+++ b/lmms_eval/tasks/vocalsound/_default_template_yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/vocalsound
+dataset_path: lmms-lab-audio/vocalsound
 dataset_kwargs:
   token: True
 doc_to_target: "answer"

--- a/lmms_eval/tasks/voicebench/_default_template_yaml
+++ b/lmms_eval/tasks/voicebench/_default_template_yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/voicebench
+dataset_path: lmms-lab-audio/voicebench
 dataset_kwargs:
   token: True
 doc_to_target: "target_text"

--- a/lmms_eval/tasks/vqav2/_default_template_vqav2_yaml
+++ b/lmms_eval/tasks/vqav2/_default_template_vqav2_yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/VQAv2
+dataset_path: lmms-lab-encoder/VQAv2
 dataset_kwargs:
   token: True
 output_type: generate_until

--- a/lmms_eval/tasks/vqav2/vqav2_val_lite.yaml
+++ b/lmms_eval/tasks/vqav2/vqav2_val_lite.yaml
@@ -1,5 +1,5 @@
 task: "vqav2_val_lite"
-dataset_path: lmms-lab/LMMs-Eval-Lite
+dataset_path: lmms-lab-encoder/LMMs-Eval-Lite
 dataset_name: vqav2_val
 dataset_kwargs:
   token: True

--- a/lmms_eval/tasks/vstar_bench/README.md
+++ b/lmms_eval/tasks/vstar_bench/README.md
@@ -6,7 +6,7 @@ V*-Bench is a visual question-answering benchmark designed to evaluate multimoda
 
 ## Dataset Details
 
-- **Dataset**: `lmms-lab/vstar-bench`
+- **Dataset**: `lmms-lab-encoder/vstar-bench`
 - **Size**: 191 test samples
 - **Format**: Multiple-choice questions with 4 options (A, B, C, D)
 - **Modalities**: Image + Text
@@ -81,4 +81,4 @@ vstar_bench/
 
 ## References
 
-- Dataset: https://huggingface.co/datasets/lmms-lab/vstar-bench
+- Dataset: https://huggingface.co/datasets/lmms-lab-encoder/vstar-bench

--- a/lmms_eval/tasks/vstar_bench/_default_template_yaml
+++ b/lmms_eval/tasks/vstar_bench/_default_template_yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/vstar-bench
+dataset_path: lmms-lab-encoder/vstar-bench
 task: "vstar_bench"
 test_split: test
 output_type: generate_until

--- a/lmms_eval/tasks/wenet_speech/_default_template_yaml
+++ b/lmms_eval/tasks/wenet_speech/_default_template_yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/WenetSpeech
+dataset_path: lmms-lab-audio/WenetSpeech
 dataset_kwargs:
   token: True
 doc_to_target: "text"

--- a/lmms_eval/tasks/where2place/utils.py
+++ b/lmms_eval/tasks/where2place/utils.py
@@ -3,8 +3,7 @@ from typing import Any, Dict, List
 
 import numpy as np
 
-from lmms_eval.tasks._task_utils.default_template_yaml import \
-    load_default_template_yaml
+from lmms_eval.tasks._task_utils.default_template_yaml import load_default_template_yaml
 from lmms_eval.tasks._task_utils.point_format import parse_point2d
 
 PROMPT_SUFFIX_0_999 = "Your answer should be formatted as a list of tuples, i.e. [(x1, y1), (x2, y2), ...], where each tuple contains the x and y coordinates of a point satisfying the conditions above. The coordinates should be integers between 0 and 999, representing the pixel locations scaled to a 1000×1000 grid."

--- a/lmms_eval/tasks/worldqa/_default_template_yaml
+++ b/lmms_eval/tasks/worldqa/_default_template_yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/worldqa
+dataset_path: lmms-eval/worldqa
 dataset_kwargs:
   token: True
   video: True

--- a/lmms_eval/tasks/worldvqa/_default_template_yaml
+++ b/lmms_eval/tasks/worldvqa/_default_template_yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/worldqa
+dataset_path: lmms-eval/worldqa
 dataset_kwargs:
   token: True
   video: True

--- a/lmms_eval/tasks/youcook2/_default_template_yaml
+++ b/lmms_eval/tasks/youcook2/_default_template_yaml
@@ -1,4 +1,4 @@
-dataset_path: lmms-lab/YouCook2
+dataset_path: lmms-eval/YouCook2
 dataset_kwargs:
   token: True
   video: True


### PR DESCRIPTION
The `lmms-lab` org is running out of storage. This moves 94 datasets (~2.5TB) referenced by tasks into three orgs and updates all `dataset_path` references.

| Destination | Repos | Size |
|---|---|---|
| `lmms-eval` (video) | 21 | ~1.4TB |
| `lmms-lab-audio` (audio) | 20 | ~188GB |
| `lmms-lab-encoder` (image/text) | 53 | ~939GB |

The HF-side `move_repo` has already been executed, so old paths still resolve via redirect but should no longer be relied on.

Also fixes `refcoco+/_default_template_bbox_rec_yaml`, which pointed at a non-existent `lmms-lab/RefCOCOPlus` (wrong capitalization).

Gated/private repos (`AIR_Bench`, `ChartQAPro`, `D170_v4.1_*`, `II-Bench`, `VideoDetailDescription`, `worldsense`) and model repos were left untouched.