### PR TITLE
perf: (PR 1/4) add baseline phase recorder

### DIFF
--- a/.github/workflows/hermetic-cpu-contracts.yml
+++ b/.github/workflows/hermetic-cpu-contracts.yml
@@ -49,3 +49,4 @@ jobs:
           test/performance/test_legacy_redaction.py
           test/performance/test_legacy_invocation.py
           test/performance/test_provenance.py
+          test/performance/test_baseline_recorder.py

--- a/lmms_eval/_performance/recorder.py
+++ b/lmms_eval/_performance/recorder.py
@@ -1,0 +1,188 @@
+import re
+import time
+from collections.abc import Mapping
+from contextlib import contextmanager
+from copy import deepcopy
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from .json_v1 import canonical_json_bytes, validate_v1_json
+from .legacy_invocation import build_legacy_invocation, validate_legacy_invocation
+from .provenance import capture_baseline_provenance, peak_host_rss_bytes
+
+PHASE_ORDER = ("queue_wait", "model_load", "task_resolution", "request_build", "preprocess", "inference", "filter_and_normalize", "score", "aggregate", "artifact_stage", "reset")
+CACHE_STATES = {"cold", "warm", "mixed", "disabled"}
+_PHASE_OWNERS = {"control", "worker", "publisher"}
+_FORBIDDEN_IDENTITY_KEYS = {"eval_spec", "identity", "intent_id", "resolved_eval_id", "spec_digest", "runtime_id", "run_id", "attempt_id"}
+_REPETITION_KEYS = {"suite_id", "case_id", "repetition_index", "warmup"}
+_SAFE_INTEGER_MAX = 2**53 - 1
+_SHA256_RE = re.compile(r"sha256:[0-9a-f]{64}")
+
+
+def _validate_repetition(repetition: Mapping[str, Any]) -> dict[str, Any]:
+    if set(repetition) != _REPETITION_KEYS:
+        raise ValueError(f"repetition must contain exactly {sorted(_REPETITION_KEYS)}")
+    if type(repetition["suite_id"]) is not str or not repetition["suite_id"]:
+        raise TypeError("repetition suite_id must be a non-empty string")
+    if type(repetition["case_id"]) is not str or not repetition["case_id"]:
+        raise TypeError("repetition case_id must be a non-empty string")
+    if type(repetition["repetition_index"]) is not int or not 0 <= repetition["repetition_index"] <= _SAFE_INTEGER_MAX:
+        raise TypeError("repetition repetition_index must be a non-negative IEEE-754 safe integer")
+    if type(repetition["warmup"]) is not bool:
+        raise TypeError("repetition warmup must be a boolean")
+    return dict(repetition)
+
+
+def _future_identity_key(value: Any) -> str | None:
+    if isinstance(value, Mapping):
+        for key, item in value.items():
+            if found := key if key in _FORBIDDEN_IDENTITY_KEYS else _future_identity_key(item):
+                return found
+    elif isinstance(value, (list, tuple)):
+        for item in value:
+            if found := _future_identity_key(item):
+                return found
+    return None
+
+
+def _validate_record(record: Mapping[str, Any]) -> None:
+    if type(record["schema_version"]) is not int or record["schema_version"] != 1 or record["record_kind"] != "baseline":
+        raise ValueError("invalid baseline record header")
+    if type(record["source_commit"]) is not str or not record["source_commit"]:
+        raise TypeError("source_commit must be a non-empty string")
+    for name in ("source_tree_digest", "environment_lock_digest"):
+        if type(record[name]) is not str or _SHA256_RE.fullmatch(record[name]) is None:
+            raise ValueError(f"{name} must be a SHA-256 digest")
+    if type(record["hardware"]) is not str or not record["hardware"] or record["cache_state"] not in CACHE_STATES:
+        raise ValueError("invalid hardware or cache state")
+    _validate_repetition(record["repetition"])
+    validate_legacy_invocation(record["legacy_invocation"])
+    for phase in record["phases"]:
+        if set(phase) != {"name", "owner", "duration_ns", "overlapped"}:
+            raise ValueError("invalid phase fields")
+        if phase["name"] not in PHASE_ORDER or phase["owner"] not in _PHASE_OWNERS:
+            raise ValueError("invalid phase name or owner")
+        if type(phase["duration_ns"]) is not int or not 0 <= phase["duration_ns"] <= _SAFE_INTEGER_MAX:
+            raise TypeError("phase duration_ns must be a non-negative IEEE-754 safe integer")
+        if type(phase["overlapped"]) is not bool:
+            raise TypeError("phase overlapped must be a boolean")
+    if type(record["counters"]) is not dict or type(record["resources"]) is not dict:
+        raise TypeError("counters and resources must be open maps")
+    validate_v1_json(record, path="$", allow_null=True)
+
+
+@dataclass
+class _AccumulatedPhase:
+    duration_ns: int = 0
+    owner: str = "worker"
+    overlapped: bool = False
+
+
+@dataclass
+class BaselinePerformanceRecorder:
+    source_commit: str
+    source_tree_digest: str
+    legacy_invocation: dict[str, Any]
+    environment_lock_digest: str
+    hardware: str
+    cache_state: str
+    repetition: dict[str, Any]
+    counters: dict[str, Any] = field(default_factory=lambda: {"failures": 0})
+    resources: dict[str, Any] = field(default_factory=dict)
+    _phases: dict[str, _AccumulatedPhase] = field(default_factory=dict)
+    _start_ns: int | None = None
+    _finished: bool = False
+    _active_phases: int = 0
+
+    @classmethod
+    def capture(cls, *, repo_root: Path, legacy_arguments: Mapping[str, Any], cache_state: str, repetition: Mapping[str, Any], digest_legacy_arguments: bool = False) -> "BaselinePerformanceRecorder":
+        if cache_state not in CACHE_STATES:
+            raise ValueError(f"invalid cache state: {cache_state}")
+        provenance = capture_baseline_provenance(repo_root)
+        invocation = build_legacy_invocation(legacy_arguments, digest_only=digest_legacy_arguments)
+        return cls(provenance.source_commit, provenance.source_tree_digest, invocation, provenance.environment_lock_digest, provenance.hardware, cache_state, _validate_repetition(repetition))
+
+    def start(self) -> None:
+        if self._start_ns is not None:
+            raise RuntimeError("recorder already started")
+        self._start_ns = time.perf_counter_ns()
+
+    @contextmanager
+    def phase(self, name: str, *, owner: str = "worker", overlapped: bool = False):
+        if name not in PHASE_ORDER or owner not in _PHASE_OWNERS:
+            raise ValueError(f"invalid phase: {name}/{owner}")
+        if type(overlapped) is not bool:
+            raise TypeError("phase overlapped must be a boolean")
+        if self._start_ns is None:
+            raise RuntimeError("recorder has not started")
+        if self._finished:
+            raise RuntimeError("recorder is already finished")
+        current = self._phases.get(name)
+        if current is None:
+            current = self._phases[name] = _AccumulatedPhase(owner=owner, overlapped=overlapped)
+        elif (current.owner, current.overlapped) != (owner, overlapped):
+            raise ValueError(f"inconsistent phase metadata: {name}")
+        started = time.perf_counter_ns()
+        self._active_phases += 1
+        try:
+            yield
+        except BaseException:
+            self.increment("failures")
+            raise
+        finally:
+            try:
+                current.duration_ns += time.perf_counter_ns() - started
+            finally:
+                self._active_phases -= 1
+
+    def increment(self, name: str, amount: int | float = 1) -> None:
+        self.counters[name] = self.counters.get(name, 0) + amount
+
+    def set_resource(self, name: str, value: Any) -> None:
+        self.resources[name] = value
+
+    def finish(self) -> None:
+        if self._start_ns is None:
+            raise RuntimeError("recorder has not started")
+        if self._finished:
+            raise RuntimeError("recorder is already finished")
+        if self._active_phases:
+            raise RuntimeError("recorder has an active phase")
+        self.resources["end_to_end_duration_ns"] = time.perf_counter_ns() - self._start_ns
+        self.resources["peak_host_rss_bytes"] = peak_host_rss_bytes()
+        self._finished = True
+
+    def to_record(self) -> dict[str, Any]:
+        if self._active_phases:
+            raise RuntimeError("recorder has an active phase")
+        if not self._finished:
+            raise RuntimeError("recorder must be finished before record emission")
+        unknown_phases = set(self._phases).difference(PHASE_ORDER)
+        if unknown_phases:
+            raise ValueError(f"invalid phase names: {sorted(unknown_phases)}")
+        phases = [{"name": name, "owner": value.owner, "duration_ns": value.duration_ns, "overlapped": value.overlapped} for name in PHASE_ORDER if (value := self._phases.get(name)) is not None]
+        record = {
+            "schema_version": 1,
+            "record_kind": "baseline",
+            "source_commit": self.source_commit,
+            "source_tree_digest": self.source_tree_digest,
+            "legacy_invocation": self.legacy_invocation,
+            "environment_lock_digest": self.environment_lock_digest,
+            "hardware": self.hardware,
+            "cache_state": self.cache_state,
+            "repetition": self.repetition,
+            "phases": phases,
+            "counters": dict(self.counters),
+            "resources": dict(self.resources),
+        }
+        if key := _future_identity_key(record):
+            raise ValueError(f"future identity is not allowed in baseline record: {key}")
+        _validate_record(record)
+        return deepcopy(record)
+
+    def write_json(self, path: Path) -> Path:
+        payload = canonical_json_bytes(self.to_record())
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(payload)
+        return path

