### PR TITLE
fix(evaluator): resolve sample limits independently per task

### DIFF
--- a/.github/workflows/hermetic-cpu-contracts.yml
+++ b/.github/workflows/hermetic-cpu-contracts.yml
@@ -44,5 +44,6 @@ jobs:
           test/eval/test_request_construction_contract.py
           test/eval/test_task_pipeline.py
           test/eval/test_evaluator.py
+          test/eval/test_evaluator_sample_limits.py
           test/entrypoints/test_job_scheduler_subprocess.py
           test/tui/test_server.py

--- a/lmms_eval/evaluator.py
+++ b/lmms_eval/evaluator.py
@@ -1091,6 +1091,7 @@ def evaluate(
         lm._rank = global_rank
         lm._world_size = world_size
 
+    task_limits = {}
     for task_output in eval_tasks:
         task = task_output.task
         task_name = task_output.task_name
@@ -1124,9 +1125,10 @@ def evaluate(
         if ("group_alias" in configs[task_name]) and (group_name not in task_group_alias) and (group_name is not None):
             task_group_alias[group_name] = configs[task_name]["group_alias"]
 
-        limit = get_sample_size(task, limit)
+        task_limit = get_sample_size(task, limit)
+        task_limits[task_name] = task_limit
         task.build_all_requests(
-            limit=limit,
+            limit=task_limit,
             offset=offset,
             rank=global_rank,
             world_size=world_size,
@@ -1287,6 +1289,7 @@ def evaluate(
 
     for task_output in eval_tasks:
         task = task_output.task
+        task_limit = task_limits[task_output.task_name]
         task.apply_filters()
         set_task_context(task_output.task_name)
 
@@ -1329,17 +1332,17 @@ def evaluate(
                 doc_iterator = create_iterator(
                     enumerate(task.eval_docs_no_media),
                     rank=RANK,
-                    limit=int(limit) if limit else None,
+                    limit=int(task_limit) if task_limit else None,
                     world_size=WORLD_SIZE,
                     offset=offset,
                 )
             else:
-                doc_iterator = task.doc_iterator(rank=RANK, limit=limit, world_size=WORLD_SIZE, offset=offset)
+                doc_iterator = task.doc_iterator(rank=RANK, limit=task_limit, world_size=WORLD_SIZE, offset=offset)
             doc_iterator_for_counting = (
                 create_iterator(
                     range(len(task.test_docs())),
                     rank=RANK,
-                    limit=limit,
+                    limit=task_limit,
                     world_size=WORLD_SIZE,
                     offset=offset,
                 )
@@ -1347,7 +1350,7 @@ def evaluate(
                 else create_iterator(
                     range(len(task.validation_docs())),
                     rank=RANK,
-                    limit=limit,
+                    limit=task_limit,
                     world_size=WORLD_SIZE,
                     offset=offset,
                 )
@@ -1552,7 +1555,7 @@ def evaluate(
                 task_output.task_name: {
                     "original": len(task_output.task.eval_docs),
                     "effective": min(
-                        limit if limit else len(task_output.task.eval_docs),
+                        task_limits[task_output.task_name] if task_limits[task_output.task_name] is not None else len(task_output.task.eval_docs),
                         len(task_output.task.eval_docs),
                     ),
                 }

--- a/test/eval/test_evaluator_sample_limits.py
+++ b/test/eval/test_evaluator_sample_limits.py
@@ -1,0 +1,153 @@
+import pytest
+
+from lmms_eval.api.instance import Instance
+from lmms_eval.api.model import lmms
+from lmms_eval.api.task import Task, TaskConfig
+from lmms_eval.evaluator import evaluate
+from lmms_eval.utils import create_iterator
+
+
+class _NoOpAccelerator:
+    def wait_for_everyone(self):
+        pass
+
+
+class _CountingLM(lmms):
+    def __init__(self):
+        super().__init__()
+        self.accelerator = _NoOpAccelerator()
+
+    def loglikelihood(self, requests):
+        raise NotImplementedError
+
+    def generate_until(self, requests):
+        return ["answer"] * len(requests)
+
+    def generate_until_multi_round(self, requests):
+        raise NotImplementedError
+
+    def clean(self):
+        pass
+
+
+class _CountingTask(Task):
+    VERSION = "test"
+    OUTPUT_TYPE = "generate_until"
+
+    def __init__(self, name, size):
+        self._docs = [{"id": i} for i in range(size)]
+        self.build_limits = []
+        self.scored_doc_ids = []
+        super().__init__()
+        self._config = TaskConfig(task=name, test_split="test", num_fewshot=0, repeats=1, reasoning_tags=None)
+
+    def download(self, data_dir=None, cache_dir=None, download_mode=None):
+        pass
+
+    @property
+    def task_name(self):
+        return self.config.task
+
+    @property
+    def eval_docs(self):
+        return self._docs
+
+    def has_training_docs(self):
+        return False
+
+    def has_validation_docs(self):
+        return False
+
+    def has_test_docs(self):
+        return True
+
+    def test_docs(self):
+        return self._docs
+
+    def doc_iterator(self, *, rank=0, limit=None, world_size=1, offset=0):
+        return create_iterator(
+            enumerate(self._docs),
+            rank=rank,
+            limit=limit,
+            world_size=world_size,
+            offset=offset,
+        )
+
+    def doc_to_text(self, doc):
+        return str(doc["id"])
+
+    def doc_to_target(self, doc):
+        return ""
+
+    def build_all_requests(self, *, limit=None, offset=0, **kwargs):
+        selected_docs = self._docs[offset:] if limit is None else self._docs[offset : offset + limit]
+        self.build_limits.append(len(selected_docs))
+        self._instances = []
+        for doc in selected_docs:
+            doc_id = doc["id"]
+            instance = Instance(
+                request_type="generate_until",
+                arguments=(
+                    "prompt",
+                    {"until": []},
+                    None,
+                    doc_id,
+                    self.task_name,
+                    "test",
+                ),
+                idx=0,
+                metadata={"task": self.task_name, "doc_id": doc_id, "repeats": 1},
+            )
+            instance.doc = doc
+            self._instances.append(instance)
+
+    def apply_filters(self):
+        for instance in self._instances:
+            instance.filtered_resps["none"] = instance.resps[0]
+
+    def construct_requests(self, doc_id, ctx, **kwargs):
+        raise NotImplementedError
+
+    def process_results(self, doc, results):
+        self.scored_doc_ids.append(doc["id"])
+        return {"score": 1.0}
+
+    def aggregation(self):
+        return {"score": lambda scores: sum(scores) / len(scores)}
+
+    def higher_is_better(self):
+        return {"score": True}
+
+    def dump_config(self):
+        return {"num_fewshot": 0}
+
+
+@pytest.mark.parametrize(
+    ("limit", "expected"),
+    [(None, (3, 7)), (-1, (3, 7)), (2, (2, 2)), (0.5, (2, 4))],
+)
+def test_evaluate_resolves_limit_per_task_for_build_scoring_and_reporting(limit, expected):
+    small = _CountingTask("small", size=3)
+    large = _CountingTask("large", size=7)
+
+    result = evaluate(
+        _CountingLM(),
+        {"small": small, "large": large},
+        limit=limit,
+        bootstrap_iters=0,
+        log_samples=False,
+    )
+
+    if limit == 0.5:
+        assert large.build_limits == [4]
+        assert large.scored_doc_ids == [0, 1, 2, 3]
+        assert result["n-samples"]["large"]["effective"] == 4
+    assert (small.build_limits, large.build_limits) == ([expected[0]], [expected[1]])
+    assert (small.scored_doc_ids, large.scored_doc_ids) == (
+        list(range(expected[0])),
+        list(range(expected[1])),
+    )
+    assert result["n-samples"] == {
+        "small": {"original": 3, "effective": expected[0]},
+        "large": {"original": 7, "effective": expected[1]},
+    }


### PR DESCRIPTION
We were applying the first task's resolved sample limit to every later task. Each task now resolves the original limit independently and uses that value for request construction, scoring, and reported sample counts.

For tasks with 3 and 7 documents, `limit=0.5` now selects 2 and 4 documents, instead of selecting 2 from each.

The change preserves the existing arguments and result format. The sample-limit regression also runs in the Hermetic CPU Contracts workflow.

## Validation

- After #1440 and #1451 landed, the sample-limit, evaluator, parallel scoring, and production request constructor tests passed: 28 tests.
- The cases cover unbounded, integer, and fractional limits.
- `uv run --no-sync pre-commit run --all-files`: passed.
- Linux CI runs the offline contract suite, including the four sample-limit cases.

This does not change the existing zero-limit behavior or request tuple layouts.
