### PR TITLE
fix(vizdoom): load benchmark specs from Hub

### DIFF
--- a/lmms_eval/tasks/vizdoom_agentic/utils.py
+++ b/lmms_eval/tasks/vizdoom_agentic/utils.py
@@ -57,8 +57,10 @@ def vizdoom_env_manager(doc=None, lmms_eval_specific_kwargs=None):
         audio_buffer=False,
         sound_enabled=False,
         window_visible=False,
-        frame_history=12,
-        tics_per_action=12,
+        # Show every simulator tic as one five-frame video segment, then ask
+        # for exactly one new action for the next five tics.
+        frame_history=5,
+        tics_per_action=5,
         capture_action_frames=True,
         emit_action_frames=os.getenv("VIZDOOM_EMIT_ACTION_FRAMES", "0").lower() in {"1", "true", "yes", "on"},
         success_reward_min=1.0,

--- a/lmms_eval/tasks/vizdoom_agentic/vizdoom.yaml
+++ b/lmms_eval/tasks/vizdoom_agentic/vizdoom.yaml
@@ -1,7 +1,5 @@
-dataset_path: json
-dataset_kwargs:
-  data_files:
-    test: lmms_eval/tasks/vizdoom_agentic/data/vizdoom.jsonl
+dataset_path: pufanyi/ViZDoom
+dataset_name: default
 task: "vizdoom"
 test_split: test
 output_type: generate_until_game

--- a/lmms_eval/tasks/vizdoom_agentic/vizdoom.yaml
+++ b/lmms_eval/tasks/vizdoom_agentic/vizdoom.yaml
@@ -3,6 +3,10 @@ dataset_name: default
 task: "vizdoom"
 test_split: test
 output_type: generate_until_game
+# The response is an episode JSON trace, not a model answer.  Applying the
+# evaluator's default reasoning-tag stripping here would corrupt any embedded
+# Qwen ``</think>`` text before ``process_results`` reads the metrics.
+reasoning_tags: none
 doc_to_visual: !function utils.vizdoom_doc_to_visual
 doc_to_text: !function utils.vizdoom_doc_to_text
 doc_to_target: !function utils.vizdoom_doc_to_target
@@ -34,5 +38,5 @@ lmms_eval_specific_kwargs:
     pre_prompt: ""
     post_prompt: ""
 metadata:
-  version: 0.1
+  version: 0.2
   description: "ViZDoom game loop with video frame history (human-view parity observations)"

--- a/test/agentic/test_vizdoom_interfaces.py
+++ b/test/agentic/test_vizdoom_interfaces.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+
 from lmms_eval.agentic import AgentInput, AgentOutput, ContentBlock, EnvState
 from lmms_eval.agentic.parsers import ParserContext
 from lmms_eval.tasks.vizdoom_agentic import utils as vizdoom_utils
@@ -57,8 +59,28 @@ def test_env_manager_factory_builds_without_vizdoom_installed():
 
     assert manager.config["screen_resolution"] == "RES_320X240"
     assert manager.config["available_buttons"] == ["MOVE_LEFT", "MOVE_RIGHT", "ATTACK"]
-    assert manager.frame_history == 12
-    assert manager.tics_per_action == 12
+    assert manager.frame_history == 5
+    assert manager.tics_per_action == 5
+
+
+def test_process_results_reads_episode_metrics_with_embedded_qwen_thinking():
+    payload = {
+        "success": False,
+        "metrics": {
+            "vizdoom_success": 0.0,
+            "vizdoom_steps": 25.0,
+            "vizdoom_invalid_actions": 1.0,
+        },
+        "steps": [{"raw_model_output": "aim, then fire</think>"}],
+    }
+
+    metrics = vizdoom_utils.vizdoom_process_results({}, [json.dumps(payload)])
+
+    assert metrics == {
+        "vizdoom_success": 0.0,
+        "vizdoom_steps": 25.0,
+        "vizdoom_invalid_actions": 1.0,
+    }
 
 
 def test_task_yaml_component_factories_are_wired():


### PR DESCRIPTION
## Summary

- load the canonical 120-episode ViZDoom benchmark from `pufanyi/ViZDoom`
- select the `default` dataset config explicitly
- stop evaluating against the two-row local JSONL stub
- use one five-frame observation segment per five simulator tics, with one new action requested per segment
- keep structured episode JSON intact during postprocessing so embedded Qwen `</think>` text cannot corrupt rollout metrics

## Dataset organization