--- a/lmms_eval/performance.py
+++ b/lmms_eval/performance.py
@@ -1,0 +1,4 @@
+from lmms_eval._performance.legacy_invocation import redact_secrets
+from lmms_eval._performance.recorder import BaselinePerformanceRecorder
+
+__all__ = ["BaselinePerformanceRecorder", "redact_secrets"]

--- a/test/performance/test_baseline_recorder.py
+++ b/test/performance/test_baseline_recorder.py
@@ -1,0 +1,206 @@
+import json
+import re
+from types import MappingProxyType, SimpleNamespace
+
+import pytest
+
+import lmms_eval._performance.recorder as recorder_module
+import lmms_eval.performance as performance
+from lmms_eval._performance.provenance import BaselineProvenance
+from lmms_eval.performance import BaselinePerformanceRecorder
+
+TOP_LEVEL = {"schema_version", "record_kind", "source_commit", "source_tree_digest", "legacy_invocation", "environment_lock_digest", "hardware", "cache_state", "repetition", "phases", "counters", "resources"}
+FORBIDDEN_KEYS = {"eval_spec", "identity", "intent_id", "resolved_eval_id", "spec_digest", "runtime_id", "run_id", "attempt_id"}
+
+
+def _all_keys(value):
+    items = value.values() if isinstance(value, dict) else value if isinstance(value, list) else ()
+    return (set(value) if isinstance(value, dict) else set()).union(*map(_all_keys, items))
+
+
+@pytest.fixture
+def recorder_factory(monkeypatch, tmp_path):
+    fixed = BaselineProvenance("a" * 40, "sha256:" + "b" * 64, "sha256:" + "c" * 64, "fixture-hardware")
+    monkeypatch.setattr(recorder_module, "capture_baseline_provenance", lambda root: fixed)
+
+    def make(*, started=False, finished=False, **overrides):
+        value = BaselinePerformanceRecorder.capture(
+            repo_root=tmp_path,
+            legacy_arguments=overrides.pop("legacy_arguments", {"model": "dummy"}),
+            cache_state=overrides.pop("cache_state", "disabled"),
+            repetition=overrides.pop("repetition", {"suite_id": "suite", "case_id": "case", "repetition_index": 0, "warmup": False}),
+            digest_legacy_arguments=overrides.pop("digest_legacy_arguments", False),
+        )
+        assert not overrides
+        if started or finished:
+            value.start()
+        if finished:
+            value.finish()
+        return value
+
+    return make
+
+
+def test_baseline_record_has_exact_v1_shape(monkeypatch, tmp_path, recorder_factory):
+    ticks = iter((100, 110, 120, 130, 150, 200))
+    monkeypatch.setattr(recorder_module.time, "perf_counter_ns", lambda: next(ticks))
+    monkeypatch.setattr(recorder_module, "peak_host_rss_bytes", lambda: 4096)
+    recorder = recorder_factory(legacy_arguments={"model": "dummy", "limit": "0.5"}, repetition={"suite_id": "hermetic-cpu-dummy-v1", "case_id": "cache-disabled", "repetition_index": 0, "warmup": False})
+    recorder.start()
+    with recorder.phase("model_load"):
+        recorder.increment("responses", 2)
+    with recorder.phase("model_load"):
+        recorder.increment("responses")
+    recorder.set_resource("model_load_reused", False)
+    recorder.finish()
+    record = recorder.to_record()
+    assert set(record) == TOP_LEVEL
+    assert (record["schema_version"], record["record_kind"]) == (1, "baseline")
+    assert record["legacy_invocation"] == {"kind": "normalized", "arguments": {"model": "dummy", "limit": "0.5"}}
+    assert record["phases"] == [{"name": "model_load", "owner": "worker", "duration_ns": 30, "overlapped": False}]
+    assert record["counters"] == {"failures": 0, "responses": 3}
+    assert record["resources"] == {"model_load_reused": False, "end_to_end_duration_ns": 100, "peak_host_rss_bytes": 4096}
+    assert FORBIDDEN_KEYS.isdisjoint(_all_keys(record))
+    assert re.fullmatch(r"sha256:[0-9a-f]{64}", record["source_tree_digest"])
+    output = recorder.write_json(tmp_path / "baseline.json")
+    assert json.loads(output.read_text(encoding="utf-8")) == record
+    assert not output.read_bytes().endswith(b"\n")
+
+
+@pytest.mark.parametrize(
+    "repetition",
+    [
+        {"suite_id": "suite", "case_id": "case", "repetition_index": 0},
+        {"suite_id": "suite", "case_id": "case", "repetition_index": 0, "warmup": False, "run": 1},
+        {"suite_id": "", "case_id": "case", "repetition_index": 0, "warmup": False},
+        {"suite_id": "suite", "case_id": "", "repetition_index": 0, "warmup": False},
+        {"suite_id": "suite", "case_id": "case", "repetition_index": True, "warmup": False},
+        {"suite_id": "suite", "case_id": "case", "repetition_index": -1, "warmup": False},
+        {"suite_id": "suite", "case_id": "case", "repetition_index": 2**53, "warmup": False},
+        {"suite_id": "suite", "case_id": "case", "repetition_index": 2**63, "warmup": False},
+        {"suite_id": "suite", "case_id": "case", "repetition_index": 0, "warmup": 0},
+        {"suite_id": "suite", "case_id": "case", "repetition_index": 0, "warmup": None},
+    ],
+)
+def test_capture_rejects_invalid_repetition(recorder_factory, repetition):
+    with pytest.raises((TypeError, ValueError), match="repetition"):
+        recorder_factory(repetition=repetition)
+
+
+@pytest.mark.parametrize(("key", "value"), [(1, "non-string-key"), ("bad", "\ud800"), ("bad", 2**53), ("bad", -(2**53)), ("bad", 2**63), ("bad", -(2**63) - 1), ("bad", float("nan")), ("bad", float("inf")), ("bad", -0.0), ("bad", object())])
+def test_to_record_rejects_invalid_v1_json_values(recorder_factory, key, value):
+    recorder = recorder_factory(finished=True)
+    recorder.resources[key] = value
+    with pytest.raises((TypeError, ValueError)):
+        recorder.to_record()
+
+
+def test_to_record_allows_json_null_inside_open_resource_map(recorder_factory):
+    recorder = recorder_factory(finished=True)
+    recorder.set_resource("optional_measurement", None)
+    assert recorder.to_record()["resources"]["optional_measurement"] is None
+
+
+def test_to_record_rejects_non_concrete_json_mapping(recorder_factory):
+    recorder = recorder_factory(finished=True)
+    recorder.set_resource("nested", MappingProxyType({"value": 1}))
+    with pytest.raises(TypeError, match="concrete dict"):
+        recorder.to_record()
+
+
+def test_to_record_returns_deeply_detached_snapshot(recorder_factory, tmp_path):
+    recorder = recorder_factory(finished=True, legacy_arguments={"nested": {"value": "stable"}})
+    recorder.counters["nested"] = {"value": "stable"}
+    recorder.set_resource("nested", {"values": [1]})
+    first = recorder.to_record()
+    first["legacy_invocation"]["arguments"]["nested"]["value"] = first["repetition"]["suite_id"] = first["counters"]["nested"]["value"] = "mutated"
+    first["resources"]["nested"]["values"].append(2)
+    second = recorder.to_record()
+    assert (second["legacy_invocation"]["arguments"]["nested"], second["repetition"]["suite_id"]) == ({"value": "stable"}, "suite")
+    assert (second["counters"]["nested"], second["resources"]["nested"]) == ({"value": "stable"}, {"values": [1]})
+    assert json.loads(recorder.write_json(tmp_path / "snapshot.json").read_text()) == second
+
+
+@pytest.mark.parametrize("phase", [("future", "worker", 1, False), ("model_load", "invalid", 1, False), *(("model_load", "worker", value, False) for value in (True, -1, 2**53)), ("model_load", "worker", 1, 0)])
+def test_to_record_rejects_invalid_phase_shape(recorder_factory, phase):
+    name, owner, duration_ns, overlapped = phase
+    recorder = recorder_factory(finished=True)
+    recorder._phases[name] = SimpleNamespace(owner=owner, duration_ns=duration_ns, overlapped=overlapped)
+    with pytest.raises((TypeError, ValueError), match="phase"):
+        recorder.to_record()
+
+
+def test_phase_rejects_inconsistent_metadata_before_body_side_effects(recorder_factory):
+    recorder = recorder_factory(started=True)
+    with recorder.phase("score", owner="worker"):
+        pass
+    entered = False
+    with pytest.raises(ValueError, match="inconsistent phase metadata"):
+        with recorder.phase("score", owner="control"):
+            entered = True
+    assert entered is False
+
+
+@pytest.mark.parametrize("overlapped", [0, None])
+def test_phase_rejects_non_boolean_overlap_before_body_and_state(recorder_factory, overlapped):
+    recorder = recorder_factory(started=True)
+    entered = False
+    with pytest.raises(TypeError, match="overlapped"):
+        with recorder.phase("score", overlapped=overlapped):
+            entered = True
+    assert (entered, recorder._phases) == (False, {})
+
+
+def test_phase_preserves_body_exception_and_counts_failure(recorder_factory):
+    recorder = recorder_factory(started=True)
+    with pytest.raises(LookupError, match="body failure"):
+        with recorder.phase("score"):
+            raise LookupError("body failure")
+    assert recorder.counters["failures"] == 1
+    recorder.finish()
+    assert recorder.to_record()["counters"]["failures"] == 1
+
+
+def test_active_phase_blocks_finish_and_record_emission(recorder_factory, tmp_path):
+    recorder = recorder_factory(started=True)
+    with recorder.phase("inference"):
+        for action in (recorder.finish, recorder.to_record, lambda: recorder.write_json(tmp_path / "invalid.json")):
+            with pytest.raises(RuntimeError, match="active phase"):
+                action()
+        assert "end_to_end_duration_ns" not in recorder.resources
+    recorder.finish()
+    assert recorder.to_record()["resources"]["end_to_end_duration_ns"] >= 0
+
+
+def test_recorder_rejects_invalid_start_finish_state(recorder_factory):
+    recorder = recorder_factory()
+    for action, match in ((recorder.finish, "started"), (recorder.to_record, "finished")):
+        with pytest.raises(RuntimeError, match=match):
+            action()
+    with pytest.raises(RuntimeError, match="started"):
+        with recorder.phase("score"):
+            pass
+    recorder.start()
+    with pytest.raises(RuntimeError, match="already started"):
+        recorder.start()
+    recorder.finish()
+    with pytest.raises(RuntimeError, match="already finished"):
+        recorder.finish()
+    with pytest.raises(RuntimeError, match="finished"):
+        with recorder.phase("score"):
+            pass
+
+
+def test_baseline_record_rejects_structural_future_identity_but_allows_runtime_observation(recorder_factory):
+    recorder = recorder_factory(finished=True)
+    recorder.set_resource("runtime", {"python": "3.10"})
+    assert recorder.to_record()["resources"]["runtime"] == {"python": "3.10"}
+    recorder.set_resource("identity", {"spec_digest": "sha256:" + "d" * 64})
+    with pytest.raises(ValueError, match="future identity"):
+        recorder.to_record()
+
+
+def test_public_performance_facade_is_narrow():
+    assert performance.__all__ == ["BaselinePerformanceRecorder", "redact_secrets"]
+    assert performance.BaselinePerformanceRecorder is BaselinePerformanceRecorder
+    assert callable(performance.redact_secrets)


