### PR TITLE
perf: (PR 4/4) add reproducible evaluator benchmark harness

### DIFF
--- a/.github/workflows/hermetic-cpu-contracts.yml
+++ b/.github/workflows/hermetic-cpu-contracts.yml
@@ -51,3 +51,4 @@ jobs:
           test/performance/test_provenance.py
           test/performance/test_baseline_recorder.py
           test/performance/test_eval_phase_instrumentation.py
+          test/performance/test_benchmark_eval_phases.py

--- a/test/performance/test_benchmark_eval_phases.py
+++ b/test/performance/test_benchmark_eval_phases.py
@@ -1,0 +1,170 @@
+import json
+import socket
+
+import pytest
+
+import tools.benchmark_eval_phases as benchmark
+from tools.benchmark_eval_phases import (
+    _build_parser,
+    _sha256,
+    _summarize,
+    _versions,
+    run_suite,
+)
+
+_FUTURE_IDENTITIES = {"eval_spec", "identity", "intent_id", "resolved_eval_id", "spec_digest", "runtime_id", "run_id", "attempt_id"}
+
+
+def _all_keys(value):
+    items = value.values() if isinstance(value, dict) else value if isinstance(value, list) else ()
+    return (set(value) if isinstance(value, dict) else set()).union(*map(_all_keys, items))
+
+
+def _records(paths):
+    return [json.loads(path.read_text(encoding="utf-8")) for path in paths]
+
+
+def test_hermetic_suite_emits_three_cache_cases_with_equal_results(monkeypatch, tmp_path):
+    monkeypatch.setattr(socket.socket, "connect", lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("network access")))
+
+    records = _records(run_suite(tmp_path, warmups=1, measured_repetitions=1, digest_legacy_arguments=False))
+
+    assert len(records) == 6
+    assert {record["repetition"]["case_id"] for record in records} == {"cache-disabled", "cache-cold", "cache-warm"}
+    assert {record["cache_state"] for record in records} == {"disabled", "cold", "warm"}
+    assert len({record["resources"]["correctness_digest"] for record in records}) == 1
+    for record in records:
+        assert {record["counters"][name] for name in ("selected_documents", "built_instances", "responses", "normalized_outputs", "scored_documents")} == {4}
+        assert record["counters"]["artifact_files"] == 3
+        assert record["counters"]["batches"] == record["counters"]["inference_dispatches"]
+        assert {"request_cache_hits", "request_cache_misses"}.isdisjoint(record["counters"])
+        assert record["counters"]["end_to_end_scored_documents_per_second"] > 0
+        assert "artifact_stage" in {phase["name"] for phase in record["phases"]}
+        assert record["resources"]["revisions"]["model"]["id"] == "dummy"
+        assert record["resources"]["outcome"] == "completed"
+        assert set(record["resources"]["backend_versions"]) == {"python", "lmms_eval", "datasets", "torch"}
+        assert set(record["resources"]["unmeasured_phases"]) == {"queue_wait", "preprocess"}
+        assert _FUTURE_IDENTITIES.isdisjoint(_all_keys(record))
+
+
+def test_existing_record_is_rejected_before_evaluation(monkeypatch, tmp_path):
+    records = tmp_path / "records"
+    records.mkdir()
+    (records / "cache-disabled-000-warmup.json").write_text("occupied")
+    monkeypatch.setattr("tools.benchmark_eval_phases.simple_evaluate", lambda **kwargs: pytest.fail("evaluation started"))
+
+    with pytest.raises(FileExistsError, match="cache-disabled-000-warmup"):
+        run_suite(tmp_path, warmups=1, measured_repetitions=1)
+
+
+def test_artifact_failure_record_exposes_only_stable_stage_and_type(monkeypatch, tmp_path):
+    secret = "credential-value-must-not-escape"
+
+    def fail(*args, **kwargs):
+        raise LookupError(secret)
+
+    monkeypatch.setattr("tools.benchmark_eval_phases.EvaluationTracker.save_results_samples", fail)
+    with pytest.raises(LookupError, match=secret):
+        run_suite(tmp_path, warmups=0, measured_repetitions=1)
+
+    failed = json.loads(next((tmp_path / "records").glob("*-failed.json")).read_text(encoding="utf-8"))
+    assert failed["resources"]["failure"] == {"stage": "artifact_stage", "type": "LookupError"}
+    assert failed["resources"]["outcome"] == "failed"
+    assert failed["resources"]["partial_artifacts"]["policy"] == "preserve"
+    assert failed["resources"]["partial_artifacts"]["files"] >= 1
+    assert failed["counters"]["failures"] == 1
+    assert secret not in json.dumps(failed)
+    monkeypatch.setattr("tools.benchmark_eval_phases.BaselinePerformanceRecorder.write_json", lambda *args: (_ for _ in ()).throw(OSError("reporting failed")))
+    with pytest.raises(LookupError, match=secret):
+        run_suite(tmp_path / "writer-failure", warmups=0, measured_repetitions=1)
+
+
+def test_warm_case_rejects_a_broken_request_cache_load(monkeypatch, tmp_path):
+    monkeypatch.setattr("lmms_eval.api.task.load_from_cache", lambda file_name: None)
+    with pytest.raises(RuntimeError, match="cache lifecycle"):
+        run_suite(tmp_path, warmups=0, measured_repetitions=1)
+    failed = json.loads(next((tmp_path / "records").glob("*-failed.json")).read_text(encoding="utf-8"))
+    assert (failed["resources"]["failure"]["stage"], failed["resources"]["outcome"]) == ("cache_validation", "failed")
+
+
+def test_repetition_atomically_claims_its_artifact_root(monkeypatch, tmp_path):
+    (tmp_path / "artifacts" / "cache-disabled-000-measured").mkdir(parents=True)
+    monkeypatch.setattr(benchmark, "simple_evaluate", lambda **kwargs: pytest.fail("evaluation started"))
+    with pytest.raises(FileExistsError):
+        benchmark._run_repetition(tmp_path, "cache-disabled", 0, False, False)
+
+
+def test_cache_validation_runs_outside_the_timed_window(monkeypatch, tmp_path):
+    events = []
+    original_snapshot = benchmark._cache_snapshot
+    original_start, original_finish = benchmark.BaselinePerformanceRecorder.start, benchmark.BaselinePerformanceRecorder.finish
+    monkeypatch.setattr(benchmark.request_cache, "PATH", str(tmp_path / "cache"))
+    monkeypatch.setattr(benchmark, "_cache_snapshot", lambda: events.append("snapshot") or original_snapshot())
+    monkeypatch.setattr(benchmark.BaselinePerformanceRecorder, "start", lambda self: events.append("start") or original_start(self))
+    monkeypatch.setattr(benchmark.BaselinePerformanceRecorder, "finish", lambda self: events.append("finish") or original_finish(self))
+
+    benchmark._run_repetition(tmp_path, "cache-disabled", 0, False, False)
+
+    assert events == ["snapshot", "start", "finish", "snapshot"]
+
+
+def test_unreadable_pretiming_cache_emits_failed_record(monkeypatch, tmp_path):
+    cache_root = tmp_path / "cache"
+    cache_root.mkdir()
+    (cache_root / f"broken{benchmark.request_cache.FILE_SUFFIX}").write_bytes(b"not a pickle")
+    monkeypatch.setattr(benchmark.request_cache, "PATH", str(cache_root))
+    with pytest.raises(RuntimeError, match="unreadable"):
+        benchmark._run_repetition(tmp_path, "cache-warm", 0, False, False)
+    failed = json.loads(next((tmp_path / "records").glob("*-failed.json")).read_text())
+    assert failed["resources"]["failure"] == {"stage": "cache_validation", "type": "RuntimeError"}
+
+
+def test_summary_excludes_warmups_and_uses_nearest_rank_p95():
+    def record(value, warmup=False):
+        return {
+            "repetition": {"case_id": "case", "warmup": warmup},
+            "phases": [{"name": "inference", "duration_ns": value}],
+            "resources": {"end_to_end_duration_ns": value, "peak_host_rss_bytes": value},
+            "counters": {"end_to_end_scored_documents_per_second": value},
+        }
+
+    summary = _summarize([record(999, True), *map(record, [1, 2, 3, 4, 100])])
+
+    assert summary["case"]["end_to_end_duration_ns"] == {"median": 3, "p95": 100, "pvariance": 1522}
+
+
+def test_correctness_mismatch_emits_no_summary(monkeypatch, tmp_path, capsys):
+    digests = iter(("sha256:" + "a" * 64, "sha256:" + "b" * 64, "sha256:" + "c" * 64))
+
+    def write_record(output_dir, case_id, index, warmup, digest_legacy_arguments):
+        path = output_dir / "records" / f"{case_id}.json"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps({"resources": {"correctness_digest": next(digests)}}), encoding="utf-8")
+        return path
+
+    monkeypatch.setattr(benchmark, "_evaluate", lambda *args, **kwargs: None)
+    monkeypatch.setattr(benchmark, "_run_repetition", write_record)
+    with pytest.raises(RuntimeError, match="correctness parity"):
+        run_suite(tmp_path, warmups=0, measured_repetitions=1)
+    assert capsys.readouterr().out == ""
+
+
+def test_digest_uses_v1_domain_and_version_does_not_require_package_metadata(monkeypatch):
+    with pytest.raises(ValueError, match="negative zero"):
+        _sha256({"value": -0.0})
+    monkeypatch.setattr(benchmark, "get_lmms_eval_cache_version", lambda: "source-revision")
+    assert _versions()["lmms_eval"] == "source-revision"
+
+
+def test_cli_requires_output_dir_and_has_stable_repetition_defaults():
+    parser = _build_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args([])
+    args = parser.parse_args(["--output-dir", "results"])
+    assert (args.output_dir.name, args.warmups, args.measured_repetitions, args.digest_legacy_arguments) == ("results", 1, 5, False)
+
+
+@pytest.mark.parametrize(("warmups", "measured"), [(-1, 1), (0, 0)])
+def test_suite_rejects_invalid_repetition_counts(tmp_path, warmups, measured):
+    with pytest.raises(ValueError):
+        run_suite(tmp_path, warmups=warmups, measured_repetitions=measured)

