### PR TITLE
perf: (PR 2/4) add fail-closed legacy redaction

### DIFF
--- a/.github/workflows/hermetic-cpu-contracts.yml
+++ b/.github/workflows/hermetic-cpu-contracts.yml
@@ -46,3 +46,4 @@ jobs:
           test/eval/test_evaluator.py
           test/entrypoints/test_job_scheduler_subprocess.py
           test/performance/test_json_v1.py
+          test/performance/test_legacy_redaction.py

--- a/lmms_eval/_performance/legacy_redaction.py
+++ b/lmms_eval/_performance/legacy_redaction.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from typing import Any
+
+_SENSITIVE_CONFIG_KEYS = {
+    "access_key",
+    "access_key_id",
+    "api_key",
+    "authorization",
+    "aws_access_key_id",
+    "aws_secret_access_key",
+    "aws_session_token",
+    "bearer",
+    "client_secret",
+    "cookie",
+    "credential",
+    "credentials",
+    "hf_token",
+    "huggingface_hub_token",
+    "huggingfacehub_api_token",
+    "private_key",
+    "proxy_authorization",
+    "secret_key",
+    "secret",
+    "set_cookie",
+    "token",
+}
+_SENSITIVE_KEY_SUFFIXES = (
+    "api_key",
+    "_token",
+    "_secret",
+    "password",
+    "_authorization",
+    "_credential",
+    "_credentials",
+    "_cookie",
+    "_private_key",
+    "_access_key",
+    "_access_key_id",
+    "_secret_key",
+)
+_ASSIGNMENT_START_RE = re.compile(r"(?i)(^|--|[?&,;\s{(\[])([A-Za-z_][\w.-]*)=")
+_HEADER_START_RE = re.compile(r"(?i)\b(Authorization|Proxy[_.-]Authorization|Cookie|Set[_.-]Cookie)\s*:\s*")
+_SIMPLE_CREDENTIAL_VALUE_RE = re.compile(r"[A-Za-z0-9._~+/-]+")
+_COOKIE_CREDENTIAL_VALUE_RE = re.compile(r"[A-Za-z0-9._~+/-]+=[A-Za-z0-9._~+/-]+")
+_AMBIGUOUS_COOKIE_RE = re.compile(r"(?i)(?:(?:^|[?&,;\s])(?:cookie|set[_.-]?cookie)=|\b(?:Cookie|Set[_.-]Cookie)\s*:)[^,\r\n]*;")
+_HF_TOKEN_VALUE_RE = re.compile(r"\bhf_[A-Za-z0-9]{20,}\b")
+_BEARER_PREFIX_RE = re.compile(r"(?i)\bBearer[ \t]+")
+_BEARER_TOKEN_RE = re.compile(r"[A-Za-z0-9._~+/=-]+")
+_ASSIGNMENT_SEQUENCE_RE = re.compile(r"[}\])]*(?:,\s*[A-Za-z_][\w.-]*=(?:\[REDACTED\]|[^,;\s}\])]+))+[}\])]*\s*")
+_QUERY_ASSIGNMENT_SEQUENCE_RE = re.compile(r"[}\])]*[?&]\s*[A-Za-z_][\w.-]*=(?:\[REDACTED\]|[^?&,;\s}\])]+)(?:[?&]\s*[A-Za-z_][\w.-]*=(?:\[REDACTED\]|[^?&,;\s}\])]+))*[}\])]*\s*")
+_COLON_FIELD_SEQUENCE_RE = re.compile(r"""(?x)(?:,\s*["']?[^"'{}\[\],:=\s]+["']?\s*:\s*(?:"[^"\r\n]*"|'[^'\r\n]*'|[^,{}\[\]\s]+))+[}\])]*\s*""")
+_CLOSING_CONTAINER_RE = re.compile(r"[}\])]+\s*")
+_OPENAI_KEY_VALUE_RE = re.compile(r"(?<![A-Za-z0-9])sk-[A-Za-z0-9_-]{16,}")
+_AWS_ACCESS_KEY_VALUE_RE = re.compile(r"\b(?:AKIA|ASIA)[A-Z0-9]{16}\b")
+_URL_USERINFO_RE = re.compile(r"(?i)\b([a-z][a-z0-9+.-]*://)[^/\s@]+@")
+_PRIVATE_KEY_BLOCK_RE = re.compile(r"-----BEGIN [^-\r\n]*PRIVATE KEY-----.*?-----END [^-\r\n]*PRIVATE KEY-----", re.IGNORECASE | re.DOTALL)
+_PRIVATE_KEY_MARKER_RE = re.compile(r"-----BEGIN [^-\r\n]*PRIVATE KEY-----", re.IGNORECASE)
+_COLON_KEY_DELIMITERS = frozenset("?&,;:= \t\r\n{[()")
+_AUTHORIZATION_KEYS = {"authorization", "proxy_authorization", "bearer"}
+
+
+def _normalized_sensitive_key(key: Any) -> str:
+    return re.sub(r"[.-]", "_", str(key).casefold())
+
+
+def _is_sensitive_key(key: Any) -> bool:
+    normalized = _normalized_sensitive_key(key)
+    return normalized in _SENSITIVE_CONFIG_KEYS or normalized.endswith(_SENSITIVE_KEY_SUFFIXES)
+
+
+def _validate_credential_boundary(value: str, end: int) -> None:
+    remainder = value[end:]
+    if not remainder or remainder.isspace() or _ASSIGNMENT_SEQUENCE_RE.fullmatch(remainder) or _QUERY_ASSIGNMENT_SEQUENCE_RE.fullmatch(remainder) or _CLOSING_CONTAINER_RE.fullmatch(remainder):
+        return
+    raise ValueError("credential-bearing value has an ambiguous boundary")
+
+
+def _bearer_value_end(value: str, start: int) -> tuple[int, bool]:
+    prefix = _BEARER_PREFIX_RE.match(value, start)
+    if prefix is None:
+        raise ValueError("credential-bearing authorization value cannot be normalized safely")
+    if value.startswith("[REDACTED]", prefix.end()):
+        end = prefix.end() + len("[REDACTED]")
+        redacted = True
+    else:
+        match = _BEARER_TOKEN_RE.match(value, prefix.end())
+        if match is None:
+            raise ValueError("credential-bearing Bearer value cannot be normalized safely")
+        end = match.end()
+        redacted = False
+    _validate_credential_boundary(value, end)
+    return end, redacted
+
+
+def _credential_value_end(value: str, start: int, key: str) -> int:
+    if value.startswith("[REDACTED]", start):
+        end = start + len("[REDACTED]")
+        _validate_credential_boundary(value, end)
+        return end
+    if key in _AUTHORIZATION_KEYS:
+        end, _ = _bearer_value_end(value, start)
+        return end
+    match = (_COOKIE_CREDENTIAL_VALUE_RE if key in {"cookie", "set_cookie"} else _SIMPLE_CREDENTIAL_VALUE_RE).match(value, start)
+    if match is None or value[start] in "{[(\"'":
+        raise ValueError("credential-bearing structured value cannot be normalized safely")
+    end = match.end()
+    if end < len(value) and value[end].isspace():
+        raise ValueError("credential-bearing free-form value cannot be normalized safely")
+    if end < len(value):
+        _validate_credential_boundary(value, end)
+    return end
+
+
+def _redact_standalone_bearers(value: str) -> str:
+    parts = []
+    cursor = 0
+    search_from = 0
+    while prefix := _BEARER_PREFIX_RE.search(value, search_from):
+        end, redacted = _bearer_value_end(value, prefix.start())
+        if redacted:
+            parts.append(value[cursor:end])
+        else:
+            parts.extend((value[cursor : prefix.end()], "[REDACTED]"))
+        cursor = end
+        search_from = end
+    parts.append(value[cursor:])
+    return "".join(parts)
+
+
+def _redact_located_credentials(value: str, locator: re.Pattern, *, key_group: int, sensitive_only: bool) -> str:
+    parts = []
+    cursor = 0
+    search_from = 0
+    while match := locator.search(value, search_from):
+        key = _normalized_sensitive_key(match.group(key_group))
+        if sensitive_only and not _is_sensitive_key(key):
+            search_from = match.end()
+            continue
+        end = _credential_value_end(value, match.end(), key)
+        parts.extend((value[cursor : match.end()], "[REDACTED]"))
+        cursor = end
+        search_from = end
+    parts.append(value[cursor:])
+    return "".join(parts)
+
+
+def _validate_colon_remainder(remainder: str) -> None:
+    remainder = remainder.lstrip()
+    if not remainder or _ASSIGNMENT_SEQUENCE_RE.fullmatch(remainder) or _QUERY_ASSIGNMENT_SEQUENCE_RE.fullmatch(remainder) or _COLON_FIELD_SEQUENCE_RE.fullmatch(remainder) or _CLOSING_CONTAINER_RE.fullmatch(remainder):
+        return
+    raise ValueError("credential-bearing value has an ambiguous boundary")
+
+
+def _validate_colon_credentials(value: str) -> None:
+    for colon, character in enumerate(value):
+        if character != ":":
+            continue
+        key_end = colon
+        while key_end and value[key_end - 1].isspace():
+            key_end -= 1
+        key_start = key_end
+        while key_start and value[key_start - 1] not in _COLON_KEY_DELIMITERS:
+            key_start -= 1
+        key = value[key_start:key_end].strip("\"'")
+        if not key or not _is_sensitive_key(key):
+            continue
+        start = colon + 1
+        while start < len(value) and value[start].isspace():
+            start += 1
+        if key in _AUTHORIZATION_KEYS and _BEARER_PREFIX_RE.match(value, start):
+            _bearer_value_end(value, start)
+            continue
+        quote = value[start] if start < len(value) and value[start] in "\"'" else ""
+        marker_start = start + bool(quote)
+        if not value.startswith("[REDACTED]", marker_start):
+            raise ValueError("credential-bearing value cannot be normalized safely")
+        end = marker_start + len("[REDACTED]")
+        if quote:
+            while end < len(value) and value[end].isspace():
+                end += 1
+            if end == len(value) or value[end] != quote:
+                raise ValueError("credential-bearing value cannot be normalized safely")
+            end += 1
+        _validate_colon_remainder(value[end:])
+
+
+def redact_secrets(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {key: "[REDACTED]" if _is_sensitive_key(key) else redact_secrets(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [redact_secrets(item) for item in value]
+    if isinstance(value, str):
+        if _AMBIGUOUS_COOKIE_RE.search(value):
+            raise ValueError("ambiguous credential-bearing cookie value cannot be normalized safely")
+        value = _PRIVATE_KEY_BLOCK_RE.sub("[REDACTED]", value)
+        value = _URL_USERINFO_RE.sub(r"\1[REDACTED]@", value)
+        value = _redact_located_credentials(value, _HEADER_START_RE, key_group=1, sensitive_only=False)
+        value = _redact_located_credentials(value, _ASSIGNMENT_START_RE, key_group=2, sensitive_only=True)
+        value = _redact_standalone_bearers(value)
+        value = _HF_TOKEN_VALUE_RE.sub("[REDACTED]", value)
+        value = _OPENAI_KEY_VALUE_RE.sub("[REDACTED]", value)
+        value = _AWS_ACCESS_KEY_VALUE_RE.sub("[REDACTED]", value)
+        if any(_is_sensitive_key(match.group(1)) and not value.startswith("[REDACTED]", match.end()) for match in re.finditer(r"([\w.-]+)=", value)):
+            raise ValueError("credential-bearing assignment cannot be normalized safely")
+        for match in re.finditer(r"([\w.-]+)=", value):
+            if _is_sensitive_key(match.group(1)):
+                _validate_credential_boundary(value, match.end() + len("[REDACTED]"))
+        _validate_colon_credentials(value)
+        if _PRIVATE_KEY_MARKER_RE.search(value):
+            raise ValueError("credential-bearing value cannot be normalized safely")
+        return value
+    return value

--- a/test/performance/test_legacy_redaction.py
+++ b/test/performance/test_legacy_redaction.py
@@ -1,0 +1,184 @@
+import pytest
+
+from lmms_eval._performance.legacy_redaction import redact_secrets
+
+
+@pytest.mark.parametrize(
+    ("access_key", "openai_key", "user", "password", "bearer", "cookie", "private_key"),
+    [
+        ("AKIAABCDEFGHIJKLMNOP", "sk-abcdefghijklmnopqrstuv", "alice", "first", "bearer-one", "cookie-one", "private-one"),
+        ("ASIAQRSTUVWXYZABCDEF", "sk-zyxwvutsrqponmlkjihgfe", "bob", "second", "bearer-two", "cookie-two", "private-two"),
+    ],
+)
+def test_redacts_nested_credentials_and_normalizes_sequences(access_key, openai_key, user, password, bearer, cookie, private_key):
+    value = {
+        "headers": {"Authorization": f"Bearer {bearer}"},
+        "aws_access_key_id": access_key,
+        "aws_secret_access_key": password * 10,
+        "cookie": f"session={cookie}",
+        "pem": f"-----BEGIN PRIVATE KEY-----\n{private_key}\n-----END PRIVATE KEY-----",
+        "raw_header": f"Authorization: Bearer {bearer}",
+        "model_args": (f"endpoint=https://{user}:{password}@example.com,bearer=Bearer {bearer}," f"key={openai_key},aws={access_key},cookie=session={cookie},temperature=0"),
+        "sequence": [f"Bearer {bearer}", ("api_key=raw",)],
+    }
+
+    assert redact_secrets(value) == {
+        "headers": {"Authorization": "[REDACTED]"},
+        "aws_access_key_id": "[REDACTED]",
+        "aws_secret_access_key": "[REDACTED]",
+        "cookie": "[REDACTED]",
+        "pem": "[REDACTED]",
+        "raw_header": "Authorization: [REDACTED]",
+        "model_args": ("endpoint=https://[REDACTED]@example.com,bearer=[REDACTED]," "key=[REDACTED],aws=[REDACTED],cookie=[REDACTED],temperature=0"),
+        "sequence": ["Bearer [REDACTED]", ["api_key=[REDACTED]"]],
+    }
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (
+            {"model_args": "api_key=raw-one,temperature=0", "hf_token": "hf_ABCDEFGHIJKLMNOPQRSTUVWXYZ"},
+            {"model_args": "api_key=[REDACTED],temperature=0", "hf_token": "[REDACTED]"},
+        ),
+        (
+            {"model_args": "api_key=raw-two,temperature=0", "hf_token": "hf_ZYXWVUTSRQPONMLKJIHGFEDCBA"},
+            {"model_args": "api_key=[REDACTED],temperature=0", "hf_token": "[REDACTED]"},
+        ),
+        ("hf_ABCDEFGHIJKLMNOPQRSTUVWXYZ", "[REDACTED]"),
+        ("settings={api_key=raw-one}", "settings={api_key=[REDACTED]}"),
+        ("settings={api_key=raw-two}", "settings={api_key=[REDACTED]}"),
+        ("settings=(api_key=raw-one)", "settings=(api_key=[REDACTED])"),
+        ("settings=[api_key=raw-one]", "settings=[api_key=[REDACTED]]"),
+        ("settings={api_key=first-secret?temperature=0}", "settings={api_key=[REDACTED]?temperature=0}"),
+        ("settings={api_key=first-secret,temperature=0}", "settings={api_key=[REDACTED],temperature=0}"),
+        ("settings={api_key=raw-secret},temperature=0", "settings={api_key=[REDACTED]},temperature=0"),
+        ("settings={api_key=raw-secret}?temperature=0", "settings={api_key=[REDACTED]}?temperature=0"),
+        ("--api_key=raw-one", "--api_key=[REDACTED]"),
+        ("--api_key=raw-two", "--api_key=[REDACTED]"),
+        ("endpoint=https://example.test?api_key=raw-one&temperature=0", "endpoint=https://example.test?api_key=[REDACTED]&temperature=0"),
+        ("endpoint=https://example.test?api_key=raw-two&temperature=0", "endpoint=https://example.test?api_key=[REDACTED]&temperature=0"),
+        ("Bearer [REDACTED]   ", "Bearer [REDACTED]   "),
+        ("credential:[REDACTED]", "credential:[REDACTED]"),
+        ("credential:[REDACTED] ", "credential:[REDACTED] "),
+        ("credential:[REDACTED],temperature=0", "credential:[REDACTED],temperature=0"),
+        ("settings={credential:[REDACTED]}", "settings={credential:[REDACTED]}"),
+        ('settings={"credential":"[REDACTED]"}', 'settings={"credential":"[REDACTED]"}'),
+        ('settings={"credential":"[REDACTED]","temperature":0}', 'settings={"credential":"[REDACTED]","temperature":0}'),
+        ("credential:[REDACTED]?temperature=0&limit=1", "credential:[REDACTED]?temperature=0&limit=1"),
+        (
+            'settings={"credential":"[REDACTED]","api.key":"[REDACTED]"}',
+            'settings={"credential":"[REDACTED]","api.key":"[REDACTED]"}',
+        ),
+    ],
+)
+def test_redacts_complete_credential_forms(value, expected):
+    sanitized = redact_secrets(value)
+    assert sanitized == expected
+    assert redact_secrets(sanitized) == expected
+
+
+@pytest.mark.parametrize("raw", ["raw-one", "raw-two"])
+def test_redacts_distinct_sensitive_assignment_values(raw):
+    value = f"aws_access_key_id={raw}-aws,access_key_id={raw}-id,access_key={raw}-access,secret_access_key={raw}-secret-access,credentials={raw}-credentials,secret_key={raw}-secret,session_token={raw}-session,temperature=0"
+    assert redact_secrets(value) == "aws_access_key_id=[REDACTED],access_key_id=[REDACTED],access_key=[REDACTED],secret_access_key=[REDACTED],credentials=[REDACTED],secret_key=[REDACTED],session_token=[REDACTED],temperature=0"
+
+
+@pytest.mark.parametrize("raw", ["raw-one", "raw-two"])
+def test_redacts_distinct_separator_normalized_assignment_values(raw):
+    value = f"api-key={raw}-api,api.key={raw}-dot,access-key-id={raw}-access,access.key.id={raw}-access-dot,secret-key={raw}-secret,temperature=0"
+    assert redact_secrets(value) == "api-key=[REDACTED],api.key=[REDACTED],access-key-id=[REDACTED],access.key.id=[REDACTED],secret-key=[REDACTED],temperature=0"
+
+
+@pytest.mark.parametrize("raw", ["raw-one", "raw-two"])
+def test_redacts_distinct_bearer_values_with_complete_assignment_tail(raw):
+    assert redact_secrets(f"authorization=Bearer {raw},temperature=0,limit=1") == "authorization=[REDACTED],temperature=0,limit=1"
+
+
+@pytest.mark.parametrize(
+    ("invocation", "zero_expected", "one_expected"),
+    [
+        ("Authorization: Bearer {secret},temperature={temperature}", "Authorization: [REDACTED],temperature=0", "Authorization: [REDACTED],temperature=1"),
+        ("Cookie: session={secret},temperature={temperature}", "Cookie: [REDACTED],temperature=0", "Cookie: [REDACTED],temperature=1"),
+        ("authorization=Bearer {secret},temperature={temperature}", "authorization=[REDACTED],temperature=0", "authorization=[REDACTED],temperature=1"),
+        ("cookie=session={secret},temperature={temperature}", "cookie=[REDACTED],temperature=0", "cookie=[REDACTED],temperature=1"),
+    ],
+)
+def test_comma_tail_preserves_non_secret_identity(invocation, zero_expected, one_expected):
+    zero = redact_secrets(invocation.format(secret="raw-zero", temperature=0))
+    same_zero = redact_secrets(invocation.format(secret="different-zero", temperature=0))
+    one = redact_secrets(invocation.format(secret="raw-one", temperature=1))
+    assert (zero, same_zero, one) == (zero_expected, zero_expected, one_expected)
+    assert zero != one
+
+
+@pytest.mark.parametrize(
+    ("tail", "zero_expected", "one_expected"),
+    [
+        ("?temperature={temperature}", "api_key=[REDACTED]?temperature=0", "api_key=[REDACTED]?temperature=1"),
+        ("?temperature={temperature}&limit=1", "api_key=[REDACTED]?temperature=0&limit=1", "api_key=[REDACTED]?temperature=1&limit=1"),
+        ("?temperature={temperature}?limit=1", "api_key=[REDACTED]?temperature=0?limit=1", "api_key=[REDACTED]?temperature=1?limit=1"),
+    ],
+)
+def test_query_tail_preserves_non_secret_identity(tail, zero_expected, one_expected):
+    zero = redact_secrets("api_key=raw-zero" + tail.format(temperature=0))
+    same_zero = redact_secrets("api_key=different-zero" + tail.format(temperature=0))
+    one = redact_secrets("api_key=raw-one" + tail.format(temperature=1))
+    assert (zero, same_zero, one) == (zero_expected, zero_expected, one_expected)
+    assert zero != one
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "authorization=Basic raw",
+        'authorization=Digest username="u",response="raw"',
+        'credentials={"user": "raw"}',
+        "authorization=Bearer raw%tail,temperature=0",
+        "Authorization: Bearer raw-one,raw-two",
+        "authorization=[REDACTED]raw,temperature=0",
+        "authorization=Bearer raw,temperature=",
+        "authorization=Bearer raw,temperature=0,raw-tail",
+        "authorization=Bearer raw,temperature=0 extra-tail",
+        "Bearer [REDACTED]raw",
+        "api_key=raw?tail",
+        "api_key=raw?temperature=",
+        "api_key=raw?temperature=0 raw-tail",
+        "api_key=raw?temperature=0&limit=",
+        "api_key=raw?temperature=0?tail",
+        "api_key=outer-secret?1_api_key=inner-secret",
+        "pem=-----BEGIN PRIVATE KEY-----\nopaque-value",
+        'settings={"credential": "opaque-value"}',
+        'settings={"api.key":"raw-secret"}',
+        'settings={"api-key":"raw-secret"}',
+        'settings={"api_key":"raw-secret"}',
+        'settings={"1_api_key":"raw-secret"}',
+        'settings={"1_api_key" : "raw-secret"}',
+        'settings={"credential:raw-secret}',
+        "credential:[REDACTED]raw-secret",
+        "credential:[REDACTED] raw-secret",
+        'settings={"credential":"[REDACTED]raw-secret"}',
+        "settings={api_key=raw-one}tail",
+        "settings={api_key=first-secret?temperature=0}password=second-secret",
+        "settings={api_key=first-secret,temperature=0}password=second-secret",
+        "settings=api_key=raw-secret",
+        "settings='api_key=raw-secret'",
+        "^api_key=first-secret",
+        "^cookie=session=first-secret",
+        "api_key=first-secret^temperature=0",
+        "api_key=first-secret^temperature=1",
+        "^api_key=[REDACTED]second-secret",
+        "settings=api_key=[REDACTED]second-secret",
+        "settings='api_key=[REDACTED]second-secret'",
+        "^cookie=[REDACTED]second-secret",
+    ],
+)
+def test_rejects_ambiguous_or_incomplete_credentials(value):
+    with pytest.raises(ValueError, match="credential") as exc_info:
+        redact_secrets(value)
+    assert all(secret not in str(exc_info.value) for secret in ("raw-secret", "first-secret", "second-secret"))
+
+
+def test_rejects_ambiguous_cookie_assignment():
+    with pytest.raises(ValueError, match="ambiguous credential"):
+        redact_secrets("cookie=session=raw;temperature=0")


