### PR TITLE
fix(blink): restrict answer extraction to valid choices and parse verbose responses

### DIFF
--- a/lmms_eval/models/chat/aero_realtime_vllm.py
+++ b/lmms_eval/models/chat/aero_realtime_vllm.py
@@ -88,8 +88,8 @@ SAMPLE_RATE = 16000
 
 @dataclass
 class RealtimeSample:
-    audio: np.ndarray            # mono float32 @ 16 kHz
-    video: np.ndarray            # (T, H, W, 3) uint8
+    audio: np.ndarray  # mono float32 @ 16 kHz
+    video: np.ndarray  # (T, H, W, 3) uint8
     video_metadata: object
     sample_fps: float
 
@@ -339,10 +339,7 @@ class AeroRealtimeVLLM(lmms):
         # vs. ``aero_realtime_chat`` which is strict, to match how other vLLM
         # wrappers behave.
         if AsyncOmni is None or AeroRealtimeForConditionalGeneration is None:
-            raise ImportError(
-                "vllm-omni is required for aero_realtime_vllm_chat. "
-                "Install vllm-omni and ensure it is importable."
-            )
+            raise ImportError("vllm-omni is required for aero_realtime_vllm_chat. " "Install vllm-omni and ensure it is importable.")
         if fetch_video is None:
             raise ImportError("qwen_vl_utils is required (`pip install qwen-vl-utils`)")
         if librosa is None:
@@ -370,9 +367,7 @@ class AeroRealtimeVLLM(lmms):
             omni_kwargs["stage_init_timeout"] = int(stage_init_timeout)
         if tensor_parallel_size is not None:
             omni_kwargs["tensor_parallel_size"] = tensor_parallel_size
-            omni_kwargs["stage_0_devices"] = stage_0_devices or ",".join(
-                str(i) for i in range(tensor_parallel_size)
-            )
+            omni_kwargs["stage_0_devices"] = stage_0_devices or ",".join(str(i) for i in range(tensor_parallel_size))
         elif stage_0_devices is not None:
             omni_kwargs["stage_0_devices"] = stage_0_devices
         if limit_mm_per_prompt:
@@ -386,6 +381,7 @@ class AeroRealtimeVLLM(lmms):
                     mm_limits[k.strip()] = int(v)
             else:
                 import json as _json
+
                 mm_limits = {k: int(v) for k, v in _json.loads(limit_mm_per_prompt).items()}
             omni_kwargs["limit_mm_per_prompt"] = mm_limits
 
@@ -394,6 +390,7 @@ class AeroRealtimeVLLM(lmms):
         overrides: dict[str, dict] = {}
         if stage_overrides:
             import json as _json
+
             overrides = _json.loads(stage_overrides)
         if enforce_eager is not None:
             overrides.setdefault("0", {})["enforce_eager"] = bool(enforce_eager)
@@ -466,9 +463,7 @@ class AeroRealtimeVLLM(lmms):
 
     # --------------------------- request -> sample ------------------------------
 
-    def _extract_video_and_text(
-        self, chat: ChatMessages
-    ) -> Tuple[str, str, Optional[float], Optional[float]]:
+    def _extract_video_and_text(self, chat: ChatMessages) -> Tuple[str, str, Optional[float], Optional[float]]:
         """Pull (first_video_path, concatenated_user_text, start_time, end_time) out of ChatMessages."""
         video_path: Optional[str] = None
         start_time: Optional[float] = None
