### PR TITLE
fix(mmmu): preserve full candidate list for open-ended eval_open scoring

### DIFF
--- a/lmms_eval/tasks/mmmu/utils.py
+++ b/lmms_eval/tasks/mmmu/utils.py
@@ -178,6 +178,18 @@ def mmmu_doc_to_visual(doc):
     return visual
 
 
+def to_submission_answer(parsed_pred):
+    """
+    Collapse a parsed prediction into the single answer the submission file expects.
+
+    A multiple-choice prediction is already a single option letter, while an open-ended
+    prediction is a list of answer candidates whose first element is the primary answer.
+    """
+    if isinstance(parsed_pred, list):
+        return str(parsed_pred[0]) if parsed_pred else ""
+    return str(parsed_pred)
+
+
 def mmmu_process_results(doc, results):
     parsed_preds = []
     for pred in results:
@@ -185,10 +197,11 @@ def mmmu_process_results(doc, results):
             index2ans, all_choices = get_multi_choice_info(ast.literal_eval(doc["options"]))
             parsed_pred = parse_multi_choice_response(pred, all_choices, index2ans)
         else:
+            # Keep the full candidate list: eval_open iterates over the candidates, so
+            # collapsing it to a string here would make it iterate over single characters.
             parsed_pred = parse_open_response(pred)
-            parsed_pred = str(parsed_pred[0]) if parsed_pred else ""
         parsed_preds.append(parsed_pred)
-    mmmu_submission = {doc["id"]: parsed_preds[0]}
+    mmmu_submission = {doc["id"]: to_submission_answer(parsed_preds[0])}
     mmmu_exact_acc = {"id": doc["id"], "subdomain": extract_subset_name(doc["id"]), "question_type": doc["question_type"], "answer": doc["answer"], "parsed_pred": parsed_preds}
     return {"mmmu_acc": mmmu_exact_acc, "mmmu_acc_pass_at_k": mmmu_exact_acc, "submission": mmmu_submission}
 

--- a/test/eval/test_mmmu_utils.py
+++ b/test/eval/test_mmmu_utils.py
@@ -1,0 +1,143 @@
+"""Tests for the MMMU scoring pipeline.
+
+Covers the contract between ``mmmu_process_results``, ``parse_open_response`` and
+``eval_open``: open-ended predictions must stay a list of answer candidates so that
+``eval_open`` iterates over candidates instead of over single characters.
+
+No dataset download, no model inference, no API keys required.
+"""
+
+from lmms_eval.tasks.mmmu import utils
+
+
+def _open_doc(answer, doc_id="validation_Math_1"):
+    return {
+        "id": doc_id,
+        "question_type": "open",
+        "question": "What is the value?",
+        "options": "[]",
+        "answer": answer,
+    }
+
+
+def _multi_choice_doc(answer, doc_id="validation_Math_2"):
+    return {
+        "id": doc_id,
+        "question_type": "multiple-choice",
+        "question": "Which one is correct?",
+        "options": "['first', 'second', 'third', 'fourth']",
+        "answer": answer,
+    }
+
+
+# ===========================================================================
+# Open-ended predictions keep their candidate list
+# ===========================================================================
+
+
+def test_open_ended_parsed_pred_stays_a_candidate_list():
+    doc = _open_doc("0.5")
+
+    result = utils.mmmu_process_results(doc, ["Therefore the answer is 0.5"])
+
+    parsed_preds = result["mmmu_acc"]["parsed_pred"]
+    assert len(parsed_preds) == 1, "one entry per generation is expected"
+    assert isinstance(parsed_preds[0], list), "candidates must not be collapsed into a string"
+    assert parsed_preds[0] == utils.parse_open_response("Therefore the answer is 0.5")
+
+
+def test_open_ended_numeric_answer_is_scored_correct():
+    doc = _open_doc("0.5")
+
+    result = utils.mmmu_process_results(doc, ["Therefore the answer is 0.5"])
+    judge_dict, metrics = utils.evaluate_mmmu([result["mmmu_acc"]])
+
+    assert judge_dict[doc["id"]] == "Correct"
+    assert metrics["acc"] == 1.0
+
+
+def test_open_ended_string_answer_is_scored_correct():
+    doc = _open_doc("hexagon")
+
+    result = utils.mmmu_process_results(doc, ["The answer is hexagon."])
+    judge_dict, metrics = utils.evaluate_mmmu([result["mmmu_acc"]])
+
+    assert judge_dict[doc["id"]] == "Correct"
+    assert metrics["acc"] == 1.0
+
+
+def test_open_ended_wrong_answer_is_scored_wrong():
+    doc = _open_doc("0.5")
+
+    result = utils.mmmu_process_results(doc, ["Therefore the answer is 42"])
+    judge_dict, metrics = utils.evaluate_mmmu([result["mmmu_acc"]])
+
+    assert judge_dict[doc["id"]] == "Wrong"
+    assert metrics["acc"] == 0.0
+
+
+def test_open_ended_scores_correct_when_any_generation_matches():
+    doc = _open_doc("0.5")
+
+    result = utils.mmmu_process_results(doc, ["The answer is 42", "The answer is 0.5"])
+    judge_dict, metrics = utils.evaluate_mmmu([result["mmmu_acc"]])
+
+    assert len(result["mmmu_acc"]["parsed_pred"]) == 2
+    assert judge_dict[doc["id"]] == "Correct"
+    assert metrics["acc"] == 1.0
+
+
+# ===========================================================================
+# Submission files still carry a single scalar answer
+# ===========================================================================
+
+
+def test_open_ended_submission_is_a_single_string():
+    doc = _open_doc("0.5")
+
+    result = utils.mmmu_process_results(doc, ["Therefore the answer is 0.5"])
+
+    submission = result["submission"]
+    assert set(submission) == {doc["id"]}
+    assert submission[doc["id"]] == "0.5"
+
+
+def test_submission_uses_the_first_generation_only():
+    doc = _open_doc("0.5")
+
+    result = utils.mmmu_process_results(doc, ["The answer is 42", "The answer is 0.5"])
+
+    # parse_open_response normalizes numbers to float, so "42" becomes 42.0
+    assert result["submission"][doc["id"]] == "42.0"
+
+
+def test_submission_answer_handles_empty_candidates():
+    assert utils.to_submission_answer([]) == ""
+
+
+def test_submission_answer_passes_through_multi_choice_letter():
+    assert utils.to_submission_answer("B") == "B"
+
+
+# ===========================================================================
+# Multiple-choice behaviour is unchanged
+# ===========================================================================
+
+
+def test_multi_choice_parsed_pred_is_an_option_letter():
+    doc = _multi_choice_doc("B")
+
+    result = utils.mmmu_process_results(doc, ["B"])
+
+    assert result["mmmu_acc"]["parsed_pred"] == ["B"]
+    assert result["submission"][doc["id"]] == "B"
+
+
+def test_multi_choice_answer_is_scored_correct():
+    doc = _multi_choice_doc("B")
+
+    result = utils.mmmu_process_results(doc, ["B"])
+    judge_dict, metrics = utils.evaluate_mmmu([result["mmmu_acc"]])
+
+    assert judge_dict[doc["id"]] == "Correct"
+    assert metrics["acc"] == 1.0