### PR DESCRIPTION
This adds fail-closed redaction on top of the canonical JSON layer. It keeps raw credentials out of both normalized records and future digests.

## Stack
- 1/4 #1452 - RFC 8785 JSON primitives
- **2/4 #1453 (this PR)** - fail-closed redaction
- 3/4 #1454 - secret-safe invocation
- 4/4 #1455 - baseline provenance
- Next stack: #1456 starts performance measurement

## Summary
- Redact credential-bearing mappings, sequences, headers, URLs, and legacy argument strings.
- Preserve safe non-secret identity tails while rejecting ambiguous boundaries.
- Fail closed on nested, quoted, marker-bypass, and unsupported credential forms.

## In scope
- Private recursive legacy redaction and its adversarial contract tests.

## Out of scope
- Building invocation identities, recording phases, or changing current CLI parsing.

## Validation
- Redaction contracts | sample size: N=80 | key metrics: 80 passed | result: pass
- Adversarial sweep | sample size: N=528 | key metrics: 0 leaks; 0 idempotence failures; 0 silent tail loss | result: pass
- Final stack gates | sample size: N=203 / 380 / 677 | key metrics: 203 performance and 380 hermetic passed; 677 collected | result: pass

## Risk / Compatibility
- Private and unused by current evaluator paths; unsupported secret-bearing syntax raises instead of being recorded.
- GitHub stack #1469, layer 2/4; land before #1454.

## Type of Change
- [ ] Bug fix (non-breaking change)
- [ ] New feature
- [ ] New benchmark/task
- [ ] New model integration
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactoring (no functional changes)