### PR TITLE
perf: parallelize document result processing

### DIFF
--- a/docs/getting-started/commands.md
+++ b/docs/getting-started/commands.md
@@ -29,6 +29,8 @@ This mode supports a number of command-line arguments, the details of which can 
 
 - `--limit` : Accepts an integer, or a float between 0.0 and 1.0 . If passed, will limit the number of documents to evaluate to the first X documents (if an integer) per task or first X% of documents per task. Useful for debugging, especially on costly API models.
 
+- `--process-docs-parallel` : Number of worker threads used for per-document `process_results` scoring. Defaults to `4`; set it to `1` to restore serial postprocessing. Results and sample logs are committed in original document order even when scoring finishes out of order.
+
 - `--use_cache` : Accepts either a cache root directory or a SQLite `.db` file path. When you pass a directory, or an explicit root `<dir>/cache.db`, lmms-eval stores the shared cache at `<dir>/cache.db` and writes each evaluation run into `<dir>/runs/<run_id>/...` before merging back into the root DB. This isolates concurrent writers automatically while keeping a single shared cache for reuse across runs. Other `.db` filenames keep the legacy single-target behavior.
 
 - `--cache_requests` : Can be "true", "refresh", or "delete". "true" means that the cache should be used. "refresh" means that you wish to regenerate the cache, which you should run if you change your dataset configuration for a given task. "delete" will delete the cache. Cached files are stored under lmms_eval/cache/.cache unless you specify a different path via the environment variable: `LM_HARNESS_CACHE_PATH`. e.g. `LM_HARNESS_CACHE_PATH=~/Documents/cache_for_lm_harness`.