### PR DESCRIPTION
This starts the measurement stack with the baseline phase recorder. It depends on the canonical contract completed in #1455.

## Stack
- **1/4 #1456 (this PR)** - baseline phase recorder
- 2/4 #1457 - atomic record writer
- 3/4 #1459 - evaluator instrumentation
- 4/4 #1460 - reproducible benchmark harness
- Depends on #1455, the final layer of the performance contract stack

## Summary
- Add the BaselinePerformanceRecorder lifecycle and fixed phase vocabulary.
- Emit the exact BaselinePerformanceRecordV1 envelope with canonical bytes.
- Expose only the recorder and redaction helper through lmms_eval.performance.

## In scope
- Phase accumulation, counters, resources, repetition identity, record validation, and the narrow facade.

## Out of scope
- Evaluator instrumentation, benchmark execution, canonical EvalSpec identities, or durable bundle publication.

## Validation
- Recorder contracts | sample size: N=38 | key metrics: lifecycle, shape, deep snapshot, and identity exclusions passed | result: pass
- Final performance stack | sample size: N=203 | key metrics: 203 passed | result: pass
- Hermetic and collection gates | sample size: N=380 / 677 | key metrics: 380 passed; 677 collected | result: pass

## Risk / Compatibility
- No existing evaluator caller changes; atomic final-path replacement is isolated in #1457.
- GitHub stack #1470, layer 1/4; depends on #1455 and lands before #1457.

## Type of Change
- [ ] Bug fix (non-breaking change)
- [ ] New feature
- [ ] New benchmark/task
- [ ] New model integration
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactoring (no functional changes)