### PR DESCRIPTION
Fixes #1436

## Problem

`mmmu_process_results` collapsed the candidate list returned by `parse_open_response`
down to a single stringified first element:

```python
parsed_pred = parse_open_response(pred)
parsed_pred = str(parsed_pred[0]) if parsed_pred else ""
```

`eval_open` iterates over whatever it receives, so handing it a string made it iterate
**character by character** instead of candidate by candidate. That breaks the official
MMMU contract, where `parse_open_response` returns a list of string/number candidates
and each candidate is compared against the gold answer.

## Impact

This is not a small under-count: correct answers were scored as wrong, because no
single character ever equals the gold string. Measured on this branch by running the
same checks against the pre-fix code:

| case | gold | model output | acc before | acc after |
|---|---|---|---|---|
| numeric | `0.5` | `Therefore the answer is 0.5` | **0.0** | 1.0 |
| string | `hepatitis` | `The answer is hepatitis` | **0.0** | 1.0 |
| wrong answer (control) | `0.5` | `The answer is 0.9` | 0.0 | 0.0 |

So MMMU open-ended numbers produced by earlier versions are too low and will rise
after this patch. Multiple-choice numbers are unaffected.

## Fix

- Keep the full candidate list on the `mmmu_acc` path so `eval_open` compares
  candidates, matching the upstream MMMU evaluator.
- Add `to_submission_answer()` and use it when building the submission entry, which
  still needs a single scalar answer. Submission output is unchanged for both
  open-ended and multiple-choice questions.

The two consumers had been conflated: the submission file genuinely wants one value,
while `mmmu_acc` needs the candidate list. Splitting them keeps both correct.

## Tests

`test/eval/test_mmmu_utils.py` pins the invariants that matter:

- open-ended `parsed_pred` stays a candidate list and is scored per candidate
- `submission` remains `{id: "<single string>"}`, uses only the first generation, and
  maps an empty candidate list to `""`
- multiple-choice regression tests, so that path stays pinned

These tests import only `lmms_eval.tasks.mmmu.utils`, so they need no model or dataset
download.