--- a/lmms_eval/__main__.py
+++ b/lmms_eval/__main__.py
@@ -69,6 +69,16 @@ def _int_or_none_list_arg_type(min_len: int, max_len: int, defaults: str, value:
     return items
 
 
+def _positive_int_arg_type(value: str) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError) as exc:
+        raise argparse.ArgumentTypeError(f"{value} is not an integer") from exc
+    if parsed < 1:
+        raise argparse.ArgumentTypeError(f"{value} must be at least 1")
+    return parsed
+
+
 def check_argument_types(parser: argparse.ArgumentParser):
     """
     Check to make sure all CLI args are typed, raises error if not
@@ -371,6 +381,15 @@ def parse_eval_args() -> tuple[argparse.ArgumentParser, argparse.Namespace]:
         "--process_with_media",
         action="store_true",
         help="Whether you will process you dataset with audio, image. By default set to False" "In case some benchmarks need to be processed with media, set this flag to True.",
+    )
+    parser.add_argument(
+        "--process-docs-parallel",
+        "--process_docs_parallel",
+        dest="process_docs_parallel",
+        type=_positive_int_arg_type,
+        default=4,
+        metavar="N",
+        help="Number of worker threads for per-document process_results calls. Set to 1 for serial postprocessing. Default: 4.",
     )
     parser.add_argument(
         "--agentic_trace_mode",
@@ -748,6 +767,7 @@ def cli_evaluate_single(args: Union[argparse.Namespace, None] = None) -> None:
         repeats=args.repeats,
         baseline=args.baseline,
         max_tokens=args.max_tokens,
+        process_docs_parallel=getattr(args, "process_docs_parallel", 4),
         **request_caching_args,
     )
 

--- a/lmms_eval/evaluator.py
+++ b/lmms_eval/evaluator.py
@@ -7,6 +7,9 @@ import mimetypes
 import os
 import random
 import re
+import time
+from concurrent.futures import FIRST_COMPLETED, ThreadPoolExecutor, wait
+from dataclasses import dataclass
 from datetime import timedelta
 from typing import Callable, List, Optional, Union
 
@@ -239,6 +242,129 @@ def _collect_input_media(doc: dict, request_args: list) -> list[str]:
     return sources
 
 
+@dataclass
+class _ProcessedDocument:
+    metrics: dict
+    per_sample_scores: dict
+    logged_sample: Optional[dict]
+
+
+def _thread_map_ordered(function: Callable, items, max_workers: int, on_complete: Optional[Callable] = None) -> list:
+    """Run ``function`` concurrently while returning results in input order.
+
+    Only ``2 * max_workers`` inputs are materialized at once. This keeps media
+    documents bounded in memory while allowing a slow early document to finish
+    after later documents without stalling the worker pool.
+    """
+
+    if max_workers < 1:
+        raise ValueError(f"process_docs_parallel must be at least 1, got {max_workers}")
+
+    if max_workers == 1:
+        results = []
+        for item in items:
+            results.append(function(item))
+            if on_complete is not None:
+                on_complete()
+        return results
+
+    indexed_items = iter(enumerate(items))
+    completed = []
+    with ThreadPoolExecutor(max_workers=max_workers, thread_name_prefix="lmms-process-results") as executor:
+        pending = {}
+
+        def submit_next() -> bool:
+            try:
+                index, item = next(indexed_items)
+            except StopIteration:
+                return False
+            pending[executor.submit(function, item)] = index
+            return True
+
+        for _ in range(max_workers * 2):
+            if not submit_next():
+                break
+
+        while pending:
+            done, _ = wait(tuple(pending), return_when=FIRST_COMPLETED)
+            for future in done:
+                index = pending.pop(future)
+                completed.append((index, future.result()))
+                if on_complete is not None:
+                    on_complete()
+                submit_next()
+
+    completed.sort(key=lambda item: item[0])
+    return [result for _, result in completed]
+
+
+def _process_document_results(item, *, task: Task, filter_key: str, reasoning_tags, log_samples: bool) -> _ProcessedDocument:
+    """Run one document's scoring without mutating shared ``TaskOutput`` state."""
+
+    doc_id, doc, requests = item
+
+    if reasoning_tags is not None:
+        for req in requests:
+            raw_resp = req.filtered_resps[filter_key]
+            req.raw_filtered_resps[filter_key] = raw_resp
+            if isinstance(raw_resp, str):
+                req.filtered_resps[filter_key] = strip_reasoning_tags(raw_resp, reasoning_tags)
+            elif isinstance(raw_resp, list):
+                req.filtered_resps[filter_key] = [strip_reasoning_tags(response, reasoning_tags) if isinstance(response, str) else response for response in raw_resp]
+
+    metrics = task.process_results(doc, [req.filtered_resps[filter_key] for req in requests])
+
+    per_sample_scores = {}
+    repeats = task.config.repeats if hasattr(task, "config") and hasattr(task.config, "repeats") else 1
+    if repeats > 1 and len(requests) == repeats:
+        for req in requests:
+            sample_metrics = task.process_results(doc, [req.filtered_resps[filter_key]])
+            for metric_name, value in sample_metrics.items():
+                per_sample_scores.setdefault(metric_name, []).append(value)
+
+    logged_sample = None
+    if log_samples:
+        target = task.doc_to_target(doc)
+        saved_doc = {key: value for key, value in doc.items() if not is_multimodal_content(value)}
+        filtered_arguments = []
+        for req in requests:
+            for value in req.args:
+                if isinstance(value, (str, int, float, bool, list, dict, type(None))):
+                    filtered_arguments.append(value)
+
+        input_media = _collect_input_media(doc, filtered_arguments)
+        per_sample_token_counts = []
+        for req in requests:
+            if req.token_counts:
+                token_counts = req.token_counts[0]
+                per_sample_token_counts.append(token_counts.to_dict() if token_counts is not None else None)
+            else:
+                per_sample_token_counts.append(None)
+
+        logged_sample = {
+            "doc_id": doc_id,
+            "doc": saved_doc,
+            "target": target,
+            "arguments": filtered_arguments,
+            "resps": [req.raw_filtered_resps.get(filter_key, req.resps) for req in requests],
+            "filtered_resps": [req.filtered_resps[filter_key] for req in requests],
+            "token_counts": per_sample_token_counts,
+            "doc_hash": hash_string(
+                json.dumps(
+                    requests[0].doc,
+                    indent=2,
+                    default=handle_non_serializable,
+                    ensure_ascii=False,
+                )
+            ),
+        }
+        if input_media:
+            logged_sample["input_media"] = input_media
+        logged_sample.update(metrics)
+
+    return _ProcessedDocument(metrics=metrics, per_sample_scores=per_sample_scores, logged_sample=logged_sample)
+
+
 @positional_deprecated
 def simple_evaluate(
     model,
@@ -278,6 +404,7 @@ def simple_evaluate(
     repeats: int = 1,
     baseline: Optional[str] = None,
     max_tokens: Optional[int] = None,
+    process_docs_parallel: int = 4,
 ):
     """Instantiate and evaluate a model on a list of tasks.
 
@@ -339,6 +466,8 @@ def simple_evaluate(
         Random seed for fewshot sampler random generator. If set to None, the seed of generator will be set to None.
     :param distributed_executor_backend: str
         The backend to use for distributed execution, `accelerate` or `torchrun`. Defaults to "accelerate" for the `accelerate` library.
+    :param process_docs_parallel: int
+        Number of worker threads used for per-document ``process_results`` calls. Set to 1 for serial postprocessing.
     :return
         Dictionary of results
     """
@@ -360,6 +489,10 @@ def simple_evaluate(
         eval_logger.info(" | ".join(seed_message))
 
     assert tasks != [], "No tasks specified, or no tasks found. Please verify the task names."
+
+    process_docs_parallel = int(process_docs_parallel)
+    if process_docs_parallel < 1:
+        raise ValueError(f"process_docs_parallel must be at least 1, got {process_docs_parallel}")
 
     assert distributed_executor_backend in {"accelerate", "torchrun"}, f"Invalid distributed executor backend: {distributed_executor_backend}. Choose either 'accelerate' or 'torchrun'."
 
@@ -538,6 +671,7 @@ def simple_evaluate(
             cli_args=cli_args,
             eval_server_launcher=eval_launcher,
             response_cache=response_cache,
+            process_docs_parallel=process_docs_parallel,
         )
         eval_succeeded = True
     finally:
@@ -576,6 +710,7 @@ def simple_evaluate(
                 "limit": limit,
                 "offset": offset,
                 "bootstrap_iters": bootstrap_iters,
+                "process_docs_parallel": process_docs_parallel,
                 "gen_kwargs": gen_kwargs,
                 "random_seed": random_seed,
                 "numpy_seed": numpy_random_seed,
@@ -845,6 +980,7 @@ def evaluate(
     eval_server_launcher: Optional[Union[str, Callable]] = None,
     cli_args=None,
     response_cache: Optional[ResponseCache] = None,
+    process_docs_parallel: int = 4,
 ):
     """Instantiate and evaluate a model on a list of tasks.
 
@@ -870,9 +1006,15 @@ def evaluate(
         Whether to provide the fewshot examples as a multiturn conversation or a single user turn.
     :param distributed_executor_backend: str
         The backend to use for distributed execution, `accelerate` or `torchrun`. Defaults to "accelerate" for the `accelerate` library.
+    :param process_docs_parallel: int
+        Number of worker threads used for per-document ``process_results`` calls. Set to 1 for serial postprocessing.
     :return
         Dictionary of results
     """
+
+    process_docs_parallel = int(process_docs_parallel)
+    if process_docs_parallel < 1:
+        raise ValueError(f"process_docs_parallel must be at least 1, got {process_docs_parallel}")
 
     # stores the final result for each task, for each metric/filter pair.
     results = collections.defaultdict(dict)
@@ -1213,93 +1355,49 @@ def evaluate(
             )
             total_docs = sum(1 for _ in doc_iterator_for_counting)
             pbar = tqdm(total=total_docs, desc="Postprocessing", disable=(RANK != 0))
-            for doc_id, doc in doc_iterator:
-                requests = instances_by_doc_id[doc_id]
-                # Defensive skip: if a doc landed in this rank's shard but has
-                # no requests (e.g. a split mismatch during a partial rerun),
-                # skip rather than crashing at `requests[0].doc` below.
-                if not requests:
-                    pbar.update(1)
-                    continue
+            postprocess_started = time.perf_counter()
 
-                # Strip reasoning tags before scoring
-                if reasoning_tags is not None:
-                    for req in requests:
-                        raw_resp = req.filtered_resps[filter_key]
-                        req.raw_filtered_resps[filter_key] = raw_resp
-                        if isinstance(raw_resp, str):
-                            req.filtered_resps[filter_key] = strip_reasoning_tags(raw_resp, reasoning_tags)
-                        elif isinstance(raw_resp, list):
-                            req.filtered_resps[filter_key] = [strip_reasoning_tags(r, reasoning_tags) if isinstance(r, str) else r for r in raw_resp]
+            def documents_to_process():
+                for doc_id, doc in doc_iterator:
+                    requests = instances_by_doc_id[doc_id]
+                    # A partial rerun can leave a document in this rank's shard
+                    # without any corresponding requests.
+                    if not requests:
+                        pbar.update(1)
+                        continue
+                    yield doc_id, doc, requests
 
-                metrics = task.process_results(doc, [req.filtered_resps[filter_key] for req in requests])
+            def process_document(item):
+                return _process_document_results(
+                    item,
+                    task=task,
+                    filter_key=filter_key,
+                    reasoning_tags=reasoning_tags,
+                    log_samples=log_samples,
+                )
 
-                # For stability metrics: compute per-sample scores when repeats > 1
-                repeats = task.config.repeats if hasattr(task, "config") and hasattr(task.config, "repeats") else 1
-                if repeats > 1 and len(requests) == repeats:
-                    # Compute per-sample scores by calling process_results for each sample individually
-                    per_sample_scores = {}
-                    for req in requests:
-                        sample_metrics = task.process_results(doc, [req.filtered_resps[filter_key]])
-                        for metric_name, value in sample_metrics.items():
-                            if metric_name not in per_sample_scores:
-                                per_sample_scores[metric_name] = []
-                            per_sample_scores[metric_name].append(value)
-                    # Store per-sample scores grouped by doc_id
-                    for metric_name, scores in per_sample_scores.items():
-                        task_output.per_sample_metrics[(metric_name, filter_key)].append(scores)
+            processed_documents = _thread_map_ordered(
+                process_document,
+                documents_to_process(),
+                max_workers=process_docs_parallel,
+                on_complete=lambda: pbar.update(1),
+            )
 
-                if log_samples:
-                    target = task.doc_to_target(doc)
-                    saved_doc = {}
-                    for key, value in doc.items():
-                        if not is_multimodal_content(value):
-                            saved_doc[key] = value
-                    filtered_arguments = []
-                    for req in requests:
-                        # check if req.args is a list of tuples, and each item in the list is a serializable object
-                        for value in req.args:
-                            if isinstance(value, (str, int, float, bool, list, dict, type(None))):
-                                filtered_arguments.append(value)
-                            # else:
-                            #     filtered_arguments.append(_handle_non_serializable(value))
-
-                    input_media = _collect_input_media(doc, filtered_arguments)
-
-                    per_sample_tc = []
-                    for req in requests:
-                        if req.token_counts:
-                            tc = req.token_counts[0]
-                            per_sample_tc.append(tc.to_dict() if tc is not None else None)
-                        else:
-                            per_sample_tc.append(None)
-
-                    example = {
-                        "doc_id": doc_id,
-                        "doc": saved_doc,
-                        "target": target,
-                        "arguments": filtered_arguments,
-                        "resps": [req.raw_filtered_resps.get(filter_key, req.resps) for req in requests],
-                        "filtered_resps": [req.filtered_resps[filter_key] for req in requests],
-                        "token_counts": per_sample_tc,
-                        "doc_hash": hash_string(
-                            json.dumps(
-                                requests[0].doc,
-                                indent=2,
-                                default=handle_non_serializable,
-                                ensure_ascii=False,
-                            )
-                        ),
-                    }
-                    if input_media:
-                        example["input_media"] = input_media
-                    example.update(metrics)
-                    task_output.logged_samples.append(example)
-                for metric, value in metrics.items():
+            # Worker completion order is intentionally unconstrained. Commit
+            # results only after restoring document order so metrics and sample
+            # logs retain the serial evaluator's deterministic ordering.
+            for processed in processed_documents:
+                for metric_name, scores in processed.per_sample_scores.items():
+                    task_output.per_sample_metrics[(metric_name, filter_key)].append(scores)
+                if processed.logged_sample is not None:
+                    task_output.logged_samples.append(processed.logged_sample)
+                for metric, value in processed.metrics.items():
                     task_output.sample_metrics[(metric, filter_key)].append(value)
-                pbar.update(1)
 
             pbar.close()
+            if RANK == 0:
+                elapsed = time.perf_counter() - postprocess_started
+                eval_logger.info(f"Postprocessed {len(processed_documents)} docs for {task_output.task_name}/{filter_key} " f"with {process_docs_parallel} worker(s) in {elapsed:.2f}s")
         set_task_context(None)
 
     if WORLD_SIZE > 1:

--- a/lmms_eval/models/model_utils/usage_metrics.py
+++ b/lmms_eval/models/model_utils/usage_metrics.py
@@ -69,7 +69,9 @@ def set_task_context(task_name: Optional[str]) -> None:
     so that LLM-judge providers — which call ``log_usage(task_name=None)``
     — automatically inherit the correct task attribution.
 
-    Single-threaded (postprocessing loop); no lock required.
+    The evaluator sets this once before launching a task's postprocessing
+    workers and clears it after they join. All workers therefore read the same
+    stable task name, so no lock is required.
     """
     global _CURRENT_TASK_CONTEXT
     _CURRENT_TASK_CONTEXT = task_name

--- a/lmms_eval/models/simple/mistral3_vl.py
+++ b/lmms_eval/models/simple/mistral3_vl.py
@@ -348,6 +348,7 @@ class Mistral3_VL(lmms):
 
             except Exception as e:
                 import traceback
+
                 eval_logger.error(f"Error during generation: {e}")
                 eval_logger.error(f"Traceback: {traceback.format_exc()}")
                 res.extend([""] * len(contexts))

--- a/lmms_eval/models/simple/qwen3_vl.py
+++ b/lmms_eval/models/simple/qwen3_vl.py
@@ -1,8 +1,8 @@
-import decord
 import re
 from concurrent.futures import ThreadPoolExecutor
 from typing import List, Optional, Tuple, Union
 
+import decord
 import torch
 from accelerate import Accelerator, DistributedType
 from loguru import logger as eval_logger
@@ -316,8 +316,8 @@ class Qwen3_VL(lmms):
                         # when video has fewer frames than max_num_frames
                         per_video_kwargs = {**video_kwargs}
                         if "nframes" in per_video_kwargs:
-                              vr = decord.VideoReader(visual)
-                              per_video_kwargs["nframes"] = min(per_video_kwargs["nframes"], len(vr))
+                            vr = decord.VideoReader(visual)
+                            per_video_kwargs["nframes"] = min(per_video_kwargs["nframes"], len(vr))
                         processed_visuals.append(
                             {
                                 "type": "video",

--- a/lmms_eval/tasks/vlmsareblind/utils.py
+++ b/lmms_eval/tasks/vlmsareblind/utils.py
@@ -106,15 +106,8 @@ def vlmsareblind_aggregate_by_task(results: list[dict]) -> dict[str, float]:
         if is_correct:
             task_correct[task] += 1
 
-    task_accuracy = {
-        task: task_correct[task] / total
-        for task, total in task_total.items()
-    }
-    task_accuracy["task_mean"] = (
-        sum(task_accuracy.values()) / len(task_accuracy)
-        if task_accuracy
-        else 0.0
-    )
+    task_accuracy = {task: task_correct[task] / total for task, total in task_total.items()}
+    task_accuracy["task_mean"] = sum(task_accuracy.values()) / len(task_accuracy) if task_accuracy else 0.0
 
     return task_accuracy
 

--- a/test/eval/test_cli_parse_args.py
+++ b/test/eval/test_cli_parse_args.py
@@ -32,6 +32,45 @@ class TestCliParseArgs(unittest.TestCase):
             _, args = main_module.parse_eval_args()
         self.assertIsNone(args.max_tokens)
 
+    def test_process_docs_parallel_defaults_to_four(self):
+        argv = [
+            "lmms-eval",
+            "--model",
+            "openai",
+            "--tasks",
+            "mme",
+        ]
+        with patch.object(sys, "argv", argv):
+            _, args = main_module.parse_eval_args()
+        self.assertEqual(args.process_docs_parallel, 4)
+
+    def test_process_docs_parallel_accepts_hyphenated_option(self):
+        argv = [
+            "lmms-eval",
+            "--model",
+            "openai",
+            "--tasks",
+            "mme",
+            "--process-docs-parallel",
+            "7",
+        ]
+        with patch.object(sys, "argv", argv):
+            _, args = main_module.parse_eval_args()
+        self.assertEqual(args.process_docs_parallel, 7)
+
+    def test_process_docs_parallel_rejects_zero(self):
+        argv = [
+            "lmms-eval",
+            "--model",
+            "openai",
+            "--tasks",
+            "mme",
+            "--process-docs-parallel",
+            "0",
+        ]
+        with patch.object(sys, "argv", argv), self.assertRaises(SystemExit):
+            main_module.parse_eval_args()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/eval/test_process_results_parallel.py
+++ b/test/eval/test_process_results_parallel.py
@@ -1,0 +1,121 @@
+import threading
+import time
+from types import SimpleNamespace
+
+import pytest
+
+from lmms_eval.api.instance import Instance, TokenCounts
+from lmms_eval.evaluator import _process_document_results, _thread_map_ordered
+
+
+def test_thread_map_runs_concurrently_and_returns_input_order():
+    barrier = threading.Barrier(4, timeout=5)
+    completion_order = []
+    completion_lock = threading.Lock()
+
+    def work(value):
+        barrier.wait()
+        time.sleep((3 - value) * 0.01)
+        with completion_lock:
+            completion_order.append(value)
+        return value * 10
+
+    results = _thread_map_ordered(work, range(4), max_workers=4)
+
+    assert completion_order != [0, 1, 2, 3]
+    assert results == [0, 10, 20, 30]
+
+
+def test_thread_map_one_worker_is_serial():
+    completion_order = []
+
+    def work(value):
+        completion_order.append(value)
+        return value
+
+    assert _thread_map_ordered(work, range(4), max_workers=1) == [0, 1, 2, 3]
+    assert completion_order == [0, 1, 2, 3]
+
+
+def test_thread_map_rejects_non_positive_worker_count():
+    with pytest.raises(ValueError, match="at least 1"):
+        _thread_map_ordered(lambda value: value, [], max_workers=0)
+
+
+def test_process_document_results_preserves_serial_scoring_and_logging_contract():
+    doc = {"question": "What is the answer?", "target": "Paris", "image": b"binary-image"}
+    request = Instance(
+        request_type="generate_until",
+        arguments=("prompt", {"until": ["stop"]}, None, 5, "test_task", "test"),
+        idx=0,
+        metadata={"task": "test_task", "doc_id": 5, "repeats": 1},
+    )
+    request.doc = doc
+    request.resps = ["<think>private chain</think> Paris"]
+    request.filtered_resps["default"] = "<think>private chain</think> Paris"
+    request.token_counts = [TokenCounts(input_tokens=11, output_tokens=7)]
+
+    seen_results = []
+
+    class FakeTask:
+        config = SimpleNamespace(repeats=1)
+
+        def process_results(self, current_doc, results):
+            assert current_doc is doc
+            seen_results.append(results)
+            return {"accuracy": float(results == ["Paris"])}
+
+        def doc_to_target(self, current_doc):
+            return current_doc["target"]
+
+    processed = _process_document_results(
+        (5, doc, [request]),
+        task=FakeTask(),
+        filter_key="default",
+        reasoning_tags=[["<think>", "</think>"]],
+        log_samples=True,
+    )
+
+    assert seen_results == [["Paris"]]
+    assert processed.metrics == {"accuracy": 1.0}
+    assert processed.per_sample_scores == {}
+    assert processed.logged_sample["doc_id"] == 5
+    assert processed.logged_sample["doc"] == {"question": "What is the answer?", "target": "Paris"}
+    assert processed.logged_sample["target"] == "Paris"
+    assert processed.logged_sample["resps"] == ["<think>private chain</think> Paris"]
+    assert processed.logged_sample["filtered_resps"] == ["Paris"]
+    assert processed.logged_sample["token_counts"] == [{"input_tokens": 11, "output_tokens": 7}]
+    assert processed.logged_sample["accuracy"] == 1.0
+
+
+def test_process_document_results_computes_repeat_scores():
+    doc = {"target": "A"}
+    requests = []
+    for index, response in enumerate(("A", "B")):
+        request = Instance(
+            request_type="generate_until",
+            arguments=("prompt", {}, None, 3, "test_task", "test"),
+            idx=index,
+            metadata={"task": "test_task", "doc_id": 3, "repeats": 2},
+        )
+        request.doc = doc
+        request.filtered_resps["default"] = response
+        requests.append(request)
+
+    class FakeTask:
+        config = SimpleNamespace(repeats=2)
+
+        def process_results(self, current_doc, results):
+            return {"accuracy": float(results[0] == current_doc["target"])}
+
+    processed = _process_document_results(
+        (3, doc, requests),
+        task=FakeTask(),
+        filter_key="default",
+        reasoning_tags=None,
+        log_samples=False,
+    )
+
+    assert processed.metrics == {"accuracy": 1.0}
+    assert processed.per_sample_scores == {"accuracy": [1.0, 0.0]}
+    assert processed.logged_sample is None


### PR DESCRIPTION
## Motivation

After model inference finishes, lmms-eval processes each document by calling:

```python
task.process_results(doc, responses)
```

This stage currently runs serially. For video benchmarks such as VBVR, `process_results` may need to decode generated videos and run CPU/OpenCV-based rule evaluators. As a result, postprocessing can become a significant bottleneck even when model inference itself is distributed across multiple GPUs.

This PR parallelizes per-document result processing and adds a CLI option to control the worker count.

> [!NOTE]
> This optimizes the evaluator's per-document `task.process_results(...)` phase shown by the `Postprocessing` progress bar. It does not change dataset-level `TaskConfig.process_docs`.

## Changes

### New CLI option

```bash
--process-docs-parallel N
```

The underscore alias is also supported:

```bash
--process_docs_parallel N
```

Behavior:

- Default: `4` worker threads
- Set to `1` to preserve the previous serial behavior
- Values smaller than `1` are rejected during argument parsing
- The configured worker count is recorded in the evaluation result config

Examples:

```bash
# Uses the default of 4 workers
lmms-eval --model fastvideo --tasks vbvr ...

# Increase postprocessing concurrency
lmms-eval --model fastvideo --tasks vbvr \
    --process-docs-parallel 8 ...

# Restore serial postprocessing
lmms-eval --model fastvideo --tasks vbvr \
    --process-docs-parallel 1 ...
```

### Parallel result processing

Per-document `task.process_results` calls now run through a bounded `ThreadPoolExecutor`.

The implementation:

- keeps at most `2 * max_workers` documents submitted at once
- avoids eagerly materializing the complete document iterator
- allows slow documents to finish after faster documents without blocking the worker pool
- updates the postprocessing progress bar as documents finish
- logs the number of processed documents, worker count, and elapsed time

Threads are used instead of processes because task objects, requests, datasets, and multimodal documents are not guaranteed to be picklable. VBVR processing also spends substantial time in video I/O and native OpenCV operations, which can benefit from thread-level concurrency.

### Deterministic output ordering

Worker completion order is intentionally unconstrained, but evaluation output remains deterministic.

Workers do not mutate shared `TaskOutput` metric or sample-log collections. Each worker returns an isolated result containing:

- aggregate metrics for the document
- repeat-level metrics, when enabled
- the sample-log entry, when requested

The main thread restores the original document order before committing these values to:

- `sample_metrics`
- `per_sample_metrics`
- `logged_samples`

This preserves the ordering behavior of the previous serial implementation even when documents finish out of order.

The existing behavior for the following paths is also preserved:

- reasoning-tag stripping
- raw-response logging
- multimodal sample logging
- token-count logging
- repeat/stability metrics
- task-level usage attribution

Tasks whose `process_results` implementation is not thread-safe can opt out by setting:

```bash
--process-docs-parallel 1
```

## Performance

### FastVideo Wan2.2 VBVR

The end-to-end path was tested with:

- FastVideo 0.2.0
- Wan2.2-I2V-A14B
- 2 × NVIDIA H800
- sequence parallel size: 2
- tensor parallel size: 1
- 81 output frames
- 256 × 256 resolution
- 2 inference steps
- `TORCH_SDPA` attention backend
- 12 VBVR documents

The second run reused all 12 generated outputs from the response cache, ensuring that the comparison measured the same videos and isolated result-processing time.

| Workers | Postprocessing time | Speedup | Reduction |
| ---: | ---: | ---: | ---: |
| 1 | 9.55 s | 1.00× | — |
| 4 | 3.09 s | **3.09×** | **67.6%** |

The serial and parallel runs produced:

- identical document ordering
- identical per-document scores
- identical aggregate and category metrics
- the same overall VBVR score: `0.1345411575`

### Full Wan2.2 VBVR scorer validation

A scorer-only validation was also run over 500 existing Wan2.2 VBVR outputs, covering all 100 VBVR evaluator types.

| Workers | Postprocessing time | Speedup | Reduction |
| ---: | ---: | ---: | ---: |
| 1 | 726.99 s | 1.00× | — |
| 4 | 201.00 s | **3.62×** | **72.35%** |

All 500 per-document results were exactly identical between the serial and parallel runs.

## Testing

The following areas are covered by the added tests:

- CLI default worker count
- hyphenated CLI option
- invalid worker-count rejection
- actual concurrent execution
- deterministic input-order restoration
- serial behavior with one worker
- reasoning-tag and raw-response handling
- sample logging and token counts
- repeat-level metrics

Relevant evaluator, CLI, task-pipeline, reasoning, usage-metrics, and FastVideo tests were run:

```text
161 passed, 8 skipped
```

The repository's pre-commit Black and isort hooks also pass.

## Scope

This PR only changes evaluator-side result processing, CLI plumbing, documentation, and tests. It does not modify model inference behavior, generation outputs, or model backend implementations.
