### PR TITLE
fix(tasks): handle zero-correct VLMSAreBlind results

### DIFF
--- a/lmms_eval/tasks/vlmsareblind/utils.py
+++ b/lmms_eval/tasks/vlmsareblind/utils.py
@@ -106,8 +106,15 @@ def vlmsareblind_aggregate_by_task(results: list[dict]) -> dict[str, float]:
         if is_correct:
             task_correct[task] += 1
 
-    task_accuracy = {task: task_correct[task] / task_total[task] for task in task_correct}
-    task_accuracy["task_mean"] = sum(task_accuracy.values()) / len(task_accuracy)
+    task_accuracy = {
+        task: task_correct[task] / total
+        for task, total in task_total.items()
+    }
+    task_accuracy["task_mean"] = (
+        sum(task_accuracy.values()) / len(task_accuracy)
+        if task_accuracy
+        else 0.0
+    )
 
     return task_accuracy
 


### PR DESCRIPTION
## Summary
- Include every evaluated VLMSAreBlind task in per-task accuracy, including tasks with zero correct answers.
- Prevent division-by-zero failures when all evaluated responses are incorrect.
- Compute the macro average across all represented tasks instead of omitting zero-accuracy tasks.

## In scope
- Update VLMSAreBlind per-task metric aggregation to iterate over observed task totals.
- Return `task_mean=0.0` when aggregation receives no task results.

## Out of scope
- No changes to response parsing, dataset sampling, prompts, model inference, or other benchmarks.
- No changes to the individual sample-level accuracy metric.

## Validation
- `VLMSAreBlind two-sample evaluation` | sample size: `N=2` | key metrics: zero-correct task accuracy `0.0`, task mean `0.0` | result: `pass`

## Risk / Compatibility
- Non-breaking correction to metric aggregation behavior.
- Reported macro accuracy may decrease for evaluations that previously omitted zero-accuracy task categories.

## Type of Change
- [x] Bug fix (non-breaking change)
- [ ] New feature
- [ ] New benchmark/task
- [ ] New model integration
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring (no functional changes)