### PR TITLE
refactor(models): (PR 3/4) route model discovery through V2

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -164,11 +164,13 @@ Models live under `lmms_eval/models/chat/` (recommended) or `lmms_eval/models/si
 1. **Create `models/chat/my_model.py`**
 2. **Inherit from `lmms`**, set `is_simple = False`
 3. **Implement required methods**: `generate_until`, `loglikelihood`, `generate_until_multi_round`
-4. **Register** in `models/__init__.py`:
+4. **Add a built-in bootstrap declaration** in `models/__init__.py`:
    ```python
-   AVAILABLE_CHAT_TEMPLATE_MODELS = {"my_model": "MyModel", ...}
+   _BUILTIN_CHAT_TEMPLATE_MODELS = {"my_model": "MyModel", ...}
    ```
-5. **Use `optional_import`** for model-specific dependencies:
+   Use `_BUILTIN_SIMPLE_MODELS` for a simple model. The public `AVAILABLE_*` and `MODEL_ALIASES` maps are read-only views.
+5. **For an external package**, publish a `lmms_eval.models` entry point that returns a `ModelManifest`. Model registration runs at process startup, so install the package before starting `lmms-eval`.
+6. **Use `optional_import`** for model-specific dependencies:
    ```python
    from lmms_eval.imports import optional_import
    MyLib, _has_mylib = optional_import("mylib", "MyLib")

--- a/docs/guides/model_guide.md
+++ b/docs/guides/model_guide.md
@@ -129,24 +129,37 @@ class MyModel(lmms):
     # is_simple = True  # simple model (legacy, default)
 ```
 
-Then add the entry in `lmms_eval/models/__init__.py`:
+For a built-in model, add one bootstrap declaration in `lmms_eval/models/__init__.py`:
 
 ```python
