### PR TITLE
[Model] Add VQToken integration for LLaVA-OneVision

### DIFF
--- a/docs/advanced/current_tasks.md
+++ b/docs/advanced/current_tasks.md
@@ -659,6 +659,7 @@ python -m lmms_eval --tasks list_with_num
 | `vila` | VILA | Image, Video |
 | `vita` | VITA | Multimodal |
 | `vora` | VoRA | Multimodal |
+| `vqtoken` | VQToken | Centroid VQToken on LLaVA-OneVision (Image, Video) |
 | `whisper` | Whisper | Audio |
 | `whisper_vllm` | WhisperVllm | Audio |
 | `xcomposer2_4KHD` | XComposer2_4KHD | High-resolution Image |

--- a/docs/advanced/current_tasks.md
+++ b/docs/advanced/current_tasks.md
@@ -659,7 +659,7 @@ python -m lmms_eval --tasks list_with_num
 | `vila` | VILA | Image, Video |
 | `vita` | VITA | Multimodal |
 | `vora` | VoRA | Multimodal |
-| `vqtoken` | VQToken | Centroid VQToken on LLaVA-OneVision (Image, Video) |
+| `vqtoken` | VQToken | Learned VQ-Attention on LLaVA-OneVision (Image, Video) |
 | `whisper` | Whisper | Audio |
 | `whisper_vllm` | WhisperVllm | Audio |
 | `xcomposer2_4KHD` | XComposer2_4KHD | High-resolution Image |

--- a/examples/models/vqtoken.sh
+++ b/examples/models/vqtoken.sh
@@ -3,10 +3,11 @@
 # From an lmms-eval checkout, install the legacy video decoder and the public
 # VQToken runtime first (the runtime supports Python 3.10 and 3.11):
 # uv pip install -e ".[video-legacy]"
-# uv pip install "llava[runtime] @ git+https://github.com/Hai-chao-Zhang/VQToken.git@fe6c28fa5907ec97b4ac3f6fe0aaef80affbd9fd"
+# uv pip install "llava[runtime] @ git+https://github.com/Hai-chao-Zhang/VQToken.git@0314eb9989a7ea843f31bfe0984113529e3f9140"
 #
 # The paper checkpoint uses Hugging Face's access-request flow. Accept its
-# terms and run `hf auth login` before evaluation.
+# terms and run `hf auth login` before evaluation. This adapter selects the
+# checkpoint's released learned VQ-Attention path, not the centroid ablation.
 accelerate launch --num_processes=1 -m lmms_eval \
     --model vqtoken \
     --model_args pretrained=haichaozhang/VQ-Token-llava-ov-0.5b,vqtoken_selection_method=fixed,vqtoken_max_clusters=32 \
@@ -16,3 +17,5 @@ accelerate launch --num_processes=1 -m lmms_eval \
 
 # vqtoken_selection_method also accepts elbow or silhouette. Configure
 # vqtoken_min_clusters and vqtoken_max_clusters to bound adaptive selection.
+# VQ-Attention requires sampled frames <= selected K, so for adaptive methods
+# also set max_frames_num <= vqtoken_min_clusters.

--- a/examples/models/vqtoken.sh
+++ b/examples/models/vqtoken.sh
@@ -3,7 +3,7 @@
 # From an lmms-eval checkout, install the legacy video decoder and the public
 # VQToken runtime first (the runtime supports Python 3.10 and 3.11):
 # uv pip install -e ".[video-legacy]"
-# uv pip install "llava[runtime] @ git+https://github.com/Hai-chao-Zhang/VQToken.git@a8e3e13e8415b575556dd779e890b77a74ecf52a"
+# uv pip install "llava[runtime] @ git+https://github.com/Hai-chao-Zhang/VQToken.git@fe6c28fa5907ec97b4ac3f6fe0aaef80affbd9fd"
 #
 # The paper checkpoint uses Hugging Face's access-request flow. Accept its
 # terms and run `hf auth login` before evaluation.

--- a/examples/models/vqtoken.sh
+++ b/examples/models/vqtoken.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# From an lmms-eval checkout, install the legacy video decoder and the public
+# VQToken runtime first (the runtime supports Python 3.10 and 3.11):
+# uv pip install -e ".[video-legacy]"
+# uv pip install "llava[runtime] @ git+https://github.com/Hai-chao-Zhang/VQToken.git@a8e3e13e8415b575556dd779e890b77a74ecf52a"
+#
+# The paper checkpoint uses Hugging Face's access-request flow. Accept its
+# terms and run `hf auth login` before evaluation.
+accelerate launch --num_processes=1 -m lmms_eval \
+    --model vqtoken \
+    --model_args pretrained=haichaozhang/VQ-Token-llava-ov-0.5b,vqtoken_selection_method=fixed,vqtoken_max_clusters=32 \
+    --tasks videomme \
+    --batch_size 1 \
+    --limit 1
+
+# vqtoken_selection_method also accepts elbow or silhouette. Configure
+# vqtoken_min_clusters and vqtoken_max_clusters to bound adaptive selection.

