### PR TITLE
feat: add VCRBench, MMR-V and VRBench video reasoning benchmarks

### DIFF
--- a/docs/advanced/current_tasks.md
+++ b/docs/advanced/current_tasks.md
@@ -283,6 +283,10 @@ python -m lmms_eval --tasks list_with_num
 - [IntPhys2](https://arxiv.org/abs/2506.09849) (intphys2)
   - intphys2_debug
 - [MLVU](https://github.com/JUNJIE99/MLVU) (mlvu)
+- [MMR-V](https://huggingface.co/datasets/JokerJan/MMR-VBench) (mmr_v)
+  - Direct answer (mmr_v)
+  - Chain-of-thought (mmr_v_cot)
+  - Both variants (mmr_v_all)
 - [MMT-Bench](https://mmt-bench.github.io/) (mmt)
   - MMT Validation (mmt_val)
   - MMT Test (mmt_test)
@@ -336,6 +340,7 @@ python -m lmms_eval --tasks list_with_num
 - [SIS-Bench](https://huggingface.co/datasets/choucsan/SIS-Bench) (sis_bench)
 - [MINERVA](https://arxiv.org/abs/2505.00681) (minerva)
 - [VANTAGE-Bench](https://huggingface.co/datasets/nvidia/PhysicalAI-VANTAGE-Bench) (vantage_vqa) - Physical AI video VQA
+- [VCRBench](https://huggingface.co/datasets/pritamqu/VCRBench) (vcrbench) - Causal step ordering over procedural video ([code](https://github.com/pritamqu/VCRBench))
 - [Video-ChatGPT](https://github.com/mbzuai-oryx/Video-ChatGPT) (videochatgpt)
   - Video-ChatGPT Generic (videochatgpt_gen)
   - Video-ChatGPT Temporal (videochatgpt_temporal)
@@ -385,6 +390,10 @@ python -m lmms_eval --tasks list_with_num
   - temporalbench_long_qa
   - temporalbench_short_caption
 - [Timescope](https://github.com/Timescope/Timescope) (timescope)
+- [VRBench](https://huggingface.co/datasets/OpenGVLab/VRBench) (vrbench) - Multi-step reasoning over long narrative video ([code](https://github.com/OpenGVLab/VRBench))
+  - Multiple-choice outcome QA (vrbench_mcq)
+  - LLM-judged reasoning process (vrbench_process)
+  - Both variants (vrbench)
 
 ### Video Captioning & Description
 - [Vatex](https://eric-xw.github.io/vatex-website/index.html) (vatex)

--- a/lmms_eval/models/chat/aero_realtime_vllm.py
+++ b/lmms_eval/models/chat/aero_realtime_vllm.py
@@ -88,8 +88,8 @@ SAMPLE_RATE = 16000
 
 @dataclass
 class RealtimeSample:
-    audio: np.ndarray            # mono float32 @ 16 kHz
-    video: np.ndarray            # (T, H, W, 3) uint8
+    audio: np.ndarray  # mono float32 @ 16 kHz
+    video: np.ndarray  # (T, H, W, 3) uint8
     video_metadata: object
     sample_fps: float
 
@@ -339,10 +339,7 @@ class AeroRealtimeVLLM(lmms):
         # vs. ``aero_realtime_chat`` which is strict, to match how other vLLM
         # wrappers behave.
         if AsyncOmni is None or AeroRealtimeForConditionalGeneration is None:
-            raise ImportError(
-                "vllm-omni is required for aero_realtime_vllm_chat. "
-                "Install vllm-omni and ensure it is importable."
-            )
+            raise ImportError("vllm-omni is required for aero_realtime_vllm_chat. " "Install vllm-omni and ensure it is importable.")
         if fetch_video is None:
             raise ImportError("qwen_vl_utils is required (`pip install qwen-vl-utils`)")
         if librosa is None:
@@ -370,9 +367,7 @@ class AeroRealtimeVLLM(lmms):
             omni_kwargs["stage_init_timeout"] = int(stage_init_timeout)
         if tensor_parallel_size is not None:
             omni_kwargs["tensor_parallel_size"] = tensor_parallel_size
-            omni_kwargs["stage_0_devices"] = stage_0_devices or ",".join(
-                str(i) for i in range(tensor_parallel_size)
-            )
+            omni_kwargs["stage_0_devices"] = stage_0_devices or ",".join(str(i) for i in range(tensor_parallel_size))
         elif stage_0_devices is not None:
             omni_kwargs["stage_0_devices"] = stage_0_devices
         if limit_mm_per_prompt:
@@ -386,6 +381,7 @@ class AeroRealtimeVLLM(lmms):
                     mm_limits[k.strip()] = int(v)
             else:
                 import json as _json
+
                 mm_limits = {k: int(v) for k, v in _json.loads(limit_mm_per_prompt).items()}
             omni_kwargs["limit_mm_per_prompt"] = mm_limits
 
@@ -394,6 +390,7 @@ class AeroRealtimeVLLM(lmms):
         overrides: dict[str, dict] = {}
         if stage_overrides:
             import json as _json
+
             overrides = _json.loads(stage_overrides)
         if enforce_eager is not None:
             overrides.setdefault("0", {})["enforce_eager"] = bool(enforce_eager)
@@ -466,9 +463,7 @@ class AeroRealtimeVLLM(lmms):
 
     # --------------------------- request -> sample ------------------------------
 
-    def _extract_video_and_text(
-        self, chat: ChatMessages
-    ) -> Tuple[str, str, Optional[float], Optional[float]]:
+    def _extract_video_and_text(self, chat: ChatMessages) -> Tuple[str, str, Optional[float], Optional[float]]:
         """Pull (first_video_path, concatenated_user_text, start_time, end_time) out of ChatMessages."""
         video_path: Optional[str] = None
         start_time: Optional[float] = None
@@ -505,9 +500,7 @@ class AeroRealtimeVLLM(lmms):
         live in the fused prefill, matching training); tail is only the
         decode-phase silence chunks."""
         all_chunks = list(chunks)
-        text_idx = next(
-            (i for i, c in enumerate(all_chunks) if c.get("text")), len(all_chunks)
-        )
+        text_idx = next((i for i, c in enumerate(all_chunks) if c.get("text")), len(all_chunks))
         return all_chunks[: text_idx + 1], all_chunks[text_idx + 1 :]
 
     def _fuse_prompts(self, prompts):
@@ -544,11 +537,7 @@ class AeroRealtimeVLLM(lmms):
         def flush_audio_buffer():
             if not pending_audio:
                 return
-            merged = (
-                pending_audio[0]
-                if len(pending_audio) == 1
-                else np.concatenate(pending_audio).astype(np.float32, copy=False)
-            )
+            merged = pending_audio[0] if len(pending_audio) == 1 else np.concatenate(pending_audio).astype(np.float32, copy=False)
             audios.append(merged)
             pids.append(audio_pad_id)
             ts_ids.extend(pending_ts_ids)
@@ -569,11 +558,7 @@ class AeroRealtimeVLLM(lmms):
             # A "pure audio" chunk: only audio_pad token(s) in the delta,
             # no video item, no extra prompt scaffolding.
             non_audio_pad_ids = [tid for tid in prompt_ids if tid != audio_pad_id]
-            is_pure_audio = (
-                audio_item is not None
-                and video_item is None
-                and not non_audio_pad_ids
-            )
+            is_pure_audio = audio_item is not None and video_item is None and not non_audio_pad_ids
 
             if is_pure_audio:
                 pending_audio.append(np.asarray(audio_item))
@@ -663,15 +648,11 @@ class AeroRealtimeVLLM(lmms):
                 for c in _iter_realtime_chunks(sample, **chunk_kwargs):
                     yield c
 
-            async for p in AeroRealtimeForConditionalGeneration.buffer_realtime_omni(
-                chunk_iter(), input_stream, self.model_config
-            ):
+            async for p in AeroRealtimeForConditionalGeneration.buffer_realtime_omni(chunk_iter(), input_stream, self.model_config):
                 yield await self._render_streaming_input(p)
 
         async def streaming_gen_prefill_decode():
-            prefill_chunks, tail_chunks = self._split_chunks(
-                _iter_realtime_chunks(sample, **chunk_kwargs)
-            )
+            prefill_chunks, tail_chunks = self._split_chunks(_iter_realtime_chunks(sample, **chunk_kwargs))
             shared_state = AeroRealtimeStreamState()
 
             # Phase 1 — fuse pre-question chunks into one prefill (every
@@ -682,9 +663,7 @@ class AeroRealtimeVLLM(lmms):
 
             prefill_q: asyncio.Queue[list[int]] = asyncio.Queue()
             prefill_prompts = []
-            async for p in AeroRealtimeForConditionalGeneration.buffer_realtime_omni(
-                pre_iter(), prefill_q, self.model_config, state=shared_state
-            ):
+            async for p in AeroRealtimeForConditionalGeneration.buffer_realtime_omni(pre_iter(), prefill_q, self.model_config, state=shared_state):
                 prefill_q.put_nowait([])
                 prefill_prompts.append(p)
             fused = self._fuse_prompts(prefill_prompts)
@@ -696,16 +675,10 @@ class AeroRealtimeVLLM(lmms):
                 for c in tail_chunks:
                     yield c
 
-            async for p in AeroRealtimeForConditionalGeneration.buffer_realtime_omni(
-                tail_iter(), input_stream, self.model_config, state=shared_state
-            ):
+            async for p in AeroRealtimeForConditionalGeneration.buffer_realtime_omni(tail_iter(), input_stream, self.model_config, state=shared_state):
                 yield await self._render_streaming_input(p)
 
-        streaming_gen = (
-            streaming_gen_prefill_decode
-            if self.mode == "prefill_decode"
-            else streaming_gen_pure
-        )
+        streaming_gen = streaming_gen_prefill_decode if self.mode == "prefill_decode" else streaming_gen_pure
 
         request_id = f"aero-rt-vllm-{uuid.uuid4()}"
         collected: list[int] = []
@@ -766,9 +739,7 @@ class AeroRealtimeVLLM(lmms):
                     chats_and_gens.append((chat, dict(gen_kwargs or {})))
 
                 t0 = time.time()
-                batch_results = await asyncio.gather(
-                    *[self._generate_one(c, g) for c, g in chats_and_gens]
-                )
+                batch_results = await asyncio.gather(*[self._generate_one(c, g) for c, g in chats_and_gens])
                 totals["elapsed"] += time.time() - t0
 
                 for i, (text, ntok) in enumerate(batch_results):

--- a/lmms_eval/tasks/mmr_v/README.md
+++ b/lmms_eval/tasks/mmr_v/README.md
@@ -1,0 +1,29 @@
+# MMR-V
+
+[MMR-V: Can MLLMs Think with Video? A Benchmark for Multimodal Deep Reasoning in Videos](https://arxiv.org/abs/2506.04141)
+asks models to mine evidence across long-range, non-adjacent frames instead of matching the
+frame named in the question. The test split holds 1,257 multiple-choice questions over 317
+videos, with 7 to 13 options per question (letters A-L), 10 `abilityType_L2` categories and
+6 `videoType` categories.
+
+`mmr_v` uses the official direct-answer prompt; `mmr_v_cot` uses the official chain-of-thought
+prompt (`--with_cot` in the reference implementation) and reads the answer back from the
+`[[X]]` block; `mmr_v_all` runs both. Scoring is rule-based exact match on the option letter,
+so no LLM judge is needed.
+
+Videos ship as the split archives `videos.tar.part.aa` .. `videos.tar.part.av` in
+[JokerJan/MMR-VBench](https://huggingface.co/datasets/JokerJan/MMR-VBench). lmms-eval
+concatenates and extracts them under `$HF_HOME/mmr_v` on the first run. Media that is already
+on disk can instead be exposed through `MMR_V_VIDEO_DIR` (or `MMR_V_ROOT`); a `videos/` or
+`videos_extracted/` subdirectory below that root is searched as well.
+
+```bash
+accelerate launch -m lmms_eval --model <model> --tasks mmr_v --batch_size 1
+```
+
+Official reference numbers for the overall accuracy, for a sanity target:
+Gemini-2.5-pro 64.3, o4-mini 52.5, Gemini-2.5-Flash 51.2, human 86.0.
+
+One upstream data defect is kept as-is: question 268 (`A Single Life - Oscar Nominated
+Animated Short.mp4`) records `(K)` as the correct answer but offers only the options A-J, so
+that question always scores 0.

--- a/lmms_eval/tasks/mmr_v/__init__.py
+++ b/lmms_eval/tasks/mmr_v/__init__.py
@@ -1,0 +1,1 @@
+"""MMR-V multimodal deep video reasoning tasks."""

--- a/lmms_eval/tasks/mmr_v/_default_template_yaml
+++ b/lmms_eval/tasks/mmr_v/_default_template_yaml
@@ -1,0 +1,65 @@
+dataset_path: JokerJan/MMR-VBench
+dataset_kwargs:
+  cache_dir: mmr_v
+  video: true
+test_split: test
+output_type: generate_until
+cluster_key: video
+doc_to_visual: !function utils.mmr_v_doc_to_visual
+doc_to_text: !function utils.mmr_v_doc_to_text
+doc_to_target: correctAnswer
+process_results: !function utils.mmr_v_process_results
+metric_list:
+  - metric: mmr_v_overall_accuracy
+    aggregation: !function utils.mmr_v_aggregate_overall
+    higher_is_better: true
+  - metric: mmr_v_theme_understanding_accuracy
+    aggregation: !function utils.mmr_v_aggregate_theme_understanding
+    higher_is_better: true
+  - metric: mmr_v_metaphor_understanding_accuracy
+    aggregation: !function utils.mmr_v_aggregate_metaphor_understanding
+    higher_is_better: true
+  - metric: mmr_v_emotion_recognition_accuracy
+    aggregation: !function utils.mmr_v_aggregate_emotion_recognition
+    higher_is_better: true
+  - metric: mmr_v_implicit_symbol_accuracy
+    aggregation: !function utils.mmr_v_aggregate_implicit_symbol
+    higher_is_better: true
+  - metric: mmr_v_causal_reasoning_accuracy
+    aggregation: !function utils.mmr_v_aggregate_causal_reasoning
+    higher_is_better: true
+  - metric: mmr_v_counterintuitive_reasoning_accuracy
+    aggregation: !function utils.mmr_v_aggregate_counterintuitive_reasoning
+    higher_is_better: true
+  - metric: mmr_v_video_type_and_intent_accuracy
+    aggregation: !function utils.mmr_v_aggregate_video_type_and_intent
+    higher_is_better: true
+  - metric: mmr_v_sequential_structure_reasoning_accuracy
+    aggregation: !function utils.mmr_v_aggregate_sequential_structure_reasoning
+    higher_is_better: true
+  - metric: mmr_v_cross_modal_creative_transfer_accuracy
+    aggregation: !function utils.mmr_v_aggregate_cross_modal_creative_transfer
+    higher_is_better: true
+  - metric: mmr_v_comment_matching_accuracy
+    aggregation: !function utils.mmr_v_aggregate_comment_matching
+    higher_is_better: true
+  - metric: mmr_v_animation_video_accuracy
+    aggregation: !function utils.mmr_v_aggregate_animation_video
+    higher_is_better: true
+  - metric: mmr_v_movie_video_accuracy
+    aggregation: !function utils.mmr_v_aggregate_movie_video
+    higher_is_better: true
+  - metric: mmr_v_tv_video_accuracy
+    aggregation: !function utils.mmr_v_aggregate_tv_video
+    higher_is_better: true
+  - metric: mmr_v_life_video_accuracy
+    aggregation: !function utils.mmr_v_aggregate_life_video
+    higher_is_better: true
+  - metric: mmr_v_art_video_accuracy
+    aggregation: !function utils.mmr_v_aggregate_art_video
+    higher_is_better: true
+  - metric: mmr_v_philosophy_video_accuracy
+    aggregation: !function utils.mmr_v_aggregate_philosophy_video
+    higher_is_better: true
+metadata:
+  version: 1.0

--- a/lmms_eval/tasks/mmr_v/mmr_v.yaml
+++ b/lmms_eval/tasks/mmr_v/mmr_v.yaml
@@ -1,0 +1,12 @@
+task: mmr_v
+include: _default_template_yaml
+generation_kwargs:
+  max_new_tokens: 16
+  temperature: 0
+  top_p: 1.0
+  num_beams: 1
+  do_sample: false
+lmms_eval_specific_kwargs:
+  default:
+    pre_prompt: ""
+    post_prompt: "\nAnswer with the option letter only."

--- a/lmms_eval/tasks/mmr_v/mmr_v_cot.yaml
+++ b/lmms_eval/tasks/mmr_v/mmr_v_cot.yaml
@@ -1,0 +1,12 @@
+task: mmr_v_cot
+include: _default_template_yaml
+generation_kwargs:
+  max_new_tokens: 1024
+  temperature: 0
+  top_p: 1.0
+  num_beams: 1
+  do_sample: false
+lmms_eval_specific_kwargs:
+  default:
+    pre_prompt: ""
+    post_prompt: "\nWrite your thinking process first, then give the final correct option letter in the format \"[[X]]\". The final correct option letter MUST be put in the \"[[]]\"."

--- a/lmms_eval/tasks/mmr_v/mmr_v_group.yaml
+++ b/lmms_eval/tasks/mmr_v/mmr_v_group.yaml
@@ -1,0 +1,6 @@
+group: mmr_v_all
+task:
+  - mmr_v
+  - mmr_v_cot
+metadata:
+  version: 1.0

--- a/lmms_eval/tasks/mmr_v/utils.py
+++ b/lmms_eval/tasks/mmr_v/utils.py
@@ -1,0 +1,204 @@
+import os
+import re
+from typing import Any, Mapping, Sequence
+
+from loguru import logger as eval_logger
+
+from lmms_eval.api.reasoning import strip_reasoning_tags
+from lmms_eval.tasks._task_utils.mcq_extract import extract_mcq_answer
+from lmms_eval.tasks._task_utils.media_resolver import resolve_media_reference
+
+Document = Mapping[str, Any]
+TaskKwargs = Mapping[str, Any]
+MetricRecord = dict[str, Any]
+
+CACHE_DIR_NAME = "mmr_v"
+VIDEO_ENV_VARS = ("MMR_V_VIDEO_DIR", "MMR_V_ROOT")
+REASONING_TAG_PAIRS = [["<think>", "</think>"], ["<thinking>", "</thinking>"]]
+
+# The 10 abilityType_L2 labels and the 6 videoType labels of the test split.
+ABILITY_TYPES = (
+    "Theme Understanding",
+    "Metaphor Understanding",
+    "Emotion Recognition",
+    "Implicit Symbol",
+    "Causal Reasoning",
+    "Counterintuitive Reasoning",
+    "Video Type and Intent",
+    "Sequential Structure Reasoning",
+    "Cross-modal Creative Transfer",
+    "Comment Matching",
+)
+VIDEO_TYPES = ("Animation", "movie", "TV", "Life", "Art", "Philosophy")
+
+# Options ship with their own "(A) " prefix and a few items skip a letter, so the
+# valid letters are read back from the option strings instead of being rebuilt
+# from the option count.
+_OPTION_LETTER = re.compile(r"^\s*\(([A-Za-z])\)")
+# Official answer formats, tried before the shared multiple-choice extractor.
+_BRACKET_ANSWER = re.compile(r"\[\[\s*([A-Za-z])\s*\]\]")
+_BOXED_ANSWER = re.compile(r"\\boxed\{\s*([A-Za-z])\s*\}")
+
+
+def _slug(value: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "_", value.lower()).strip("_")
+
+
+def _options(doc: Document) -> list[str]:
+    """Return the non-empty option strings of one example, prefixes included."""
+    return [str(option).strip() for option in doc["options"] if str(option).strip()]
+
+
+def _choices(doc: Document) -> list[str]:
+    """Return the option letters this example actually offers."""
+    letters = []
+    for option in _options(doc):
+        match = _OPTION_LETTER.match(option)
+        if match:
+            letters.append(match.group(1).upper())
+    return letters
+
+
+def mmr_v_doc_to_visual(doc: Document) -> list[str]:
+    """Resolve the local video for one MMR-V example."""
+    video_path = resolve_media_reference(
+        str(doc["video"]),
+        media_type="video",
+        cache_dir=CACHE_DIR_NAME,
+        env_vars=VIDEO_ENV_VARS,
+        extra_subdirs=("videos", "videos_extracted"),
+    )
+    if not os.path.exists(video_path):
+        raise FileNotFoundError(f"MMR-V video not found: {doc['video']}. Concatenate the videos.tar.part.* archives of JokerJan/MMR-VBench " "and set MMR_V_VIDEO_DIR to the extracted video directory if needed.")
+    return [video_path]
+
+
+def _format_question(doc: Document) -> str:
+    return f"{doc['question']}\nOptions:\n" + "\n".join(_options(doc))
+
+
+def mmr_v_doc_to_text(doc: Document, lmms_eval_specific_kwargs: TaskKwargs | None = None) -> str:
+    """Format the multiple-choice prompt; the answer format comes from post_prompt."""
+    kwargs = lmms_eval_specific_kwargs or {}
+    instruction = "Please select the best answer to the following multiple-choice question based on the video. " "Only one option is the most accurate answer in relation to the question and the video."
+    return f"{kwargs.get('pre_prompt', '')}{instruction}\n{_format_question(doc)}{kwargs.get('post_prompt', '')}"
+
+
+def extract_mmr_v_answer(response: str, choices: Sequence[str]) -> str:
+    """Extract one offered option letter, preferring the official "[[X]]" format."""
+    text = strip_reasoning_tags(response or "", REASONING_TAG_PAIRS)
+    for pattern in (_BRACKET_ANSWER, _BOXED_ANSWER):
+        matches = pattern.findall(text)
+        if matches and matches[-1].upper() in choices:
+            return matches[-1].upper()
+    return extract_mcq_answer(text, choices=list(choices))
+
+
+def mmr_v_process_results(doc: Document, results: Sequence[str]) -> dict[str, MetricRecord]:
+    """Parse a prediction and emit the overall, ability and video-type records."""
+    ability_type = str(doc["abilityType_L2"])
+    video_type = str(doc["videoType"])
+    if ability_type not in ABILITY_TYPES:
+        raise ValueError(f"Unknown MMR-V abilityType_L2: {ability_type!r}")
+    if video_type not in VIDEO_TYPES:
+        raise ValueError(f"Unknown MMR-V videoType: {video_type!r}")
+
+    prediction = results[0] if results else ""
+    parsed_prediction = extract_mmr_v_answer(str(prediction), _choices(doc))
+    answer = re.sub(r"[^A-Za-z]", "", str(doc["correctAnswer"])).upper()
+    record = {
+        "question_idx": int(doc["question_idx"]),
+        "video": str(doc["video"]),
+        "ability_type": ability_type,
+        "ability_type_l3": str(doc["abilityType_L3"]),
+        "video_type": video_type,
+        "prediction": prediction,
+        "pred_answer": parsed_prediction,
+        "answer": answer,
+        "score": float(parsed_prediction == answer),
+    }
+    return {
+        "mmr_v_overall_accuracy": record,
+        f"mmr_v_{_slug(ability_type)}_accuracy": record,
+        f"mmr_v_{_slug(video_type)}_video_accuracy": record,
+    }
+
+
+def _aggregate_accuracy(results: Sequence[MetricRecord], ability_type: str | None = None, video_type: str | None = None) -> float:
+    """Compute question-weighted accuracy as a percentage over the selected records."""
+    selected = [result for result in results if (ability_type is None or result["ability_type"] == ability_type) and (video_type is None or result["video_type"] == video_type)]
+    if not selected:
+        return 0.0
+    correct = sum(result["score"] for result in selected)
+    accuracy = 100.0 * correct / len(selected)
+    label = ability_type or video_type or "overall"
+    eval_logger.info(f"MMR-V {label} accuracy: {accuracy:.2f}% ({int(correct)}/{len(selected)})")
+    return accuracy
+
+
+def mmr_v_aggregate_overall(results: Sequence[MetricRecord]) -> float:
+    return _aggregate_accuracy(results)
+
+
+def mmr_v_aggregate_theme_understanding(results: Sequence[MetricRecord]) -> float:
+    return _aggregate_accuracy(results, ability_type="Theme Understanding")
+
+
+def mmr_v_aggregate_metaphor_understanding(results: Sequence[MetricRecord]) -> float:
+    return _aggregate_accuracy(results, ability_type="Metaphor Understanding")
+
+
+def mmr_v_aggregate_emotion_recognition(results: Sequence[MetricRecord]) -> float:
+    return _aggregate_accuracy(results, ability_type="Emotion Recognition")
+
+
+def mmr_v_aggregate_implicit_symbol(results: Sequence[MetricRecord]) -> float:
+    return _aggregate_accuracy(results, ability_type="Implicit Symbol")
+
+
+def mmr_v_aggregate_causal_reasoning(results: Sequence[MetricRecord]) -> float:
+    return _aggregate_accuracy(results, ability_type="Causal Reasoning")
+
+
+def mmr_v_aggregate_counterintuitive_reasoning(results: Sequence[MetricRecord]) -> float:
+    return _aggregate_accuracy(results, ability_type="Counterintuitive Reasoning")
+
+
+def mmr_v_aggregate_video_type_and_intent(results: Sequence[MetricRecord]) -> float:
+    return _aggregate_accuracy(results, ability_type="Video Type and Intent")
+
+
+def mmr_v_aggregate_sequential_structure_reasoning(results: Sequence[MetricRecord]) -> float:
+    return _aggregate_accuracy(results, ability_type="Sequential Structure Reasoning")
+
+
+def mmr_v_aggregate_cross_modal_creative_transfer(results: Sequence[MetricRecord]) -> float:
+    return _aggregate_accuracy(results, ability_type="Cross-modal Creative Transfer")
+
+
+def mmr_v_aggregate_comment_matching(results: Sequence[MetricRecord]) -> float:
+    return _aggregate_accuracy(results, ability_type="Comment Matching")
+
+
+def mmr_v_aggregate_animation_video(results: Sequence[MetricRecord]) -> float:
+    return _aggregate_accuracy(results, video_type="Animation")
+
+
+def mmr_v_aggregate_movie_video(results: Sequence[MetricRecord]) -> float:
+    return _aggregate_accuracy(results, video_type="movie")
+
+
+def mmr_v_aggregate_tv_video(results: Sequence[MetricRecord]) -> float:
+    return _aggregate_accuracy(results, video_type="TV")
+
+
+def mmr_v_aggregate_life_video(results: Sequence[MetricRecord]) -> float:
+    return _aggregate_accuracy(results, video_type="Life")
+
+
+def mmr_v_aggregate_art_video(results: Sequence[MetricRecord]) -> float:
+    return _aggregate_accuracy(results, video_type="Art")
+
+
+def mmr_v_aggregate_philosophy_video(results: Sequence[MetricRecord]) -> float:
+    return _aggregate_accuracy(results, video_type="Philosophy")

--- a/lmms_eval/tasks/vcrbench/README.md
+++ b/lmms_eval/tasks/vcrbench/README.md
@@ -36,6 +36,15 @@ before the official cascade runs.
 The official random baseline is 7.95 `avg_accuracy` / 24.26 `avg_step_accuracy`. A model that
 scores near those numbers is not reading the title cards.
 
+> **The frame budget is load-bearing on this benchmark.** Each video concatenates the
+> shuffled clips, and the clip index appears *only* as a burnt-in "Clip N" title card at the
+> head of every clip. Those cards are on screen briefly, so a sparse sample can miss them
+> entirely and the task becomes unanswerable for a reason unrelated to reasoning. Measured
+> with Qwen3-VL-8B-Instruct: 32 uniformly sampled frames scores **below** the paper's random
+> baseline (7.95 exact / 24.26 step), while 64 frames scores 44.0 exact / 56.1 step on a
+> 50-item sample. Use the paper's setting, or at least 64 frames, and always report the frame
+> budget alongside the score.
+
 The paper evaluates Qwen2.5-VL with `fps=1`, `max_pixels=360*420` (151200) and
 `max_new_tokens=512`; pass the frame and pixel settings through the model arguments, for
 example `--model_args ...,max_pixels=151200,fps=1`.

--- a/lmms_eval/tasks/vcrbench/README.md
+++ b/lmms_eval/tasks/vcrbench/README.md
@@ -1,0 +1,41 @@
+# VCRBench
+
+This task ports the official [VCRBench](https://github.com/pritamqu/VCRBench) protocol
+("VCRBench: Exploring Long-form Causal Reasoning Capabilities of Large Video Language Models").
+Each of the 365 examples shows one procedural activity whose clips were shuffled and
+concatenated into a single video; every clip is introduced by a burnt-in `Clip N` title card.
+The model must recover the causal order of the clips, so this is free-form generation and not
+multiple choice. The prompt is the official one and asks for `Correct order: <clip numbers>`.
+
+The dataset is public. Media is downloaded from
+https://huggingface.co/datasets/pritamqu/VCRBench and linked under `$HF_HOME/vcrbench`, so the
+videos live at `$HF_HOME/vcrbench/videos/video_<N>.mp4`. Existing media can instead be exposed
+through `VCRBENCH_VIDEO_DIR` (a directory holding the `video_<N>.mp4` files) or `VCRBENCH_ROOT`
+(a directory holding a `videos/` subdirectory).
+
+```bash
+accelerate launch -m lmms_eval --model <model> --tasks vcrbench --batch_size 1
+```
+
+## Metrics
+
+| Metric | Official name | Definition |
+| --- | --- | --- |
+| `vcrbench_accuracy` | `avg_accuracy` | Exact match of the whole predicted clip order. |
+| `vcrbench_step_accuracy` | `avg_step_accuracy` | Position-wise match over all clips; a length mismatch scores zeros. |
+| `vcrbench_weighted_accuracy` | `weighted_avg_accuracy` | Unweighted mean of the exact-match accuracy over the 12 goal classes. |
+
+Answer parsing follows the official `process.py`: the response is split into sentences, the
+first sentence whose comma-separated fields form a permutation of `1..N` wins, and a response
+with no such sentence is scored as `N` zeros. Reasoning models are supported as a pre-step:
+`<think>` blocks are stripped, and an `<answer>...</answer>` or `\boxed{...}` wrapper is read
+before the official cascade runs.
+
+## Sanity targets
+
+The official random baseline is 7.95 `avg_accuracy` / 24.26 `avg_step_accuracy`. A model that
+scores near those numbers is not reading the title cards.
+
+The paper evaluates Qwen2.5-VL with `fps=1`, `max_pixels=360*420` (151200) and
+`max_new_tokens=512`; pass the frame and pixel settings through the model arguments, for
+example `--model_args ...,max_pixels=151200,fps=1`.

--- a/lmms_eval/tasks/vcrbench/__init__.py
+++ b/lmms_eval/tasks/vcrbench/__init__.py
@@ -1,0 +1,1 @@
+"""VCRBench causal video reasoning (step ordering) task."""

--- a/lmms_eval/tasks/vcrbench/_default_template_yaml
+++ b/lmms_eval/tasks/vcrbench/_default_template_yaml
@@ -1,0 +1,33 @@
+dataset_path: pritamqu/VCRBench
+dataset_kwargs:
+  cache_dir: vcrbench
+  video: true
+  create_link: true
+test_split: test
+output_type: generate_until
+cluster_key: video_file
+doc_to_visual: !function utils.vcrbench_doc_to_visual
+doc_to_target: !function utils.vcrbench_doc_to_target
+generation_kwargs:
+  max_new_tokens: 512
+  temperature: 0
+  top_p: 1.0
+  num_beams: 1
+  do_sample: false
+process_results: !function utils.vcrbench_process_results
+metric_list:
+  - metric: vcrbench_accuracy
+    aggregation: !function utils.vcrbench_aggregate_accuracy
+    higher_is_better: true
+  - metric: vcrbench_step_accuracy
+    aggregation: !function utils.vcrbench_aggregate_step_accuracy
+    higher_is_better: true
+  - metric: vcrbench_weighted_accuracy
+    aggregation: !function utils.vcrbench_aggregate_weighted_accuracy
+    higher_is_better: true
+lmms_eval_specific_kwargs:
+  default:
+    pre_prompt: ""
+    post_prompt: ""
+metadata:
+  version: 1.0

--- a/lmms_eval/tasks/vcrbench/utils.py
+++ b/lmms_eval/tasks/vcrbench/utils.py
@@ -1,0 +1,227 @@
+import os
+import re
+from collections import defaultdict
+from typing import Any, Mapping, Sequence
+
+from loguru import logger as eval_logger
+
+from lmms_eval.api.reasoning import strip_reasoning_tags
+from lmms_eval.tasks._task_utils.media_resolver import resolve_media_reference
+
+Document = Mapping[str, Any]
+TaskKwargs = Mapping[str, Any]
+MetricRecord = dict[str, Any]
+
+# Official prompt from VCRBench/data/dataset.py (PROMPT). The two trailing spaces
+# at the end of the first and second line are part of the released prompt; keep them.
+VCRBENCH_PROMPT = """The given video consists of multiple short clips, each showing a different segment needed to complete the task: {goal}. 
+These clips are randomly shuffled, and your job is to arrange them in the correct order to complete the task: {goal}. 
+The clip numbers are mentioned at the beginning of each clip as Clip 1, Clip 2, and so on.
+In order to solve this task, first, you should identify the activity that is performed in each clip, and then use your reasoning and common sense to arrange these clips to successfully complete the task.
+
+The final output should be in this format:
+
+Correct order: <mention the Clip numbers separated by a comma>
+"""
+
+# Official phrase cascade from VCRBench/process.py. The official loop stops after the
+# first phrase that matches any sentence, and the empty phrase matches every sentence,
+# so the empty phrase is the effective path for every non-degenerate response.
+ANSWER_PHRASES = (
+    "",
+    "correct order is:",
+    "correct order:",
+    "correct order",
+    "**Correct order:**",
+    "*Correct order:*",
+    "follow these steps in order",
+    "the correct order is",
+    "the correct order is",
+    "the final output should be",
+)
+
+_REASONING_TAG_PAIRS = [["<think>", "</think>"], ["<thinking>", "</thinking>"]]
+_ANSWER_TAG_PATTERN = re.compile(r"<answer>(.*?)</answer>", re.DOTALL)
+_SENTENCE_PATTERN = re.compile(r"(?<=[.!?])\s+|\n+")
+
+
+def vcrbench_doc_to_visual(doc: Document) -> list[str]:
+    """Resolve the local video for one VCRBench example."""
+    video_path = resolve_media_reference(
+        doc["video_file"],
+        media_type="video",
+        cache_dir="vcrbench",
+        env_vars=("VCRBENCH_VIDEO_DIR", "VCRBENCH_ROOT"),
+        extra_subdirs=("videos",),
+    )
+    if not os.path.exists(video_path):
+        raise FileNotFoundError(f"VCRBench video not found: {video_path}. Set VCRBENCH_VIDEO_DIR to the directory holding the video_<N>.mp4 files, " "or VCRBENCH_ROOT to the directory holding the videos/ subdirectory.")
+    return [video_path]
+
+
+def vcrbench_doc_to_text(doc: Document, lmms_eval_specific_kwargs: TaskKwargs | None = None) -> str:
+    """Format the official VCRBench step-ordering prompt for one goal."""
+    kwargs = lmms_eval_specific_kwargs or {}
+    prompt = VCRBENCH_PROMPT.format(goal=doc["goal"])
+    return f"{kwargs.get('pre_prompt', '')}{prompt}{kwargs.get('post_prompt', '')}"
+
+
+def vcrbench_target_order(doc: Document) -> list[int]:
+    """Return the ground-truth clip order as 1-indexed clip numbers."""
+    return [step + 1 for step in doc["ground_truth"]]
+
+
+def vcrbench_doc_to_target(doc: Document) -> str:
+    """Render the ground-truth clip order the way the prompt asks for it."""
+    return ", ".join(str(clip) for clip in vcrbench_target_order(doc))
+
+
+def fetch_predicted_order(text: str) -> list[int]:
+    """Read one comma-separated clip order, taking the first integer of every field."""
+    predicted_order = []
+    for part in str(text).split(","):
+        match = re.search(r"\d+", part.strip())
+        if match is not None:
+            predicted_order.append(int(match.group()))
+    return predicted_order
+
+
+def extract_following_text(text: str, phrase: str) -> list[str]:
+    """Return the text that follows ``phrase`` in every sentence that contains it."""
+    phrase_regex = re.compile(re.escape(phrase), re.IGNORECASE)
+    results = []
+    for sentence in _SENTENCE_PATTERN.split(text):
+        match = phrase_regex.search(sentence)
+        if match:
+            results.append(sentence[match.end() :].strip())
+    return results
+
+
+def is_consecutive_in_range(sequence: Sequence[int], start: int, end: int) -> bool:
+    """Check that ``sequence`` is a permutation of every integer in ``[start, end]``."""
+    return set(sequence) == set(range(start, end + 1))
+
+
+def compare_lists(target: Sequence[int], prediction: Sequence[int]) -> list[int]:
+    """Score the prediction position by position; a length mismatch scores all zeros."""
+    if len(target) != len(prediction):
+        return [0] * len(target)
+    return [1 if a == b else 0 for a, b in zip(target, prediction)]
+
+
+def _wrapped_answer(response: str) -> str | None:
+    """Return the payload of an ``<answer>`` or ``\\boxed{}`` wrapper, if the model used one."""
+    match = _ANSWER_TAG_PATTERN.search(response)
+    if match:
+        return match.group(1)
+
+    boxed_start = response.rfind("\\boxed{")
+    if boxed_start == -1:
+        return None
+    depth = 0
+    for position in range(boxed_start + len("\\boxed{") - 1, len(response)):
+        if response[position] == "{":
+            depth += 1
+        elif response[position] == "}":
+            depth -= 1
+            if depth == 0:
+                return response[boxed_start + len("\\boxed{") : position]
+    return None
+
+
+def extract_predicted_order(response: str, num_steps: int) -> list[int]:
+    """Extract the predicted clip order, falling back to zeros when no valid order is found.
+
+    Reasoning models are handled first: ``<think>`` blocks are stripped and an
+    ``<answer>`` or ``\\boxed{}`` wrapper is read directly. Everything after that
+    follows the official VCRBench ``process.py`` cascade, including its habit of
+    filling the prediction with zeros when no permutation of ``1..num_steps``
+    can be recovered.
+
+    Args:
+        response: Raw model output for one example.
+        num_steps: Number of clips in the ground-truth order.
+
+    Returns:
+        A list of ``num_steps`` clip numbers, or ``num_steps`` zeros on failure.
+    """
+    response = strip_reasoning_tags(response or "", _REASONING_TAG_PAIRS)
+
+    wrapped = _wrapped_answer(response)
+    if wrapped is not None:
+        predicted_order = fetch_predicted_order(wrapped)
+        if len(predicted_order) == num_steps and is_consecutive_in_range(predicted_order, 1, num_steps):
+            return predicted_order
+
+    for phrase in ANSWER_PHRASES:
+        cleaned = response.replace("*", "")
+        candidates = extract_following_text(cleaned, phrase=phrase)
+        if len(candidates) == 0:
+            continue
+        for candidate in candidates:
+            predicted_order = fetch_predicted_order(candidate)
+            if len(predicted_order) == num_steps and is_consecutive_in_range(predicted_order, 1, num_steps):
+                return predicted_order
+        # The official implementation stops after the first phrase that matches a sentence.
+        break
+
+    return [0] * num_steps
+
+
+def vcrbench_process_results(doc: Document, results: Sequence[str]) -> dict[str, MetricRecord]:
+    """Parse a prediction and emit the shared VCRBench metric record."""
+    prediction = results[0] if results else ""
+    target_order = vcrbench_target_order(doc)
+    predicted_order = extract_predicted_order(prediction, len(target_order))
+    if predicted_order == [0] * len(target_order):
+        eval_logger.debug(f"VCRBench qid={doc['qid']}: no valid clip order found in the response.")
+    record = {
+        "qid": doc["qid"],
+        "goal": doc["goal"],
+        "num_steps": len(target_order),
+        "prediction": prediction,
+        "predicted_order": predicted_order,
+        "answer": target_order,
+        "score": float(predicted_order == target_order),
+        "step_scores": compare_lists(target_order, predicted_order),
+    }
+    return {
+        "vcrbench_accuracy": record,
+        "vcrbench_step_accuracy": record,
+        "vcrbench_weighted_accuracy": record,
+    }
+
+
+def vcrbench_aggregate_accuracy(results: Sequence[MetricRecord]) -> float:
+    """Aggregate the official ``avg_accuracy``: exact match of the whole clip order."""
+    if not results:
+        return 0.0
+    accuracy = 100.0 * sum(result["score"] for result in results) / len(results)
+    step_scores = defaultdict(list)
+    for result in results:
+        step_scores[result["num_steps"]].append(result["score"])
+    for num_steps, scores in sorted(step_scores.items()):
+        eval_logger.info(f"VCRBench/{num_steps}-step accuracy: {100.0 * sum(scores) / len(scores):.2f}")
+    return accuracy
+
+
+def vcrbench_aggregate_step_accuracy(results: Sequence[MetricRecord]) -> float:
+    """Aggregate the official ``avg_step_accuracy``: position-wise match over all clips."""
+    step_scores = [score for result in results for score in result["step_scores"]]
+    if not step_scores:
+        return 0.0
+    return 100.0 * sum(step_scores) / len(step_scores)
+
+
+def vcrbench_aggregate_weighted_accuracy(results: Sequence[MetricRecord]) -> float:
+    """Aggregate the official ``weighted_avg_accuracy``: unweighted mean over the goal classes."""
+    if not results:
+        return 0.0
+    goal_scores = defaultdict(list)
+    for result in results:
+        goal_scores[result["goal"]].append(result["score"])
+    per_goal = {}
+    for goal, scores in sorted(goal_scores.items()):
+        per_goal[goal] = 100.0 * sum(scores) / len(scores)
+        eval_logger.info(f"VCRBench/{goal}: {per_goal[goal]:.2f}")
+    return sum(per_goal.values()) / len(per_goal)

--- a/lmms_eval/tasks/vcrbench/vcrbench.yaml
+++ b/lmms_eval/tasks/vcrbench/vcrbench.yaml
@@ -1,0 +1,3 @@
+task: vcrbench
+include: _default_template_yaml
+doc_to_text: !function utils.vcrbench_doc_to_text

--- a/lmms_eval/tasks/vrbench/README.md
+++ b/lmms_eval/tasks/vrbench/README.md
@@ -1,0 +1,104 @@
+# VRBench
+
+[VRBench](https://vrbench.github.io/) is a multi-step reasoning benchmark over long
+narrative videos (ICCV 2025, [arXiv:2506.10857](https://arxiv.org/abs/2506.10857)).
+It holds 960 videos of 1.6 hours on average and 8,243 human-labelled questions with
+25,106 timestamped reasoning steps. Every question carries exactly four options and
+one of seven reasoning types.
+
+The official protocol scores one model response at two levels, so this port ships two
+tasks that share `_default_template_yaml` and the same prompt:
+
+* `vrbench_mcq` — outcome level. The option letter is recovered by the regex cascade
+  ported from `evaluation/calculate_scores.py:extract_mcq_answer`, and scored as exact
+  accuracy. No judge is involved.
+* `vrbench_process` — process level. An LLM judge rates the reasoning chain from 0 to 10
+  behind a `<rate>` tag, using the prompts in `evaluation/model_api/prompt.py`. The
+  routing of `evaluation/run_process_eval.py` is reproduced: `Event Attribution`,
+  `Multi-element Inference`, `Implicit Inference` and `Logical Linkage` use the
+  unique-answer prompt; `Hypothetical Reasoning` and `Event Prediction` use the
+  non-unique-answer prompt and also receive the video summary. `Event Summarization`
+  and any other type stay unjudged and are excluded from the process aggregate.
+* `vrbench` — the group that runs both tasks and reports the paper's headline number.
+
+Both tasks report a `vrbench_score` on a 0-100 scale plus a per-reasoning-type
+breakdown. The group takes the unweighted mean of the two `vrbench_score` values, which
+is exactly the paper's `Overall = (MCQ_accuracy + process_score * 10) / 2`.
+
+## Data
+
+The annotations load straight from the Hub, so no manual step is needed:
+
+```yaml
+dataset_path: json
+dataset_kwargs:
+  data_files:
+    test: hf://datasets/OpenGVLab/VRBench/VRBench_eval.jsonl
+```
+
+`process_docs` flattens the 960 video-level records into 8,243 question-level documents.
+
+The videos are **not** downloaded automatically. They ship as a 421 GB split zip
+(`v001_360p.zip` plus `.z01`-`.z39`) that the generic archive handling cannot unpack.
+Download and extract them yourself, then point one env var at the result:
+
+| Variable | Required | Meaning |
+|---|---|---|
+| `VRBENCH_VIDEO_DIR` | yes | Directory holding the extracted `.mp4` files |
+| `VRBENCH_ROOT` | no | Alternative root, searched after `VRBENCH_VIDEO_DIR` |
+| `LMMS_EVAL_MEDIA_ROOT` | no | Global media root, searched after the two above |
+
+The annotation field is `VRBench/videos/v001/<video_id>.mp4`, and the resolver also
+accepts `<root>/videos/<video_id>.mp4` and `<root>/<video_id>.mp4`.
+
+```bash
+hf download OpenGVLab/VRBench --repo-type dataset --local-dir /data/VRBench
+cd /data/VRBench/v001_360p_zips && zip -s 0 v001_360p.zip --out v001_360p_joined.zip && unzip v001_360p_joined.zip
+export VRBENCH_VIDEO_DIR=/data/VRBench
+```
+
+## Judge configuration (process track only)
+
+The judge goes through the shared `lmms_eval.verifiers` layer, so it uses the standard
+judge env vars. The paper uses DeepSeek:
+
+```bash
+export API_TYPE=openai
+export OPENAI_API_URL=https://api.deepseek.com/v1
+export OPENAI_API_KEY=<your deepseek key>
+export MODEL_VERSION=deepseek-chat   # default when unset
+```
+
+A judge call that fails after its retries is dropped from the aggregate instead of
+counting as a zero.
+
+## Run
+
+```bash
+accelerate launch -m lmms_eval --model <model> --tasks vrbench --batch_size 1
+```
+
+Use `--tasks vrbench_mcq` for the rule-based track alone, which needs no API key.
+Note that the group runs generation twice, once per task; the official pipeline
+generates once and scores the same file twice.
+
+`lmms_eval_specific_kwargs.include_video_summary` defaults to `true`, which matches the
+official prompt: the model sees the video and the human-written narrative summary. Set
+it to `false` for a video-only ablation.
+
+## Official numbers
+
+From the project page, on the `Overall / MCQ-O / OE-P` scale this port reproduces
+(all 0-100, `OE-P` being the 0-10 process score times ten):
+
+| Model | Overall | MCQ-O | OE-P |
+|---|---|---|---|
+| Gemini-2.0-Pro | 74.61 | 83.29 | 65.93 |
+| GPT-4o | 68.68 | 81.23 | 56.13 |
+| InternVL2.5-78B | 62.31 | 76.61 | 48.01 |
+| Kimi-VL-A3B-Thinking-2506 | 61.82 | 61.67 | 61.97 |
+| Qwen2.5-VL-72B | 61.71 | 66.85 | 56.57 |
+| Keye-VL-8B-Preview | 60.44 | 64.41 | 56.47 |
+| Qwen2.5-VL-7B | 56.52 | 69.61 | 43.43 |
+
+Every question has four options, so random choice scores 25.0 on `vrbench_mcq`.

--- a/lmms_eval/tasks/vrbench/__init__.py
+++ b/lmms_eval/tasks/vrbench/__init__.py
@@ -1,0 +1,1 @@
+"""VRBench multi-step reasoning tasks for long narrative videos."""

--- a/lmms_eval/tasks/vrbench/_default_template_yaml
+++ b/lmms_eval/tasks/vrbench/_default_template_yaml
@@ -1,0 +1,24 @@
+dataset_path: json
+dataset_kwargs:
+  data_files:
+    test: hf://datasets/OpenGVLab/VRBench/VRBench_eval.jsonl
+test_split: test
+output_type: generate_until
+cluster_key: video_id
+process_docs: !function utils.vrbench_process_docs
+doc_to_visual: !function utils.vrbench_doc_to_visual
+doc_to_text: !function utils.vrbench_doc_to_text
+doc_to_target: answer
+generation_kwargs:
+  max_new_tokens: 1024
+  temperature: 0
+  top_p: 1.0
+  num_beams: 1
+  do_sample: false
+lmms_eval_specific_kwargs:
+  default:
+    pre_prompt: ""
+    post_prompt: ""
+    include_video_summary: true
+metadata:
+  version: 1.0

--- a/lmms_eval/tasks/vrbench/utils.py
+++ b/lmms_eval/tasks/vrbench/utils.py
@@ -1,0 +1,571 @@
+import os
+import re
+import threading
+from typing import Any, Mapping, Sequence
+
+from datasets import Dataset
+from loguru import logger as eval_logger
+
+from lmms_eval.tasks._task_utils.media_resolver import resolve_media_reference
+from lmms_eval.verifiers import VerificationPipeline, VerifyResult
+from lmms_eval.verifiers.extractors import StripReasoningExtractor
+from lmms_eval.verifiers.openai import OpenAIVerifier
+
+Document = Mapping[str, Any]
+TaskKwargs = Mapping[str, Any]
+MetricRecord = dict[str, Any]
+
+CHOICES = ("A", "B", "C", "D")
+
+# Reasoning-type spellings exactly as they appear in VRBench_eval.jsonl.
+# "Counting Porblems" is misspelled in the released annotations; matching it
+# verbatim is required, so only the metric slug fixes the spelling.
+REASONING_TYPE_SLUGS = {
+    "Event Attribution": "event_attribution",
+    "Hypothetical Reasoning": "hypothetical_reasoning",
+    "Event Summarization": "event_summarization",
+    "Implicit Inference": "implicit_inference",
+    "Event Prediction": "event_prediction",
+    "Counting Porblems": "counting_problems",
+    "Logical Linkage": "logical_linkage",
+}
+
+# Judge routing, reproduced from VRBench/evaluation/run_process_eval.py.
+# "Multi-element Inference" is kept for parity with the official list even
+# though no released annotation carries it.
+UNIQUE_ANSWER_TYPES = frozenset({"Event Attribution", "Multi-element Inference", "Implicit Inference", "Logical Linkage"})
+NON_UNIQUE_ANSWER_TYPES = frozenset({"Hypothetical Reasoning", "Event Prediction"})
+
+# The official judge truncates the narrative summary before prompting.
+VIDEO_SUMMARY_CHAR_LIMIT = 10000
+
+JUDGE_MODEL = os.getenv("MODEL_VERSION", "deepseek-chat")
+
+# ---------------------------------------------------------------------------
+# Prompts — ported verbatim from the official VRBench repository
+# ---------------------------------------------------------------------------
+
+# VRBench/inference/utils/constant.py :: MCQ_COT_PROMPT
+MCQ_COT_PROMPT = """
+You are a helpful video understanding assistant that answers multi-choice questions through step-by-step reasoning based on the video and its summary.
+
+# Instructions:
+1. Break down the reasoning process into clear, specific events.
+2. Conclude with the best option letter(A/B/C/D) at last.
+
+# Output Format:
+<Step 1> Description of event/observation
+<Step 2> Description of event/observation
+...
+<Answer> [Option letter]
+
+# Multiple Choice Question
+{multiple_choice_question}
+
+# Video Summary
+{video_summary}
+"""
+
+# VRBench/evaluation/model_api/prompt.py :: UNIQUE_ANSWER_EVAL_SYSTEM_PROMPT
+UNIQUE_ANSWER_EVAL_SYSTEM_PROMPT = """
+You are a reasoning process evaluation model. Given the question, your task is to compare the model's reasoning process with the correct reasoning process provided, and assess the accuracy of the model's reasoning.
+Based on the number of correct steps and the overall correctness, give a score between 0 and 10, where 10 means fully correct.
+
+Evaluation Criteria:
+    1. **Step-by-Step Match**: How closely each reasoning step aligns with the ground truth process. Highest weight (40%).
+    2. **Logical Integrity**: Whether the reasoning maintains valid logical progression and complete argumentation (30%).
+    3. **Factual Correctness**: Absence of factual errors conflicting with established truths (20%).
+    4. **Process Clarity**: Clear articulation and organization of reasoning steps (10%).
+
+    Scoring:
+    - **0-3**: Multiple missing/critical deviations from correct steps (≤30% match), broken logic, severe factual errors, or incoherent presentation.
+    - **4-6**: Partial step alignment (40-60% match), basic logical structure with gaps, minor factual slips, or ambiguous explanations.
+    - **7-9**: Majority steps correct (70-90% match), sound logic with minor jumps, near-perfect factual accuracy, and clear presentation.
+    - **10**: Full step correspondence (100% match), flawless logic, perfect factual accuracy, and exceptionally clear reasoning flow.
+
+Please provide the reasons for your scoring at the end.
+Output Format:
+<rate>the score (0-10)</rate>.
+<reason>Briefly explain the reason for the score.</reason>
+"""
+
+# VRBench/evaluation/model_api/prompt.py :: NON_UNIQUE_ANSWER_EVAL_SYSTEM_PROMPT
+NON_UNIQUE_ANSWER_EVAL_SYSTEM_PROMPT = """
+You are a reasoning process evaluation model. Given the question, your task is to evaluate the model's reasoning process with the correct reasoning process provided, and assess the accuracy of the model's reasoning.
+In addition to referring to the provided reasoning process and result, you may also assess the reasoning's validity based on the video summary. If the reasoning is logical and the result is reasonable, you can adjust the score accordingly.
+Based on the correctness and reasonableness of the reasoning process, provide a score between 0 and 10, where 10 means fully correct and reasonable.
+
+Evaluation Criteria:
+    1. **Relevance and Completeness**: Evaluate whether the reasoning process adequately addresses the question and covers all essential steps, even if the approach differs from the provided standard. (40%)
+    2. **Logical Consistency**: Assess the logical progression, coherence, and structural integrity of the reasoning process (30%).
+    3. **Factual Accuracy**: Check for correctness and the absence of significant factual errors (20%).
+    4. **Clarity and Persuasiveness**: Consider the clarity, organization, and persuasiveness of the reasoning, including the explanation of alternative valid approaches (10%).
+
+Scoring:
+    - **0-3**: The reasoning process shows significant omissions, major logical inconsistencies, or severe factual errors, resulting in an unclear and unconvincing explanation.
+    - **4-6**: The reasoning process partially addresses the question with some logical or factual issues, and the explanation may be somewhat ambiguous or incomplete.
+    - **7-9**: The reasoning process is largely relevant and logically consistent, with minor issues in clarity or factual details, leading to a well-argued explanation.
+    - **10**: The reasoning process fully addresses the question with impeccable logic, complete factual accuracy, and is presented in a clear and highly persuasive manner.
+
+Output Format:
+<rate>the score (0-10)</rate>.
+<reason>Briefly explain the reason for the score.</reason>
+"""
+
+# VRBench/evaluation/model_api/prompt.py :: UNIQUE_ANSWER_EVAL_HUMAN_PROMPT_TEMPLATE
+UNIQUE_ANSWER_EVAL_HUMAN_PROMPT_TEMPLATE = """
+# Question
+{question}
+# Model's reasoning process and Answer
+{response}
+# Correct reasoning step and Answer
+Reasoning Step:
+{procedure}
+Answer:
+{answer}
+Please provide your rating and brief reasons.
+"""
+
+# VRBench/evaluation/model_api/prompt.py :: NON_UNIQUE_ANSWER_EVAL_HUMAN_PROMPT_TEMPLATE
+NON_UNIQUE_ANSWER_EVAL_HUMAN_PROMPT_TEMPLATE = """
+# Video Summary
+{video_summary}
+# Question
+{question}
+# Model's reasoning process and Answer
+{response}
+# Correct reasoning step and Answer
+Answer:
+{answer}
+Reasoning Step:
+{procedure}
+Please provide your rating and brief reasons.
+"""
+
+
+# ---------------------------------------------------------------------------
+# Dataset flattening
+# ---------------------------------------------------------------------------
+
+
+def _qa_sort_key(qa_key: str) -> tuple[int, int, str]:
+    """Order the ``qa1``…``qaN`` keys numerically instead of lexicographically."""
+    match = re.fullmatch(r"qa(\d+)", qa_key)
+    if match:
+        return (0, int(match.group(1)), "")
+    return (1, 0, qa_key)
+
+
+def format_reasoning_process(procedure: Any) -> str:
+    """Render the annotated reasoning steps as the official ``<Step N> …`` block."""
+    if isinstance(procedure, str):
+        return procedure
+    if not procedure:
+        return ""
+    steps = sorted(procedure.items(), key=lambda item: int(item[0]) if str(item[0]).isdigit() else 0)
+    return "\n".join(f"<Step {number}> {description}" for number, description in steps)
+
+
+def vrbench_process_docs(dataset: Dataset) -> Dataset:
+    """Flatten one annotation record per video into one document per question.
+
+    ``VRBench_eval.jsonl`` stores 960 videos, each carrying an ``mcq`` mapping of
+    6-10 questions, for 8,243 questions in total.  lmms-eval scores one document
+    per request, so the mapping is expanded here and the video-level fields are
+    copied onto every question.
+    """
+    flattened: list[dict[str, Any]] = []
+    for record in dataset:
+        video_id = record["video_id"]
+        video_summary = record.get("video_summary") or ""
+        for qa_key in sorted(record["mcq"], key=_qa_sort_key):
+            qa = record["mcq"][qa_key]
+            flattened.append(
+                {
+                    "question_id": f"{video_id}_{qa_key}",
+                    "qa_key": qa_key,
+                    "video_id": video_id,
+                    "video_path": record["video_path"],
+                    "video_read_type": record.get("video_read_type") or "",
+                    "video_summary": video_summary,
+                    "question": qa["question"],
+                    "options": qa["options"],
+                    "answer": qa["answer"],
+                    "original_answer": qa.get("original_answer") or "",
+                    "reasoning_process": format_reasoning_process(qa.get("reasoning_process")),
+                    "reasoning_type": qa["reasoning_type"],
+                }
+            )
+    eval_logger.info(f"VRBench: flattened {len(dataset)} videos into {len(flattened)} questions.")
+    return Dataset.from_list(flattened)
+
+
+# ---------------------------------------------------------------------------
+# Visual / text doc helpers
+# ---------------------------------------------------------------------------
+
+
+def _resolve_video(doc: Document) -> str:
+    return resolve_media_reference(
+        doc["video_path"],
+        media_type="video",
+        cache_dir="vrbench",
+        env_vars=("VRBENCH_VIDEO_DIR", "VRBENCH_ROOT"),
+        extra_subdirs=("videos", "videos/v001", "VRBench/videos", "VRBench/videos/v001"),
+    )
+
+
+def vrbench_doc_to_visual(doc: Document) -> list[str]:
+    """Resolve the local video for one VRBench question."""
+    video_path = _resolve_video(doc)
+    if not os.path.exists(video_path):
+        raise FileNotFoundError(
+            f"VRBench video not found: {video_path}. Download the split archives from " "https://huggingface.co/datasets/OpenGVLab/VRBench, extract them, and point " "VRBENCH_VIDEO_DIR at the directory that holds the .mp4 files."
+        )
+    return [video_path]
+
+
+def _format_question(doc: Document) -> str:
+    """Render the question and its options in the official ``dict_to_text`` layout."""
+    options = doc["options"]
+    keys = [key for key in CHOICES if key in options] + [key for key in sorted(options) if key not in CHOICES]
+    option_prompt = "\n".join(f"{key}: {options[key]}" for key in keys)
+    return f"Question: {doc['question']}\nOptions:\n{option_prompt}"
+
+
+def vrbench_doc_to_text(doc: Document, lmms_eval_specific_kwargs: TaskKwargs | None = None) -> str:
+    """Render the official step-by-step VRBench prompt for one question."""
+    kwargs = lmms_eval_specific_kwargs or {}
+    video_summary = doc.get("video_summary") or "" if kwargs.get("include_video_summary", True) else ""
+    prompt = MCQ_COT_PROMPT.format(multiple_choice_question=_format_question(doc), video_summary=video_summary)
+    return f"{kwargs.get('pre_prompt', '')}{prompt}{kwargs.get('post_prompt', '')}"
+
+
+# ---------------------------------------------------------------------------
+# Rule-based MCQ extraction — ported from
+# VRBench/evaluation/calculate_scores.py :: extract_mcq_answer
+# ---------------------------------------------------------------------------
+
+_PERIOD_STRIP = re.compile(r"(?!<=\d)(\.)(?!\d)")
+_COMMA_STRIP = re.compile(r"(\d)(\,)(\d)")
+_PUNCTUATION = [";", r"/", "[", "]", '"', "{", "}", "(", ")", "=", "+", "\\", "_", "-", ">", "<", "@", "`", ",", "?", "!"]
+
+_ANSWER_PATTERNS = [
+    r"Answer[:\s]+([A-E])(?:\s|$|\.|,)",
+    r"answer is[:\s]+([A-E])(?:\s|$|\.|,)",
+    r"correct answer[:\s]+([A-E])(?:\s|$|\.|,)",
+    r"final answer[:\s]+([A-E])(?:\s|$|\.|,)",
+    r"final[:\s]+([A-E])(?:\s|$|\.|,)",
+    r"therefore[:\s]+([A-E])(?:\s|$|\.|,)",
+    r"conclusion[:\s]+([A-E])(?:\s|$|\.|,)",
+]
+
+_OPTION_PATTERNS = [r"([A-E])\.", r"([A-E])\)", r"([A-E]):"]
+
+
+def _process_punctuation(text: str) -> str:
+    """Strip punctuation the way the official scorer does before the final scan."""
+    output = text
+    for punctuation in _PUNCTUATION:
+        if (punctuation + " " in text or " " + punctuation in text) or (re.search(_COMMA_STRIP, text) is not None):
+            output = output.replace(punctuation, "")
+        else:
+            output = output.replace(punctuation, " ")
+    return _PERIOD_STRIP.sub("", output, re.UNICODE)
+
+
+def extract_mcq_answer(response_text: str) -> str | None:
+    """Extract the chosen option letter from a model response.
+
+    Faithful port of the regex cascade in
+    ``VRBench/evaluation/calculate_scores.py``.  Each stage returns the *last*
+    match it finds, which keeps the final answer of a long chain-of-thought
+    response instead of an option discussed on the way there.
+
+    Args:
+        response_text: Raw model output.
+
+    Returns:
+        An uppercase option letter, or ``None`` when no letter can be recovered.
+    """
+    if not response_text:
+        return None
+
+    # 1. \boxed{A}
+    boxed_match = re.search(r"\\boxed\{([A-E])\}", response_text, re.IGNORECASE)
+    if boxed_match:
+        return boxed_match.group(1).upper()
+
+    # 2. <Answer> A
+    answer_match = re.search(r"<Answer>\s*([A-E])", response_text, re.IGNORECASE)
+    if answer_match:
+        return answer_match.group(1).upper()
+
+    # 3. A line that starts with "A. <option text>"
+    option_format_matches = re.findall(r"^([A-E])\.\s*(.+)$", response_text.strip(), re.IGNORECASE | re.MULTILINE)
+    if option_format_matches:
+        return option_format_matches[-1][0].upper()
+
+    # 4. Explicit answer statements
+    all_answer_matches: list[str] = []
+    for pattern in _ANSWER_PATTERNS:
+        all_answer_matches.extend(re.findall(pattern, response_text, re.IGNORECASE))
+    if all_answer_matches:
+        return all_answer_matches[-1].upper()
+
+    # 5. Bare option labels
+    for pattern in _OPTION_PATTERNS:
+        matches = re.findall(pattern, response_text, re.IGNORECASE)
+        if matches:
+            return matches[-1].upper()
+
+    # 6. A standalone letter followed by a space
+    matches = re.findall(r"(?:^|\n|\s)([A-E])\s+(?=[A-Z]|$|\n)", response_text, re.IGNORECASE | re.MULTILINE)
+    if matches:
+        return matches[-1].upper()
+
+    # 7. Punctuation-stripped rescan
+    processed_text = response_text.replace("\n", " ").replace("\t", " ").strip()
+    processed_text = _process_punctuation(processed_text)
+    processed_text = processed_text.strip("'").strip('"').strip(")").strip("(").strip().lower()
+    processed_letters = re.findall(r"\b([A-E])\b", processed_text, re.IGNORECASE)
+    if processed_letters:
+        return processed_letters[-1].upper()
+
+    # 8. Fallback: prefer a letter near the end of the response
+    choices = re.findall(r"\b([A-E])\b", response_text)
+    if choices:
+        end_choices = re.findall(r"\b([A-E])\b", response_text.lower()[-50:], re.IGNORECASE)
+        if end_choices:
+            return end_choices[-1].upper()
+        return choices[-1].upper()
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# MCQ track — process_results / aggregations
+# ---------------------------------------------------------------------------
+
+
+def vrbench_mcq_process_results(doc: Document, results: Sequence[str]) -> dict[str, MetricRecord]:
+    """Parse a prediction and emit the VRBench MCQ accuracy record."""
+    prediction = results[0] if results else ""
+    parsed_prediction = extract_mcq_answer(prediction)
+    answer = str(doc["answer"]).strip().upper()
+    reasoning_type = str(doc["reasoning_type"])
+    record: MetricRecord = {
+        "question_id": doc["question_id"],
+        "video_id": doc["video_id"],
+        "reasoning_type": reasoning_type,
+        "prediction": prediction,
+        "parsed_prediction": parsed_prediction,
+        "answer": answer,
+        "score": float(parsed_prediction == answer),
+    }
+    metrics: dict[str, MetricRecord] = {"vrbench_score": record}
+    slug = REASONING_TYPE_SLUGS.get(reasoning_type)
+    if slug is not None:
+        metrics[f"vrbench_mcq_{slug}_accuracy"] = record
+    return metrics
+
+
+def _aggregate_mcq(results: Sequence[MetricRecord], reasoning_type: str | None = None) -> float:
+    """Compute question-weighted MCQ accuracy as a percentage."""
+    selected = [result for result in results if reasoning_type is None or result["reasoning_type"] == reasoning_type]
+    if not selected:
+        return 0.0
+    correct = sum(result["score"] for result in selected)
+    accuracy = 100.0 * correct / len(selected)
+    eval_logger.info(f"VRBench MCQ {reasoning_type or 'overall'} accuracy: {accuracy:.2f}% ({int(correct)}/{len(selected)})")
+    return accuracy
+
+
+def vrbench_mcq_aggregate_results(results: Sequence[MetricRecord]) -> float:
+    """Aggregate overall VRBench MCQ accuracy."""
+    return _aggregate_mcq(results)
+
+
+def vrbench_mcq_aggregate_event_attribution(results: Sequence[MetricRecord]) -> float:
+    """Aggregate MCQ accuracy for the Event Attribution questions."""
+    return _aggregate_mcq(results, "Event Attribution")
+
+
+def vrbench_mcq_aggregate_hypothetical_reasoning(results: Sequence[MetricRecord]) -> float:
+    """Aggregate MCQ accuracy for the Hypothetical Reasoning questions."""
+    return _aggregate_mcq(results, "Hypothetical Reasoning")
+
+
+def vrbench_mcq_aggregate_event_summarization(results: Sequence[MetricRecord]) -> float:
+    """Aggregate MCQ accuracy for the Event Summarization questions."""
+    return _aggregate_mcq(results, "Event Summarization")
+
+
+def vrbench_mcq_aggregate_implicit_inference(results: Sequence[MetricRecord]) -> float:
+    """Aggregate MCQ accuracy for the Implicit Inference questions."""
+    return _aggregate_mcq(results, "Implicit Inference")
+
+
+def vrbench_mcq_aggregate_event_prediction(results: Sequence[MetricRecord]) -> float:
+    """Aggregate MCQ accuracy for the Event Prediction questions."""
+    return _aggregate_mcq(results, "Event Prediction")
+
+
+def vrbench_mcq_aggregate_counting_problems(results: Sequence[MetricRecord]) -> float:
+    """Aggregate MCQ accuracy for the counting questions."""
+    return _aggregate_mcq(results, "Counting Porblems")
+
+
+def vrbench_mcq_aggregate_logical_linkage(results: Sequence[MetricRecord]) -> float:
+    """Aggregate MCQ accuracy for the Logical Linkage questions."""
+    return _aggregate_mcq(results, "Logical Linkage")
+
+
+# ---------------------------------------------------------------------------
+# Process track — LLM judge
+# ---------------------------------------------------------------------------
+
+_RATE_PATTERN = re.compile(r"<rate>(.*?)</rate>", re.DOTALL)
+_NUMBER_PATTERN = re.compile(r"-?\d+(?:\.\d+)?")
+
+
+def _parse_rate_response(text: str) -> VerifyResult:
+    """Parse the ``<rate>0-10</rate>`` block returned by the VRBench judge."""
+    rate = 0.0
+    parsed = False
+    match = _RATE_PATTERN.search(text or "")
+    if match:
+        numbers = _NUMBER_PATTERN.findall(match.group(1))
+        if numbers:
+            rate = max(0.0, min(10.0, float(numbers[0])))
+            parsed = True
+    return VerifyResult(score=rate / 10.0, is_correct=rate >= 5.0, raw_output=text, metadata={"rate": rate, "rate_parsed": parsed})
+
+
+def _unique_judge_prompt(question: str, prediction: str, ground_truth: str, **kwargs: Any) -> str:
+    """Build the judge prompt for reasoning types that have a unique answer."""
+    human_prompt = UNIQUE_ANSWER_EVAL_HUMAN_PROMPT_TEMPLATE.format(question=question, response=prediction, procedure=kwargs.get("procedure", ""), answer=ground_truth)
+    return f"{UNIQUE_ANSWER_EVAL_SYSTEM_PROMPT}{human_prompt}"
+
+
+def _non_unique_judge_prompt(question: str, prediction: str, ground_truth: str, **kwargs: Any) -> str:
+    """Build the judge prompt for reasoning types that accept several answers."""
+    human_prompt = NON_UNIQUE_ANSWER_EVAL_HUMAN_PROMPT_TEMPLATE.format(
+        video_summary=kwargs.get("video_summary", ""),
+        question=question,
+        response=prediction,
+        procedure=kwargs.get("procedure", ""),
+        answer=ground_truth,
+    )
+    return f"{NON_UNIQUE_ANSWER_EVAL_SYSTEM_PROMPT}{human_prompt}"
+
+
+_pipelines: dict[str, VerificationPipeline] = {}
+_pipeline_lock = threading.Lock()
+
+
+def _get_pipeline(route: str) -> VerificationPipeline:
+    """Return the lazily built judge pipeline for ``unique`` or ``non_unique``."""
+    pipeline = _pipelines.get(route)
+    if pipeline is None:
+        with _pipeline_lock:
+            pipeline = _pipelines.get(route)
+            if pipeline is None:  # double-check
+                pipeline = VerificationPipeline(
+                    extractors=[StripReasoningExtractor()],
+                    verifier=OpenAIVerifier(
+                        model=JUDGE_MODEL,
+                        custom_prompt=_unique_judge_prompt if route == "unique" else _non_unique_judge_prompt,
+                        response_parser=_parse_rate_response,
+                        max_retries=3,
+                        retry_delay=2.0,
+                        max_tokens=1024,
+                    ),
+                )
+                _pipelines[route] = pipeline
+    return pipeline
+
+
+def vrbench_process_process_results(doc: Document, results: Sequence[str]) -> dict[str, MetricRecord]:
+    """Score one reasoning trace with the VRBench process judge.
+
+    Event Summarization and any reasoning type outside the official routing
+    table are left unjudged, matching ``run_process_eval.py``.  Their records
+    are still emitted so the sample log stays complete, but the aggregation
+    skips them.
+    """
+    prediction = results[0] if results else ""
+    reasoning_type = str(doc["reasoning_type"])
+    record: MetricRecord = {
+        "question_id": doc["question_id"],
+        "video_id": doc["video_id"],
+        "reasoning_type": reasoning_type,
+        "prediction": prediction,
+        "judged": False,
+        "score": 0.0,
+        "judge_output": "",
+    }
+
+    if reasoning_type in UNIQUE_ANSWER_TYPES:
+        route = "unique"
+        judge_kwargs: dict[str, Any] = {"procedure": doc["reasoning_process"]}
+    elif reasoning_type in NON_UNIQUE_ANSWER_TYPES:
+        route = "non_unique"
+        judge_kwargs = {"procedure": doc["reasoning_process"], "video_summary": (doc.get("video_summary") or "")[:VIDEO_SUMMARY_CHAR_LIMIT]}
+    else:
+        return {"vrbench_score": record}
+
+    result = _get_pipeline(route)(question=doc["question"], prediction=prediction, ground_truth=doc["original_answer"], **judge_kwargs)
+    if result.metadata.get("judge_failed"):
+        eval_logger.warning(f"VRBench process judge failed for {record['question_id']}; the question is excluded.")
+        return {"vrbench_score": record}
+
+    record["judged"] = True
+    record["score"] = float(result.metadata.get("rate", 0.0))
+    record["judge_output"] = result.raw_output
+
+    metrics: dict[str, MetricRecord] = {"vrbench_score": record}
+    slug = REASONING_TYPE_SLUGS.get(reasoning_type)
+    if slug is not None:
+        metrics[f"vrbench_process_{slug}_score"] = record
+    return metrics
+
+
+def _aggregate_process(results: Sequence[MetricRecord], reasoning_type: str | None = None) -> float:
+    """Average the judged 0-10 process scores and rescale them to 0-100."""
+    selected = [result for result in results if result["judged"] and (reasoning_type is None or result["reasoning_type"] == reasoning_type)]
+    if not selected:
+        return 0.0
+    mean_rate = sum(result["score"] for result in selected) / len(selected)
+    eval_logger.info(f"VRBench process {reasoning_type or 'overall'} score: {mean_rate:.2f}/10 ({len(selected)} judged)")
+    return 10.0 * mean_rate
+
+
+def vrbench_process_aggregate_results(results: Sequence[MetricRecord]) -> float:
+    """Aggregate the overall VRBench process score."""
+    return _aggregate_process(results)
+
+
+def vrbench_process_aggregate_event_attribution(results: Sequence[MetricRecord]) -> float:
+    """Aggregate the process score for the Event Attribution questions."""
+    return _aggregate_process(results, "Event Attribution")
+
+
+def vrbench_process_aggregate_hypothetical_reasoning(results: Sequence[MetricRecord]) -> float:
+    """Aggregate the process score for the Hypothetical Reasoning questions."""
+    return _aggregate_process(results, "Hypothetical Reasoning")
+
+
+def vrbench_process_aggregate_implicit_inference(results: Sequence[MetricRecord]) -> float:
+    """Aggregate the process score for the Implicit Inference questions."""
+    return _aggregate_process(results, "Implicit Inference")
+
+
+def vrbench_process_aggregate_event_prediction(results: Sequence[MetricRecord]) -> float:
+    """Aggregate the process score for the Event Prediction questions."""
+    return _aggregate_process(results, "Event Prediction")
+
+
+def vrbench_process_aggregate_logical_linkage(results: Sequence[MetricRecord]) -> float:
+    """Aggregate the process score for the Logical Linkage questions."""
+    return _aggregate_process(results, "Logical Linkage")

--- a/lmms_eval/tasks/vrbench/vrbench_group.yaml
+++ b/lmms_eval/tasks/vrbench/vrbench_group.yaml
@@ -1,0 +1,10 @@
+group: vrbench
+task:
+  - vrbench_mcq
+  - vrbench_process
+aggregate_metric_list:
+  - metric: vrbench_score
+    aggregation: mean
+    weight_by_size: false
+metadata:
+  version: 1.0

--- a/lmms_eval/tasks/vrbench/vrbench_mcq.yaml
+++ b/lmms_eval/tasks/vrbench/vrbench_mcq.yaml
@@ -1,0 +1,28 @@
+task: vrbench_mcq
+include: _default_template_yaml
+process_results: !function utils.vrbench_mcq_process_results
+metric_list:
+  - metric: vrbench_score
+    aggregation: !function utils.vrbench_mcq_aggregate_results
+    higher_is_better: true
+  - metric: vrbench_mcq_event_attribution_accuracy
+    aggregation: !function utils.vrbench_mcq_aggregate_event_attribution
+    higher_is_better: true
+  - metric: vrbench_mcq_hypothetical_reasoning_accuracy
+    aggregation: !function utils.vrbench_mcq_aggregate_hypothetical_reasoning
+    higher_is_better: true
+  - metric: vrbench_mcq_event_summarization_accuracy
+    aggregation: !function utils.vrbench_mcq_aggregate_event_summarization
+    higher_is_better: true
+  - metric: vrbench_mcq_implicit_inference_accuracy
+    aggregation: !function utils.vrbench_mcq_aggregate_implicit_inference
+    higher_is_better: true
+  - metric: vrbench_mcq_event_prediction_accuracy
+    aggregation: !function utils.vrbench_mcq_aggregate_event_prediction
+    higher_is_better: true
+  - metric: vrbench_mcq_counting_problems_accuracy
+    aggregation: !function utils.vrbench_mcq_aggregate_counting_problems
+    higher_is_better: true
+  - metric: vrbench_mcq_logical_linkage_accuracy
+    aggregation: !function utils.vrbench_mcq_aggregate_logical_linkage
+    higher_is_better: true

--- a/lmms_eval/tasks/vrbench/vrbench_process.yaml
+++ b/lmms_eval/tasks/vrbench/vrbench_process.yaml
@@ -1,0 +1,22 @@
+task: vrbench_process
+include: _default_template_yaml
+process_results: !function utils.vrbench_process_process_results
+metric_list:
+  - metric: vrbench_score
+    aggregation: !function utils.vrbench_process_aggregate_results
+    higher_is_better: true
+  - metric: vrbench_process_event_attribution_score
+    aggregation: !function utils.vrbench_process_aggregate_event_attribution
+    higher_is_better: true
+  - metric: vrbench_process_hypothetical_reasoning_score
+    aggregation: !function utils.vrbench_process_aggregate_hypothetical_reasoning
+    higher_is_better: true
+  - metric: vrbench_process_implicit_inference_score
+    aggregation: !function utils.vrbench_process_aggregate_implicit_inference
+    higher_is_better: true
+  - metric: vrbench_process_event_prediction_score
+    aggregation: !function utils.vrbench_process_aggregate_event_prediction
+    higher_is_better: true
+  - metric: vrbench_process_logical_linkage_score
+    aggregation: !function utils.vrbench_process_aggregate_logical_linkage
+    higher_is_better: true

--- a/test/eval/test_mmr_v.py
+++ b/test/eval/test_mmr_v.py
@@ -1,0 +1,168 @@
+import re
+from pathlib import Path
+from typing import Any
+
+import cv2
+import numpy as np
+import pytest
+
+from lmms_eval.tasks import TaskManager
+from lmms_eval.tasks.mmr_v import utils as mmr_v_utils
+
+
+def _letters(option_count: int) -> list[str]:
+    return [chr(ord("A") + index) for index in range(option_count)]
+
+
+def _doc(
+    option_count: int = 8,
+    answer: str = "(C)",
+    ability_type: str = "Metaphor Understanding",
+    video_type: str = "Animation",
+    question_idx: int = 0,
+    video: str = "demo video.mp4",
+) -> dict[str, Any]:
+    return {
+        "video": video,
+        "videoType": video_type,
+        "question": "What does the object being chased by the people refer to?",
+        "options": [f"({letter}) Option {letter}" for letter in _letters(option_count)],
+        "correctAnswer": answer,
+        "abilityType_L2": ability_type,
+        "abilityType_L3": "Ontological Metaphor",
+        "question_idx": question_idx,
+    }
+
+
+def _write_test_video(path: Path, frame_count: int = 4, fps: int = 2) -> None:
+    writer = cv2.VideoWriter(str(path), cv2.VideoWriter_fourcc(*"mp4v"), fps, (8, 8))
+    assert writer.isOpened(), "OpenCV cannot create the temporary MP4 test fixture"
+    for value in range(frame_count):
+        writer.write(np.full((8, 8, 3), value * 50, dtype=np.uint8))
+    writer.release()
+
+
+def _isolate_media_env(monkeypatch: pytest.MonkeyPatch, root: Path) -> None:
+    monkeypatch.setenv("MMR_V_VIDEO_DIR", str(root))
+    monkeypatch.delenv("MMR_V_ROOT", raising=False)
+    monkeypatch.delenv("LMMS_EVAL_MEDIA_ROOT", raising=False)
+
+
+def _declared_metrics() -> set[str]:
+    template = Path(mmr_v_utils.__file__).parent / "_default_template_yaml"
+    return set(re.findall(r"^\s*- metric:\s*(\S+)\s*$", template.read_text(encoding="utf-8"), flags=re.MULTILINE))
+
+
+def test_mmr_v_tasks_are_registered() -> None:
+    task_manager = TaskManager("ERROR")
+    expected = {"mmr_v", "mmr_v_cot", "mmr_v_all"}
+    assert not expected.difference(task_manager.all_tasks)
+
+
+@pytest.mark.parametrize("option_count,letter", [(7, "G"), (11, "K"), (13, "M")])
+def test_mmr_v_extracts_every_offered_letter(option_count: int, letter: str) -> None:
+    choices = _letters(option_count)
+
+    assert mmr_v_utils.extract_mmr_v_answer(f"[[{letter}]]", choices) == letter
+    assert mmr_v_utils.extract_mmr_v_answer(f"Option A is wrong. Option B is a distractor. [[{letter}]]", choices) == letter
+    assert mmr_v_utils.extract_mmr_v_answer(f"<think>Option (A) looks close.</think>\n[[{letter}]]", choices) == letter
+    assert mmr_v_utils.extract_mmr_v_answer(f"\\boxed{{{letter}}}", choices) == letter
+
+
+def test_mmr_v_rejects_a_letter_the_question_does_not_offer() -> None:
+    assert mmr_v_utils.extract_mmr_v_answer("[[M]]", _letters(7)) == ""
+
+
+def test_mmr_v_reads_the_letters_back_from_options_that_skip_one() -> None:
+    doc = _doc()
+    doc["options"] = ["(A) First", "(B) Second", "", "(D) Fourth"]
+
+    offered = mmr_v_utils.mmr_v_process_results(dict(doc, correctAnswer="(D)"), ["The answer is [[D]]."])["mmr_v_overall_accuracy"]
+    skipped = mmr_v_utils.mmr_v_process_results(dict(doc, correctAnswer="(D)"), ["[[C]]"])["mmr_v_overall_accuracy"]
+
+    assert offered["pred_answer"] == "D"
+    assert offered["score"] == 1.0
+    assert skipped["pred_answer"] == ""
+    assert skipped["score"] == 0.0
+
+
+def test_mmr_v_doc_to_text_keeps_the_dataset_option_letters() -> None:
+    prompt = mmr_v_utils.mmr_v_doc_to_text(_doc(13), {"pre_prompt": "Video QA:\n", "post_prompt": "\nAnswer with the option letter only."})
+
+    assert prompt.startswith("Video QA:\nPlease select the best answer")
+    assert "Options:\n(A) Option A\n(B) Option B\n" in prompt
+    assert "(M) Option M" in prompt
+    assert "A. (A)" not in prompt
+    assert prompt.count("(A)") == 1
+    assert prompt.endswith("\nAnswer with the option letter only.")
+
+
+def test_mmr_v_doc_to_text_defaults_to_an_empty_prompt_wrapper() -> None:
+    prompt = mmr_v_utils.mmr_v_doc_to_text(_doc())
+
+    assert prompt.startswith("Please select the best answer")
+    assert prompt.endswith("(H) Option H")
+
+
+def test_mmr_v_doc_to_visual_resolves_configured_media_root(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    video = tmp_path / "videos" / "demo video.mp4"
+    video.parent.mkdir()
+    _write_test_video(video)
+    _isolate_media_env(monkeypatch, tmp_path)
+
+    assert mmr_v_utils.mmr_v_doc_to_visual(_doc()) == [str(video)]
+
+
+def test_mmr_v_doc_to_visual_reports_a_missing_video(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _isolate_media_env(monkeypatch, tmp_path)
+
+    with pytest.raises(FileNotFoundError, match="MMR-V video not found"):
+        mmr_v_utils.mmr_v_doc_to_visual(_doc(video="absent video.mp4"))
+
+
+def test_mmr_v_parenthesised_gold_matches_a_bare_prediction() -> None:
+    bare = mmr_v_utils.mmr_v_process_results(_doc(answer="(C)"), ["C"])["mmr_v_overall_accuracy"]
+    verbose = mmr_v_utils.mmr_v_process_results(_doc(answer="(C)"), ["The best answer is (C)."])["mmr_v_overall_accuracy"]
+    wrong = mmr_v_utils.mmr_v_process_results(_doc(answer="(C)"), ["[[D]]"])["mmr_v_overall_accuracy"]
+
+    assert bare["answer"] == "C"
+    assert bare["pred_answer"] == "C"
+    assert bare["score"] == 1.0
+    assert verbose["score"] == 1.0
+    assert wrong["pred_answer"] == "D"
+    assert wrong["score"] == 0.0
+
+
+def test_mmr_v_process_results_emits_the_declared_metric_keys() -> None:
+    declared = _declared_metrics()
+
+    for ability_type in mmr_v_utils.ABILITY_TYPES:
+        for video_type in mmr_v_utils.VIDEO_TYPES:
+            doc = _doc(ability_type=ability_type, video_type=video_type)
+            keys = set(mmr_v_utils.mmr_v_process_results(doc, ["[[C]]"]))
+            assert len(keys) == 3
+            assert "mmr_v_overall_accuracy" in keys
+            assert keys.issubset(declared)
+
+
+def test_mmr_v_process_results_rejects_unknown_labels() -> None:
+    with pytest.raises(ValueError, match="abilityType_L2"):
+        mmr_v_utils.mmr_v_process_results(_doc(ability_type="Mind Reading"), ["C"])
+    with pytest.raises(ValueError, match="videoType"):
+        mmr_v_utils.mmr_v_process_results(_doc(video_type="Documentary"), ["C"])
+
+
+def test_mmr_v_aggregates_per_ability_type_and_per_video_type() -> None:
+    records = [
+        mmr_v_utils.mmr_v_process_results(_doc(answer="(C)", ability_type="Theme Understanding", video_type="Animation", question_idx=1), ["[[C]]"])["mmr_v_overall_accuracy"],
+        mmr_v_utils.mmr_v_process_results(_doc(answer="(C)", ability_type="Theme Understanding", video_type="movie", question_idx=2), ["[[D]]"])["mmr_v_overall_accuracy"],
+        mmr_v_utils.mmr_v_process_results(_doc(answer="(B)", ability_type="Causal Reasoning", video_type="Animation", question_idx=3), ["[[B]]"])["mmr_v_overall_accuracy"],
+    ]
+
+    assert mmr_v_utils.mmr_v_aggregate_overall(records) == pytest.approx(200.0 / 3.0)
+    assert mmr_v_utils.mmr_v_aggregate_theme_understanding(records) == 50.0
+    assert mmr_v_utils.mmr_v_aggregate_causal_reasoning(records) == 100.0
+    assert mmr_v_utils.mmr_v_aggregate_metaphor_understanding(records) == 0.0
+    assert mmr_v_utils.mmr_v_aggregate_animation_video(records) == 100.0
+    assert mmr_v_utils.mmr_v_aggregate_movie_video(records) == 0.0
+    assert mmr_v_utils.mmr_v_aggregate_philosophy_video(records) == 0.0

--- a/test/eval/test_vcrbench.py
+++ b/test/eval/test_vcrbench.py
@@ -1,0 +1,176 @@
+from pathlib import Path
+from typing import Any, Sequence
+
+import cv2
+import numpy as np
+import pytest
+
+from lmms_eval.tasks import TaskManager
+from lmms_eval.tasks.vcrbench import utils as vcrbench_utils
+
+
+def _doc(ground_truth: Sequence[int] = (2, 0, 3, 1), goal: str = "make a pizza", qid: int = 7) -> dict[str, Any]:
+    return {
+        "qid": qid,
+        "video_file": "video_7.mp4",
+        "goal": goal,
+        "ground_truth": list(ground_truth),
+    }
+
+
+def _write_test_video(path: Path, frame_count: int = 4, fps: int = 2) -> None:
+    writer = cv2.VideoWriter(str(path), cv2.VideoWriter_fourcc(*"mp4v"), fps, (8, 8))
+    assert writer.isOpened(), "OpenCV cannot create the temporary MP4 test fixture"
+    for value in range(frame_count):
+        writer.write(np.full((8, 8, 3), value * 50, dtype=np.uint8))
+    writer.release()
+
+
+def test_vcrbench_task_is_registered() -> None:
+    task_manager = TaskManager("ERROR")
+    assert "vcrbench" in task_manager.all_tasks
+
+
+def test_vcrbench_doc_to_visual_resolves_configured_video_dir(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    video_dir = tmp_path / "flat_videos"
+    video_dir.mkdir()
+    _write_test_video(video_dir / "video_7.mp4")
+    monkeypatch.setenv("VCRBENCH_VIDEO_DIR", str(video_dir))
+
+    assert vcrbench_utils.vcrbench_doc_to_visual(_doc()) == [str(video_dir / "video_7.mp4")]
+
+
+def test_vcrbench_doc_to_visual_resolves_root_with_videos_subdir(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    video_dir = tmp_path / "videos"
+    video_dir.mkdir()
+    _write_test_video(video_dir / "video_7.mp4")
+    monkeypatch.setenv("VCRBENCH_ROOT", str(tmp_path))
+
+    assert vcrbench_utils.vcrbench_doc_to_visual(_doc()) == [str(video_dir / "video_7.mp4")]
+
+
+def test_vcrbench_doc_to_visual_reports_the_missing_video(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("VCRBENCH_VIDEO_DIR", str(tmp_path))
+
+    with pytest.raises(FileNotFoundError, match="VCRBench video not found"):
+        vcrbench_utils.vcrbench_doc_to_visual(_doc())
+
+
+def test_vcrbench_doc_to_text_substitutes_the_goal_into_both_slots() -> None:
+    prompt = vcrbench_utils.vcrbench_doc_to_text(_doc(goal="make a pizza"))
+
+    assert prompt.count("make a pizza") == 2
+    assert "{goal}" not in prompt
+    assert "Clip 1, Clip 2" in prompt
+    assert prompt.endswith("Correct order: <mention the Clip numbers separated by a comma>\n")
+
+
+def test_vcrbench_doc_to_text_wraps_the_prompt_with_task_kwargs() -> None:
+    prompt = vcrbench_utils.vcrbench_doc_to_text(_doc(), {"pre_prompt": "Video:\n", "post_prompt": "\nOrder only."})
+
+    assert prompt.startswith("Video:\nThe given video consists of multiple short clips")
+    assert prompt.endswith("\nOrder only.")
+
+
+def test_vcrbench_target_order_is_one_indexed() -> None:
+    assert vcrbench_utils.vcrbench_target_order(_doc()) == [3, 1, 4, 2]
+    assert vcrbench_utils.vcrbench_doc_to_target(_doc()) == "3, 1, 4, 2"
+
+
+def test_vcrbench_extracts_a_boxed_permutation() -> None:
+    assert vcrbench_utils.extract_predicted_order("Reasoning omitted. \\boxed{3, 1, 4, 2}", 4) == [3, 1, 4, 2]
+
+
+def test_vcrbench_extracts_an_answer_tag_permutation() -> None:
+    response = "<think>Clip 1 comes first.</think><answer>3, 1, 4, 2</answer>"
+
+    assert vcrbench_utils.extract_predicted_order(response, 4) == [3, 1, 4, 2]
+
+
+def test_vcrbench_extracts_the_official_correct_order_phrase() -> None:
+    response = "First I identify each clip.\nCorrect order: 3, 1, 4, 2\n"
+
+    assert vcrbench_utils.extract_predicted_order(response, 4) == [3, 1, 4, 2]
+
+
+def test_vcrbench_extracts_a_clip_prefixed_order() -> None:
+    assert vcrbench_utils.extract_predicted_order("Clip 3, Clip 1, Clip 4, Clip 2.", 4) == [3, 1, 4, 2]
+
+
+def test_vcrbench_returns_zeros_for_a_length_mismatch() -> None:
+    assert vcrbench_utils.extract_predicted_order("Correct order: 1, 2", 4) == [0, 0, 0, 0]
+
+
+def test_vcrbench_returns_zeros_for_an_unparseable_answer() -> None:
+    assert vcrbench_utils.extract_predicted_order("I cannot determine the order of the clips.", 4) == [0, 0, 0, 0]
+
+
+def test_vcrbench_rejects_an_order_that_is_not_a_permutation() -> None:
+    assert vcrbench_utils.extract_predicted_order("Correct order: 1, 1, 2, 3", 4) == [0, 0, 0, 0]
+
+
+def test_vcrbench_compare_lists_scores_a_length_mismatch_as_target_length_zeros() -> None:
+    assert vcrbench_utils.compare_lists([3, 1, 4, 2], [3, 1, 4, 2]) == [1, 1, 1, 1]
+    assert vcrbench_utils.compare_lists([3, 1, 4, 2], [3, 2, 4, 1]) == [1, 0, 1, 0]
+    assert vcrbench_utils.compare_lists([3, 1, 4, 2], [3, 1]) == [0, 0, 0, 0]
+
+
+def test_vcrbench_process_results_reports_exact_match_and_step_scores() -> None:
+    metrics = vcrbench_utils.vcrbench_process_results(_doc(), ["Correct order: 3, 2, 4, 1"])
+    record = metrics["vcrbench_accuracy"]
+
+    assert set(metrics) == {"vcrbench_accuracy", "vcrbench_step_accuracy", "vcrbench_weighted_accuracy"}
+    assert record["qid"] == 7
+    assert record["num_steps"] == 4
+    assert record["answer"] == [3, 1, 4, 2]
+    assert record["predicted_order"] == [3, 2, 4, 1]
+    assert record["score"] == 0.0
+    assert record["step_scores"] == [1, 0, 1, 0]
+
+
+def test_vcrbench_process_results_scores_an_exact_order() -> None:
+    record = vcrbench_utils.vcrbench_process_results(_doc(), ["Correct order: 3, 1, 4, 2"])["vcrbench_accuracy"]
+
+    assert record["score"] == 1.0
+    assert record["step_scores"] == [1, 1, 1, 1]
+
+
+def test_vcrbench_process_results_zero_fills_an_unparseable_prediction() -> None:
+    record = vcrbench_utils.vcrbench_process_results(_doc(), ["No idea."])["vcrbench_step_accuracy"]
+
+    assert record["predicted_order"] == [0, 0, 0, 0]
+    assert record["step_scores"] == [0, 0, 0, 0]
+
+
+def _record(goal: str, score: float, step_scores: list[int]) -> dict[str, Any]:
+    return {
+        "qid": 0,
+        "goal": goal,
+        "num_steps": len(step_scores),
+        "prediction": "",
+        "predicted_order": [],
+        "answer": [],
+        "score": score,
+        "step_scores": step_scores,
+    }
+
+
+def test_vcrbench_aggregate_accuracy_is_the_exact_match_rate() -> None:
+    results = [_record("pizza", 1.0, [1, 1]), _record("pizza", 0.0, [1, 0]), _record("tea", 1.0, [1, 1])]
+
+    assert vcrbench_utils.vcrbench_aggregate_accuracy(results) == pytest.approx(200.0 / 3.0)
+    assert vcrbench_utils.vcrbench_aggregate_accuracy([]) == 0.0
+
+
+def test_vcrbench_aggregate_step_accuracy_pools_every_clip_position() -> None:
+    results = [_record("pizza", 1.0, [1, 1]), _record("pizza", 0.0, [1, 0]), _record("tea", 1.0, [1, 1])]
+
+    assert vcrbench_utils.vcrbench_aggregate_step_accuracy(results) == pytest.approx(500.0 / 6.0)
+    assert vcrbench_utils.vcrbench_aggregate_step_accuracy([]) == 0.0
+
+
+def test_vcrbench_aggregate_weighted_accuracy_averages_over_the_goal_classes() -> None:
+    results = [_record("pizza", 1.0, [1, 1]), _record("pizza", 0.0, [1, 0]), _record("tea", 1.0, [1, 1])]
+
+    assert vcrbench_utils.vcrbench_aggregate_weighted_accuracy(results) == pytest.approx(75.0)
+    assert vcrbench_utils.vcrbench_aggregate_weighted_accuracy([]) == 0.0

--- a/test/eval/test_vcrbench.py
+++ b/test/eval/test_vcrbench.py
@@ -7,6 +7,18 @@ import pytest
 
 from lmms_eval.tasks import TaskManager
 from lmms_eval.tasks.vcrbench import utils as vcrbench_utils
+@pytest.fixture(autouse=True)
+def _isolate_media_env(monkeypatch, tmp_path):
+    """Stop the media resolver from finding a developer's real video cache.
+
+    media_resolver falls through VCRBENCH_ROOT -> LMMS_EVAL_MEDIA_ROOT -> HF_HOME.
+    A shell that exports any of those makes the FileNotFoundError tests resolve a
+    real file and silently stop testing anything. Clear them for every test and
+    point HF_HOME at an empty tmp dir.
+    """
+    for var in ("VCRBENCH_ROOT", "VCRBENCH_VIDEO_DIR", "LMMS_EVAL_MEDIA_ROOT"):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("HF_HOME", str(tmp_path / "_empty_hf_home"))
 
 
 def _doc(ground_truth: Sequence[int] = (2, 0, 3, 1), goal: str = "make a pizza", qid: int = 7) -> dict[str, Any]:

--- a/test/eval/test_vcrbench.py
+++ b/test/eval/test_vcrbench.py
@@ -7,6 +7,8 @@ import pytest
 
 from lmms_eval.tasks import TaskManager
 from lmms_eval.tasks.vcrbench import utils as vcrbench_utils
+
+
 @pytest.fixture(autouse=True)
 def _isolate_media_env(monkeypatch, tmp_path):
     """Stop the media resolver from finding a developer's real video cache.

--- a/test/eval/test_vrbench.py
+++ b/test/eval/test_vrbench.py
@@ -1,0 +1,274 @@
+from pathlib import Path
+from typing import Any
+
+import cv2
+import numpy as np
+import pytest
+from datasets import Dataset
+
+from lmms_eval.tasks import TaskManager
+from lmms_eval.tasks.vrbench import utils as vrbench_utils
+from lmms_eval.verifiers.base import VerifyResult
+
+VIDEO_SUMMARY = "The detective returns to the harbour at night and confronts the smuggler."
+
+
+def _qa(question: str, answer: str, reasoning_type: str) -> dict[str, Any]:
+    return {
+        "question": question,
+        "options": {"A": "First", "B": "Second", "C": "Third", "D": "Fourth"},
+        "answer": answer,
+        "original_question": question,
+        "original_answer": "Fourth" if answer == "D" else "First",
+        "reasoning_process": {"1": "The detective boards the boat.", "2": "The smuggler runs away."},
+        "reasoning_type": reasoning_type,
+    }
+
+
+def _record() -> dict[str, Any]:
+    return {
+        "video_id": "demo-video",
+        "video_path": "VRBench/videos/v001/demo-video.mp4",
+        "video_summary": VIDEO_SUMMARY,
+        "video_read_type": "video",
+        "mcq": {
+            "qa1": _qa("Why did the detective return?", "D", "Implicit Inference"),
+            "qa2": _qa("What happens next?", "A", "Event Prediction"),
+            "qa10": _qa("Summarise the chase.", "B", "Event Summarization"),
+        },
+    }
+
+
+def _doc(reasoning_type: str = "Implicit Inference", answer: str = "D") -> dict[str, Any]:
+    return {
+        "question_id": "demo-video_qa1",
+        "qa_key": "qa1",
+        "video_id": "demo-video",
+        "video_path": "VRBench/videos/v001/demo-video.mp4",
+        "video_read_type": "video",
+        "video_summary": VIDEO_SUMMARY,
+        "question": "Why did the detective return?",
+        "options": {"A": "First", "B": "Second", "C": "Third", "D": "Fourth"},
+        "answer": answer,
+        "original_answer": "Fourth",
+        "reasoning_process": "<Step 1> The detective boards the boat.\n<Step 2> The smuggler runs away.",
+        "reasoning_type": reasoning_type,
+    }
+
+
+def _write_test_video(path: str, frame_count: int = 4, fps: int = 2) -> None:
+    writer = cv2.VideoWriter(str(path), cv2.VideoWriter_fourcc(*"mp4v"), fps, (8, 8))
+    assert writer.isOpened(), "OpenCV cannot create the temporary MP4 test fixture"
+    for value in range(frame_count):
+        writer.write(np.full((8, 8, 3), value * 50, dtype=np.uint8))
+    writer.release()
+
+
+class _RecordingPipeline:
+    """Stand-in for the judge pipeline that records its call and never uses the network."""
+
+    def __init__(self, route: str, calls: list[dict[str, Any]], judge_reply: str) -> None:
+        self.route = route
+        self.calls = calls
+        self.judge_reply = judge_reply
+
+    def __call__(self, question: str, prediction: str, ground_truth: str, **kwargs: Any) -> VerifyResult:
+        self.calls.append({"route": self.route, "question": question, "prediction": prediction, "ground_truth": ground_truth, "kwargs": kwargs})
+        return vrbench_utils._parse_rate_response(self.judge_reply)
+
+
+@pytest.fixture
+def judge_calls(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
+    """Replace the judge pipeline factory so no judge API is ever contacted."""
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(
+        vrbench_utils,
+        "_get_pipeline",
+        lambda route: _RecordingPipeline(route, calls, "<rate>7</rate>.\n<reason>The steps match the annotation.</reason>"),
+    )
+    return calls
+
+
+def test_vrbench_tasks_are_registered() -> None:
+    task_manager = TaskManager("ERROR")
+    expected = {"vrbench_mcq", "vrbench_process", "vrbench"}
+    assert not expected.difference(task_manager.all_tasks)
+
+
+def test_vrbench_process_docs_flattens_one_document_per_question() -> None:
+    docs = vrbench_utils.vrbench_process_docs(Dataset.from_list([_record()]))
+
+    assert len(docs) == 3
+    assert [doc["question_id"] for doc in docs] == ["demo-video_qa1", "demo-video_qa2", "demo-video_qa10"]
+    assert [doc["qa_key"] for doc in docs] == ["qa1", "qa2", "qa10"]
+    assert {doc["video_id"] for doc in docs} == {"demo-video"}
+    assert {doc["video_summary"] for doc in docs} == {VIDEO_SUMMARY}
+    assert docs[0]["reasoning_type"] == "Implicit Inference"
+    assert docs[0]["reasoning_process"] == "<Step 1> The detective boards the boat.\n<Step 2> The smuggler runs away."
+
+
+def test_vrbench_doc_to_visual_resolves_configured_media_root(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    video = tmp_path / "VRBench" / "videos" / "v001" / "demo-video.mp4"
+    video.parent.mkdir(parents=True)
+    _write_test_video(video)
+    monkeypatch.setenv("VRBENCH_VIDEO_DIR", str(tmp_path))
+
+    assert vrbench_utils.vrbench_doc_to_visual(_doc()) == [str(video)]
+
+
+def test_vrbench_doc_to_visual_reports_the_missing_download(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("VRBENCH_VIDEO_DIR", str(tmp_path / "empty-root"))
+
+    with pytest.raises(FileNotFoundError, match="VRBENCH_VIDEO_DIR"):
+        vrbench_utils.vrbench_doc_to_visual(_doc())
+
+
+def test_vrbench_prompt_lists_every_option_and_keeps_the_step_format() -> None:
+    prompt = vrbench_utils.vrbench_doc_to_text(_doc(), {"pre_prompt": "Video QA:\n", "post_prompt": "\nLetter only.", "include_video_summary": True})
+
+    assert prompt.startswith("Video QA:\n")
+    assert "Question: Why did the detective return?" in prompt
+    assert "A: First" in prompt
+    assert "D: Fourth" in prompt
+    assert "<Answer> [Option letter]" in prompt
+    assert prompt.endswith("\nLetter only.")
+
+
+def test_vrbench_video_summary_is_removable_from_the_model_prompt() -> None:
+    """``include_video_summary: false`` must strip the narrative summary completely.
+
+    The summary retells the plot, so a model that reads it can answer without
+    watching the video.  The official protocol keeps it (see the README), so the
+    port only guarantees that the ablation switch removes every trace of it.
+    """
+    ablated = vrbench_utils.vrbench_doc_to_text(_doc(), {"include_video_summary": False})
+
+    assert VIDEO_SUMMARY not in ablated
+    assert "detective returns to the harbour" not in ablated
+    assert "Question: Why did the detective return?" in ablated
+
+
+def test_vrbench_extract_mcq_answer_follows_the_official_cascade() -> None:
+    assert vrbench_utils.extract_mcq_answer("Reasoning ... \\boxed{B}") == "B"
+    assert vrbench_utils.extract_mcq_answer("<Step 1> x\n<Answer> C") == "C"
+    assert vrbench_utils.extract_mcq_answer("<Answer> a") == "A"
+    assert vrbench_utils.extract_mcq_answer("A. first option\nD. last option") == "D"
+    assert vrbench_utils.extract_mcq_answer("Some talk.\nAnswer: A") == "A"
+    assert vrbench_utils.extract_mcq_answer("The best option is B)") == "B"
+    assert vrbench_utils.extract_mcq_answer("I pick C and stop") == "C"
+    assert vrbench_utils.extract_mcq_answer("") is None
+    assert vrbench_utils.extract_mcq_answer("no letters here") is None
+
+
+def test_vrbench_extract_mcq_answer_keeps_the_last_letter_of_a_long_chain() -> None:
+    response = "<Step 1> Option A looks plausible.\n<Step 2> Option B is wrong.\n<Answer> D"
+
+    assert vrbench_utils.extract_mcq_answer(response) == "D"
+
+
+def test_vrbench_mcq_process_results_and_aggregate_accuracy() -> None:
+    correct = vrbench_utils.vrbench_mcq_process_results(_doc(answer="D"), ["<Answer> D"])
+    wrong = vrbench_utils.vrbench_mcq_process_results(_doc(answer="B"), ["<Answer> C"])
+    correct_record = correct["vrbench_score"]
+    wrong_record = wrong["vrbench_score"]
+
+    assert correct_record["question_id"] == "demo-video_qa1"
+    assert correct_record["parsed_prediction"] == "D"
+    assert correct_record["score"] == 1.0
+    assert wrong_record["score"] == 0.0
+    assert "vrbench_mcq_implicit_inference_accuracy" in correct
+    assert vrbench_utils.vrbench_mcq_aggregate_results([correct_record, wrong_record]) == 50.0
+    assert vrbench_utils.vrbench_mcq_aggregate_implicit_inference([correct_record, wrong_record]) == 50.0
+    assert vrbench_utils.vrbench_mcq_aggregate_logical_linkage([correct_record, wrong_record]) == 0.0
+
+
+def test_vrbench_parse_rate_response_reads_the_rate_tag() -> None:
+    result = vrbench_utils._parse_rate_response("<rate>7</rate>.\n<reason>Mostly correct.</reason>")
+
+    assert result.metadata["rate"] == 7.0
+    assert result.metadata["rate_parsed"] is True
+    assert result.score == pytest.approx(0.7)
+    assert result.is_correct is True
+
+
+def test_vrbench_parse_rate_response_clamps_and_flags_unparsable_replies() -> None:
+    clamped = vrbench_utils._parse_rate_response("<rate>13</rate>")
+    missing = vrbench_utils._parse_rate_response("The reasoning is good but I forgot the tag.")
+
+    assert clamped.metadata["rate"] == 10.0
+    assert missing.metadata["rate"] == 0.0
+    assert missing.metadata["rate_parsed"] is False
+    assert missing.is_correct is False
+
+
+@pytest.mark.parametrize("reasoning_type", sorted(vrbench_utils.UNIQUE_ANSWER_TYPES))
+def test_vrbench_unique_types_use_the_unique_judge_without_the_summary(reasoning_type: str, judge_calls: list[dict[str, Any]]) -> None:
+    metrics = vrbench_utils.vrbench_process_process_results(_doc(reasoning_type), ["<Step 1> ...\n<Answer> D"])
+    record = metrics["vrbench_score"]
+
+    assert len(judge_calls) == 1
+    assert judge_calls[0]["route"] == "unique"
+    assert judge_calls[0]["kwargs"] == {"procedure": _doc()["reasoning_process"]}
+    assert "video_summary" not in judge_calls[0]["kwargs"]
+    assert record["judged"] is True
+    assert record["score"] == 7.0
+
+
+@pytest.mark.parametrize("reasoning_type", sorted(vrbench_utils.NON_UNIQUE_ANSWER_TYPES))
+def test_vrbench_non_unique_types_use_the_non_unique_judge_with_the_summary(reasoning_type: str, judge_calls: list[dict[str, Any]]) -> None:
+    metrics = vrbench_utils.vrbench_process_process_results(_doc(reasoning_type), ["<Step 1> ...\n<Answer> A"])
+    record = metrics["vrbench_score"]
+
+    assert len(judge_calls) == 1
+    assert judge_calls[0]["route"] == "non_unique"
+    assert judge_calls[0]["kwargs"]["video_summary"] == VIDEO_SUMMARY
+    assert judge_calls[0]["kwargs"]["procedure"] == _doc()["reasoning_process"]
+    assert record["judged"] is True
+    assert record["score"] == 7.0
+
+
+def test_vrbench_non_unique_summary_is_truncated_for_the_judge(judge_calls: list[dict[str, Any]]) -> None:
+    doc = dict(_doc("Event Prediction"))
+    doc["video_summary"] = "x" * (vrbench_utils.VIDEO_SUMMARY_CHAR_LIMIT + 50)
+
+    vrbench_utils.vrbench_process_process_results(doc, ["<Answer> A"])
+
+    assert len(judge_calls[0]["kwargs"]["video_summary"]) == vrbench_utils.VIDEO_SUMMARY_CHAR_LIMIT
+
+
+@pytest.mark.parametrize("reasoning_type", ["Event Summarization", "Counting Porblems", "Brand New Type"])
+def test_vrbench_unrouted_types_are_never_judged(reasoning_type: str, judge_calls: list[dict[str, Any]]) -> None:
+    metrics = vrbench_utils.vrbench_process_process_results(_doc(reasoning_type), ["<Step 1> ...\n<Answer> B"])
+
+    assert judge_calls == []
+    assert list(metrics) == ["vrbench_score"]
+    assert metrics["vrbench_score"]["judged"] is False
+    assert metrics["vrbench_score"]["score"] == 0.0
+
+
+def test_vrbench_judge_prompts_place_the_summary_only_on_the_non_unique_route() -> None:
+    unique_prompt = vrbench_utils._unique_judge_prompt("Q?", "prediction", "gt", procedure="<Step 1> a", video_summary=VIDEO_SUMMARY)
+    non_unique_prompt = vrbench_utils._non_unique_judge_prompt("Q?", "prediction", "gt", procedure="<Step 1> a", video_summary=VIDEO_SUMMARY)
+
+    assert VIDEO_SUMMARY not in unique_prompt
+    assert "# Video Summary" not in unique_prompt
+    assert VIDEO_SUMMARY in non_unique_prompt
+    assert "<rate>the score (0-10)</rate>" in unique_prompt
+    assert "<rate>the score (0-10)</rate>" in non_unique_prompt
+
+
+def test_vrbench_process_aggregate_scales_judged_rates_to_percent(judge_calls: list[dict[str, Any]]) -> None:
+    judged = vrbench_utils.vrbench_process_process_results(_doc("Logical Linkage"), ["<Answer> D"])["vrbench_score"]
+    unjudged = vrbench_utils.vrbench_process_process_results(_doc("Event Summarization"), ["<Answer> D"])["vrbench_score"]
+
+    assert vrbench_utils.vrbench_process_aggregate_results([judged, unjudged]) == 70.0
+    assert vrbench_utils.vrbench_process_aggregate_logical_linkage([judged, unjudged]) == 70.0
+    assert vrbench_utils.vrbench_process_aggregate_event_attribution([judged, unjudged]) == 0.0
+
+
+def test_vrbench_format_reasoning_process_renders_numbered_steps() -> None:
+    rendered = vrbench_utils.format_reasoning_process({"2": "Second step", "1": "First step", "10": "Tenth step"})
+
+    assert rendered == "<Step 1> First step\n<Step 2> Second step\n<Step 10> Tenth step"
+    assert vrbench_utils.format_reasoning_process("already a string") == "already a string"
+    assert vrbench_utils.format_reasoning_process(None) == ""


### PR DESCRIPTION
## Summary

- Adds **VCRBench** (long-form causal step ordering, 365 items), **MMR-V** (multimodal deep reasoning, 1257 items) and **VRBench** (multi-step reasoning over long narrative video, 8243 QA over 960 videos averaging 1.6 h).
- Each task ports the benchmark's *own* official prompt, answer parser and metrics rather than a generic MCQ path, and additionally accepts `\boxed{}` / `<answer>` forms that current reasoning models emit.
- VRBench ships both official tracks: `vrbench_mcq` (rule-based) and `vrbench_process` (LLM-judged reasoning chain), plus a `vrbench` group.

## In scope

- `lmms_eval/tasks/vcrbench/`, `lmms_eval/tasks/mmr_v/`, `lmms_eval/tasks/vrbench/` following the cgbench layout (`README.md`, `__init__.py`, `_default_template_yaml`, task yamls, group yamls, `utils.py`).
- Task names registered: `vcrbench`, `mmr_v`, `mmr_v_cot`, `mmr_v_all`, `vrbench_mcq`, `vrbench_process`, `vrbench`.
- `test/eval/test_vcrbench.py`, `test_mmr_v.py`, `test_vrbench.py` — 59 tests, no network, no judge API, cv2 fixtures in `tmp_path`.
- `docs/advanced/current_tasks.md` entries.

## Out of scope

- No changes to any existing task, model or shared utility.
- `vrbench_process` is **implemented but not executed** here: it requires a DeepSeek API key, which I do not have. Its prompts and routing are ported verbatim from the authors' `evaluation/model_api/prompt.py` and `run_process_eval.py`, but the judge path is unverified end to end. Flagging this explicitly rather than implying coverage.
- Dataset hosting is unchanged; all three read from their published HF datasets with a local media root.

## Validation

Run against `Qwen/Qwen3-VL-8B-Instruct` on 8xH100 via the `vllm` chat model class.

```
python3 -m lmms_eval --model vllm --model_args model=<qwen3vl-8b>,tensor_parallel_size=1,gpu_memory_utilization=0.8,max_model_len=65536,nframes=32,max_new_tokens=1024 --tasks <task> --limit 8 --batch_size 1 --log_samples
```

| command | sample size | key metrics | result |
|---|---|---|---|
| `--tasks mmr_v --limit 8` | N=8 | `mmr_v_overall_accuracy` 50.0 | pass |
| `--tasks vrbench_mcq --limit 8` | N=8 | `vrbench_score` 62.5 | pass |
| `--tasks vcrbench --limit 8` | N=8 | `vcrbench_accuracy` 0.0, `vcrbench_step_accuracy` 6.90 | pass (runs correctly; see note) |
| `pytest test/eval/test_vcrbench.py test/eval/test_mmr_v.py test/eval/test_vrbench.py` | 59 tests | all pass | pass |

Every aggregate reconciles against the per-sample records (mmr_v 4/8, vrbench_mcq 5/8, vcrbench 0/8 exact with 2 of 29 step positions correct). Answer extraction is genuinely exercised: MMR-V recovered letter `I` from an 11-option question, VRBench recovered letters from `<Step N>` reasoning chains, and VCRBench's official cascade parsed both a well-formed `Correct order: Clip 1, ...` and a refusal (scored as N zeros, per the paper).

**Note on the VCRBench number.** It is below the paper's random baseline (7.95 exact / 24.26 step) because `nframes=32` is too sparse for this benchmark, not because the port is wrong. The clip index exists only as a burnt-in "Clip N" title card at the head of each concatenated clip, so a sparse sample misses it. The same model on the same items scores **44.0 exact / 56.1 step** at 64 frames. The paper's setting is `fps=1, max_pixels=151200`. This is now documented prominently in `lmms_eval/tasks/vcrbench/README.md`.

## Risk / Compatibility

- Additive only. No existing task, model or shared utility is touched, so no existing result can change.
- `mmr_v` uses a variable option count (7-13, letters **A-M**). The extractor accepts a wide letter class and then checks membership against the options the question actually offers; a class capped at `A-L` silently falls through to the generic matcher and can return a wrong letter when the model answers `M`.
- VRBench annotations hold one record per video with an `mcq` dict, so the task flattens to one doc per QA (8243 docs from 960 records).
- VRBench videos average 1.6 hours; expect the media root to be large.
- Unrelated pre-existing bug noticed but **not** touched: `lmms_eval/models/simple/vllm.py:521` references an undefined `params` in `SamplingParams(**params)`, so `--force_simple` raises `NameError`. It predates this branch (commit 9e698346) and is not reached on the chat path.

## Type of Change

- [x] New benchmark/task
- [ ] Bug fix
- [ ] New model
- [ ] Breaking change
