### PR TITLE
docs(models): (PR 4/4) align registry contribution guidance

### DIFF
--- a/lmms_eval/tasks/unig2u/README.md
+++ b/lmms_eval/tasks/unig2u/README.md
@@ -129,14 +129,16 @@ class MyModel(lmms):
         return res
 ```
 
-Register in `lmms_eval/models/__init__.py`:
+For an in-tree model, add a private bootstrap declaration in `lmms_eval/models/__init__.py`:
 
 ```python
-AVAILABLE_SIMPLE_MODELS = {
+_BUILTIN_SIMPLE_MODELS = {
     ...
     "my_model": "MyModel",
 }
 ```
+
+The public `AVAILABLE_SIMPLE_MODELS` mapping is a read-only compatibility view. For an external package, expose a `ModelManifest` through the `lmms_eval.models` entry-point group instead. Install the package before starting `lmms-eval`; registration runs at startup.
 
 Then run: `--tasks unig2u --model my_model`
 

--- a/skills/lmms-eval-guide/SKILL.md
+++ b/skills/lmms-eval-guide/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: lmms-eval-guide
-version: v0.7
 description: Guides AI coding agents through the lmms-eval codebase - a unified evaluation framework for Large Multimodal Models (LMMs). Use when integrating new models, adding evaluation tasks/benchmarks, running YAML config-driven evaluations, orchestrating non-blocking training-time evaluation via the HTTP eval server, or navigating the evaluation pipeline architecture.
 ---
 
@@ -76,7 +75,7 @@ lmms_eval/
 │   ├── reasoning.py         # strip_reasoning_tags(), parse_reasoning_tags_config()
 │   └── registry.py          # @register_model, @register_task decorators
 ├── models/
-│   ├── __init__.py           # AVAILABLE_SIMPLE_MODELS, AVAILABLE_CHAT_TEMPLATE_MODELS, MODEL_ALIASES
+│   ├── __init__.py           # Private built-in declarations + read-only compatibility views
 │   ├── registry_v2.py        # ModelManifest, ModelRegistryV2 - resolution prefers chat over simple
 │   ├── chat/                 # Chat models (14+, RECOMMENDED for new models)
 │   │   ├── async_openai.py   # OpenAI-compatible API (message_format parameter)
@@ -122,11 +121,12 @@ oai_messages = messages.to_openai_messages()  # for OpenAI API
 
 ## Model Registration
 
-Models register in `models/__init__.py` via two dicts mapping `model_id -> ClassName`:
-- `AVAILABLE_CHAT_TEMPLATE_MODELS` - chat models in `models/chat/`
-- `AVAILABLE_SIMPLE_MODELS` - simple models in `models/simple/`
+In-tree models use private bootstrap declarations in `models/__init__.py`:
+- `_BUILTIN_CHAT_TEMPLATE_MODELS` - chat models in `models/chat/`
+- `_BUILTIN_SIMPLE_MODELS` - simple models in `models/simple/`
+- `_BUILTIN_MODEL_ALIASES` - backward-compatible names
 
-`MODEL_ALIASES` provides backward-compatible name mappings. Registry prefers chat over simple when both exist.
+External packages should expose a `ModelManifest` through the `lmms_eval.models` entry-point group. Registration runs at startup. `AVAILABLE_SIMPLE_MODELS`, `AVAILABLE_CHAT_TEMPLATE_MODELS`, `MODEL_ALIASES`, and `AVAILABLE_MODELS` are read-only compatibility views. Registry resolution prefers chat over simple when both exist.
 
 ## Reference Routing Matrix
 

--- a/skills/lmms-eval-guide/references/models.md
+++ b/skills/lmms-eval-guide/references/models.md
@@ -102,21 +102,44 @@ class MyModel(lmms):
         raise NotImplementedError("generate_until_multi_round not implemented.")
 ```
 
-## Register in `__init__.py`
+## Register the Model
 
-Edit `lmms_eval/models/__init__.py`:
+For an in-tree chat model, add a row to the private bootstrap declaration in `lmms_eval/models/__init__.py`:
 
 ```python
-AVAILABLE_CHAT_TEMPLATE_MODELS = {
+_BUILTIN_CHAT_TEMPLATE_MODELS = {
     # ... existing ...
     "my_model": "MyModel",  # Maps to lmms_eval.models.chat.my_model.MyModel
 }
 
 # Optional: backward-compatible aliases
-MODEL_ALIASES: dict[str, tuple[str, ...]] = {
+_BUILTIN_MODEL_ALIASES: dict[str, tuple[str, ...]] = {
     "my_model": ("my_model_v1", "old_name"),
 }
 ```
+
+Use `_BUILTIN_SIMPLE_MODELS` for an in-tree simple model. The public `AVAILABLE_SIMPLE_MODELS`, `AVAILABLE_CHAT_TEMPLATE_MODELS`, `MODEL_ALIASES`, and `AVAILABLE_MODELS` mappings are read-only views.
+
+For an external package, expose a `ModelManifest` through the `lmms_eval.models` entry-point group:
+
+```toml
+[project.entry-points."lmms_eval.models"]
+my_model = "my_plugin.models:model_manifest"
+```
+
+```python
+from lmms_eval.models.registry_v2 import ModelManifest
+
+
+def model_manifest():
+    return ModelManifest(
+        model_id="my_model",
+        chat_class_path="my_plugin.models.MyModel",
+        aliases=("my_model_v1",),
+    )
+```
+
+Install external plugins before starting `lmms-eval`. Model registration runs at startup.
 
 ## Test
 
@@ -158,7 +181,7 @@ oai_messages = messages.to_openai_messages()          # For OpenAI API (base64 i
 
 ### Model Resolution
 
-When `model_id` exists in both `AVAILABLE_CHAT_TEMPLATE_MODELS` and `AVAILABLE_SIMPLE_MODELS`, the registry creates one `ModelManifest` with both paths. Resolution prefers chat unless `force_simple=True`.
+When `model_id` exists in both `_BUILTIN_CHAT_TEMPLATE_MODELS` and `_BUILTIN_SIMPLE_MODELS`, startup creates one `ModelManifest` with both paths. External entry-point manifests use the same resolution rules. Resolution prefers chat unless `force_simple=True`.
 
 ## Reference Implementations
 


### PR DESCRIPTION
This updates the active model-integration guidance to match the authoritative V2 registry. In-tree contributors edit private bootstrap declarations; external packages register manifests through the `lmms_eval.models` entry-point group.

Depends on #1448.

GitHub review stack #1468.

## Stack
- 1/4 #1446 - transactional plugin registration
- 2/4 #1447 - read-only legacy views
- 3/4 #1448 - V2 discovery consumers
- **4/4 #1449 (this PR)** - contribution guidance
- Merge surface: #1450 collector only

This is review layer 4 of 4. Do not merge this PR; the final collector will land the complete authoritative registry atomically.

## Summary
- Replace public-map mutation instructions with `_BUILTIN_*` in-tree guidance.
- Add external `ModelManifest` entry-point examples.
- Mark compatibility mappings read-only and registration startup-only.

## In scope
- Active lmms-eval guide, model reference, and UniG2U integration README.

## Out of scope
- Historical release notes and runtime code.
- This layer is not an independently mergeable release unit.

## Validation
- Skill validation | sample size: `N=1 skill package` | key metrics: `pass` | result: `pass`
- Local Markdown links | sample size: `N=9 links` | key metrics: `9 valid` | result: `pass`
- `pre-commit run --all-files` | sample size: `N=all tracked files` | key metrics: `Black and isort clean` | result: `pass`

## Risk / Compatibility
- Existing model names and import paths do not change.
- The collector is the only branch authorized to merge this registry stack.

## Type of Change
- [ ] Bug fix (non-breaking change)
- [ ] New feature
- [ ] New benchmark/task
- [ ] New model integration
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring (no functional changes)