--- a/lmms_eval/models/__init__.py
+++ b/lmms_eval/models/__init__.py
@@ -113,6 +113,7 @@ AVAILABLE_SIMPLE_MODELS = {
     "vita": "VITA",
     "vllm": "VLLM",
     "vora": "VoRA",
+    "vqtoken": "VQToken",
     "whisper_vllm": "WhisperVllm",
     "whisper": "Whisper",
     "whisper_tt": "WhisperTT",

--- a/lmms_eval/models/simple/llava_onevision.py
+++ b/lmms_eval/models/simple/llava_onevision.py
@@ -3,7 +3,7 @@ import json
 import logging
 import warnings
 from datetime import timedelta
-from typing import List, Optional, Tuple, Union
+from typing import Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import PIL
@@ -121,6 +121,7 @@ class Llava_OneVision(lmms):
         overwrite_config = {}
         overwrite_config["mm_spatial_pool_stride"] = self.mm_spatial_pool_stride
         overwrite_config["mm_spatial_pool_mode"] = self.mm_spatial_pool_mode
+        overwrite_config.update(self._get_model_overwrite_config())
         cfg_pretrained = AutoConfig.from_pretrained(self.pretrained)
 
         llava_model_args["overwrite_config"] = overwrite_config
@@ -190,6 +191,10 @@ class Llava_OneVision(lmms):
             self.model.to(self._device)
             self._rank = 0
             self._world_size = 1
+
+    def _get_model_overwrite_config(self) -> Dict[str, object]:
+        """Return model-specific config overrides for subclasses."""
+        return {}
 
     @property
     def config(self):

--- a/lmms_eval/models/simple/vqtoken.py
+++ b/lmms_eval/models/simple/vqtoken.py
@@ -1,0 +1,114 @@
+"""VQToken on LLaVA-OneVision."""
+
+from __future__ import annotations
+
+from typing import Optional, Union
+
+from lmms_eval.api.registry import register_model
+from lmms_eval.imports import optional_import
+from lmms_eval.models.simple.llava_onevision import (
+    Llava_OneVision,
+    best_fit_attn_implementation,
+)
+
+_SUPPORTED_SELECTION_METHODS = frozenset({"fixed", "elbow", "silhouette"})
+_RUNTIME_INSTALL = "llava[runtime] @ git+https://github.com/Hai-chao-Zhang/VQToken.git@a8e3e13e8415b575556dd779e890b77a74ecf52a"
+
+
+def _validate_cluster_config(selection_method: str, min_clusters: int, max_clusters: int) -> None:
+    if selection_method not in _SUPPORTED_SELECTION_METHODS:
+        raise ValueError("vqtoken_selection_method must be one of " f"{sorted(_SUPPORTED_SELECTION_METHODS)}, got {selection_method!r}")
+    if isinstance(min_clusters, bool) or not isinstance(min_clusters, int) or min_clusters < 1:
+        raise ValueError("vqtoken_min_clusters must be a positive integer")
+    if isinstance(max_clusters, bool) or not isinstance(max_clusters, int) or max_clusters < 1:
+        raise ValueError("vqtoken_max_clusters must be a positive integer")
+    if selection_method != "fixed" and max_clusters < min_clusters:
+        raise ValueError("adaptive VQToken requires max_clusters to be greater than or equal to min_clusters")
+
+
+def _require_vqtoken_runtime() -> object:
+    runtime, has_runtime = optional_import("VQToken")
+    if not has_runtime:
+        raise ImportError(f"VQToken requires its public LLaVA runtime. Install with: uv pip install '{_RUNTIME_INSTALL}'")
+
+    capabilities = getattr(runtime, "VQTOKEN_CAPABILITIES", {})
+    modes = set(capabilities.get("modes", ()))
+    methods = set(capabilities.get("selection_methods", ()))
+    if "centroids" not in modes or not _SUPPORTED_SELECTION_METHODS.issubset(methods):
+        raise ImportError("The installed VQToken runtime is too old for lmms-eval. " f"Upgrade with: uv pip install --upgrade '{_RUNTIME_INSTALL}'")
+    return runtime
+
+
+@register_model("vqtoken")
+class VQToken(Llava_OneVision):
+    """Evaluate the public centroid VQToken checkpoint with LLaVA-OneVision."""
+
+    def __init__(
+        self,
+        pretrained: str = "haichaozhang/VQ-Token-llava-ov-0.5b",
+        truncation: Optional[bool] = True,
+        device: Optional[str] = "cuda:0",
+        batch_size: Optional[Union[int, str]] = 1,
+        model_name: Optional[str] = "llava_qwen",
+        attn_implementation: Optional[str] = best_fit_attn_implementation,
+        device_map: Optional[str] = "cuda:0",
+        conv_template: Optional[str] = "qwen_1_5",
+        use_cache: Optional[bool] = True,
+        truncate_context: Optional[bool] = False,
+        customized_config: Optional[str] = None,
+        max_frames_num: Optional[int] = 32,
+        mm_spatial_pool_stride: Optional[int] = 2,
+        mm_spatial_pool_mode: Optional[str] = "bilinear",
+        token_strategy: Optional[str] = "single",
+        video_decode_backend: str = "decord",
+        vqtoken_selection_method: str = "fixed",
+        vqtoken_min_clusters: int = 12,
+        vqtoken_max_clusters: int = 32,
+        use_embedded_vision: Optional[bool] = None,
+        **kwargs,
+    ) -> None:
+        _validate_cluster_config(vqtoken_selection_method, vqtoken_min_clusters, vqtoken_max_clusters)
+        if token_strategy != "single":
+            raise ValueError("VQToken supports token_strategy=single for video inputs")
+        runtime = _require_vqtoken_runtime()
+
+        if use_embedded_vision is None:
+            use_embedded_vision = pretrained.rstrip("/") in {
+                "haichaozhang/VQ-Token-llava-ov-0.5b",
+                "lmms-lab/llava-onevision-qwen2-0.5b-ov",
+            }
+            detector = getattr(runtime, "has_embedded_vision_weights", None)
+            if not use_embedded_vision and callable(detector):
+                use_embedded_vision = detector(pretrained)
+
+        self._vqtoken_overwrite_config = {
+            "use_vqtoken": True,
+            "vqtoken_mode": "centroids",
+            "vqtoken_selection_method": vqtoken_selection_method,
+            "vqtoken_min_clusters": vqtoken_min_clusters,
+            "vqtoken_max_clusters": vqtoken_max_clusters,
+            "use_embedded_vision": use_embedded_vision,
+        }
+        super().__init__(
+            pretrained=pretrained,
+            truncation=truncation,
+            device=device,
+            batch_size=batch_size,
+            model_name=model_name,
+            attn_implementation=attn_implementation,
+            device_map=device_map,
+            conv_template=conv_template,
+            use_cache=use_cache,
+            truncate_context=truncate_context,
+            customized_config=customized_config,
+            max_frames_num=max_frames_num,
+            mm_spatial_pool_stride=mm_spatial_pool_stride,
+            mm_spatial_pool_mode=mm_spatial_pool_mode,
+            token_strategy=token_strategy,
+            video_decode_backend=video_decode_backend,
+            **kwargs,
+        )
+
+    def _get_model_overwrite_config(self) -> dict[str, object]:
+        """Return a copy so the parent cannot mutate the adapter's settings."""
+        return dict(self._vqtoken_overwrite_config)

--- a/lmms_eval/models/simple/vqtoken.py
+++ b/lmms_eval/models/simple/vqtoken.py
@@ -12,7 +12,8 @@ from lmms_eval.models.simple.llava_onevision import (
 )
 
 _SUPPORTED_SELECTION_METHODS = frozenset({"fixed", "elbow", "silhouette"})
-_RUNTIME_INSTALL = "llava[runtime] @ git+https://github.com/Hai-chao-Zhang/VQToken.git@fe6c28fa5907ec97b4ac3f6fe0aaef80affbd9fd"
+_RELEASED_CHECKPOINT = "haichaozhang/VQ-Token-llava-ov-0.5b"
+_RUNTIME_INSTALL = "llava[runtime] @ git+https://github.com/Hai-chao-Zhang/VQToken.git@0314eb9989a7ea843f31bfe0984113529e3f9140"
 
 
 def _validate_cluster_config(selection_method: str, min_clusters: int, max_clusters: int) -> None:
@@ -26,6 +27,15 @@ def _validate_cluster_config(selection_method: str, min_clusters: int, max_clust
         raise ValueError("adaptive VQToken requires max_clusters to be greater than or equal to min_clusters")
 
 
+def _validate_attention_frame_budget(selection_method: str, min_clusters: int, max_clusters: int, max_frames_num: int) -> None:
+    if isinstance(max_frames_num, bool) or not isinstance(max_frames_num, int) or max_frames_num < 1:
+        raise ValueError("max_frames_num must be a positive integer")
+
+    guaranteed_clusters = max_clusters if selection_method == "fixed" else min_clusters
+    if max_frames_num > guaranteed_clusters:
+        raise ValueError("released VQ-Attention requires max_frames_num <= selected K; " f"set max_frames_num <= {guaranteed_clusters} for {selection_method!r} selection")
+
+
 def _require_vqtoken_runtime() -> object:
     runtime, has_runtime = optional_import("VQToken")
     if not has_runtime:
@@ -34,18 +44,28 @@ def _require_vqtoken_runtime() -> object:
     capabilities = getattr(runtime, "VQTOKEN_CAPABILITIES", {})
     modes = set(capabilities.get("modes", ()))
     methods = set(capabilities.get("selection_methods", ()))
-    if "centroids" not in modes or not _SUPPORTED_SELECTION_METHODS.issubset(methods):
+    if "attention" not in modes or not _SUPPORTED_SELECTION_METHODS.issubset(methods):
         raise ImportError("The installed VQToken runtime is too old for lmms-eval. " f"Upgrade with: uv pip install --upgrade '{_RUNTIME_INSTALL}'")
     return runtime
 
 
+def _require_released_attention_weights(pretrained: str, runtime: object) -> None:
+    """Fail closed instead of running a randomly initialized attention module."""
+
+    if pretrained.rstrip("/") == _RELEASED_CHECKPOINT:
+        return
+    detector = getattr(runtime, "has_released_vq_attention_weights", None)
+    if not callable(detector) or not detector(pretrained):
+        raise ValueError("VQToken attention requires the released paper checkpoint or a local " "checkpoint containing its complete learned cross_attention weights")
+
+
 @register_model("vqtoken")
 class VQToken(Llava_OneVision):
-    """Evaluate the public centroid VQToken checkpoint with LLaVA-OneVision."""
+    """Evaluate the released learned VQ-Attention checkpoint."""
 
     def __init__(
         self,
-        pretrained: str = "haichaozhang/VQ-Token-llava-ov-0.5b",
+        pretrained: str = _RELEASED_CHECKPOINT,
         truncation: Optional[bool] = True,
         device: Optional[str] = "cuda:0",
         batch_size: Optional[Union[int, str]] = 1,
@@ -68,22 +88,21 @@ class VQToken(Llava_OneVision):
         **kwargs,
     ) -> None:
         _validate_cluster_config(vqtoken_selection_method, vqtoken_min_clusters, vqtoken_max_clusters)
+        _validate_attention_frame_budget(vqtoken_selection_method, vqtoken_min_clusters, vqtoken_max_clusters, max_frames_num)
         if token_strategy != "single":
             raise ValueError("VQToken supports token_strategy=single for video inputs")
         runtime = _require_vqtoken_runtime()
+        _require_released_attention_weights(pretrained, runtime)
 
         if use_embedded_vision is None:
-            use_embedded_vision = pretrained.rstrip("/") in {
-                "haichaozhang/VQ-Token-llava-ov-0.5b",
-                "lmms-lab/llava-onevision-qwen2-0.5b-ov",
-            }
+            use_embedded_vision = pretrained.rstrip("/") == _RELEASED_CHECKPOINT
             detector = getattr(runtime, "has_embedded_vision_weights", None)
             if not use_embedded_vision and callable(detector):
                 use_embedded_vision = detector(pretrained)
 
         self._vqtoken_overwrite_config = {
             "use_vqtoken": True,
-            "vqtoken_mode": "centroids",
+            "vqtoken_mode": "attention",
             "vqtoken_selection_method": vqtoken_selection_method,
             "vqtoken_min_clusters": vqtoken_min_clusters,
             "vqtoken_max_clusters": vqtoken_max_clusters,

--- a/lmms_eval/models/simple/vqtoken.py
+++ b/lmms_eval/models/simple/vqtoken.py
@@ -12,7 +12,7 @@ from lmms_eval.models.simple.llava_onevision import (
 )
 
 _SUPPORTED_SELECTION_METHODS = frozenset({"fixed", "elbow", "silhouette"})
-_RUNTIME_INSTALL = "llava[runtime] @ git+https://github.com/Hai-chao-Zhang/VQToken.git@a8e3e13e8415b575556dd779e890b77a74ecf52a"
+_RUNTIME_INSTALL = "llava[runtime] @ git+https://github.com/Hai-chao-Zhang/VQToken.git@fe6c28fa5907ec97b4ac3f6fe0aaef80affbd9fd"
 
 
 def _validate_cluster_config(selection_method: str, min_clusters: int, max_clusters: int) -> None:

--- a/test/models/test_vqtoken.py
+++ b/test/models/test_vqtoken.py
@@ -22,16 +22,18 @@ from lmms_eval.models import get_model  # noqa: E402
 from lmms_eval.models.simple.llava_onevision import Llava_OneVision  # noqa: E402
 from lmms_eval.models.simple.vqtoken import (  # noqa: E402
     VQToken,
+    _require_released_attention_weights,
     _require_vqtoken_runtime,
+    _validate_attention_frame_budget,
     _validate_cluster_config,
 )
 
 
 @pytest.mark.parametrize("method", ["fixed", "elbow", "silhouette"])
-def test_vqtoken_passes_public_centroid_config(method: str) -> None:
+def test_vqtoken_passes_released_attention_config(method: str) -> None:
     runtime = SimpleNamespace(
         VQTOKEN_CAPABILITIES={
-            "modes": ("centroids",),
+            "modes": ("centroids", "attention"),
             "selection_methods": ("fixed", "elbow", "silhouette"),
         }
     )
@@ -39,14 +41,14 @@ def test_vqtoken_passes_public_centroid_config(method: str) -> None:
         patch("lmms_eval.models.simple.vqtoken.optional_import", return_value=(runtime, True)),
         patch.object(Llava_OneVision, "__init__", return_value=None) as parent_init,
     ):
-        model = VQToken(vqtoken_selection_method=method, vqtoken_min_clusters=12, vqtoken_max_clusters=32)
+        model = VQToken(max_frames_num=8, vqtoken_selection_method=method, vqtoken_min_clusters=12, vqtoken_max_clusters=32)
 
     kwargs = parent_init.call_args.kwargs
     assert kwargs["pretrained"] == "haichaozhang/VQ-Token-llava-ov-0.5b"
     assert kwargs["model_name"] == "llava_qwen"
     assert model._get_model_overwrite_config() == {
         "use_vqtoken": True,
-        "vqtoken_mode": "centroids",
+        "vqtoken_mode": "attention",
         "vqtoken_selection_method": method,
         "vqtoken_min_clusters": 12,
         "vqtoken_max_clusters": 32,
@@ -69,8 +71,13 @@ def test_vqtoken_runtime_is_lazy_and_actionable() -> None:
             _require_vqtoken_runtime()
 
 
-def test_vqtoken_rejects_runtime_without_centroid_capability() -> None:
-    runtime = SimpleNamespace(VQTOKEN_CAPABILITIES={"modes": (), "selection_methods": ()})
+def test_vqtoken_rejects_runtime_without_attention_capability() -> None:
+    runtime = SimpleNamespace(
+        VQTOKEN_CAPABILITIES={
+            "modes": ("centroids",),
+            "selection_methods": ("fixed", "elbow", "silhouette"),
+        }
+    )
     with patch("lmms_eval.models.simple.vqtoken.optional_import", return_value=(runtime, True)):
         with pytest.raises(ImportError, match="too old"):
             _require_vqtoken_runtime()
@@ -78,6 +85,23 @@ def test_vqtoken_rejects_runtime_without_centroid_capability() -> None:
 
 def test_fixed_selection_uses_max_clusters_as_k() -> None:
     _validate_cluster_config("fixed", 12, 8)
+
+
+@pytest.mark.parametrize(
+    ("method", "min_clusters", "max_clusters", "max_frames_num"),
+    [("fixed", 12, 32, 33), ("elbow", 12, 32, 13), ("silhouette", 12, 32, 13)],
+)
+def test_vqtoken_rejects_frame_budget_larger_than_guaranteed_k(method: str, min_clusters: int, max_clusters: int, max_frames_num: int) -> None:
+    with pytest.raises(ValueError, match="max_frames_num <= selected K"):
+        _validate_attention_frame_budget(method, min_clusters, max_clusters, max_frames_num)
+
+
+@pytest.mark.parametrize(
+    ("method", "min_clusters", "max_clusters", "max_frames_num"),
+    [("fixed", 12, 32, 32), ("elbow", 12, 32, 12), ("silhouette", 24, 32, 8)],
+)
+def test_vqtoken_accepts_frame_budget_not_larger_than_guaranteed_k(method: str, min_clusters: int, max_clusters: int, max_frames_num: int) -> None:
+    _validate_attention_frame_budget(method, min_clusters, max_clusters, max_frames_num)
 
 
 def test_vqtoken_resolves_through_v2_registry() -> None:
@@ -89,30 +113,42 @@ def test_vqtoken_rejects_multiple_video_placeholders() -> None:
         VQToken(token_strategy="multiple")
 
 
-def test_vqtoken_defaults_unknown_checkpoint_to_external_vision() -> None:
+def test_vqtoken_rejects_base_checkpoint_without_learned_attention() -> None:
+    pretrained = "lmms-lab/llava-onevision-qwen2-0.5b-ov"
+    attention_detector = MagicMock(return_value=False)
     runtime = SimpleNamespace(
         VQTOKEN_CAPABILITIES={
-            "modes": ("centroids",),
+            "modes": ("centroids", "attention"),
             "selection_methods": ("fixed", "elbow", "silhouette"),
-        }
+        },
+        has_released_vq_attention_weights=attention_detector,
     )
-    with (
-        patch("lmms_eval.models.simple.vqtoken.optional_import", return_value=(runtime, True)),
-        patch.object(Llava_OneVision, "__init__", return_value=None),
-    ):
-        model = VQToken(pretrained="local/custom-checkpoint")
+    with patch("lmms_eval.models.simple.vqtoken.optional_import", return_value=(runtime, True)):
+        with pytest.raises(ValueError, match="complete learned cross_attention weights"):
+            VQToken(pretrained=pretrained)
 
-    assert model._get_model_overwrite_config()["use_embedded_vision"] is False
+    attention_detector.assert_called_once_with(pretrained)
+
+
+def test_released_hub_checkpoint_does_not_require_local_header_inspection() -> None:
+    detector = MagicMock(return_value=False)
+    runtime = SimpleNamespace(has_released_vq_attention_weights=detector)
+
+    _require_released_attention_weights("haichaozhang/VQ-Token-llava-ov-0.5b/", runtime)
+
+    detector.assert_not_called()
 
 
 def test_vqtoken_detects_embedded_vision_in_local_checkpoint() -> None:
-    detector = MagicMock(return_value=True)
+    attention_detector = MagicMock(return_value=True)
+    vision_detector = MagicMock(return_value=True)
     runtime = SimpleNamespace(
         VQTOKEN_CAPABILITIES={
-            "modes": ("centroids",),
+            "modes": ("centroids", "attention"),
             "selection_methods": ("fixed", "elbow", "silhouette"),
         },
-        has_embedded_vision_weights=detector,
+        has_released_vq_attention_weights=attention_detector,
+        has_embedded_vision_weights=vision_detector,
     )
     with (
         patch("lmms_eval.models.simple.vqtoken.optional_import", return_value=(runtime, True)),
@@ -120,14 +156,15 @@ def test_vqtoken_detects_embedded_vision_in_local_checkpoint() -> None:
     ):
         model = VQToken(pretrained="local/checkpoint")
 
-    detector.assert_called_once_with("local/checkpoint")
+    attention_detector.assert_called_once_with("local/checkpoint")
+    vision_detector.assert_called_once_with("local/checkpoint")
     assert model._get_model_overwrite_config()["use_embedded_vision"] is True
 
 
 def test_parent_loader_merges_only_subclass_overrides() -> None:
     runtime = SimpleNamespace(
         VQTOKEN_CAPABILITIES={
-            "modes": ("centroids",),
+            "modes": ("centroids", "attention"),
             "selection_methods": ("fixed", "elbow", "silhouette"),
         }
     )
@@ -155,7 +192,7 @@ def test_parent_loader_merges_only_subclass_overrides() -> None:
         "mm_spatial_pool_stride": 2,
         "mm_spatial_pool_mode": "bilinear",
         "use_vqtoken": True,
-        "vqtoken_mode": "centroids",
+        "vqtoken_mode": "attention",
         "vqtoken_selection_method": "fixed",
         "vqtoken_min_clusters": 12,
         "vqtoken_max_clusters": 32,

--- a/test/models/test_vqtoken.py
+++ b/test/models/test_vqtoken.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import sys
+import types
+from importlib.machinery import ModuleSpec
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# decord is optional and unavailable on some lmms-eval test platforms. The
+# wrapper tests do not decode video, so provide the same minimal import stub
+# used by other model tests before importing the LLaVA-OneVision module.
+_decord_stub = types.ModuleType("decord")
+_decord_stub.__spec__ = ModuleSpec("decord", loader=None)
+_decord_stub.VideoReader = MagicMock()
+_decord_stub.cpu = MagicMock()
+sys.modules.setdefault("decord", _decord_stub)
+
+import lmms_eval.models.simple.llava_onevision as llava_onevision_module  # noqa: E402
+from lmms_eval.models import get_model  # noqa: E402
+from lmms_eval.models.simple.llava_onevision import Llava_OneVision  # noqa: E402
+from lmms_eval.models.simple.vqtoken import (  # noqa: E402
+    VQToken,
+    _require_vqtoken_runtime,
+    _validate_cluster_config,
+)
+
+
+@pytest.mark.parametrize("method", ["fixed", "elbow", "silhouette"])
+def test_vqtoken_passes_public_centroid_config(method: str) -> None:
+    runtime = SimpleNamespace(
+        VQTOKEN_CAPABILITIES={
+            "modes": ("centroids",),
+            "selection_methods": ("fixed", "elbow", "silhouette"),
+        }
+    )
+    with (
+        patch("lmms_eval.models.simple.vqtoken.optional_import", return_value=(runtime, True)),
+        patch.object(Llava_OneVision, "__init__", return_value=None) as parent_init,
+    ):
+        model = VQToken(vqtoken_selection_method=method, vqtoken_min_clusters=12, vqtoken_max_clusters=32)
+
+    kwargs = parent_init.call_args.kwargs
+    assert kwargs["pretrained"] == "haichaozhang/VQ-Token-llava-ov-0.5b"
+    assert kwargs["model_name"] == "llava_qwen"
+    assert model._get_model_overwrite_config() == {
+        "use_vqtoken": True,
+        "vqtoken_mode": "centroids",
+        "vqtoken_selection_method": method,
+        "vqtoken_min_clusters": 12,
+        "vqtoken_max_clusters": 32,
+        "use_embedded_vision": True,
+    }
+
+
+@pytest.mark.parametrize(
+    ("method", "min_clusters", "max_clusters"),
+    [("attention", 12, 32), ("fixed", 0, 32), ("elbow", 33, 32), ("fixed", True, 32)],
+)
+def test_vqtoken_rejects_non_public_or_invalid_config(method: str, min_clusters: int, max_clusters: int) -> None:
+    with pytest.raises(ValueError):
+        _validate_cluster_config(method, min_clusters, max_clusters)
+
+
+def test_vqtoken_runtime_is_lazy_and_actionable() -> None:
+    with patch("lmms_eval.models.simple.vqtoken.optional_import", return_value=(None, False)):
+        with pytest.raises(ImportError, match="Hai-chao-Zhang/VQToken"):
+            _require_vqtoken_runtime()
+
+
+def test_vqtoken_rejects_runtime_without_centroid_capability() -> None:
+    runtime = SimpleNamespace(VQTOKEN_CAPABILITIES={"modes": (), "selection_methods": ()})
+    with patch("lmms_eval.models.simple.vqtoken.optional_import", return_value=(runtime, True)):
+        with pytest.raises(ImportError, match="too old"):
+            _require_vqtoken_runtime()
+
+
+def test_fixed_selection_uses_max_clusters_as_k() -> None:
+    _validate_cluster_config("fixed", 12, 8)
+
+
+def test_vqtoken_resolves_through_v2_registry() -> None:
+    assert get_model("vqtoken", force_simple=True) is VQToken
+
+
+def test_vqtoken_rejects_multiple_video_placeholders() -> None:
+    with pytest.raises(ValueError, match="token_strategy=single"):
+        VQToken(token_strategy="multiple")
+
+
+def test_vqtoken_defaults_unknown_checkpoint_to_external_vision() -> None:
+    runtime = SimpleNamespace(
+        VQTOKEN_CAPABILITIES={
+            "modes": ("centroids",),
+            "selection_methods": ("fixed", "elbow", "silhouette"),
+        }
+    )
+    with (
+        patch("lmms_eval.models.simple.vqtoken.optional_import", return_value=(runtime, True)),
+        patch.object(Llava_OneVision, "__init__", return_value=None),
+    ):
+        model = VQToken(pretrained="local/custom-checkpoint")
+
+    assert model._get_model_overwrite_config()["use_embedded_vision"] is False
+
+
+def test_vqtoken_detects_embedded_vision_in_local_checkpoint() -> None:
+    detector = MagicMock(return_value=True)
+    runtime = SimpleNamespace(
+        VQTOKEN_CAPABILITIES={
+            "modes": ("centroids",),
+            "selection_methods": ("fixed", "elbow", "silhouette"),
+        },
+        has_embedded_vision_weights=detector,
+    )
+    with (
+        patch("lmms_eval.models.simple.vqtoken.optional_import", return_value=(runtime, True)),
+        patch.object(Llava_OneVision, "__init__", return_value=None),
+    ):
+        model = VQToken(pretrained="local/checkpoint")
+
+    detector.assert_called_once_with("local/checkpoint")
+    assert model._get_model_overwrite_config()["use_embedded_vision"] is True
+
+
+def test_parent_loader_merges_only_subclass_overrides() -> None:
+    runtime = SimpleNamespace(
+        VQTOKEN_CAPABILITIES={
+            "modes": ("centroids",),
+            "selection_methods": ("fixed", "elbow", "silhouette"),
+        }
+    )
+    accelerator = SimpleNamespace(num_processes=1, local_process_index=0)
+    fake_model = MagicMock()
+    fake_model.config = SimpleNamespace()
+    loader_result = (MagicMock(), fake_model, MagicMock(), 4096)
+
+    with (
+        patch("lmms_eval.models.simple.vqtoken.optional_import", return_value=(runtime, True)),
+        patch.object(llava_onevision_module, "Accelerator", return_value=accelerator),
+        patch.object(llava_onevision_module.AutoConfig, "from_pretrained", return_value=SimpleNamespace()),
+        patch.object(llava_onevision_module, "load_pretrained_model", create=True, return_value=loader_result) as loader,
+    ):
+        Llava_OneVision(pretrained="local/base", model_name="llava_qwen")
+        base_overrides = loader.call_args.kwargs["overwrite_config"]
+        model = VQToken()
+        vqtoken_overrides = loader.call_args.kwargs["overwrite_config"]
+
+    assert base_overrides == {
+        "mm_spatial_pool_stride": 2,
+        "mm_spatial_pool_mode": "bilinear",
+    }
+    assert vqtoken_overrides == {
+        "mm_spatial_pool_stride": 2,
+        "mm_spatial_pool_mode": "bilinear",
+        "use_vqtoken": True,
+        "vqtoken_mode": "centroids",
+        "vqtoken_selection_method": "fixed",
+        "vqtoken_min_clusters": 12,
+        "vqtoken_max_clusters": 32,
+        "use_embedded_vision": True,
+    }
+    vqtoken_overrides["use_vqtoken"] = False
+    assert model._get_model_overwrite_config()["use_vqtoken"] is True


### PR DESCRIPTION
## Summary

- add a lazily registered `vqtoken` model adapter on LLaVA-OneVision
- evaluate the released learned VQ-Attention path of `haichaozhang/VQ-Token-llava-ov-0.5b`
- expose fixed, elbow, and silhouette cluster selection with explicit token-budget validation
- pass model overrides through a protected OneVision hook without changing the default adapter

## In scope

- the released paper checkpoint and public VQToken runtime pinned exactly at `0314eb9989a7ea843f31bfe0984113529e3f9140`
- learned `vqtoken_mode=attention`; the adapter requires the runtime's attention capability
- fail-closed checkpoint handling: the named paper checkpoint is accepted, while other checkpoints must be local and contain the complete released `cross_attention` weights
- fail-fast VQ-Attention shape contract: sampled frames must not exceed selected K (`max_frames_num <= vqtoken_max_clusters` for fixed selection and `max_frames_num <= vqtoken_min_clusters` for adaptive selection)
- image/video-compatible registration, validation, example command, and regression tests

## Out of scope

- progressive long-video experiments, slice policies, learned budget controllers, MLP policies, training code, and benchmark-result claims
- centroid-only ablation as the default paper method

## Validation

- `python -m pytest -q test/models/test_vqtoken.py test/models/test_model_registry_v2.py` | sample size: `N=34 tests` | key checks: registry, loader override, learned-attention capability gate, complete-weight fail-closed behavior, fixed/adaptive F<=K validation, and config validation | result: `pass`
- `black --check lmms_eval/models/simple/vqtoken.py test/models/test_vqtoken.py` | result: `pass`
- `python -m compileall -q lmms_eval/models/simple/vqtoken.py test/models/test_vqtoken.py` | result: `pass`
- `bash -n examples/models/vqtoken.sh` and `git diff --check` | result: `pass`
- `pip wheel --no-deps "llava[runtime] @ git+https://github.com/Hai-chao-Zhang/VQToken.git@0314eb9989a7ea843f31bfe0984113529e3f9140"` | sample size: `N=1 clean build` | key metrics: exact public commit resolved and `llava-1.7.0.dev1` wheel built | result: `pass`

## Smoke-test scope

An earlier A100 single-video wrapper smoke used the ungated `lmms-lab/llava-onevision-qwen2-0.5b-ov` base checkpoint and exercised only the mechanical centroid path (`2916 -> 32` visual tokens with generated text). That run does **not** validate the released learned VQ-Attention weights and is not presented as attention-mode or benchmark evidence. This PR's attention guarantees are covered by the fail-closed adapter tests above; paper-checkpoint quality requires an authenticated benchmark run.

## Risk / Compatibility

- Depends on [Hai-chao-Zhang/VQToken#3](https://github.com/Hai-chao-Zhang/VQToken/pull/3); the exact public commit is pinned so this PR is reproducible before that PR merges. The dependency must be repinned to a merged immutable commit if PR #3 is rebased or squashed.
- The paper checkpoint is public but Hugging Face currently reports `gated=auto`; users must accept its access terms and authenticate before evaluation.
- Adaptive K selection can return its lower bound, so the adapter conservatively validates `max_frames_num <= vqtoken_min_clusters`. Fixed selection validates against `vqtoken_max_clusters`.
- Unknown Hub checkpoints are rejected because the public runtime can only inspect complete learned attention weights in local checkpoint headers. This avoids silently evaluating random VQ-Attention parameters.

## Type of Change

- [ ] Bug fix (non-breaking change)
- [x] New feature
- [ ] New benchmark/task
- [x] New model integration
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring (no functional changes)
