### PR TITLE
security(tui): (PR 2/3) reject disallowed browser origins

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,7 +400,7 @@ LMMS-Eval includes an optional Web UI for interactive evaluation configuration.
 uv run lmms-eval-ui
 
 # Custom port
-LMMS_SERVER_PORT=3000 uv run lmms-eval-ui
+LMMS_SERVER_PORT=3000 LMMS_EVAL_TUI_ALLOWED_ORIGINS=http://localhost:3000 uv run lmms-eval-ui
 ```
 
 The web UI provides:

--- a/lmms_eval/tui/server.py
+++ b/lmms_eval/tui/server.py
@@ -23,9 +23,9 @@ from typing import Any
 from urllib.parse import quote, unquote, urlsplit
 
 import yaml
-from fastapi import FastAPI, HTTPException, Query
+from fastapi import FastAPI, HTTPException, Query, Request
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import FileResponse, StreamingResponse
+from fastapi.responses import FileResponse, JSONResponse, StreamingResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
 
@@ -72,13 +72,26 @@ def _allowed_tui_origins() -> tuple[str, ...]:
     return origins
 
 
+_ALLOWED_TUI_ORIGINS = _allowed_tui_origins()
+
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=list(_allowed_tui_origins()),
+    allow_origins=list(_ALLOWED_TUI_ORIGINS),
     allow_credentials=False,
     allow_methods=["GET", "POST", "OPTIONS"],
     allow_headers=["Content-Type"],
 )
+
+
+@app.middleware("http")
+async def reject_disallowed_origin(request: Request, call_next):
+    origin = request.headers.get("origin")
+    is_preflight = request.method == "OPTIONS" and "access-control-request-method" in request.headers
+    if origin is not None and origin not in _ALLOWED_TUI_ORIGINS and not is_preflight:
+        return JSONResponse(status_code=403, content={"detail": "Origin not allowed"})
+    return await call_next(request)
+
 
 # In-memory job storage
 _jobs: dict[str, dict[str, Any]] = {}

--- a/test/tui/test_server.py
+++ b/test/tui/test_server.py
@@ -73,6 +73,22 @@ def test_cors_allows_only_configured_origin():
     assert "access-control-allow-origin" not in denied.headers
 
 
+def test_disallowed_origin_cannot_stop_job(monkeypatch):
+    job_id = "disallowed-origin-stop"
+    job = {"status": "running", "process": None}
+    monkeypatch.setitem(server._jobs, job_id, job)
+
+    response = _request(
+        "POST",
+        f"/eval/{job_id}/stop",
+        headers={"Origin": "https://attacker.invalid"},
+    )
+
+    assert response.status_code == 403
+    assert response.json() == {"detail": "Origin not allowed"}
+    assert "stopped" not in job
+
+
 @pytest.mark.parametrize(
     ("field", "value"),
     [


### PR DESCRIPTION
This blocks disallowed browser origins before FastAPI dispatches a state-changing route. CORS still controls browser response access, while the application guard prevents a hostile simple request from stopping or starting work.

Depends on #1442.

GitHub review stack #1467.

## Stack
- 1/3 #1442 - structured evaluation argv
- **2/3 #1443 (this PR)** - browser origin guard
- 3/3 #1444 - frontend controls and rebuilt bundle
- Merge surface: #1445 collector only

This is review layer 2 of 3. Do not merge this PR; the final collector will land the complete reviewed tree atomically.

## Summary
- Return HTTP 403 for any present Origin outside the exact startup allowlist.
- Keep requests without Origin available to trusted non-browser callers.
- Prove a hostile-origin stop request cannot mutate an existing job.

## In scope
- Application-level origin enforcement using the same list as CORS.
- Custom-port documentation for the matching browser origin.

## Out of scope
- Authentication, authorization, rate limiting, and public-network exposure.
- Frontend request cleanup and rebuilt package assets, which are review layer 3.

## Validation
- `python -m pytest -q test/tui/test_server.py` | sample size: `N=17 tests` | key metrics: `17 passed` | result: `pass`
- `pre-commit run --all-files` | sample size: `N=all tracked files` | key metrics: `Black and isort clean` | result: `pass`

## Risk / Compatibility
- Exact allowed origins and origin-free calls remain unchanged from layer 1.
- The collector is the only branch authorized to merge this stack into `main`.

## Type of Change
- [x] Bug fix (non-breaking change)
- [ ] New feature
- [ ] New benchmark/task
- [ ] New model integration
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