- benchmark specifications remain in [`pufanyi/ViZDoom`](https://huggingface.co/datasets/pufanyi/ViZDoom)
- model rollout artifacts now live in [`pufanyi/ViZDoom-Agentic-Rollouts`](https://huggingface.co/datasets/pufanyi/ViZDoom-Agentic-Rollouts)

## Validation

- loaded `vizdoom` through the lmms-eval `TaskManager`
- confirmed the `test` split contains 120 rows
- confirmed the first example is `vizdoom_basic_seed_00`
- `14 passed`:
  - `test/agentic/test_vizdoom_interfaces.py`
  - `test/agentic/test_runner.py`
  - `test/eval/test_reasoning.py`
- `git diff --check` passes
- GitHub `lint` and `compare-task-input-boundary` checks pass

## Qwen3.6-27B end-to-end smoke report

**Verdict: PASS** on pushed head commit `37bc4f1d7009b726ab7c1e2e49b0b1342441838e` (2026-08-01, one real episode). This is a compatibility smoke test with `--limit 1`, not a benchmark score.

### Runtime

- dataset: `pufanyi/ViZDoom`, config `default`, cached Hub revision `ea929dd5c36def2b74d70ad4bc65f4ab3808a317`
- episode: `vizdoom_basic_seed_00`, `game_seed=0`
- model: `Qwen3.6-27B`, served by vLLM `0.23.0`
- hardware: 2x NVIDIA H100 80GB, tensor parallelism 2
- context: 32,768 tokens
- rollout: rolling conversation, up to 32 preceding video/action exchanges
- observation/action cadence: every simulator tic captured; 5 frames per segment; one action every 5 tics
- generation: thinking enabled, greedy (`temperature=0`, `top_p=1`), `max_new_tokens=512`, `max_game_steps=64`

### Result

- process exit: `0`
- rollout wall time: `22.21 s`
- model requests / environment decisions: `14`
- `vizdoom_success`: `1.0`
- `vizdoom_steps`: `14.0`
- `vizdoom_total_reward`: `14.0` (terminal-step reward `99.0`)
- `vizdoom_invalid_actions`: `3.0`
- `vizdoom_timeout`: `0.0`
- `vizdoom_player_dead`: `0.0`
- episode ended naturally after the monster was killed
- all 13 non-terminal action segments captured exactly 5 frames and ran exactly 5 tics; the terminal segment captured 1 frame because the kill ended the episode early
- aggregate JSON and sample trace agree on success, step count, and invalid-action count

The three invalid actions came from Qwen mentioning the unavailable alias `STRAFE`; the environment rejected them, recorded them, and safely executed its fallback. The episode still completed successfully.

### Artifacts produced

- aggregated result JSON
- full sample/episode JSONL
- `summary.md`
- `actions.jsonl`
- combined `rollout.mp4` (430,942 bytes)
- 14 per-step MP4 segments

Local validation root: `outputs/pr1420_qwen36_37bc4f1d_5tic_20260801/`.

### Reproduction

Start vLLM without a one-video multimodal cap. A rolling history of 32 preceding exchanges plus the current observation can contain 33 videos; `--limit-mm-per-prompt '{"video": 1}'` fails on the second turn.

```bash
CUDA_VISIBLE_DEVICES=0,1 .venv/bin/vllm serve outputs/models/Qwen3.6-27B \
  --served-model-name Qwen3.6-27B \
  --tensor-parallel-size 2 \
  --max-model-len 32768 \
  --trust-remote-code \
  --host 0.0.0.0 \
  --port 8000
```

```bash
VIZDOOM_EMIT_ACTION_FRAMES=1 LMMS_AGENTIC_ARTIFACT_FPS=35 \
.venv/bin/python -m lmms_eval \
  --model dummy \
  --tasks vizdoom \
  --batch_size 1 \
  --limit 1 \
  --log_samples \
  --output_path outputs/pr1420_qwen36_37bc4f1d_5tic_20260801 \
  --agentic_model_server openai \
  --agentic_model_server_args 'model=Qwen3.6-27B,base_url=http://127.0.0.1:8000/v1,api_key=EMPTY,timeout=600,enable_thinking=true' \
  --agentic_output_parser qwen \
  --agentic_max_parallel_rollouts 1 \
  --agentic_trace_mode full \
  --gen_kwargs 'max_game_steps=64,temperature=0,top_p=1,max_new_tokens=512,multiturn=true,history_turns=32,game_seed=0'
```