-# Recommended (ModelRegistryV2 manifest)
-from lmms_eval.models.registry_v2 import ModelManifest
-
-MODEL_REGISTRY_V2.register_manifest(
-    ModelManifest(
-        model_id="my_model",
-        chat_class_path="lmms_eval.models.chat.my_model.MyModel",
-    )
-)
-
-# Legacy (still supported)
-AVAILABLE_CHAT_TEMPLATE_MODELS["my_model"] = "MyModel"
+_BUILTIN_CHAT_TEMPLATE_MODELS = {
+    # ...
+    "my_model": "MyModel",
+}
 ```
 
-For external plugin packages, prefer Python entry-points (`lmms_eval.models`) over `LMMS_EVAL_PLUGINS`.
+Use `_BUILTIN_SIMPLE_MODELS` for a simple model. The registry converts these private declarations into `ModelManifest` objects at startup. `AVAILABLE_SIMPLE_MODELS`, `AVAILABLE_CHAT_TEMPLATE_MODELS`, `MODEL_ALIASES`, and `AVAILABLE_MODELS` are read-only compatibility views. Do not mutate them.
+
+External packages register through the `lmms_eval.models` entry-point group. An entry point can expose one `ModelManifest`, an iterable of manifests, or a function that returns either form:
+
+```toml
+[project.entry-points."lmms_eval.models"]
+my_model = "my_plugin.models:model_manifest"
+```
+
+```python
+# my_plugin/models.py
+from lmms_eval.models.registry_v2 import ModelManifest
+
+
+def model_manifest():
+    return ModelManifest(
+        model_id="my_model",
+        chat_class_path="my_plugin.models.MyModel",
+    )
+```
+
+Install the plugin before starting `lmms-eval`. Registration is a startup-only operation. Restart the process after changing installed plugins. `LMMS_EVAL_PLUGINS` remains available for older packages, but new packages should use entry points.
 
 ## Complete Example (Chat Model)
 

--- a/lmms_eval/api/registry.py
+++ b/lmms_eval/api/registry.py
@@ -26,10 +26,11 @@ def register_model(*names):
 
 
 def get_model(model_name):
-    try:
+    if model_name in MODEL_REGISTRY:
         return MODEL_REGISTRY[model_name]
-    except KeyError:
-        raise ValueError(f"Attempted to load model '{model_name}', but no model for this name found! Supported model names: {', '.join(MODEL_REGISTRY.keys())}")
+    from lmms_eval.models import get_model as get_model_v2
+
+    return get_model_v2(model_name)
 
 
 TASK_REGISTRY = {}  # Key: task name, Value: task ConfigurableTask class

--- a/lmms_eval/cli/models_cmd.py
+++ b/lmms_eval/cli/models_cmd.py
@@ -25,20 +25,21 @@ def _col(text: str, width: int) -> str:
     return text[:width].ljust(width)
 
 
+def _model_rows() -> list[tuple[str, str, tuple[str, ...]]]:
+    from lmms_eval.models import MODEL_REGISTRY_V2
+
+    rows = []
+    for manifest in MODEL_REGISTRY_V2.list_manifests():
+        kind = "chat+simple" if manifest.chat_class_path and manifest.simple_class_path else "chat" if manifest.chat_class_path else "simple"
+        rows.append((manifest.model_id, kind, manifest.aliases))
+    return rows
+
+
 def run_models(args: argparse.Namespace) -> None:
-    from lmms_eval.models import (
-        AVAILABLE_CHAT_TEMPLATE_MODELS,
-        AVAILABLE_SIMPLE_MODELS,
-        MODEL_ALIASES,
-    )
-
-    chat_only = sorted(set(AVAILABLE_CHAT_TEMPLATE_MODELS) - set(AVAILABLE_SIMPLE_MODELS))
-    simple_only = sorted(set(AVAILABLE_SIMPLE_MODELS) - set(AVAILABLE_CHAT_TEMPLATE_MODELS))
-    dual = sorted(set(AVAILABLE_CHAT_TEMPLATE_MODELS) & set(AVAILABLE_SIMPLE_MODELS))
-
-    def _alias_str(name: str) -> str:
-        aliases = MODEL_ALIASES.get(name, ())
-        return ", ".join(aliases) if aliases else ""
+    rows = _model_rows()
+    chat_only = [row for row in rows if row[1] == "chat"]
+    dual = [row for row in rows if row[1] == "chat+simple"]
+    simple_only = [row for row in rows if row[1] == "simple"]
 
     show_aliases = getattr(args, "aliases", False)
 
@@ -48,26 +49,26 @@ def run_models(args: argparse.Namespace) -> None:
     else:
         header = f"{_col('Name', 28)}{_col('Type', 14)}"
         sep = "-" * 42
-    print(f"\nRegistered Models ({len(chat_only) + len(simple_only) + len(dual)} total)\n")
+    print(f"\nRegistered Models ({len(rows)} total)\n")
     print(header)
     print(sep)
 
-    def _print_row(name: str, typ: str) -> None:
+    def _print_row(name: str, typ: str, aliases: tuple[str, ...]) -> None:
         if show_aliases:
-            alias = _alias_str(name)
+            alias = ", ".join(aliases)
             print(f"{_col(name, 28)}{_col(typ, 14)}{alias}")
         else:
             print(f"{_col(name, 28)}{_col(typ, 14)}")
 
     # Chat-only models first (recommended)
-    for name in chat_only:
-        _print_row(name, "chat")
+    for row in chat_only:
+        _print_row(*row)
     # Dual-mode models
-    for name in dual:
-        _print_row(name, "chat+simple")
+    for row in dual:
+        _print_row(*row)
     # Simple-only models
-    for name in simple_only:
-        _print_row(name, "simple")
+    for row in simple_only:
+        _print_row(*row)
 
     print(sep)
     print(f"\n  chat-only: {len(chat_only)}  |  chat+simple: {len(dual)}  |  simple-only: {len(simple_only)}")

--- a/lmms_eval/cli/wizard.py
+++ b/lmms_eval/cli/wizard.py
@@ -85,24 +85,21 @@ def _pick_from_list(
 # ── wizard steps ─────────────────────────────────────────────────────
 
 
+def _model_choices() -> list[tuple[str, str]]:
+    from lmms_eval.models import MODEL_REGISTRY_V2
+
+    choices = []
+    for manifest in MODEL_REGISTRY_V2.list_manifests():
+        kind = "chat+simple" if manifest.chat_class_path and manifest.simple_class_path else "chat" if manifest.chat_class_path else "simple"
+        choices.append((manifest.model_id, kind))
+    return [choice for choice in choices if choice[1] != "simple"] + [choice for choice in choices if choice[1] == "simple"]
+
+
 def _step_model() -> tuple[str, str]:
     """Step 1: pick model and model_args."""
-    from lmms_eval.models import (
-        AVAILABLE_CHAT_TEMPLATE_MODELS,
-        AVAILABLE_SIMPLE_MODELS,
-    )
-
-    # Build ordered list: chat first (recommended), then simple-only
-    chat_names = sorted(AVAILABLE_CHAT_TEMPLATE_MODELS.keys())
-    simple_only = sorted(set(AVAILABLE_SIMPLE_MODELS.keys()) - set(chat_names))
-
-    # Label chat models with a marker
-    labeled: list[tuple[str, str]] = []
-    for n in chat_names:
-        tag = "chat+simple" if n in AVAILABLE_SIMPLE_MODELS else "chat"
-        labeled.append((n, tag))
-    for n in simple_only:
-        labeled.append((n, "simple"))
+    labeled = _model_choices()
+    chat_names = [name for name, tag in labeled if tag.startswith("chat")]
+    simple_only = [name for name, tag in labeled if tag == "simple"]
 
     print("\n" + "=" * 60)
     print("  Step 1/4 \u2014 Select model")
@@ -119,7 +116,6 @@ def _step_model() -> tuple[str, str]:
             break
 
     print("\n  Simple models (legacy):")
-    simple_start = len(chat_names) + 1
     shown = 0
     for i, (name, tag) in enumerate(labeled, 1):
         if tag == "simple":

--- a/lmms_eval/models/__init__.py
+++ b/lmms_eval/models/__init__.py
@@ -230,22 +230,7 @@ def _load_legacy_plugin_models(registry: ModelRegistryV2, plugins: str | None) -
 def _initialize_model_registry() -> ModelRegistryV2:
     registry = ModelRegistryV2()
     registry.register_manifests(_build_builtin_manifests())
-
-    plugins = os.environ.get("LMMS_EVAL_PLUGINS")
-    if plugins:
-        warnings.warn(
-            "LMMS_EVAL_PLUGINS is deprecated. Prefer Python entry-points group " "'lmms_eval.models' for plugin model registration.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-    failures = (*_load_legacy_plugin_models(registry, plugins), *registry.load_entrypoint_manifests(overwrite=True))
-    for failure in failures:
-        logger.warning(f"Failed to load model plugin {failure.source}: {failure.error_type}: {failure.message}")
-
     return registry
-
-
-MODEL_REGISTRY_V2 = _initialize_model_registry()
 
 
 class _RegistryView(Mapping[str, object]):
@@ -303,7 +288,24 @@ def _build_legacy_views(registry: ModelRegistryV2):
     )
 
 
+def _load_model_plugins(registry: ModelRegistryV2) -> None:
+    """Load trusted plugins during module startup and report all failures."""
+
+    plugins = os.environ.get("LMMS_EVAL_PLUGINS")
+    if plugins:
+        warnings.warn(
+            "LMMS_EVAL_PLUGINS is deprecated. Prefer Python entry-points group " "'lmms_eval.models' for plugin model registration.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+    failures = (*_load_legacy_plugin_models(registry, plugins), *registry.load_entrypoint_manifests(overwrite=True))
+    for failure in failures:
+        logger.warning(f"Failed to load model plugin {failure.source}: {failure.error_type}: {failure.message}")
+
+
+MODEL_REGISTRY_V2 = _initialize_model_registry()
 AVAILABLE_SIMPLE_MODELS, AVAILABLE_CHAT_TEMPLATE_MODELS, MODEL_ALIASES, AVAILABLE_MODELS = _build_legacy_views(MODEL_REGISTRY_V2)
+_load_model_plugins(MODEL_REGISTRY_V2)
 
 
 def list_available_models(include_aliases: bool = False) -> list[str]:

--- a/lmms_eval/models/registry_v2.py
+++ b/lmms_eval/models/registry_v2.py
@@ -96,10 +96,23 @@ class ModelRegistryV2:
             )
             for name in (merged.model_id, *merged.aliases):
                 owner = candidate_names.get(name)
-                if owner is not None and owner != merged.model_id and not overwrite:
+                if owner is None or owner == merged.model_id:
+                    continue
+                if name != merged.model_id and name in candidate_manifests:
+                    raise ValueError(
+                        f"Model alias '{name}' cannot shadow canonical model id '{name}'",
+                    )
+                if not overwrite:
                     raise ValueError(
                         f"Model name '{name}' already points to '{owner}', " f"cannot remap to '{merged.model_id}'",
                     )
+                previous = candidate_manifests[owner]
+                candidate_manifests[owner] = ModelManifest(
+                    model_id=previous.model_id,
+                    simple_class_path=previous.simple_class_path,
+                    chat_class_path=previous.chat_class_path,
+                    aliases=tuple(alias for alias in previous.aliases if alias != name),
+                )
             candidate_manifests[merged.model_id] = merged
             for name in (merged.model_id, *merged.aliases):
                 candidate_names[name] = merged.model_id
@@ -179,13 +192,18 @@ class ModelRegistryV2:
         """
 
         failures: list[PluginLoadFailure] = []
-        selected = sorted(
-            self._select_entry_points(group),
-            key=lambda ep: (ep.name, getattr(ep, "value", "")),
-        )
+        discovery_source = f"entrypoints:{group}"
+        try:
+            selected = sorted(
+                self._select_entry_points(group),
+                key=lambda ep: (ep.name, getattr(ep, "value", "")),
+            )
+        except Exception as exc:
+            return (PluginLoadFailure(discovery_source, type(exc).__name__, str(exc)),)
         for ep in selected:
-            source = f"{ep.name} ({getattr(ep, 'value', '')})"
+            source = discovery_source
             try:
+                source = f"{ep.name} ({getattr(ep, 'value', '')})"
                 self.register_manifests(
                     self._coerce_payload_to_manifests(ep.load()),
                     overwrite=overwrite,

--- a/test/models/test_model_registry_compatibility.py
+++ b/test/models/test_model_registry_compatibility.py
@@ -5,7 +5,7 @@ import hashlib
 import json
 import subprocess
 import sys
-from types import SimpleNamespace
+from types import ModuleType, SimpleNamespace
 
 import pytest
 
@@ -75,6 +75,49 @@ def test_frontend_discovery_uses_v2_manifests(monkeypatch):
     ]
     assert asyncio.run(http_server.list_available_models()) == {"models": ["chat_plugin", "dual_plugin", "simple_plugin"]}
     assert dict(tui_discovery.discover_models())["dual_plugin"] == "dual_plugin (dual_alias)"
+
+
+def test_frontend_discovery_agrees_after_alias_ownership_transfer(monkeypatch):
+    registry = ModelRegistryV2()
+    registry.register_manifest(models.ModelManifest("original", simple_class_path="plugin.Original", aliases=("shared",)))
+    registry.register_manifest(models.ModelManifest("replacement", simple_class_path="plugin.Replacement", aliases=("shared",)), overwrite=True)
+    monkeypatch.setattr(models, "MODEL_REGISTRY_V2", registry)
+
+    assert models_cmd._model_rows() == [
+        ("original", "simple", ()),
+        ("replacement", "simple", ("shared",)),
+    ]
+    assert wizard._model_choices() == [
+        ("original", "simple"),
+        ("replacement", "simple"),
+    ]
+    assert asyncio.run(http_server.list_available_models()) == {"models": ["original", "replacement"]}
+    assert dict(tui_discovery.discover_models()) == {
+        "original": "original",
+        "replacement": "replacement (shared)",
+    }
+
+    fastmcp = ModuleType("mcp.server.fastmcp")
+    fastmcp.FastMCP = object
+    monkeypatch.setitem(sys.modules, "mcp.server.fastmcp", fastmcp)
+    from lmms_eval.mcp import tools as mcp_tools
+
+    class CapturingMCP:
+        def __init__(self):
+            self.tools = {}
+
+        def tool(self):
+            def register(function):
+                self.tools[function.__name__] = function
+                return function
+
+            return register
+
+    mcp = CapturingMCP()
+    mcp_tools.register_tools(mcp, scheduler=None)
+    mcp_models = {item["model_id"]: item for item in mcp.tools["list_models"](include_aliases=True)["models"]}
+    assert mcp_models["original"]["aliases"] == []
+    assert mcp_models["replacement"]["aliases"] == ["shared"]
 
 
 def test_builtin_manifests_preserve_all_model_resolutions():
@@ -184,6 +227,27 @@ def test_legacy_alias_view_exposes_only_current_owner_after_remap():
 def test_discovery_does_not_import_backend_modules():
     code = "import sys; import lmms_eval.models; assert 'lmms_eval.models.simple.qwen3_vl' not in sys.modules; assert 'lmms_eval.models.chat.vllm' not in sys.modules"
     subprocess.run([sys.executable, "-c", code], check=True)
+
+
+def test_public_legacy_views_exist_before_legacy_plugin_import(tmp_path):
+    plugin = tmp_path / "reads_legacy_views"
+    plugin.mkdir()
+    (plugin / "__init__.py").write_text("")
+    (plugin / "models.py").write_text(
+        "from lmms_eval.models import AVAILABLE_SIMPLE_MODELS\n" "assert 'qwen3_vl' in AVAILABLE_SIMPLE_MODELS\n" "AVAILABLE_MODELS = {'startup_visible': 'StartupVisible'}\n",
+    )
+    env = {
+        "LMMS_EVAL_PLUGINS": "reads_legacy_views",
+        "PYTHONPATH": str(tmp_path),
+    }
+    code = (
+        "from lmms_eval.models import AVAILABLE_SIMPLE_MODELS, MODEL_REGISTRY_V2; "
+        "assert AVAILABLE_SIMPLE_MODELS['startup_visible'] == "
+        "'reads_legacy_views.models.startup_visible.StartupVisible'; "
+        "assert MODEL_REGISTRY_V2.resolve('startup_visible').model_id == 'startup_visible'"
+    )
+
+    subprocess.run([sys.executable, "-c", code], check=True, env=env)
 
 
 def test_legacy_environment_plugins_isolate_failures(monkeypatch):

--- a/test/models/test_model_registry_compatibility.py
+++ b/test/models/test_model_registry_compatibility.py
@@ -1,5 +1,6 @@
 """Compatibility tests for model-registry startup and legacy projections."""
 
+import asyncio
 import hashlib
 import json
 import subprocess
@@ -9,12 +10,71 @@ from types import SimpleNamespace
 import pytest
 
 from lmms_eval import models
+from lmms_eval.api import registry as legacy_registry
+from lmms_eval.api.model import lmms
+from lmms_eval.cli import models_cmd, wizard
+from lmms_eval.entrypoints import http_server
 from lmms_eval.models.registry_v2 import ModelRegistryV2
+from lmms_eval.tui import discovery as tui_discovery
 
 
 def _resolution_tuple(registry, model_name, *, force_simple=False):
     resolved = registry.resolve(model_name, force_simple=force_simple)
     return resolved.model_id, resolved.model_type, resolved.class_path
+
+
+def test_legacy_decorator_lookup_preserves_registered_model(monkeypatch):
+    model_name = "compat_decorated"
+    monkeypatch.setitem(legacy_registry.MODEL_REGISTRY, model_name, lmms)
+    del legacy_registry.MODEL_REGISTRY[model_name]
+
+    @legacy_registry.register_model(model_name)
+    class CompatDecorated(lmms):
+        pass
+
+    assert legacy_registry.get_model(model_name) is CompatDecorated
+
+
+def test_legacy_decorator_lookup_falls_back_to_v2(monkeypatch):
+    sentinel = object()
+
+    def get_model_v2(model_name):
+        assert model_name == "compat_external"
+        return sentinel
+
+    monkeypatch.setattr(models, "get_model", get_model_v2)
+
+    assert legacy_registry.get_model("compat_external") is sentinel
+
+
+def test_frontend_discovery_uses_v2_manifests(monkeypatch):
+    registry = ModelRegistryV2()
+    registry.register_manifests(
+        (
+            models.ModelManifest("chat_plugin", chat_class_path="plugin.Chat"),
+            models.ModelManifest(
+                "dual_plugin",
+                simple_class_path="plugin.DualSimple",
+                chat_class_path="plugin.DualChat",
+                aliases=("dual_alias",),
+            ),
+            models.ModelManifest("simple_plugin", simple_class_path="plugin.Simple"),
+        ),
+    )
+    monkeypatch.setattr(models, "MODEL_REGISTRY_V2", registry)
+
+    assert models_cmd._model_rows() == [
+        ("chat_plugin", "chat", ()),
+        ("dual_plugin", "chat+simple", ("dual_alias",)),
+        ("simple_plugin", "simple", ()),
+    ]
+    assert wizard._model_choices() == [
+        ("chat_plugin", "chat"),
+        ("dual_plugin", "chat+simple"),
+        ("simple_plugin", "simple"),
+    ]
+    assert asyncio.run(http_server.list_available_models()) == {"models": ["chat_plugin", "dual_plugin", "simple_plugin"]}
+    assert dict(tui_discovery.discover_models())["dual_plugin"] == "dual_plugin (dual_alias)"
 
 
 def test_builtin_manifests_preserve_all_model_resolutions():

--- a/test/models/test_model_registry_v2.py
+++ b/test/models/test_model_registry_v2.py
@@ -4,6 +4,7 @@ import importlib.util
 import pathlib
 import sys
 import unittest
+from unittest.mock import patch
 
 _REGISTRY_PATH = pathlib.Path(__file__).resolve().parents[2] / "lmms_eval" / "models" / "registry_v2.py"
 _SPEC = importlib.util.spec_from_file_location("registry_v2_for_tests", _REGISTRY_PATH)
@@ -28,6 +29,17 @@ class _FakeEntryPoint:
         if self.error:
             raise self.error
         return self.payload
+
+
+class _BrokenIterable:
+    def __iter__(self):
+        raise RuntimeError("iteration failed")
+
+
+class _BrokenSortEntryPoint:
+    @property
+    def name(self):
+        raise RuntimeError("sort key failed")
 
 
 class TestModelRegistryV2(unittest.TestCase):
@@ -126,8 +138,82 @@ class TestModelRegistryV2(unittest.TestCase):
             ],
         )
 
+    def test_overwrite_transfers_alias_and_removes_stale_owner(self):
+        registry = ModelRegistryV2()
+        registry.register_manifest(ModelManifest("original", simple_class_path="pkg.Original", aliases=("shared",)))
+
+        registry.register_manifest(ModelManifest("replacement", simple_class_path="pkg.Replacement", aliases=("shared",)), overwrite=True)
+
+        self.assertEqual(registry.resolve("original").model_id, "original")
+        self.assertEqual(registry.resolve("replacement").model_id, "replacement")
+        self.assertEqual(registry.resolve("shared").model_id, "replacement")
+        self.assertEqual(registry.get_manifest("original").aliases, ())
+
+    def test_overwrite_canonical_id_takes_ownership_from_old_alias(self):
+        registry = ModelRegistryV2()
+        registry.register_manifest(ModelManifest("original", simple_class_path="pkg.Original", aliases=("replacement",)))
+
+        registry.register_manifest(ModelManifest("replacement", simple_class_path="pkg.Replacement"), overwrite=True)
+
+        self.assertEqual(registry.resolve("original").model_id, "original")
+        self.assertEqual(registry.resolve("replacement").model_id, "replacement")
+        self.assertEqual(registry.get_manifest("original").aliases, ())
+
+    def test_overwrite_alias_cannot_shadow_another_canonical_id(self):
+        registry = ModelRegistryV2()
+        registry.register_manifest(ModelManifest("protected", simple_class_path="pkg.Protected"))
+
+        with self.assertRaisesRegex(ValueError, "canonical model id"):
+            registry.register_manifests(
+                (
+                    ModelManifest("innocent", simple_class_path="pkg.Innocent"),
+                    ModelManifest("contender", simple_class_path="pkg.Contender", aliases=("protected",)),
+                ),
+                overwrite=True,
+            )
+
+        self.assertEqual(registry.resolve("protected").model_id, "protected")
+        with self.assertRaisesRegex(ValueError, "innocent"):
+            registry.resolve("innocent")
+        with self.assertRaisesRegex(ValueError, "contender"):
+            registry.resolve("contender")
+
 
 class TestEntryPointRegistration(unittest.TestCase):
+    def _assert_discovery_failure(self, registry, failures, message):
+        self.assertEqual(
+            [(failure.source, failure.error_type, failure.message) for failure in failures],
+            [("entrypoints:lmms_eval.models", "RuntimeError", message)],
+        )
+        self.assertEqual(registry.resolve("builtin").class_path, "pkg.Builtin")
+
+    def test_entry_point_enumeration_failure_is_reported(self):
+        registry = ModelRegistryV2()
+        registry.register_manifest(ModelManifest("builtin", simple_class_path="pkg.Builtin"))
+
+        with patch.object(_MODULE, "entry_points", side_effect=RuntimeError("enumeration failed")):
+            failures = registry.load_entrypoint_manifests()
+
+        self._assert_discovery_failure(registry, failures, "enumeration failed")
+
+    def test_entry_point_selection_iteration_failure_is_reported(self):
+        registry = ModelRegistryV2()
+        registry.register_manifest(ModelManifest("builtin", simple_class_path="pkg.Builtin"))
+        registry._select_entry_points = lambda group: _BrokenIterable()
+
+        failures = registry.load_entrypoint_manifests()
+
+        self._assert_discovery_failure(registry, failures, "iteration failed")
+
+    def test_entry_point_sort_key_failure_is_reported(self):
+        registry = ModelRegistryV2()
+        registry.register_manifest(ModelManifest("builtin", simple_class_path="pkg.Builtin"))
+        registry._select_entry_points = lambda group: [_BrokenSortEntryPoint()]
+
+        failures = registry.load_entrypoint_manifests()
+
+        self._assert_discovery_failure(registry, failures, "sort key failed")
+
     def test_entry_point_failure_is_reported_and_later_plugin_loads(self):
         registry = ModelRegistryV2()
         registry._select_entry_points = lambda group: [


### PR DESCRIPTION
This routes every maintained discovery surface through the live V2 manifests and closes the remaining startup ownership invariants. External entry-point models now appear in the CLI and wizard without editing the static model catalog.

Depends on #1447.

GitHub review stack #1468.

## Stack
- 1/4 #1446 - transactional plugin registration
- 2/4 #1447 - read-only legacy views
- **3/4 #1448 (this PR)** - V2 discovery consumers
- 4/4 #1449 - contribution guidance
- Merge surface: #1450 collector only

This is review layer 3 of 4. Do not merge this PR; the final collector will land the complete authoritative registry atomically.

## Summary
- Keep legacy decorator registrations first, then fall through to V2 on cache misses.
- Derive CLI and wizard rows from live manifests; verify HTTP, TUI, and MCP parity.
- Guard discovery-level failures and reconcile overwrite alias ownership without shadowing canonical IDs.

## In scope
- Consumer discovery parity, startup failure resilience, and canonical self-resolution.
- Collision and plugin-import compatibility tests.
- Core `CONTRIBUTING.md` and model-guide updates for read-only compatibility views.

## Out of scope
- Remaining agent guide and UniG2U guidance is review layer 4.
- Runtime model backends, evaluator behavior, and task semantics remain unchanged.

## Validation
- `python -m pytest -q test/models/test_model_registry_v2.py test/models/test_model_registry_compatibility.py test/cli/test_cli_dispatch_parametrized.py` | sample size: `N=55 tests` | key metrics: `55 passed` | result: `pass`
- Parent hermetic CPU contract command | sample size: `N=189 tests` | key metrics: `189 passed` | result: `pass`
- `python -m lmms_eval models --aliases` | sample size: `N=117 canonical models` | key metrics: `all listed` | result: `pass`

## Risk / Compatibility
- Registration remains a startup-only operation; no speculative runtime locking is added.
- The collector is the only branch authorized to merge this registry stack.

## Type of Change
- [x] Bug fix (non-breaking change)
- [ ] New feature
- [ ] New benchmark/task
- [ ] New model integration
- [ ] Breaking change
- [x] Documentation update
- [x] Refactoring (no functional changes)
