### PR TITLE
feat(tasks): add owner-aligned MicroVQA benchmark

### DIFF
--- a/lmms_eval/models/chat/aero_realtime_vllm.py
+++ b/lmms_eval/models/chat/aero_realtime_vllm.py
@@ -88,8 +88,8 @@ SAMPLE_RATE = 16000
 
 @dataclass
 class RealtimeSample:
-    audio: np.ndarray            # mono float32 @ 16 kHz
-    video: np.ndarray            # (T, H, W, 3) uint8
+    audio: np.ndarray  # mono float32 @ 16 kHz
+    video: np.ndarray  # (T, H, W, 3) uint8
     video_metadata: object
     sample_fps: float
 
@@ -339,10 +339,7 @@ class AeroRealtimeVLLM(lmms):
         # vs. ``aero_realtime_chat`` which is strict, to match how other vLLM
         # wrappers behave.
         if AsyncOmni is None or AeroRealtimeForConditionalGeneration is None:
-            raise ImportError(
-                "vllm-omni is required for aero_realtime_vllm_chat. "
-                "Install vllm-omni and ensure it is importable."
-            )
+            raise ImportError("vllm-omni is required for aero_realtime_vllm_chat. " "Install vllm-omni and ensure it is importable.")
         if fetch_video is None:
             raise ImportError("qwen_vl_utils is required (`pip install qwen-vl-utils`)")
         if librosa is None:
@@ -370,9 +367,7 @@ class AeroRealtimeVLLM(lmms):
             omni_kwargs["stage_init_timeout"] = int(stage_init_timeout)
         if tensor_parallel_size is not None:
             omni_kwargs["tensor_parallel_size"] = tensor_parallel_size
-            omni_kwargs["stage_0_devices"] = stage_0_devices or ",".join(
-                str(i) for i in range(tensor_parallel_size)
-            )
+            omni_kwargs["stage_0_devices"] = stage_0_devices or ",".join(str(i) for i in range(tensor_parallel_size))
         elif stage_0_devices is not None:
             omni_kwargs["stage_0_devices"] = stage_0_devices
         if limit_mm_per_prompt:
@@ -386,6 +381,7 @@ class AeroRealtimeVLLM(lmms):
                     mm_limits[k.strip()] = int(v)
             else:
                 import json as _json
+
                 mm_limits = {k: int(v) for k, v in _json.loads(limit_mm_per_prompt).items()}
             omni_kwargs["limit_mm_per_prompt"] = mm_limits
 
@@ -394,6 +390,7 @@ class AeroRealtimeVLLM(lmms):
         overrides: dict[str, dict] = {}
         if stage_overrides:
             import json as _json
+
             overrides = _json.loads(stage_overrides)
         if enforce_eager is not None:
             overrides.setdefault("0", {})["enforce_eager"] = bool(enforce_eager)
@@ -466,9 +463,7 @@ class AeroRealtimeVLLM(lmms):
 
     # --------------------------- request -> sample ------------------------------
 
-    def _extract_video_and_text(
-        self, chat: ChatMessages
-    ) -> Tuple[str, str, Optional[float], Optional[float]]:
+    def _extract_video_and_text(self, chat: ChatMessages) -> Tuple[str, str, Optional[float], Optional[float]]:
         """Pull (first_video_path, concatenated_user_text, start_time, end_time) out of ChatMessages."""
         video_path: Optional[str] = None
         start_time: Optional[float] = None
