### PR TITLE
fix(openai): preserve per-request sampling parameters

### DIFF
--- a/lmms_eval/models/chat/aero_realtime_vllm.py
+++ b/lmms_eval/models/chat/aero_realtime_vllm.py
@@ -88,8 +88,8 @@ SAMPLE_RATE = 16000
 
 @dataclass
 class RealtimeSample:
-    audio: np.ndarray            # mono float32 @ 16 kHz
-    video: np.ndarray            # (T, H, W, 3) uint8
+    audio: np.ndarray  # mono float32 @ 16 kHz
+    video: np.ndarray  # (T, H, W, 3) uint8
     video_metadata: object
     sample_fps: float
 
@@ -339,10 +339,7 @@ class AeroRealtimeVLLM(lmms):
         # vs. ``aero_realtime_chat`` which is strict, to match how other vLLM
         # wrappers behave.
         if AsyncOmni is None or AeroRealtimeForConditionalGeneration is None:
-            raise ImportError(
-                "vllm-omni is required for aero_realtime_vllm_chat. "
-                "Install vllm-omni and ensure it is importable."
-            )
+            raise ImportError("vllm-omni is required for aero_realtime_vllm_chat. " "Install vllm-omni and ensure it is importable.")
         if fetch_video is None:
             raise ImportError("qwen_vl_utils is required (`pip install qwen-vl-utils`)")
         if librosa is None:
@@ -370,9 +367,7 @@ class AeroRealtimeVLLM(lmms):
             omni_kwargs["stage_init_timeout"] = int(stage_init_timeout)
         if tensor_parallel_size is not None:
             omni_kwargs["tensor_parallel_size"] = tensor_parallel_size
-            omni_kwargs["stage_0_devices"] = stage_0_devices or ",".join(
-                str(i) for i in range(tensor_parallel_size)
-            )
+            omni_kwargs["stage_0_devices"] = stage_0_devices or ",".join(str(i) for i in range(tensor_parallel_size))
         elif stage_0_devices is not None:
             omni_kwargs["stage_0_devices"] = stage_0_devices
         if limit_mm_per_prompt:
@@ -386,6 +381,7 @@ class AeroRealtimeVLLM(lmms):
                     mm_limits[k.strip()] = int(v)
             else:
                 import json as _json
+
                 mm_limits = {k: int(v) for k, v in _json.loads(limit_mm_per_prompt).items()}
             omni_kwargs["limit_mm_per_prompt"] = mm_limits
 
@@ -394,6 +390,7 @@ class AeroRealtimeVLLM(lmms):
         overrides: dict[str, dict] = {}
         if stage_overrides:
             import json as _json
+
             overrides = _json.loads(stage_overrides)
         if enforce_eager is not None:
             overrides.setdefault("0", {})["enforce_eager"] = bool(enforce_eager)
@@ -466,9 +463,7 @@ class AeroRealtimeVLLM(lmms):
 
     # --------------------------- request -> sample ------------------------------
 
-    def _extract_video_and_text(
-        self, chat: ChatMessages
-    ) -> Tuple[str, str, Optional[float], Optional[float]]:
+    def _extract_video_and_text(self, chat: ChatMessages) -> Tuple[str, str, Optional[float], Optional[float]]:
         """Pull (first_video_path, concatenated_user_text, start_time, end_time) out of ChatMessages."""
         video_path: Optional[str] = None
         start_time: Optional[float] = None
