### PR TITLE
refactor(models): (PR 2/4) derive legacy views from V2

### DIFF
--- a/lmms_eval/models/__init__.py
+++ b/lmms_eval/models/__init__.py
@@ -4,18 +4,23 @@ import importlib
 import os
 import sys
 import warnings
+from collections.abc import Callable, Mapping
 from typing import Literal
 
 from loguru import logger
 
-from lmms_eval.models.registry_v2 import ModelManifest, ModelRegistryV2
+from lmms_eval.models.registry_v2 import (
+    ModelManifest,
+    ModelRegistryV2,
+    PluginLoadFailure,
+)
 
 logger.remove()
 log_format = "<green>{time:YYYY-MM-DD HH:mm:ss}</green> | " "<level>{level: <8}</level> | " "<cyan>{name}</cyan>:<cyan>{function}</cyan>:<cyan>{line}</cyan> - " "<level>{message}</level>"
 logger.add(sys.stdout, level="WARNING", format=log_format)
 
 
-AVAILABLE_SIMPLE_MODELS = {
+_BUILTIN_SIMPLE_MODELS = {
     "aero": "Aero",
     "generation_api": "GenerationApi",
     "cosmos_wm": "CosmosWorldModel",
@@ -120,7 +125,7 @@ AVAILABLE_SIMPLE_MODELS = {
     "xcomposer2d5": "XComposer2D5",
 }
 
-AVAILABLE_CHAT_TEMPLATE_MODELS = {
+_BUILTIN_CHAT_TEMPLATE_MODELS = {
     "gemini": "Gemini",
     "aero_realtime_vllm": "AeroRealtimeVLLM",
     "bagel_lmms_engine": "BagelLmmsEngine",
@@ -153,7 +158,7 @@ AVAILABLE_CHAT_TEMPLATE_MODELS = {
     "lfm2_5_vl": "LFM2_5_VL",
 }
 
-MODEL_ALIASES: dict[str, tuple[str, ...]] = {
+_BUILTIN_MODEL_ALIASES: dict[str, tuple[str, ...]] = {
     "aero_realtime_vllm": ("aero_realtime_vllm_chat",),
     "gemini": ("gemini_api",),
     "dummy": ("dummy_video_reader",),
@@ -176,13 +181,13 @@ def _build_class_path(
 
 def _build_builtin_manifests() -> list[ModelManifest]:
     model_ids = sorted(
-        set(AVAILABLE_SIMPLE_MODELS) | set(AVAILABLE_CHAT_TEMPLATE_MODELS),
+        set(_BUILTIN_SIMPLE_MODELS) | set(_BUILTIN_CHAT_TEMPLATE_MODELS),
     )
     manifests: list[ModelManifest] = []
     for model_id in model_ids:
-        simple_class = AVAILABLE_SIMPLE_MODELS.get(model_id)
-        chat_class = AVAILABLE_CHAT_TEMPLATE_MODELS.get(model_id)
-        aliases = MODEL_ALIASES.get(model_id, ())
+        simple_class = _BUILTIN_SIMPLE_MODELS.get(model_id)
+        chat_class = _BUILTIN_CHAT_TEMPLATE_MODELS.get(model_id)
+        aliases = _BUILTIN_MODEL_ALIASES.get(model_id, ())
         manifests.append(
             ModelManifest(
                 model_id=model_id,
@@ -194,40 +199,48 @@ def _build_builtin_manifests() -> list[ModelManifest]:
     return manifests
 
 
-def _merge_legacy_plugin_models(registry: ModelRegistryV2) -> None:
-    plugins = os.environ.get("LMMS_EVAL_PLUGINS")
-    if not plugins:
-        return
-
-    warnings.warn(
-        "LMMS_EVAL_PLUGINS is deprecated. Prefer Python entry-points group " "'lmms_eval.models' for plugin model registration.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    for plugin in plugins.split(","):
-        module = importlib.import_module(f"{plugin}.models")
-        for model_name, model_class in getattr(module, "AVAILABLE_MODELS").items():
-            class_path = f"{plugin}.models.{model_name}.{model_class}"
-            AVAILABLE_SIMPLE_MODELS[model_name] = class_path
-            registry.register_manifest(
-                ModelManifest(
-                    model_id=model_name,
-                    simple_class_path=class_path,
+def _load_legacy_plugin_models(registry: ModelRegistryV2, plugins: str | None) -> tuple[PluginLoadFailure, ...]:
+    failures: list[PluginLoadFailure] = []
+    for plugin in (item.strip() for item in (plugins or "").split(",")):
+        if not plugin:
+            continue
+        try:
+            module = importlib.import_module(f"{plugin}.models")
+            available_models = getattr(module, "AVAILABLE_MODELS")
+            if not isinstance(available_models, Mapping):
+                raise TypeError("AVAILABLE_MODELS must be a mapping")
+            entries = tuple(available_models.items())
+            if any(not isinstance(value, str) or not value.strip() for pair in entries for value in pair):
+                raise TypeError("AVAILABLE_MODELS must contain non-empty string pairs")
+            registry.register_manifests(
+                (
+                    ModelManifest(
+                        model_id=model_name,
+                        simple_class_path=f"{plugin}.models.{model_name}.{model_class}",
+                    )
+                    for model_name, model_class in entries
                 ),
                 overwrite=True,
             )
+        except Exception as exc:
+            failures.append(PluginLoadFailure(f"legacy:{plugin}", type(exc).__name__, str(exc)))
+    return tuple(failures)
 
 
 def _initialize_model_registry() -> ModelRegistryV2:
     registry = ModelRegistryV2()
-    for manifest in _build_builtin_manifests():
-        registry.register_manifest(manifest)
+    registry.register_manifests(_build_builtin_manifests())
 
-    _merge_legacy_plugin_models(registry)
-    try:
-        registry.load_entrypoint_manifests(overwrite=True)
-    except Exception as exc:  # pragma: no cover
-        logger.warning(f"Failed to load model entry-point manifests: {exc}")
+    plugins = os.environ.get("LMMS_EVAL_PLUGINS")
+    if plugins:
+        warnings.warn(
+            "LMMS_EVAL_PLUGINS is deprecated. Prefer Python entry-points group " "'lmms_eval.models' for plugin model registration.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+    failures = (*_load_legacy_plugin_models(registry, plugins), *registry.load_entrypoint_manifests(overwrite=True))
+    for failure in failures:
+        logger.warning(f"Failed to load model plugin {failure.source}: {failure.error_type}: {failure.message}")
 
     return registry
 
@@ -235,17 +248,62 @@ def _initialize_model_registry() -> ModelRegistryV2:
 MODEL_REGISTRY_V2 = _initialize_model_registry()
 
 
-def _build_available_models_preferred() -> dict[str, str]:
-    model_map: dict[str, str] = {}
-    for model_id in MODEL_REGISTRY_V2.list_canonical_model_ids():
-        manifest = MODEL_REGISTRY_V2.get_manifest(model_id)
-        class_path = manifest.chat_class_path or manifest.simple_class_path
-        if class_path:
-            model_map[model_id] = class_path.rsplit(".", 1)[-1]
-    return model_map
+class _RegistryView(Mapping[str, object]):
+    def __init__(
+        self,
+        registry: ModelRegistryV2,
+        project: Callable[[list[ModelManifest]], dict[str, object]],
+    ) -> None:
+        self._registry = registry
+        self._project = project
+
+    def _snapshot(self) -> dict[str, object]:
+        return self._project(self._registry.list_manifests())
+
+    def __getitem__(self, key: str) -> object:
+        return self._snapshot()[key]
+
+    def __iter__(self):
+        return iter(self._snapshot())
+
+    def __len__(self) -> int:
+        return len(self._snapshot())
 
 
-AVAILABLE_MODELS = _build_available_models_preferred()
+def _build_legacy_views(registry: ModelRegistryV2):
+    def project_lane(
+        manifests: list[ModelManifest],
+        model_type: Literal["simple", "chat"],
+    ) -> dict[str, object]:
+        projected: dict[str, object] = {}
+        for manifest in manifests:
+            class_path = getattr(manifest, f"{model_type}_class_path")
+            if class_path is None:
+                continue
+            prefix = f"lmms_eval.models.{model_type}.{manifest.model_id}."
+            projected[manifest.model_id] = class_path.rsplit(".", 1)[-1] if class_path.startswith(prefix) else class_path
+        return projected
+
+    def project_aliases(manifests: list[ModelManifest]) -> dict[str, object]:
+        projected: dict[str, object] = {}
+        for manifest in manifests:
+            aliases = tuple(alias for alias in manifest.aliases if registry.resolve(alias).model_id == manifest.model_id)
+            if aliases:
+                projected[manifest.model_id] = aliases
+        return projected
+
+    def project_preferred(manifests: list[ModelManifest]) -> dict[str, object]:
+        return {manifest.model_id: (manifest.chat_class_path or manifest.simple_class_path).rsplit(".", 1)[-1] for manifest in manifests}
+
+    return (
+        _RegistryView(registry, lambda manifests: project_lane(manifests, "simple")),
+        _RegistryView(registry, lambda manifests: project_lane(manifests, "chat")),
+        _RegistryView(registry, project_aliases),
+        _RegistryView(registry, project_preferred),
+    )
+
+
+AVAILABLE_SIMPLE_MODELS, AVAILABLE_CHAT_TEMPLATE_MODELS, MODEL_ALIASES, AVAILABLE_MODELS = _build_legacy_views(MODEL_REGISTRY_V2)
 
 
 def list_available_models(include_aliases: bool = False) -> list[str]:

--- a/test/models/test_model_registry_compatibility.py
+++ b/test/models/test_model_registry_compatibility.py
@@ -1,0 +1,179 @@
+"""Compatibility tests for model-registry startup and legacy projections."""
+
+import hashlib
+import json
+import subprocess
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from lmms_eval import models
+from lmms_eval.models.registry_v2 import ModelRegistryV2
+
+
+def _resolution_tuple(registry, model_name, *, force_simple=False):
+    resolved = registry.resolve(model_name, force_simple=force_simple)
+    return resolved.model_id, resolved.model_type, resolved.class_path
+
+
+def test_builtin_manifests_preserve_all_model_resolutions():
+    registry = ModelRegistryV2()
+    registry.register_manifests(models._build_builtin_manifests())
+
+    rows = [
+        {
+            "name": name,
+            "default": _resolution_tuple(registry, name),
+            "force_simple": _resolution_tuple(registry, name, force_simple=True),
+        }
+        for name in registry.list_model_names()
+    ]
+    payload = json.dumps(rows, sort_keys=True, separators=(",", ":"))
+
+    assert len(registry.list_canonical_model_ids()) == 117
+    assert len(registry.list_model_names()) == 127
+    assert hashlib.sha256(payload.encode()).hexdigest() == "45bb84f87177d5489d702387fb917f8942507d2cc75bc686334aa864893157a5"
+
+
+def _registry_with_projection_fixtures():
+    registry = ModelRegistryV2()
+    registry.register_manifests(
+        (
+            models.ModelManifest(
+                "builtin",
+                simple_class_path="lmms_eval.models.simple.builtin.BuiltinSimple",
+                chat_class_path="lmms_eval.models.chat.builtin.BuiltinChat",
+                aliases=("builtin_alias",),
+            ),
+            models.ModelManifest(
+                "external",
+                simple_class_path="external.models.external.ExternalSimple",
+                chat_class_path="external.models.external.ExternalChat",
+                aliases=("external_alias",),
+            ),
+        ),
+    )
+    return registry
+
+
+def test_legacy_views_project_manifests_without_importing_classes():
+    registry = _registry_with_projection_fixtures()
+
+    simple, chat, aliases, preferred = models._build_legacy_views(registry)
+
+    assert dict(simple) == {
+        "builtin": "BuiltinSimple",
+        "external": "external.models.external.ExternalSimple",
+    }
+    assert dict(chat) == {
+        "builtin": "BuiltinChat",
+        "external": "external.models.external.ExternalChat",
+    }
+    assert dict(aliases) == {
+        "builtin": ("builtin_alias",),
+        "external": ("external_alias",),
+    }
+    assert dict(preferred) == {
+        "builtin": "BuiltinChat",
+        "external": "ExternalChat",
+    }
+
+
+def test_legacy_views_are_read_only():
+    views = models._build_legacy_views(_registry_with_projection_fixtures())
+
+    for view in views:
+        try:
+            view["new"] = "New"
+        except TypeError:
+            pass
+        else:
+            raise AssertionError(f"{type(view).__name__} accepted assignment")
+
+
+def test_legacy_views_reflect_later_registration():
+    registry = _registry_with_projection_fixtures()
+    simple, chat, aliases, preferred = models._build_legacy_views(registry)
+
+    registry.register_manifest(
+        models.ModelManifest(
+            "later",
+            simple_class_path="plugin.models.later.LaterSimple",
+            aliases=("later_alias",),
+        ),
+    )
+
+    assert simple["later"] == "plugin.models.later.LaterSimple"
+    assert "later" not in chat
+    assert aliases["later"] == ("later_alias",)
+    assert preferred["later"] == "LaterSimple"
+
+
+def test_legacy_alias_view_exposes_only_current_owner_after_remap():
+    registry = ModelRegistryV2()
+    registry.register_manifest(models.ModelManifest("original", simple_class_path="pkg.Original", aliases=("shared",)))
+    _, _, aliases, _ = models._build_legacy_views(registry)
+
+    registry.register_manifest(models.ModelManifest("replacement", simple_class_path="pkg.Replacement", aliases=("shared",)), overwrite=True)
+
+    assert "original" not in aliases
+    assert aliases["replacement"] == ("shared",)
+
+
+def test_discovery_does_not_import_backend_modules():
+    code = "import sys; import lmms_eval.models; assert 'lmms_eval.models.simple.qwen3_vl' not in sys.modules; assert 'lmms_eval.models.chat.vllm' not in sys.modules"
+    subprocess.run([sys.executable, "-c", code], check=True)
+
+
+def test_legacy_environment_plugins_isolate_failures(monkeypatch):
+    registry = ModelRegistryV2()
+    builtin_simple_before = models._BUILTIN_SIMPLE_MODELS.copy()
+
+    def import_module(name):
+        if name == "broken.models":
+            raise RuntimeError("boom")
+        if name == "healthy.models":
+            return SimpleNamespace(AVAILABLE_MODELS={"external_simple": "ExternalSimple"})
+        raise AssertionError(f"unexpected import: {name}")
+
+    monkeypatch.setattr(models.importlib, "import_module", import_module)
+
+    failures = models._load_legacy_plugin_models(registry, "broken,healthy")
+
+    assert [(failure.source, failure.error_type, failure.message) for failure in failures] == [("legacy:broken", "RuntimeError", "boom")]
+    assert registry.resolve("external_simple").class_path == "healthy.models.external_simple.ExternalSimple"
+    assert models._BUILTIN_SIMPLE_MODELS == builtin_simple_before
+
+
+def test_legacy_environment_plugin_preserves_existing_name_overwrite(monkeypatch):
+    registry = ModelRegistryV2()
+    registry.register_manifests(models._build_builtin_manifests())
+    plugin = SimpleNamespace(AVAILABLE_MODELS={"qwen3_vl": "ReplacementQwen"})
+    monkeypatch.setattr(models.importlib, "import_module", lambda name: plugin)
+
+    failures = models._load_legacy_plugin_models(registry, "healthy")
+
+    assert failures == ()
+    assert registry.resolve("qwen3_vl", force_simple=True).class_path == "healthy.models.qwen3_vl.ReplacementQwen"
+    assert registry.resolve("qwen3_vl").class_path == "lmms_eval.models.chat.qwen3_vl.Qwen3_VL"
+
+
+def test_legacy_environment_plugins_validate_each_package_atomically(monkeypatch):
+    registry = ModelRegistryV2()
+    modules = {
+        "invalid_pair.models": SimpleNamespace(AVAILABLE_MODELS={"valid": "Valid", "": "Empty"}),
+        "not_mapping.models": SimpleNamespace(AVAILABLE_MODELS=[("other", "Other")]),
+        "healthy.models": SimpleNamespace(AVAILABLE_MODELS={"healthy": "Healthy"}),
+    }
+    monkeypatch.setattr(models.importlib, "import_module", modules.__getitem__)
+
+    failures = models._load_legacy_plugin_models(registry, "invalid_pair,not_mapping,healthy")
+
+    assert [(failure.source, failure.error_type) for failure in failures] == [
+        ("legacy:invalid_pair", "TypeError"),
+        ("legacy:not_mapping", "TypeError"),
+    ]
+    with pytest.raises(ValueError, match="valid"):
+        registry.resolve("valid")
+    assert registry.resolve("healthy").class_path == "healthy.models.healthy.Healthy"


### PR DESCRIPTION
This makes ModelRegistryV2 the live startup authority while keeping the old model maps as read-only compatibility views. Legacy environment plugins and Python entry points update the same registry without importing every backend.

Depends on #1446.

GitHub review stack #1468.

## Stack
- 1/4 #1446 - transactional plugin registration
- **2/4 #1447 (this PR)** - read-only legacy views
- 3/4 #1448 - V2 discovery consumers
- 4/4 #1449 - contribution guidance
- Merge surface: #1450 collector only

This is review layer 2 of 4. Do not merge this PR; the final collector will land the complete authoritative registry atomically.

## Summary
- Keep built-in declarations as private, import-free bootstrap data.
- Bind live read-only `AVAILABLE_*`, `MODEL_ALIASES`, and `AVAILABLE_MODELS` projections.
- Isolate legacy plugin failures and preserve startup overwrite precedence.

## In scope
- Authoritative model startup and compatibility-map behavior.
- Golden built-in resolution, lazy import, plugin isolation, and live-view tests.

## Out of scope
- CLI, wizard, decorator fallback, and documentation are later review layers.
- This layer is not an independently mergeable release unit.

## Validation
- `python -m pytest -q test/models/test_model_registry_v2.py test/models/test_model_registry_compatibility.py` | sample size: `N=27 tests` | key metrics: `27 passed` | result: `pass`
- `pre-commit run --files lmms_eval/models/__init__.py test/models/test_model_registry_compatibility.py` | sample size: `N=2 files` | result: `pass`

## Risk / Compatibility
- The public compatibility mappings remain available but become read-only.
- The collector is the only branch authorized to merge this registry stack.

## Type of Change
- [ ] Bug fix (non-breaking change)
- [ ] New feature
- [ ] New benchmark/task
- [ ] New model integration
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactoring (no functional changes)
