### PR TITLE
fix: build SGLang sampling params per request instead of per batch (#1397)

### DIFF
--- a/lmms_eval/models/chat/sglang.py
+++ b/lmms_eval/models/chat/sglang.py
@@ -296,9 +296,11 @@ class Sglang(lmms):
             video_data = [vids for _, _, vids in prepared]
             has_video = any(len(vids) > 0 for vids in video_data)
 
-            # Extract generation parameters
-            ctx, doc_to_messages, gen_kwargs, doc_id, task, split = batch_requests[0].arguments
-            params = self._extract_gen_params(gen_kwargs)
+            # Extract generation parameters. Sampling settings belong to the
+            # individual request, so build one entry per request instead of
+            # reusing the first one for the whole batch. SGLang's Engine
+            # accepts a list of sampling_params aligned with the prompts.
+            params = [self._extract_gen_params(request.arguments[2]) for request in batch_requests]
 
             # Apply chat template
             texts = self.processor.apply_chat_template(
@@ -494,9 +496,13 @@ class Sglang(lmms):
         )
 
     def req_level_generate(self, input_ids, image_data, sampling_params, batched_messages):
-        """Per-request generation with tool calling support."""
+        """Per-request generation with tool calling support.
+
+        ``sampling_params`` is a list holding one entry per request, aligned
+        with ``input_ids`` / ``batched_messages``.
+        """
         loop = asyncio.get_event_loop()
-        text_list = loop.run_until_complete(asyncio.gather(*[self.async_a_request(iid, img, sampling_params, msgs) for iid, img, msgs in zip(input_ids, image_data, batched_messages)]))
+        text_list = loop.run_until_complete(asyncio.gather(*[self.async_a_request(iid, img, params, msgs) for iid, img, params, msgs in zip(input_ids, image_data, sampling_params, batched_messages)]))
         return [{"text": text} for text in text_list]
 
     def batch_level_generate(self, input_ids, image_data, sampling_params):


### PR DESCRIPTION
## Summary

- `lmms_eval/models/chat/sglang.py::generate_until` read `gen_kwargs` from `batch_requests[0]` only, then reused the resulting sampling params for **every** request in the batch.
- With `--batch_size > 1`, any request whose `max_new_tokens` / `temperature` / `top_p` differed from the first request in its slice was generated with the wrong settings — silently, since nothing validates the params against the request.
- The chat vLLM backend already does this per request (`make_one_request` → `batched_sampling_params` → `[SamplingParams(**params) for ...]`). This brings the SGLang backend in line with it.

Fixes #1397

## In scope

- Build one params dict per request: `params = [self._extract_gen_params(request.arguments[2]) for request in batch_requests]`.
- `req_level_generate` (the MCP tool-calling path) now zips the per-request params alongside `input_ids` / `batched_messages`, so each `async_a_request` gets its own settings.

`sglang.srt.entrypoints.engine.Engine.generate` declares `sampling_params: Optional[Union[List[Dict], Dict]] = None`, so passing the aligned list is the supported batch form and no change is needed inside `_generate_image` / `_generate_video`.

## Out of scope

- **`until` → `stop`.** The issue also notes that `_extract_gen_params` drops `until`. That is not SGLang-specific: `simple/vllm.py::_build_sampling_params_dict` emits only `max_tokens` / `temperature` / `top_p`, and `chat/vllm.py::_resolve_sampling_params` explicitly does `gen.pop("until", None)`. Wiring stop strings into the backends looks like a deliberate repo-wide choice rather than an oversight here, so I left it alone rather than making SGLang diverge from the vLLM backends. Happy to add it in a follow-up if maintainers want stop strings pushed down to the engines.
- The `_generate_image` MCP path flattens images across requests (`flat_images`) before `req_level_generate` zips them per request. That is a separate pre-existing mismatch and is untouched here.

## Validation

No SGLang GPU available locally, so I extracted `generate_until` with `ast` and executed it against a stub `self` (fake processor + fake Engine that records the `sampling_params` it receives), running the same three requests through the pre- and post-change function bodies:

```python
reqs = [Req({"max_new_tokens": 16,   "temperature": 0.0}),
        Req({"max_new_tokens": 512,  "temperature": 0.7, "top_p": 0.8}),
        Req({"max_new_tokens": 2048, "temperature": 1.0})]   # batch_size = 3
```

```
OLD  {'temperature': 0.0, 'max_new_tokens': 16, 'top_p': 0.95}

NEW  [{'temperature': 0.0, 'max_new_tokens': 16,   'top_p': 0.95},
      {'temperature': 0.7, 'max_new_tokens': 512,  'top_p': 0.8},
      {'temperature': 1.0, 'max_new_tokens': 2048, 'top_p': 0.95}]
```

Before the change all three requests are capped at 16 tokens at `temperature=0`; after it each keeps its own settings. A single-request batch produces a one-element list, which `Engine.generate` treats identically to the previous scalar dict, so `--batch_size 1` runs are unchanged.

`black --line-length=240` reports the file unchanged. (`isort --profile black` reorders the imports in this file on `main` as well — pre-existing drift, so I did not touch the import block.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