@@ -505,9 +500,7 @@ class AeroRealtimeVLLM(lmms):
         live in the fused prefill, matching training); tail is only the
         decode-phase silence chunks."""
         all_chunks = list(chunks)
-        text_idx = next(
-            (i for i, c in enumerate(all_chunks) if c.get("text")), len(all_chunks)
-        )
+        text_idx = next((i for i, c in enumerate(all_chunks) if c.get("text")), len(all_chunks))
         return all_chunks[: text_idx + 1], all_chunks[text_idx + 1 :]
 
     def _fuse_prompts(self, prompts):
@@ -544,11 +537,7 @@ class AeroRealtimeVLLM(lmms):
         def flush_audio_buffer():
             if not pending_audio:
                 return
-            merged = (
-                pending_audio[0]
-                if len(pending_audio) == 1
-                else np.concatenate(pending_audio).astype(np.float32, copy=False)
-            )
+            merged = pending_audio[0] if len(pending_audio) == 1 else np.concatenate(pending_audio).astype(np.float32, copy=False)
             audios.append(merged)
             pids.append(audio_pad_id)
             ts_ids.extend(pending_ts_ids)
@@ -569,11 +558,7 @@ class AeroRealtimeVLLM(lmms):
             # A "pure audio" chunk: only audio_pad token(s) in the delta,
             # no video item, no extra prompt scaffolding.
             non_audio_pad_ids = [tid for tid in prompt_ids if tid != audio_pad_id]
-            is_pure_audio = (
-                audio_item is not None
-                and video_item is None
-                and not non_audio_pad_ids
-            )
+            is_pure_audio = audio_item is not None and video_item is None and not non_audio_pad_ids
 
             if is_pure_audio:
                 pending_audio.append(np.asarray(audio_item))
@@ -663,15 +648,11 @@ class AeroRealtimeVLLM(lmms):
                 for c in _iter_realtime_chunks(sample, **chunk_kwargs):
                     yield c
 
-            async for p in AeroRealtimeForConditionalGeneration.buffer_realtime_omni(
-                chunk_iter(), input_stream, self.model_config
-            ):
+            async for p in AeroRealtimeForConditionalGeneration.buffer_realtime_omni(chunk_iter(), input_stream, self.model_config):
                 yield await self._render_streaming_input(p)
 
         async def streaming_gen_prefill_decode():
-            prefill_chunks, tail_chunks = self._split_chunks(
-                _iter_realtime_chunks(sample, **chunk_kwargs)
-            )
+            prefill_chunks, tail_chunks = self._split_chunks(_iter_realtime_chunks(sample, **chunk_kwargs))
             shared_state = AeroRealtimeStreamState()
 
             # Phase 1 — fuse pre-question chunks into one prefill (every
@@ -682,9 +663,7 @@ class AeroRealtimeVLLM(lmms):
 
             prefill_q: asyncio.Queue[list[int]] = asyncio.Queue()
             prefill_prompts = []
-            async for p in AeroRealtimeForConditionalGeneration.buffer_realtime_omni(
-                pre_iter(), prefill_q, self.model_config, state=shared_state
-            ):
+            async for p in AeroRealtimeForConditionalGeneration.buffer_realtime_omni(pre_iter(), prefill_q, self.model_config, state=shared_state):
                 prefill_q.put_nowait([])
                 prefill_prompts.append(p)
             fused = self._fuse_prompts(prefill_prompts)
@@ -696,16 +675,10 @@ class AeroRealtimeVLLM(lmms):
                 for c in tail_chunks:
                     yield c
 
-            async for p in AeroRealtimeForConditionalGeneration.buffer_realtime_omni(
-                tail_iter(), input_stream, self.model_config, state=shared_state
-            ):
+            async for p in AeroRealtimeForConditionalGeneration.buffer_realtime_omni(tail_iter(), input_stream, self.model_config, state=shared_state):
                 yield await self._render_streaming_input(p)
 
-        streaming_gen = (
-            streaming_gen_prefill_decode
-            if self.mode == "prefill_decode"
-            else streaming_gen_pure
-        )
+        streaming_gen = streaming_gen_prefill_decode if self.mode == "prefill_decode" else streaming_gen_pure
 
         request_id = f"aero-rt-vllm-{uuid.uuid4()}"
         collected: list[int] = []
@@ -766,9 +739,7 @@ class AeroRealtimeVLLM(lmms):
                     chats_and_gens.append((chat, dict(gen_kwargs or {})))
 
                 t0 = time.time()
-                batch_results = await asyncio.gather(
-                    *[self._generate_one(c, g) for c, g in chats_and_gens]
-                )
+                batch_results = await asyncio.gather(*[self._generate_one(c, g) for c, g in chats_and_gens])
                 totals["elapsed"] += time.time() - t0
 
                 for i, (text, ntok) in enumerate(batch_results):

--- a/lmms_eval/tasks/blink/utils.py
+++ b/lmms_eval/tasks/blink/utils.py
@@ -7,9 +7,14 @@ from lmms_eval.tasks._task_utils.default_template_yaml import load_default_templ
 config = load_default_template_yaml(__file__)
 
 
-def _extract_answer_letter(text: str) -> str:
+def _extract_answer_letter(text: str, valid_letters: str = string.ascii_uppercase) -> str:
     """
-    Extract the answer choice letter from a string.
+    Extract the answer choice letter from a model response.
+
+    Handles terse answers as well as verbose responses that state the answer
+    later in the text. Only letters in ``valid_letters`` are accepted, so a
+    prose opener like "The correct answer is (B)." is parsed as 'B', never as
+    the 'T' of "The".
 
     Examples:
     'A answer1' -> 'A'
@@ -18,11 +23,33 @@ def _extract_answer_letter(text: str) -> str:
     'C' -> 'C'
     '(C)' -> 'C'
     'A.' -> 'A'
+    'The correct answer is (B).' -> 'B'
+    'I think the answer is C because ...' -> 'C'
 