@@ -505,9 +500,7 @@ class AeroRealtimeVLLM(lmms):
         live in the fused prefill, matching training); tail is only the
         decode-phase silence chunks."""
         all_chunks = list(chunks)
-        text_idx = next(
-            (i for i, c in enumerate(all_chunks) if c.get("text")), len(all_chunks)
-        )
+        text_idx = next((i for i, c in enumerate(all_chunks) if c.get("text")), len(all_chunks))
         return all_chunks[: text_idx + 1], all_chunks[text_idx + 1 :]
 
     def _fuse_prompts(self, prompts):
@@ -544,11 +537,7 @@ class AeroRealtimeVLLM(lmms):
         def flush_audio_buffer():
             if not pending_audio:
                 return
-            merged = (
-                pending_audio[0]
-                if len(pending_audio) == 1
-                else np.concatenate(pending_audio).astype(np.float32, copy=False)
-            )
+            merged = pending_audio[0] if len(pending_audio) == 1 else np.concatenate(pending_audio).astype(np.float32, copy=False)
             audios.append(merged)
             pids.append(audio_pad_id)
             ts_ids.extend(pending_ts_ids)
@@ -569,11 +558,7 @@ class AeroRealtimeVLLM(lmms):
             # A "pure audio" chunk: only audio_pad token(s) in the delta,
             # no video item, no extra prompt scaffolding.
             non_audio_pad_ids = [tid for tid in prompt_ids if tid != audio_pad_id]
-            is_pure_audio = (
-                audio_item is not None
-                and video_item is None
-                and not non_audio_pad_ids
-            )
+            is_pure_audio = audio_item is not None and video_item is None and not non_audio_pad_ids
 
             if is_pure_audio:
                 pending_audio.append(np.asarray(audio_item))
@@ -663,15 +648,11 @@ class AeroRealtimeVLLM(lmms):
                 for c in _iter_realtime_chunks(sample, **chunk_kwargs):
                     yield c
 
-            async for p in AeroRealtimeForConditionalGeneration.buffer_realtime_omni(
-                chunk_iter(), input_stream, self.model_config
-            ):
+            async for p in AeroRealtimeForConditionalGeneration.buffer_realtime_omni(chunk_iter(), input_stream, self.model_config):
                 yield await self._render_streaming_input(p)
 
         async def streaming_gen_prefill_decode():
-            prefill_chunks, tail_chunks = self._split_chunks(
-                _iter_realtime_chunks(sample, **chunk_kwargs)
-            )
+            prefill_chunks, tail_chunks = self._split_chunks(_iter_realtime_chunks(sample, **chunk_kwargs))
             shared_state = AeroRealtimeStreamState()
 
             # Phase 1 — fuse pre-question chunks into one prefill (every
@@ -682,9 +663,7 @@ class AeroRealtimeVLLM(lmms):
 
             prefill_q: asyncio.Queue[list[int]] = asyncio.Queue()
             prefill_prompts = []
-            async for p in AeroRealtimeForConditionalGeneration.buffer_realtime_omni(
-                pre_iter(), prefill_q, self.model_config, state=shared_state
-            ):
+            async for p in AeroRealtimeForConditionalGeneration.buffer_realtime_omni(pre_iter(), prefill_q, self.model_config, state=shared_state):
                 prefill_q.put_nowait([])
                 prefill_prompts.append(p)
             fused = self._fuse_prompts(prefill_prompts)
@@ -696,16 +675,10 @@ class AeroRealtimeVLLM(lmms):
                 for c in tail_chunks:
                     yield c
 
-            async for p in AeroRealtimeForConditionalGeneration.buffer_realtime_omni(
-                tail_iter(), input_stream, self.model_config, state=shared_state
-            ):
+            async for p in AeroRealtimeForConditionalGeneration.buffer_realtime_omni(tail_iter(), input_stream, self.model_config, state=shared_state):
                 yield await self._render_streaming_input(p)
 
-        streaming_gen = (
-            streaming_gen_prefill_decode
-            if self.mode == "prefill_decode"
-            else streaming_gen_pure
-        )
+        streaming_gen = streaming_gen_prefill_decode if self.mode == "prefill_decode" else streaming_gen_pure
 
         request_id = f"aero-rt-vllm-{uuid.uuid4()}"
         collected: list[int] = []
@@ -766,9 +739,7 @@ class AeroRealtimeVLLM(lmms):
                     chats_and_gens.append((chat, dict(gen_kwargs or {})))
 
                 t0 = time.time()
-                batch_results = await asyncio.gather(
-                    *[self._generate_one(c, g) for c, g in chats_and_gens]
-                )
+                batch_results = await asyncio.gather(*[self._generate_one(c, g) for c, g in chats_and_gens])
                 totals["elapsed"] += time.time() - t0
 
                 for i, (text, ntok) in enumerate(batch_results):

--- a/lmms_eval/tasks/microvqa/microvqa.yaml
+++ b/lmms_eval/tasks/microvqa/microvqa.yaml
@@ -1,0 +1,22 @@
+dataset_path: jmhb/microvqa
+task: microvqa
+test_split: test
+output_type: generate_until
+doc_to_visual: !function utils.doc_to_visual
+doc_to_text: !function utils.doc_to_text
+doc_to_messages: !function utils.doc_to_messages
+doc_to_target: !function utils.doc_to_target
+generation_kwargs:
+  max_new_tokens: 2048
+  temperature: 1.0
+  top_p: 1.0
+  do_sample: true
+  seed: 0
+process_results: !function utils.process_results
+metric_list:
+  - metric: accuracy
+    aggregation: mean
+    higher_is_better: true
+metadata:
+  version: 1.0
+  owner_commit: 3b52dc7131c3a285c33654856b349d9073e3604b

--- a/lmms_eval/tasks/microvqa/utils.py
+++ b/lmms_eval/tasks/microvqa/utils.py
@@ -1,0 +1,48 @@
+"""MicroVQA evaluation protocol.
+
+Source: jmhb0/microvqa@3b52dc7131c3a285c33654856b349d9073e3604b.
+"""
+
+import re
+
+PROMPT_TEMPLATE = """\
+The following is a multiple choice question (with answers).
+Think step by step and then output the answer in the format of \"The answer is (X)\" at the end.
+
+{{QUESTION}}
+
+Options:
+{{CHOICES}}
+"""
+
+ANSWER_PATTERN = r"answer is \*?\*?\(?([0-9])\)?\*?\*?"
+
+
+def doc_to_text(doc, lmms_eval_specific_kwargs=None):
+    prompt = PROMPT_TEMPLATE.replace("{{QUESTION}}", doc["question"])
+    choices = "".join(f"  ({index + 1}): {choice}\n" for index, choice in enumerate(doc["choices"]))
+    return prompt.replace("{{CHOICES}}", choices)
+
+
+def doc_to_visual(doc):
+    images = doc["images_list"]
+    assert images, "MicroVQA owner protocol requires at least one image"
+    assert all(image is not None for image in images), "MicroVQA sample contains a null image"
+    return [image.convert("RGB") for image in images]
+
+
+def doc_to_messages(doc, lmms_eval_specific_kwargs=None):
+    content = [{"type": "text", "text": doc_to_text(doc)}]
+    content.extend({"type": "image", "url": image} for image in doc_to_visual(doc))
+    return [{"role": "user", "content": content}]
+
+
+def doc_to_target(doc):
+    return doc["correct_index"]
+
+
+def process_results(doc, results):
+    assert len(results) == 1, f"Expected one response, got {len(results)}"
+    match = re.search(ANSWER_PATTERN, results[0])
+    prediction = int(match.group(1)) - 1 if match is not None else -1
+    return {"accuracy": float(prediction == doc["correct_index"])}

--- a/test/eval/test_microvqa.py
+++ b/test/eval/test_microvqa.py
@@ -1,0 +1,118 @@
+"""Contract tests for the owner-aligned MicroVQA task."""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+import yaml
+from PIL import Image
+
+TASK_DIR = Path(__file__).resolve().parents[2] / "lmms_eval" / "tasks" / "microvqa"
+
+
+class _YamlLoader(yaml.SafeLoader):
+    pass
+
+
+_YamlLoader.add_multi_constructor(
+    "!",
+    lambda loader, tag_suffix, node: loader.construct_scalar(node),
+)
+
+
+def _load_utils():
+    utils_path = TASK_DIR / "utils.py"
+    spec = importlib.util.spec_from_file_location("microvqa_utils", utils_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _doc(correct_index=1):
+    return {
+        "question": "Which structure is visible?",
+        "choices": ["Alpha", "Beta", "Gamma"],
+        "correct_index": correct_index,
+    }
+
+
+def test_microvqa_uses_owner_numeric_answer_contract():
+    utils = _load_utils()
+
+    assert utils.doc_to_text(_doc()) == (
+        "The following is a multiple choice question (with answers).\n"
+        'Think step by step and then output the answer in the format of "The '
+        'answer is (X)" at the end.\n\n'
+        "Which structure is visible?\n\n"
+        "Options:\n"
+        "  (1): Alpha\n"
+        "  (2): Beta\n"
+        "  (3): Gamma\n\n"
+    )
+    assert utils.process_results(_doc(), ["Reasoning. The answer is **(2)**"]) == {"accuracy": 1.0}
+    assert utils.process_results(_doc(), ["Reasoning. The answer is (B)"]) == {"accuracy": 0.0}
+
+
+def test_microvqa_places_text_before_all_images():
+    utils = _load_utils()
+    first = Image.new("RGB", (2, 3), color="red")
+    second = Image.new("RGB", (4, 5), color="blue")
+    doc = {**_doc(), "images_list": [first, second]}
+
+    messages = utils.doc_to_messages(doc)
+
+    assert len(messages) == 1
+    assert messages[0]["role"] == "user"
+    content = messages[0]["content"]
+    assert [item["type"] for item in content] == ["text", "image", "image"]
+    assert content[0]["text"] == utils.doc_to_text(doc)
+    assert [item["url"].size for item in content[1:]] == [(2, 3), (4, 5)]
+
+
+@pytest.mark.parametrize("images", [[], [None]])
+def test_microvqa_rejects_missing_images(images):
+    utils = _load_utils()
+    doc = {**_doc(), "images_list": images}
+
+    with pytest.raises(AssertionError, match="image"):
+        utils.doc_to_messages(doc)
+
+
+def test_microvqa_task_config_matches_owner_protocol():
+    config = yaml.load(
+        (TASK_DIR / "microvqa.yaml").read_text(),
+        Loader=_YamlLoader,
+    )
+
+    assert config["dataset_path"] == "jmhb/microvqa"
+    assert config["task"] == "microvqa"
+    assert config["test_split"] == "test"
+    assert config["output_type"] == "generate_until"
+    assert config["doc_to_messages"] == "utils.doc_to_messages"
+    assert config["generation_kwargs"] == {
+        "max_new_tokens": 2048,
+        "temperature": 1.0,
+        "top_p": 1.0,
+        "do_sample": True,
+        "seed": 0,
+    }
+    assert config["metric_list"] == [
+        {
+            "metric": "accuracy",
+            "aggregation": "mean",
+            "higher_is_better": True,
+        }
+    ]
+    assert config["metadata"] == {
+        "version": 1.0,
+        "owner_commit": "3b52dc7131c3a285c33654856b349d9073e3604b",
+    }
+
+
+@pytest.mark.parametrize("results", [[], ["first", "second"]])
+def test_microvqa_requires_exactly_one_response(results):
+    utils = _load_utils()
+
+    with pytest.raises(AssertionError, match="one response"):
+        utils.process_results(_doc(), results)


### PR DESCRIPTION
## Summary
- add MicroVQA as a discoverable lmms-eval task on the public jmhb/microvqa test split
- reproduce the benchmark owner numeric-choice prompt and strict numeric answer parser
- preserve the owner text-first, multi-image message order
- use mean accuracy and the owner generation settings that are portable across lmms-eval backends
- fail closed on missing images and non-single response inputs

## Protocol provenance
This integration follows jmhb0/microvqa@3b52dc7131c3a285c33654856b349d9073e3604b:
- owner evaluation code: https://github.com/jmhb0/microvqa/blob/3b52dc7131c3a285c33654856b349d9073e3604b/eval/eval.py
- owner API defaults: https://github.com/jmhb0/microvqa/blob/3b52dc7131c3a285c33654856b349d9073e3604b/eval/openai_api.py
- public dataset: https://huggingface.co/datasets/jmhb/microvqa

The provider-specific zero-valued penalties and n=1 defaults are not added to the task YAML; seed=0 is retained because seed is already part of existing lmms-eval task configuration vocabulary.

## Validation
- pytest -q test/eval/test_microvqa.py — 7 passed
- TaskManager discovery smoke — microvqa discovered
- pre-commit run --all-files — Black and isort passed
- python -m compileall -q lmms_eval/tasks/microvqa test/eval/test_microvqa.py
- git diff --check

## Scope
This PR does not include our WebUI, DLC worker, Qwen3.5 scheduling, or single-client deployment logic.

## Formatting note
The first commit contains the same mechanical Black-only fix for lmms_eval/models/chat/aero_realtime_vllm.py that is already present in #1426. The base main currently fails repository-wide lint on that file. Keeping it as a separate commit makes the overlap explicit; once the base contains the formatting fix, the overlapping file diff disappears. The MicroVQA implementation is isolated in the second commit.

Related: #1426 makes the chat OpenAI backend honor task-level seed and other sampling parameters.