### PR TITLE
fix: cap nframes to actual video frame count in qwen3_vl

### DIFF
--- a/lmms_eval/models/simple/qwen3_vl.py
+++ b/lmms_eval/models/simple/qwen3_vl.py
@@ -1,3 +1,4 @@
+import decord
 import re
 from concurrent.futures import ThreadPoolExecutor
 from typing import List, Optional, Tuple, Union
@@ -311,11 +312,17 @@ class Qwen3_VL(lmms):
             if visual_list[i] is not None:
                 for visual in visual_list[i]:
                     if _is_video_path(visual):
+                        # Cap nframes to actual video frame count to avoid ValueError
+                        # when video has fewer frames than max_num_frames
+                        per_video_kwargs = {**video_kwargs}
+                        if "nframes" in per_video_kwargs:
+                              vr = decord.VideoReader(visual)
+                              per_video_kwargs["nframes"] = min(per_video_kwargs["nframes"], len(vr))
                         processed_visuals.append(
                             {
                                 "type": "video",
                                 "video": visual,
-                                **video_kwargs,
+                                **per_video_kwargs,
                             }
                         )
                     elif isinstance(visual, Image.Image):


### PR DESCRIPTION
## Bug

When `max_num_frames` exceeds the total frames of a video,
`process_vision_info` raises `ValueError`:

ValueError: nframes should in interval [2, 31], but got 32.

This commonly occurs on datasets like MVBench where some videos have fewer frames than the configured `max_num_frames` (e.g. 31 < 32).

## Root Cause

In `_preprocess_chunk`, `_build_video_kwargs()` returns a fixed `nframes=max_num_frames` that is passed to all videos without checking the actual frame count.

## Fix

Probe the actual frame count via `decord.VideoReader` for each video and cap `nframes` before passing to `process_vision_info`.

## Reproduce

```bash
accelerate launch -m lmms_eval \
  --model qwen3_vl \
  --model_args pretrained=Qwen/Qwen3-VL-8B-Instruct,max_num_frames=32 \
  --tasks mvbench \
  --batch_size 1