### PR TITLE
perf: (PR 2/4) atomically write baseline records

### DIFF
--- a/lmms_eval/_performance/recorder.py
+++ b/lmms_eval/_performance/recorder.py
@@ -1,3 +1,4 @@
+import os
 import re
 import time
 from collections.abc import Mapping
@@ -5,6 +6,7 @@ from contextlib import contextmanager
 from copy import deepcopy
 from dataclasses import dataclass, field
 from pathlib import Path
+from tempfile import NamedTemporaryFile
 from typing import Any
 
 from .json_v1 import canonical_json_bytes, validate_v1_json
@@ -184,5 +186,15 @@ class BaselinePerformanceRecorder:
     def write_json(self, path: Path) -> Path:
         payload = canonical_json_bytes(self.to_record())
         path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_bytes(payload)
+        temporary = NamedTemporaryFile("wb", dir=path.parent, prefix=f".{path.name}.", delete=False)
+        temporary_path = Path(temporary.name)
+        try:
+            with temporary:
+                temporary.write(payload)
+                temporary.flush()
+                os.fsync(temporary.fileno())
+            os.replace(temporary_path, path)
+        except BaseException:
+            temporary_path.unlink(missing_ok=True)
+            raise
         return path

--- a/test/performance/test_baseline_recorder.py
+++ b/test/performance/test_baseline_recorder.py
@@ -1,5 +1,7 @@
 import json
+import os
 import re
+from pathlib import Path
 from types import MappingProxyType, SimpleNamespace
 
 import pytest
@@ -119,6 +121,27 @@ def test_to_record_returns_deeply_detached_snapshot(recorder_factory, tmp_path):
     assert (second["legacy_invocation"]["arguments"]["nested"], second["repetition"]["suite_id"]) == ({"value": "stable"}, "suite")
     assert (second["counters"]["nested"], second["resources"]["nested"]) == ({"value": "stable"}, {"values": [1]})
     assert json.loads(recorder.write_json(tmp_path / "snapshot.json").read_text()) == second
+
+
+@pytest.mark.parametrize("stage", ["fsync", "replace"])
+def test_write_json_failure_preserves_target_and_cleans_temp(monkeypatch, recorder_factory, tmp_path, stage):
+    target = tmp_path / "baseline.json"
+    target.write_bytes(b"existing")
+    recorder = recorder_factory(finished=True)
+
+    def fail(*args):
+        if stage == "replace":
+            source, destination = map(Path, args)
+            assert source.parent == target.parent
+            assert json.loads(source.read_text()) == recorder.to_record()
+            assert destination == target
+        raise OSError(f"{stage} failed")
+
+    monkeypatch.setattr(os, stage, fail)
+    with pytest.raises(OSError, match=f"{stage} failed"):
+        recorder.write_json(target)
+    assert target.read_bytes() == b"existing"
+    assert set(tmp_path.iterdir()) == {target}
 
 
 @pytest.mark.parametrize("phase", [("future", "worker", 1, False), ("model_load", "invalid", 1, False), *(("model_load", "worker", value, False) for value in (True, -1, 2**53)), ("model_load", "worker", 1, 0)])


### PR DESCRIPTION
This makes baseline record visibility atomic without changing the recorder schema. It stays separate so the recorder lifecycle remains easy to review.

## Stack
- 1/4 #1456 - baseline phase recorder
- **2/4 #1457 (this PR)** - atomic record writer
- 3/4 #1459 - evaluator instrumentation
- 4/4 #1460 - reproducible benchmark harness
- Depends on #1455, the final layer of the performance contract stack

## Summary
- Write baseline records through a same-directory temporary file.
- Flush and fsync complete bytes before atomic replacement.
- Preserve an existing record and remove temporary files on fsync or replace failure.

## In scope
- Atomic visibility for BaselinePerformanceRecorder.write_json and filesystem fault tests.

## Out of scope
- Parent-directory durability, immutable run bundles, or manifest publication.

## Validation
- Atomic writer faults | sample size: N=2 | key metrics: fsync and replace failures preserve old bytes and leave no temp file | result: pass
- Recorder suite | sample size: N=40 | key metrics: 40 passed | result: pass
- Final stack gates | sample size: N=203 / 380 / 677 | key metrics: 203 performance and 380 hermetic passed; 677 collected | result: pass

## Risk / Compatibility
- Keeps the existing write_json API and canonical payload bytes; parent-directory fsync remains part of later bundle publication.
- GitHub stack #1470, layer 2/4; depends on #1456 and lands before #1459.

## Type of Change
- [ ] Bug fix (non-breaking change)
- [ ] New feature
- [ ] New benchmark/task
- [ ] New model integration
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactoring (no functional changes)