--- a/tools/benchmark_eval_phases.py
+++ b/tools/benchmark_eval_phases.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+import argparse
+import hashlib
+import json
+import math
+import platform
+import shutil
+import statistics
+import tempfile
+from pathlib import Path
+
+import datasets
+import torch
+from datasets import Dataset, DatasetDict
+
+import lmms_eval.caching.cache as request_cache
+from lmms_eval._performance.json_v1 import canonical_json_bytes
+from lmms_eval.api.task import ConfigurableTask
+from lmms_eval.evaluator import simple_evaluate
+from lmms_eval.loggers.evaluation_tracker import EvaluationTracker
+from lmms_eval.performance import BaselinePerformanceRecorder
+from lmms_eval.utils import get_lmms_eval_cache_version
+
+_SUITE_ID = "hermetic-cpu-dummy-v1"
+_CASES = ("cache-disabled", "cache-cold", "cache-warm")
+_TASK_SIZES = {"phase_baseline_small": 4, "phase_baseline_large": 10}
+
+
+class _SyntheticTask(ConfigurableTask):
+    def __init__(self, task_name: str, size: int) -> None:
+        self._benchmark_documents = Dataset.from_list(_documents(task_name, size))
+        super().__init__(
+            config={
+                "task": task_name,
+                "dataset_path": None,
+                "test_split": "test",
+                "output_type": "generate_until",
+                "doc_to_text": "question",
+                "doc_to_target": "answer",
+                "doc_to_visual": lambda doc: [],
+                "generation_kwargs": {"max_new_tokens": 1},
+                "metric_list": [{"metric": "exact_match", "aggregation": "mean", "higher_is_better": True}],
+            }
+        )
+
+    def download(self, dataset_kwargs=None) -> None:
+        self.dataset = DatasetDict({"test": self._benchmark_documents})
+        self.dataset_no_image = self.dataset
+
+
+def _documents(task_name: str, size: int) -> list[dict[str, str]]:
+    return [{"question": f"{task_name} question {index}", "answer": "A"} for index in range(size)]
+
+
+def _make_tasks() -> list[ConfigurableTask]:
+    return [_SyntheticTask(name, size) for name, size in _TASK_SIZES.items()]
+
+
+def _legacy_arguments(case_id: str) -> dict[str, object]:
+    return {
+        "model": "dummy",
+        "model_args": "response=A",
+        "tasks": list(_TASK_SIZES),
+        "limit": 2,
+        "bootstrap_iters": 0,
+        "log_samples": True,
+        "cache_requests": case_id != "cache-disabled",
+        "device": "cpu",
+    }
+
+
+def _evaluate(tasks, *, recorder=None, tracker=None, cache_requests_enabled: bool):
+    return simple_evaluate(
+        model="dummy",
+        model_args="response=A",
+        tasks=tasks,
+        device="cpu",
+        limit=2,
+        bootstrap_iters=0,
+        log_samples=True,
+        cache_requests=cache_requests_enabled,
+        evaluation_tracker=tracker,
+        performance_recorder=recorder,
+    )
+
+
+def _sha256(value: object) -> str:
+    return "sha256:" + hashlib.sha256(canonical_json_bytes(value)).hexdigest()
+
+
+def _correctness_projection(results: dict, samples: dict) -> dict:
+    sample_projection = []
+    for task_name in sorted(samples):
+        for sample in sorted(samples[task_name], key=lambda item: item["doc_id"]):
+            sample_projection.append(
+                {
+                    "task": task_name,
+                    "doc_id": sample["doc_id"],
+                    "raw_outputs": sample["resps"],
+                    "normalized_outputs": sample["filtered_resps"],
+                    "scores": {"exact_match": float(sample["exact_match"])},
+                }
+            )
+    aggregate_projection = {task: float(metrics["exact_match,none"]) for task, metrics in sorted(results["results"].items())}
+    return {"samples": sample_projection, "aggregate_metrics": aggregate_projection}
+
+
+def _versions() -> dict[str, str]:
+    return {
+        "python": platform.python_version(),
+        "lmms_eval": get_lmms_eval_cache_version(),
+        "datasets": datasets.__version__,
+        "torch": str(torch.__version__),
+    }
+
+
+def _cache_snapshot() -> dict:
+    root = Path(request_cache.PATH)
+    paths = list(root.glob(f"*{request_cache.FILE_SUFFIX}")) if root.exists() else []
+    if any(request_cache.load_from_cache(path.name.removesuffix(request_cache.FILE_SUFFIX)) is None for path in paths):
+        raise RuntimeError("request cache lifecycle produced an unreadable file")
+    return {path.name: (path.stat().st_mtime_ns, hashlib.sha256(path.read_bytes()).digest()) for path in paths}
+
+
+def _resources(recorder: BaselinePerformanceRecorder) -> dict[str, object]:
+    return {
+        "model_load_reused": False,
+        "batch_scope": "dummy model-method submission",
+        "host_rss_scope": "process lifetime high-water",
+        "peak_gpu_allocation_unavailable": "CPU-only workload",
+        "reset_scope": "legacy model cleanup; no reuse health check",
+        "phase_sum_may_exceed_end_to_end": False,
+        "unavailable_counters": ["input_tokens", "output_tokens", "inference_tokens_per_second"],
+        "unmeasured_phases": {
+            "queue_wait": "legacy in-process benchmark has no EvaluationControl admission",
+            "preprocess": "dummy performs no media/message conversion",
+        },
+        "revisions": {
+            "model": {"id": "dummy", "revision": recorder.source_tree_digest},
+            "datasets": {name: _sha256(_documents(name, size)) for name, size in _TASK_SIZES.items()},
+        },
+        "backend_versions": _versions(),
+    }
+
+
+def _run_repetition(output_dir: Path, case_id: str, index: int, warmup: bool, digest_legacy_arguments: bool) -> Path:
+    label = "warmup" if warmup else "measured"
+    stem = f"{case_id}-{index:03d}-{label}"
+    record_path = output_dir / "records" / f"{stem}.json"
+    failed_path = output_dir / "records" / f"{stem}-failed.json"
+    artifact_root = output_dir / "artifacts" / stem
+    artifact_root.mkdir(parents=True, exist_ok=False)
+    recorder = BaselinePerformanceRecorder.capture(
+        repo_root=Path(__file__).resolve().parents[1],
+        legacy_arguments=_legacy_arguments(case_id),
+        cache_state=case_id.removeprefix("cache-"),
+        repetition={"suite_id": _SUITE_ID, "case_id": case_id, "repetition_index": index, "warmup": warmup},
+        digest_legacy_arguments=digest_legacy_arguments,
+    )
+    for name, value in _resources(recorder).items():
+        recorder.set_resource(name, value)
+    stage = "cache_validation"
+    started = False
+    finished = False
+    try:
+        cache_before = _cache_snapshot()
+        recorder.start()
+        started = True
+        stage = "task_resolution"
+        with recorder.phase("task_resolution"):
+            tasks = _make_tasks()
+        stage = "evaluation"
+        tracker = EvaluationTracker(output_path=str(artifact_root))
+        results = _evaluate(tasks, recorder=recorder, tracker=tracker, cache_requests_enabled=case_id != "cache-disabled")
+        samples = results.pop("samples")
+        correctness = _correctness_projection(results, samples)
+        stage = "artifact_stage"
+        with recorder.phase("artifact_stage"):
+            tracker.save_results_aggregated(results=results, samples=samples, datetime_str=stem)
+            for task_name in sorted(samples):
+                tracker.save_results_samples(task_name=task_name, samples=samples[task_name])
+            artifact_files = sum(path.is_file() for path in artifact_root.rglob("*"))
+            if artifact_files != 3:
+                raise RuntimeError("artifact stage did not write exactly three files")
+        recorder.increment("artifact_files", artifact_files)
+        recorder.counters["batches"] = recorder.counters["inference_dispatches"]
+        correctness["artifact_files"] = artifact_files
+        recorder.set_resource("correctness_digest", _sha256(correctness))
+        recorder.set_resource("outcome", "completed")
+        recorder.finish()
+        finished = True
+        duration_s = recorder.resources["end_to_end_duration_ns"] / 1_000_000_000
+        recorder.counters["end_to_end_scored_documents_per_second"] = recorder.counters["scored_documents"] / duration_s
+        stage = "cache_validation"
+        cache_after = _cache_snapshot()
+        expected_cache = {"cache-disabled": (0, 0, True), "cache-cold": (0, 2, False), "cache-warm": (2, 2, True)}[case_id]
+        if (len(cache_before), len(cache_after), cache_before == cache_after) != expected_cache:
+            raise RuntimeError("request cache lifecycle did not match the benchmark case")
+    except BaseException as exc:
+        if recorder.counters["failures"] == 0:
+            recorder.increment("failures")
+        recorder.set_resource("failure", {"stage": stage, "type": type(exc).__name__})
+        recorder.set_resource("outcome", "failed")
+        recorder.set_resource("partial_artifacts", {"policy": "preserve", "files": sum(path.is_file() for path in artifact_root.rglob("*"))})
+        try:
+            if not started:
+                recorder.start()
+            if not finished:
+                recorder.finish()
+            recorder.write_json(failed_path)
+        except BaseException:
+            pass
+        raise
+    return recorder.write_json(record_path)
+
+
+def _summarize(records: list[dict]) -> dict[str, dict[str, dict[str, float]]]:
+    grouped: dict[str, list[dict]] = {}
+    for record in records:
+        if not record["repetition"]["warmup"]:
+            grouped.setdefault(record["repetition"]["case_id"], []).append(record)
+    summary = {}
+    for case_id, case_records in grouped.items():
+        metrics = {
+            "end_to_end_duration_ns": [record["resources"]["end_to_end_duration_ns"] for record in case_records],
+            "peak_host_rss_bytes": [record["resources"]["peak_host_rss_bytes"] for record in case_records],
+            "end_to_end_scored_documents_per_second": [record["counters"]["end_to_end_scored_documents_per_second"] for record in case_records],
+        }
+        for phase in {phase["name"] for record in case_records for phase in record["phases"]}:
+            metrics[f"phase.{phase}.duration_ns"] = [next(item["duration_ns"] for item in record["phases"] if item["name"] == phase) for record in case_records]
+        summary[case_id] = {
+            name: {
+                "median": statistics.median(values),
+                "p95": sorted(values)[math.ceil(0.95 * len(values)) - 1],
+                "pvariance": statistics.pvariance(values),
+            }
+            for name, values in metrics.items()
+        }
+    return summary
+
+
+def run_suite(output_dir: Path, *, warmups: int = 1, measured_repetitions: int = 5, digest_legacy_arguments: bool = False) -> list[Path]:
+    if warmups < 0 or measured_repetitions < 1:
+        raise ValueError("warmups must be non-negative and measured_repetitions must be positive")
+    output_dir = Path(output_dir)
+    repetitions = [(index, index < warmups) for index in range(warmups + measured_repetitions)]
+    for case_id in _CASES:
+        for index, warmup in repetitions:
+            label = "warmup" if warmup else "measured"
+            artifact_root = output_dir / "artifacts" / f"{case_id}-{index:03d}-{label}"
+            if artifact_root.exists():
+                raise FileExistsError(artifact_root)
+            for suffix in (".json", "-failed.json"):
+                path = output_dir / "records" / f"{case_id}-{index:03d}-{label}{suffix}"
+                if path.exists():
+                    raise FileExistsError(path)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    cache_root = Path(tempfile.mkdtemp(prefix="lmms-eval-benchmark-cache-"))
+    original_cache_path = request_cache.PATH
+    paths = []
+    try:
+        for case_id in _CASES:
+            if case_id == "cache-warm":
+                request_cache.PATH = str(cache_root / "warm")
+                _evaluate(_make_tasks(), cache_requests_enabled=True)
+            for index, warmup in repetitions:
+                request_cache.PATH = str(cache_root / ("warm" if case_id == "cache-warm" else f"{case_id}-{index}"))
+                paths.append(_run_repetition(output_dir, case_id, index, warmup, digest_legacy_arguments))
+    finally:
+        request_cache.PATH = original_cache_path
+        shutil.rmtree(cache_root)
+    records = [json.loads(path.read_text(encoding="utf-8")) for path in paths]
+    if len({record["resources"]["correctness_digest"] for record in records}) != 1:
+        raise RuntimeError("benchmark correctness parity failed")
+    print(json.dumps(_summarize(records), sort_keys=True))
+    return paths
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run the hermetic evaluator phase benchmark")
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--warmups", type=int, default=1)
+    parser.add_argument("--measured-repetitions", type=int, default=5)
+    parser.add_argument("--digest-legacy-arguments", action="store_true")
+    return parser
+
+
+def main() -> None:
+    args = _build_parser().parse_args()
+    run_suite(args.output_dir, warmups=args.warmups, measured_repetitions=args.measured_repetitions, digest_legacy_arguments=args.digest_legacy_arguments)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This adds the offline CPU harness that exercises the complete measurement path. It reports timings only after correctness and cache-state checks pass.