@@ -505,9 +500,7 @@ class AeroRealtimeVLLM(lmms):
         live in the fused prefill, matching training); tail is only the
         decode-phase silence chunks."""
         all_chunks = list(chunks)
-        text_idx = next(
-            (i for i, c in enumerate(all_chunks) if c.get("text")), len(all_chunks)
-        )
+        text_idx = next((i for i, c in enumerate(all_chunks) if c.get("text")), len(all_chunks))
         return all_chunks[: text_idx + 1], all_chunks[text_idx + 1 :]
 
     def _fuse_prompts(self, prompts):
@@ -544,11 +537,7 @@ class AeroRealtimeVLLM(lmms):
         def flush_audio_buffer():
             if not pending_audio:
                 return
-            merged = (
-                pending_audio[0]
-                if len(pending_audio) == 1
-                else np.concatenate(pending_audio).astype(np.float32, copy=False)
-            )
+            merged = pending_audio[0] if len(pending_audio) == 1 else np.concatenate(pending_audio).astype(np.float32, copy=False)
             audios.append(merged)
             pids.append(audio_pad_id)
             ts_ids.extend(pending_ts_ids)
@@ -569,11 +558,7 @@ class AeroRealtimeVLLM(lmms):
             # A "pure audio" chunk: only audio_pad token(s) in the delta,
             # no video item, no extra prompt scaffolding.
             non_audio_pad_ids = [tid for tid in prompt_ids if tid != audio_pad_id]
-            is_pure_audio = (
-                audio_item is not None
-                and video_item is None
-                and not non_audio_pad_ids
-            )
+            is_pure_audio = audio_item is not None and video_item is None and not non_audio_pad_ids
 
             if is_pure_audio:
                 pending_audio.append(np.asarray(audio_item))
@@ -663,15 +648,11 @@ class AeroRealtimeVLLM(lmms):
                 for c in _iter_realtime_chunks(sample, **chunk_kwargs):
                     yield c
 
-            async for p in AeroRealtimeForConditionalGeneration.buffer_realtime_omni(
-                chunk_iter(), input_stream, self.model_config
-            ):
+            async for p in AeroRealtimeForConditionalGeneration.buffer_realtime_omni(chunk_iter(), input_stream, self.model_config):
                 yield await self._render_streaming_input(p)
 
         async def streaming_gen_prefill_decode():
-            prefill_chunks, tail_chunks = self._split_chunks(
-                _iter_realtime_chunks(sample, **chunk_kwargs)
-            )
+            prefill_chunks, tail_chunks = self._split_chunks(_iter_realtime_chunks(sample, **chunk_kwargs))
             shared_state = AeroRealtimeStreamState()
 
             # Phase 1 — fuse pre-question chunks into one prefill (every
@@ -682,9 +663,7 @@ class AeroRealtimeVLLM(lmms):
 
             prefill_q: asyncio.Queue[list[int]] = asyncio.Queue()
             prefill_prompts = []
-            async for p in AeroRealtimeForConditionalGeneration.buffer_realtime_omni(
-                pre_iter(), prefill_q, self.model_config, state=shared_state
-            ):
+            async for p in AeroRealtimeForConditionalGeneration.buffer_realtime_omni(pre_iter(), prefill_q, self.model_config, state=shared_state):
                 prefill_q.put_nowait([])
                 prefill_prompts.append(p)
             fused = self._fuse_prompts(prefill_prompts)
@@ -696,16 +675,10 @@ class AeroRealtimeVLLM(lmms):
                 for c in tail_chunks:
                     yield c
 
-            async for p in AeroRealtimeForConditionalGeneration.buffer_realtime_omni(
-                tail_iter(), input_stream, self.model_config, state=shared_state
-            ):
+            async for p in AeroRealtimeForConditionalGeneration.buffer_realtime_omni(tail_iter(), input_stream, self.model_config, state=shared_state):
                 yield await self._render_streaming_input(p)
 
-        streaming_gen = (
-            streaming_gen_prefill_decode
-            if self.mode == "prefill_decode"
-            else streaming_gen_pure
-        )
+        streaming_gen = streaming_gen_prefill_decode if self.mode == "prefill_decode" else streaming_gen_pure
 
         request_id = f"aero-rt-vllm-{uuid.uuid4()}"
         collected: list[int] = []
@@ -766,9 +739,7 @@ class AeroRealtimeVLLM(lmms):
                     chats_and_gens.append((chat, dict(gen_kwargs or {})))
 
                 t0 = time.time()
-                batch_results = await asyncio.gather(
-                    *[self._generate_one(c, g) for c, g in chats_and_gens]
-                )
+                batch_results = await asyncio.gather(*[self._generate_one(c, g) for c, g in chats_and_gens])
                 totals["elapsed"] += time.time() - t0
 
                 for i, (text, ntok) in enumerate(batch_results):

--- a/lmms_eval/models/chat/openai.py
+++ b/lmms_eval/models/chat/openai.py
@@ -31,6 +31,13 @@ cpu, _ = optional_import("decord", "cpu")
 load_dotenv(verbose=True)
 
 
+def _validate_single_choice_n(gen_kwargs: dict) -> None:
+    """Reject choice counts that this backend cannot return faithfully."""
+    n = gen_kwargs.get("n")
+    if n is not None and (isinstance(n, bool) or not isinstance(n, int) or n != 1):
+        raise ValueError("generation parameter n must be the integer 1 because this backend consumes exactly one response choice")
+
+
 @register_model("openai")
 class OpenAICompatible(OpenAICompatibleSimple):
     is_simple = False
@@ -45,6 +52,8 @@ class OpenAICompatible(OpenAICompatibleSimple):
             return []
 
         reordered_requests = list(requests)
+        for request in reordered_requests:
+            _validate_single_choice_n(request.args[2])
         pbar = tqdm(
             total=len(reordered_requests),
             disable=(self.rank != 0),
@@ -197,6 +206,10 @@ class OpenAICompatible(OpenAICompatibleSimple):
                 "max_tokens": max_new_tokens,
                 "temperature": temperature,
             }
+            for parameter in ("top_p", "seed", "presence_penalty", "frequency_penalty", "n"):
+                value = request_gen_kwargs.get(parameter)
+                if value is not None:
+                    payload[parameter] = value
             extra_body = {}
             if self.pass_video_url:
                 extra_body["media_io_kwargs"] = {"video": {"num_frames": int(self.max_frames_num)}}

--- a/test/models/test_openai.py
+++ b/test/models/test_openai.py
@@ -26,6 +26,22 @@ def _request(*args) -> SimpleNamespace:
     return SimpleNamespace(args=args)
 
 
+def _chat_request(gen_kwargs: dict) -> SimpleNamespace:
+    return _request(
+        "",
+        lambda _doc: [
+            {
+                "role": "user",
+                "content": [{"type": "text", "text": "Respond to this"}],
+            }
+        ],
+        gen_kwargs,
+        0,
+        "demo",
+        "test",
+    )
+
+
 def _configure_openai_model(model, completions: _CaptureCompletions, *, model_version: str = "gpt-4o") -> None:
     model.client = SimpleNamespace(chat=SimpleNamespace(completions=completions))
     model.model_version = model_version
@@ -38,11 +54,13 @@ def _configure_openai_model(model, completions: _CaptureCompletions, *, model_ve
     model.prefix_hash_chars = 256
     model.max_frames_num = 1
     model.video_fps = None
+    model.pass_video_url = False
+    model.enable_thinking_kwarg = None
     model._rank = 0
     model.task_dict = {"demo": {"test": [{"id": 0}]}}
 
 
-class TestOpenAICompatibleMaxTokens(unittest.TestCase):
+class TestOpenAICompatibleGenerationParameters(unittest.TestCase):
     def test_simple_backend_preserves_requested_max_new_tokens(self):
         completions = _CaptureCompletions()
         model = SimpleOpenAICompatible.__new__(SimpleOpenAICompatible)
@@ -113,6 +131,50 @@ class TestOpenAICompatibleMaxTokens(unittest.TestCase):
 
         self.assertNotIn("max_tokens", completions.payloads[0])
         self.assertEqual(completions.payloads[0]["max_completion_tokens"], 32768)
+
+    def test_chat_backend_preserves_per_request_sampling_parameters(self):
+        completions = _CaptureCompletions()
+        model = ChatOpenAICompatible.__new__(ChatOpenAICompatible)
+        _configure_openai_model(model, completions)
+        generation_kwargs = {
+            "max_new_tokens": 512,
+            "temperature": 0.4,
+            "top_p": 0.8,
+            "seed": 42,
+            "presence_penalty": 0.1,
+            "frequency_penalty": -0.2,
+        }
+        original_generation_kwargs = dict(generation_kwargs)
+
+        model.generate_until([_chat_request(generation_kwargs)])
+
+        payload = completions.payloads[0]
+        self.assertEqual(payload["top_p"], 0.8)
+        self.assertEqual(payload["seed"], 42)
+        self.assertEqual(payload["presence_penalty"], 0.1)
+        self.assertEqual(payload["frequency_penalty"], -0.2)
+        self.assertEqual(generation_kwargs, original_generation_kwargs)
+
+    def test_chat_backend_accepts_one_response_choice(self):
+        completions = _CaptureCompletions()
+        model = ChatOpenAICompatible.__new__(ChatOpenAICompatible)
+        _configure_openai_model(model, completions)
+
+        model.generate_until([_chat_request({"n": 1})])
+
+        self.assertEqual(completions.payloads[0]["n"], 1)
+
+    def test_chat_backend_rejects_unsupported_response_choice_counts(self):
+        for invalid_n in (0, 2, -1, 1.0, True, "1"):
+            with self.subTest(n=invalid_n):
+                completions = _CaptureCompletions()
+                model = ChatOpenAICompatible.__new__(ChatOpenAICompatible)
+                _configure_openai_model(model, completions)
+
+                with self.assertRaisesRegex(ValueError, "n.*integer 1"):
+                    model.generate_until([_chat_request({"n": invalid_n})])
+
+                self.assertEqual(completions.payloads, [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- forward per-request top_p, seed, presence_penalty, and frequency_penalty through the chat OpenAI backend
- preserve explicit n=1 and reject unsupported choice counts before sending any requests
- keep caller-owned generation kwargs unchanged
- align the existing fake chat-model fixture with the current video/thinking attributes

## Why
The chat backend currently rebuilds each Chat Completions payload with only max_tokens and temperature. Other task-level sampling parameters are silently dropped, so OpenAI-compatible evaluations do not follow the task configuration and are harder to reproduce.

The backend consumes only response.choices[0]. Accepting n > 1 would silently discard paid generations, so this PR fails fast instead.

## Validation
- pytest -q test/models/test_openai.py — 6 passed, 6 subtests passed
- pre-commit run --files lmms_eval/models/chat/openai.py test/models/test_openai.py
- python -m compileall -q lmms_eval/models/chat/openai.py test/models/test_openai.py

A broader non-GPU model test run passed 35 tests and 14 subtests. Two existing Qwen3-VL simple-model tests remain failing because the current implementation no longer exposes decord / _subsample_video_inputs; neither affected file is touched by this PR.

## CI follow-up
The first repository-wide lint run failed because Black reformatted lmms_eval/models/chat/aero_realtime_vllm.py, an existing formatting issue also present on base main@75571cfe. A separate mechanical formatting commit now includes that exact Black output. The file’s Python AST hash is unchanged, and pre-commit run --all-files now passes locally.