### PR TITLE
fix(vllm): preserve per-request sampling parameters

### DIFF
--- a/lmms_eval/models/chat/aero_realtime_vllm.py
+++ b/lmms_eval/models/chat/aero_realtime_vllm.py
@@ -88,8 +88,8 @@ SAMPLE_RATE = 16000
 
 @dataclass
 class RealtimeSample:
-    audio: np.ndarray            # mono float32 @ 16 kHz
-    video: np.ndarray            # (T, H, W, 3) uint8
+    audio: np.ndarray  # mono float32 @ 16 kHz
+    video: np.ndarray  # (T, H, W, 3) uint8
     video_metadata: object
     sample_fps: float
 
@@ -339,10 +339,7 @@ class AeroRealtimeVLLM(lmms):
         # vs. ``aero_realtime_chat`` which is strict, to match how other vLLM
         # wrappers behave.
         if AsyncOmni is None or AeroRealtimeForConditionalGeneration is None:
-            raise ImportError(
-                "vllm-omni is required for aero_realtime_vllm_chat. "
-                "Install vllm-omni and ensure it is importable."
-            )
+            raise ImportError("vllm-omni is required for aero_realtime_vllm_chat. " "Install vllm-omni and ensure it is importable.")
         if fetch_video is None:
             raise ImportError("qwen_vl_utils is required (`pip install qwen-vl-utils`)")
         if librosa is None:
@@ -370,9 +367,7 @@ class AeroRealtimeVLLM(lmms):
             omni_kwargs["stage_init_timeout"] = int(stage_init_timeout)
         if tensor_parallel_size is not None:
             omni_kwargs["tensor_parallel_size"] = tensor_parallel_size
-            omni_kwargs["stage_0_devices"] = stage_0_devices or ",".join(
-                str(i) for i in range(tensor_parallel_size)
-            )
+            omni_kwargs["stage_0_devices"] = stage_0_devices or ",".join(str(i) for i in range(tensor_parallel_size))
         elif stage_0_devices is not None:
             omni_kwargs["stage_0_devices"] = stage_0_devices
         if limit_mm_per_prompt:
@@ -386,6 +381,7 @@ class AeroRealtimeVLLM(lmms):
                     mm_limits[k.strip()] = int(v)
             else:
                 import json as _json
+
                 mm_limits = {k: int(v) for k, v in _json.loads(limit_mm_per_prompt).items()}
             omni_kwargs["limit_mm_per_prompt"] = mm_limits
 
@@ -394,6 +390,7 @@ class AeroRealtimeVLLM(lmms):
         overrides: dict[str, dict] = {}
         if stage_overrides:
             import json as _json
+
             overrides = _json.loads(stage_overrides)
         if enforce_eager is not None:
             overrides.setdefault("0", {})["enforce_eager"] = bool(enforce_eager)
@@ -466,9 +463,7 @@ class AeroRealtimeVLLM(lmms):
 
     # --------------------------- request -> sample ------------------------------
 
-    def _extract_video_and_text(
-        self, chat: ChatMessages
-    ) -> Tuple[str, str, Optional[float], Optional[float]]:
+    def _extract_video_and_text(self, chat: ChatMessages) -> Tuple[str, str, Optional[float], Optional[float]]:
         """Pull (first_video_path, concatenated_user_text, start_time, end_time) out of ChatMessages."""
         video_path: Optional[str] = None
         start_time: Optional[float] = None