## Stack
- 1/4 #1456 - baseline phase recorder
- 2/4 #1457 - atomic record writer
- 3/4 #1459 - evaluator instrumentation
- **4/4 #1460 (this PR)** - reproducible benchmark harness
- Depends on #1455, the final layer of the performance contract stack

## Summary
- Add a network-free CPU dummy harness for disabled, cold, and warm request-cache states.
- Emit one standalone BaselinePerformanceRecordV1 per repetition and require correctness parity before reporting timing.
- Preserve failure evidence without leaking exception messages or overwriting another harness run.

## In scope
- Inline synthetic tasks, controlled cache lifecycle checks, artifact staging, failure records, CLI statistics, and the required hermetic test.

## Out of scope
- GPU or checkpoint benchmarks, performance optimization, evaluator changes, sample-limit behavior, or speedup claims.

## Validation
- Harness contracts | sample size: N=13 | key metrics: 13 passed | result: pass
- Default offline run | sample size: N=18 | key metrics: 18 records; 54 artifacts; 1 correctness digest | result: pass
- Cumulative gates | sample size: N=219 / 396 / 693 | key metrics: 219 performance and 396 hermetic passed; 693 collected | result: pass

## Risk / Compatibility
- The observed local dummy medians are diagnostic baseline data, not evidence that one cache state is faster.
- GitHub stack #1470, layer 4/4; depends on #1459 and uses integer limit=2 to remain independent from #1441.

## Type of Change
- [ ] Bug fix (non-breaking change)
- [ ] New feature
- [x] New benchmark/task
- [ ] New model integration
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring (no functional changes)