-    Return an empty string if no letter is found.
+    Return an empty string if no answer letter is found.
     """
     text = text.strip()
-    match = re.match(r"[\(\s]*([A-Z])[\)\.\s]*", text, flags=re.IGNORECASE)
+    letters = re.escape(valid_letters.upper())
+
+    # 1) Terse response: the first line is (almost) nothing but the letter.
+    first_line = text.split("\n", 1)[0].strip()
+    if len(first_line) <= 4:
+        match = re.match(rf"^\(?([{letters}])\)?[\.\s:,)]*$", first_line, flags=re.IGNORECASE)
+        if match:
+            return match.group(1).upper()
+
+    # 2) Explicit statement, e.g. "the correct answer is (B)"; use the last one.
+    matches = re.findall(rf"answers?(?:\s+is)?\s*[:\-]?\s*\(?([{letters}])\)?(?![A-Za-z])", text, flags=re.IGNORECASE)
+    if matches:
+        return matches[-1].upper()
+
+    # 3) Parenthesized option anywhere, e.g. "... so I pick (C)"; use the last one.
+    matches = re.findall(rf"\(([{letters}])\)", text)
+    if matches:
+        return matches[-1].upper()
+
+    # 4) Leading letter, restricted to the valid choices.
+    match = re.match(rf"[\(\s]*([{letters}])[\)\.\s]*", text, flags=re.IGNORECASE)
     if match:
         return match.group(1).upper()
     return ""
@@ -103,8 +130,9 @@ def blink_process_results(doc: Dict, result: List[str]) -> Dict[str, Dict]:
     grounded_output = doc["answer"].strip("()")
     response = result[0]
 
-    # extract predicted answer
-    pred_letter = _extract_answer_letter(response)
+    # extract predicted answer, accepting only this doc's option letters
+    valid_letters = string.ascii_uppercase[: len(doc.get("choices") or [])] or string.ascii_uppercase
+    pred_letter = _extract_answer_letter(response, valid_letters)
     flag = pred_letter == grounded_output
 
     omnispatial_submission = {"id": doc["idx"], "gt_content": grounded_output, "pred_parsed": pred_letter, "pred": response, "sub_task": doc["sub_task"], "is_correct": flag}


### PR DESCRIPTION
## Summary

#### The bug

BLINK grades a response by grabbing the **first capital letter** it sees. That's fine for `B` or `(B) Point B` — but the moment a model explains itself, grading falls apart. A real response from Qwen3-VL-2B:

> The reference point 'REF' is located on the lower part of the bird's leg ... **The correct answer is (B).**

Ground truth: `(B)`. Old parser: extracts `T` — from the word *"The"* — and marks it **wrong**. The mirror image also exists: a response opening with *"Based on..."* parses as `B`, which silently becomes a lucky *hit* whenever B is the ground truth. Models are being graded on their writing style, not their perception. Full measurements in #1434.

#### The fix

 Read the response the way a human grader would:

1. If the reply is just a letter (`B`, `(B).`) → take it.
2. Otherwise find where the model *declares* its answer — “the answer is (B)” — and take the **last** such declaration (final answers come last in chain-of-thought).
3. Failing that, take the last parenthesized option like `(C)` mentioned anywhere.
4. As a last resort, keep the old leading-letter behavior.

One rule guards every step: **only letters that are actual choices for this question count** (derived from `doc["choices"]`), so *"The..."* can never again produce a phantom `T`. If nothing matches, return `""` and mark it wrong — that's what strict grading should look like.

Fixes #1434.

## In scope

- `lmms_eval/tasks/blink/utils.py` only: `_extract_answer_letter()` + its call site in `blink_process_results()`.
- (Second commit is unrelated lint debt on `main` — see PR comment below.)

## Out of scope

- Prompts, YAMLs, `doc_to_text` / `doc_to_messages`, aggregation, other tasks — untouched. The `compare-task-input-boundary` check confirms task inputs are byte-identical.

## Validation

- **Does it fix the problem?** Re-scored the logged `blink` val responses of Qwen3-VL-2B-Instruct | `N=1901` | acc `43.29 → 51.71`, recovering 160 answers that were correct but misparsed. Subtasks that sat *below random* under the old parser (Semantic_Correspondence `1.4%`, Functional_Correspondence `0.0%`) return to sane levels (`54.0` / `30.0`) | result: pass
- **Does it disturb well-behaved models?** Qwen3-VL-4B / 8B answer with a bare letter on 100% of val docs | `N=1901` each | scores bit-identical before vs after: `64.23` / `64.97` | result: pass
- **Are the old formats still parsed the same?** All six docstring formats (`A answer1`, `A) answer2`, `(B) answer`, `C`, `(C)`, `A.`) → unchanged letters | result: pass

## Risk / Compatibility

- Scores only move for responses the old regex misread (verbose / thinking-style outputs, mostly small models). Terse letter answers take the exact same code path, so existing numbers for compliant models don't shift.
- A response that never states a valid option letter still scores 0 — strictness is preserved, only the misreads are gone.

## Type of Change

- [x] Bug fix (non-breaking change)
- [ ] New feature
- [ ] New benchmark/task
- [ ] New model integration
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