@@ -505,9 +500,7 @@ class AeroRealtimeVLLM(lmms):
         live in the fused prefill, matching training); tail is only the
         decode-phase silence chunks."""
         all_chunks = list(chunks)
-        text_idx = next(
-            (i for i, c in enumerate(all_chunks) if c.get("text")), len(all_chunks)
-        )
+        text_idx = next((i for i, c in enumerate(all_chunks) if c.get("text")), len(all_chunks))
         return all_chunks[: text_idx + 1], all_chunks[text_idx + 1 :]
 
     def _fuse_prompts(self, prompts):
@@ -544,11 +537,7 @@ class AeroRealtimeVLLM(lmms):
         def flush_audio_buffer():
             if not pending_audio:
                 return
-            merged = (
-                pending_audio[0]
-                if len(pending_audio) == 1
-                else np.concatenate(pending_audio).astype(np.float32, copy=False)
-            )
+            merged = pending_audio[0] if len(pending_audio) == 1 else np.concatenate(pending_audio).astype(np.float32, copy=False)
             audios.append(merged)
             pids.append(audio_pad_id)
             ts_ids.extend(pending_ts_ids)
@@ -569,11 +558,7 @@ class AeroRealtimeVLLM(lmms):
             # A "pure audio" chunk: only audio_pad token(s) in the delta,
             # no video item, no extra prompt scaffolding.
             non_audio_pad_ids = [tid for tid in prompt_ids if tid != audio_pad_id]
-            is_pure_audio = (
-                audio_item is not None
-                and video_item is None
-                and not non_audio_pad_ids
-            )
+            is_pure_audio = audio_item is not None and video_item is None and not non_audio_pad_ids
 
             if is_pure_audio:
                 pending_audio.append(np.asarray(audio_item))
@@ -663,15 +648,11 @@ class AeroRealtimeVLLM(lmms):
                 for c in _iter_realtime_chunks(sample, **chunk_kwargs):
                     yield c
 
-            async for p in AeroRealtimeForConditionalGeneration.buffer_realtime_omni(
-                chunk_iter(), input_stream, self.model_config
-            ):
+            async for p in AeroRealtimeForConditionalGeneration.buffer_realtime_omni(chunk_iter(), input_stream, self.model_config):
                 yield await self._render_streaming_input(p)
 
         async def streaming_gen_prefill_decode():
-            prefill_chunks, tail_chunks = self._split_chunks(
-                _iter_realtime_chunks(sample, **chunk_kwargs)
-            )
+            prefill_chunks, tail_chunks = self._split_chunks(_iter_realtime_chunks(sample, **chunk_kwargs))
             shared_state = AeroRealtimeStreamState()
 
             # Phase 1 — fuse pre-question chunks into one prefill (every
@@ -682,9 +663,7 @@ class AeroRealtimeVLLM(lmms):
 
             prefill_q: asyncio.Queue[list[int]] = asyncio.Queue()
             prefill_prompts = []
-            async for p in AeroRealtimeForConditionalGeneration.buffer_realtime_omni(
-                pre_iter(), prefill_q, self.model_config, state=shared_state
-            ):
+            async for p in AeroRealtimeForConditionalGeneration.buffer_realtime_omni(pre_iter(), prefill_q, self.model_config, state=shared_state):
                 prefill_q.put_nowait([])
                 prefill_prompts.append(p)
             fused = self._fuse_prompts(prefill_prompts)
@@ -696,16 +675,10 @@ class AeroRealtimeVLLM(lmms):
                 for c in tail_chunks:
                     yield c
 
-            async for p in AeroRealtimeForConditionalGeneration.buffer_realtime_omni(
-                tail_iter(), input_stream, self.model_config, state=shared_state
-            ):
+            async for p in AeroRealtimeForConditionalGeneration.buffer_realtime_omni(tail_iter(), input_stream, self.model_config, state=shared_state):
                 yield await self._render_streaming_input(p)
 
-        streaming_gen = (
-            streaming_gen_prefill_decode
-            if self.mode == "prefill_decode"
-            else streaming_gen_pure
-        )
+        streaming_gen = streaming_gen_prefill_decode if self.mode == "prefill_decode" else streaming_gen_pure
 
         request_id = f"aero-rt-vllm-{uuid.uuid4()}"
         collected: list[int] = []
@@ -766,9 +739,7 @@ class AeroRealtimeVLLM(lmms):
                     chats_and_gens.append((chat, dict(gen_kwargs or {})))
 
                 t0 = time.time()
-                batch_results = await asyncio.gather(
-                    *[self._generate_one(c, g) for c, g in chats_and_gens]
-                )
+                batch_results = await asyncio.gather(*[self._generate_one(c, g) for c, g in chats_and_gens])
                 totals["elapsed"] += time.time() - t0
 
                 for i, (text, ntok) in enumerate(batch_results):

--- a/lmms_eval/models/simple/vllm.py
+++ b/lmms_eval/models/simple/vllm.py
@@ -350,11 +350,28 @@ class VLLM(lmms):
         return top_p
 
     def _build_sampling_params_dict(self, gen_kwargs: dict[str, Any]) -> dict[str, Any]:
-        return {
+        n = gen_kwargs.get("n")
+        if n is not None and (isinstance(n, bool) or not isinstance(n, int) or n != 1):
+            raise ValueError("generation parameter n must be the integer 1 because the vLLM backends consume exactly one output")
+
+        params = {
             "max_tokens": gen_kwargs["max_new_tokens"],
             "temperature": gen_kwargs["temperature"],
             "top_p": self._normalize_top_p_for_vllm(gen_kwargs["top_p"]),
         }
+        optional_params = (
+            "n",
+            "seed",
+            "top_k",
+            "min_p",
+            "repetition_penalty",
+            "presence_penalty",
+            "frequency_penalty",
+        )
+        for key in optional_params:
+            if gen_kwargs.get(key) is not None:
+                params[key] = gen_kwargs[key]
+        return params
 
     def _run_tp_synced(
         self,

--- a/test/models/test_vllm_sampling_contract.py
+++ b/test/models/test_vllm_sampling_contract.py
@@ -1,0 +1,100 @@
+"""Behavioral contract for task-level vLLM sampling parameters."""
+
+from copy import deepcopy
+from types import SimpleNamespace
+
+import pytest
+
+from lmms_eval.models.chat.vllm import VLLM
+
+
+def _model():
+    model = VLLM.__new__(VLLM)
+    model.task_dict = {"task": {"test": [{"question": "What is shown?"}]}}
+    model.max_new_tokens = 16
+    model.max_pixels = 1605632
+    model.min_image_pixels = 28
+    model.max_frame_num = 32
+    model.fps = None
+    model.nframes = 32
+    return model
+
+
+def _request(generation_kwargs):
+    def doc_to_messages(doc):
+        return [
+            {
+                "role": "user",
+                "content": [{"type": "text", "text": doc["question"]}],
+            }
+        ]
+
+    return SimpleNamespace(
+        arguments=(
+            "context",
+            doc_to_messages,
+            generation_kwargs,
+            0,
+            "task",
+            "test",
+        )
+    )
+
+
+def test_vllm_forwards_task_sampling_parameters_without_mutating_input():
+    model = _model()
+    generation_kwargs = {
+        "max_new_tokens": 64,
+        "temperature": 0.7,
+        "top_p": 0.8,
+        "seed": 0,
+        "top_k": 20,
+        "min_p": 0.1,
+        "repetition_penalty": 1.1,
+        "presence_penalty": 0.0,
+        "frequency_penalty": 0.0,
+    }
+    original_generation_kwargs = deepcopy(generation_kwargs)
+
+    _, sampling_params = model.make_one_request(_request(generation_kwargs))
+
+    assert sampling_params == {
+        "max_tokens": 64,
+        "temperature": 0.7,
+        "top_p": 0.8,
+        "seed": 0,
+        "top_k": 20,
+        "min_p": 0.1,
+        "repetition_penalty": 1.1,
+        "presence_penalty": 0.0,
+        "frequency_penalty": 0.0,
+    }
+    assert generation_kwargs == original_generation_kwargs
+
+
+def test_vllm_preserves_explicit_single_choice():
+    model = _model()
+    generation_kwargs = {
+        "max_new_tokens": 64,
+        "temperature": 0.0,
+        "top_p": 1.0,
+        "n": 1,
+    }
+
+    _, sampling_params = model.make_one_request(_request(generation_kwargs))
+
+    assert sampling_params["n"] == 1
+
+
+@pytest.mark.parametrize("n", [0, 2, -1, 1.0, True, "1"])
+def test_vllm_rejects_unsupported_choice_counts(n):
+    model = _model()
+    generation_kwargs = {
+        "max_new_tokens": 64,
+        "temperature": 0.0,
+        "top_p": 1.0,
+        "n": n,
+    }
+
+    with pytest.raises(ValueError, match="n.*integer 1"):
+        model.make_one_request(_request(generation_kwargs))


### PR DESCRIPTION
## Summary
- preserve task-level seed, top_k, min_p, repetition_penalty, presence_penalty, and frequency_penalty when building vLLM SamplingParams
- preserve an explicit n=1
- reject unsupported choice counts because all affected vLLM backends consume outputs[0]
- keep caller-owned generation kwargs unchanged

## Why
The shared vLLM builder currently reconstructs SamplingParams with only max_tokens, temperature, and top_p. Existing lmms-eval task configs already use seed, repetition_penalty, and top_k, so those task-level settings are silently ignored on the vLLM, vLLM chat, and vLLM generate paths.

The forwarded fields are longstanding vLLM SamplingParams fields: https://github.com/vllm-project/vllm/blob/main/vllm/sampling_params.py

The backends currently return only the first output sequence. Accepting n greater than 1 would generate extra sequences and silently discard them, so this PR fails closed instead.

## Validation
- pytest -q test/models/test_vllm_sampling_contract.py test/models/test_vllm_sampling_params.py — 10 passed
- pre-commit run --all-files — Black and isort passed
- python -m compileall -q lmms_eval/models/simple/vllm.py test/models/test_vllm_sampling_contract.py
- git diff --check

The regression test exercises the real VLLM.make_one_request boundary without initializing a model or GPU and verifies that the input dictionary is unchanged.

## Scope
This PR does not change task stop/until handling, max-token selection, top-p normalization, OpenAI, SGLang, WebUI, or DLC behavior.

## Formatting note
The first commit contains the same mechanical Black-only fix for lmms_eval/models/chat/aero_realtime_vllm.py that is already present in #1426. The base main currently fails repository-wide lint on that file. The functional vLLM change remains isolated in the second commit, and the overlapping file diff disappears once the base contains the formatting fix.

Related: #1426 fixes the analogous sampling-loss bug in the chat OpenAI backend.