### PR TITLE
fix(vllm): avoid eager Decord loading

### DIFF
--- a/lmms_eval/models/model_utils/load_video.py
+++ b/lmms_eval/models/model_utils/load_video.py
@@ -2,8 +2,9 @@ import importlib
 import os
 from typing import Optional, Union
 
-import av
 import numpy as np
+
+SUPPORTED_VIDEO_DECODE_BACKENDS = ("pyav", "torchcodec", "dali", "decord")
 
 
 def _resolve_video_path(video_path: Union[str, tuple, list]) -> str:
@@ -16,12 +17,28 @@ def _resolve_video_path(video_path: Union[str, tuple, list]) -> str:
 
 def _normalize_decode_backend(backend: Optional[str]) -> str:
     selected = (backend or os.getenv("LMMS_VIDEO_DECODE_BACKEND", "pyav")).strip().lower()
-    if selected not in {"pyav", "torchcodec", "dali"}:
-        raise ValueError(f"Unsupported video decode backend: {selected}. Expected one of: pyav, torchcodec, dali")
+    if selected not in SUPPORTED_VIDEO_DECODE_BACKENDS:
+        expected = ", ".join(SUPPORTED_VIDEO_DECODE_BACKENDS)
+        raise ValueError(f"Unsupported video decode backend: {selected}. Expected one of: {expected}")
     return selected
 
 
+def _import_pyav():
+    try:
+        return importlib.import_module("av")
+    except ModuleNotFoundError as exc:
+        raise ImportError("PyAV backend requires `av`. Install it via `uv add av`.") from exc
+
+
+def _import_decord():
+    try:
+        return importlib.import_module("decord")
+    except ModuleNotFoundError as exc:
+        raise ImportError("Decord backend requires the legacy video extra. Install via `uv sync --extra video-legacy`.") from exc
+
+
 def _probe_video_metadata(video_path: str) -> tuple[int, Optional[float]]:
+    av = _import_pyav()
     container = av.open(video_path)
     try:
         stream = container.streams.video[0]
@@ -34,7 +51,12 @@ def _probe_video_metadata(video_path: str) -> tuple[int, Optional[float]]:
 
 def _compute_sample_count(total_frames: int, num_frm: int, fps: Optional[float], frame_rate: Optional[float]) -> int:
     if total_frames <= 0:
-        return max(1, num_frm)
+        raise ValueError("Cannot sample a video with no decoded frames")
+    if num_frm <= 0:
+        raise ValueError("num_frm must be greater than zero")
+    if fps is not None and fps <= 0:
+        raise ValueError("fps must be greater than zero when provided")
+
     sampled = min(total_frames, num_frm)
     if fps is not None and frame_rate and frame_rate > 0:
         video_length = total_frames / frame_rate
@@ -45,37 +67,72 @@ def _compute_sample_count(total_frames: int, num_frm: int, fps: Optional[float],
 def _compute_uniform_indices(total_frames: int, sampled_frm: int, force_include_last_frame: bool = False) -> np.ndarray:
     if total_frames <= 0:
         raise ValueError("total_frames must be > 0")
-    indices = np.linspace(0, total_frames - 1, sampled_frm, dtype=int)
-    if force_include_last_frame:
-        last_frame = total_frames - 1
-        if last_frame not in indices:
-            if sampled_frm <= 1:
-                indices = np.array([last_frame], dtype=int)
-            else:
-                base = np.linspace(0, max(0, total_frames - 2), sampled_frm - 1, dtype=int)
-                indices = np.append(base, last_frame)
-    return np.unique(indices)
+    if sampled_frm <= 0 or sampled_frm > total_frames:
+        raise ValueError("sampled_frm must be between 1 and total_frames")
+
+    if sampled_frm == 1:
+        index = total_frames - 1 if force_include_last_frame else 0
+        return np.array([index], dtype=int)
+
+    # With sampled_frm <= total_frames, these indices are unique and include
+    # both endpoints. Keeping one index policy across random-access backends
+    # makes decoder comparisons and evaluation reproduction easier.
+    return np.linspace(0, total_frames - 1, sampled_frm, dtype=int)
+
+
+def _open_decord_reader(video_path: Union[str, tuple, list]):
+    decord = _import_decord()
+    resolved_path = _resolve_video_path(video_path)
+    num_threads = int(os.getenv("LMMS_VIDEO_DECORD_THREADS", "2"))
+    return decord.VideoReader(resolved_path, ctx=decord.cpu(0), num_threads=num_threads)
 
 
 def load_video_decord(video_path, max_frames_num):
-    try:
-        decord = importlib.import_module("decord")
-    except ModuleNotFoundError as exc:
-        raise ImportError("load_video_decord requires `decord`. Install decord to use this backend.") from exc
+    """Legacy Decord helper that always returns ``max_frames_num`` frames.
 
-    VideoReader = decord.VideoReader
-    cpu = decord.cpu
-    num_threads = int(os.getenv("LMMS_VIDEO_DECORD_THREADS", "2"))
-    if isinstance(video_path, str):
-        vr = VideoReader(video_path, ctx=cpu(0), num_threads=num_threads)
-    else:
-        vr = VideoReader(video_path[0], ctx=cpu(0), num_threads=num_threads)
-    total_frame_num = len(vr)
-    uniform_sampled_frames = np.linspace(0, total_frame_num - 1, max_frames_num, dtype=int)
-    frame_idx = uniform_sampled_frames.tolist()
-    spare_frames = vr.get_batch(frame_idx).asnumpy()
-    del vr  # Release VideoReader to prevent memory leak
-    return spare_frames  # (frames, height, width, channels)
+    This intentionally retains duplicate indices for short videos because a
+    few model adapters rely on that historical behavior. New code should use
+    :func:`read_video` with ``backend="decord"`` for maximum-count semantics.
+    """
+
+    if max_frames_num <= 0:
+        raise ValueError("max_frames_num must be greater than zero")
+
+    vr = _open_decord_reader(video_path)
+    try:
+        total_frame_num = len(vr)
+        if total_frame_num <= 0:
+            raise ValueError("Cannot decode frames from an empty video")
+        frame_idx = np.linspace(0, total_frame_num - 1, max_frames_num, dtype=int).tolist()
+        return np.ascontiguousarray(vr.get_batch(frame_idx).asnumpy())
+    finally:
+        del vr  # Release VideoReader before interpreter teardown.
+
+
+def read_video_decord(
+    video_path: Union[str, tuple, list],
+    *,
+    num_frm: int = 8,
+    fps: Optional[float] = None,
+    format="rgb24",
+    force_include_last_frame=False,
+) -> np.ndarray:
+    if format != "rgb24":
+        raise ValueError("Decord backend currently supports format='rgb24' only")
+
+    vr = _open_decord_reader(video_path)
+    try:
+        total_frames = len(vr)
+        get_avg_fps = getattr(vr, "get_avg_fps", None)
+        frame_rate = float(get_avg_fps()) if get_avg_fps is not None else None
+        sampled_frm = _compute_sample_count(total_frames, num_frm, fps, frame_rate)
+        indices = _compute_uniform_indices(total_frames, sampled_frm, force_include_last_frame=force_include_last_frame)
+        frames = vr.get_batch(indices.tolist()).asnumpy()
+        if frames.dtype != np.uint8:
+            frames = frames.astype(np.uint8)
+        return np.ascontiguousarray(frames)
+    finally:
+        del vr  # Release VideoReader before interpreter teardown.
 
 
 # This one is faster
@@ -105,38 +162,41 @@ def record_video_length_packet(container):
 
 
 def load_video_stream(container, num_frm: int = 8, fps: Optional[float] = None, force_include_last_frame=False):
-    # container = av.open(video_path)
-    total_frames = container.streams.video[0].frames
-    frame_rate = container.streams.video[0].average_rate
-    if fps is not None:
-        video_length = total_frames / frame_rate
-        num_frm = min(num_frm, int(video_length * fps))
-    sampled_frm = min(total_frames, num_frm)
-    indices = np.linspace(0, total_frames - 1, sampled_frm, dtype=int)
-    if force_include_last_frame:
-        last_frame = total_frames - 1
-        if last_frame not in indices:
-            indices = np.linspace(0, total_frames - 2, sampled_frm - 1, dtype=int)
-            indices = np.append(indices, last_frame)
+    stream = container.streams.video[0]
+    total_frames = int(stream.frames or 0)
+    if total_frames <= 0:
+        raise ValueError("Video stream does not report a reliable frame count")
 
-    return record_video_length_stream(container, indices)
+    frame_rate = float(stream.average_rate) if stream.average_rate is not None else None
+    sampled_frm = _compute_sample_count(total_frames, num_frm, fps, frame_rate)
+    indices = _compute_uniform_indices(total_frames, sampled_frm, force_include_last_frame=force_include_last_frame)
+    frames = record_video_length_stream(container, indices)
+    if len(frames) != len(indices):
+        raise RuntimeError(f"Video metadata reported {total_frames} frames, but only {len(frames)} sampled frames could be decoded")
+    return frames
 
 
-def load_video_packet(container, num_frm: int = 8, fps: Optional[float] = None):
+def load_video_packet(container, num_frm: int = 8, fps: Optional[float] = None, force_include_last_frame=False):
     frames = record_video_length_packet(container)
     total_frames = len(frames)
-    frame_rate = container.streams.video[0].average_rate
-    if fps is not None:
-        video_length = total_frames / frame_rate
-        num_frm = min(num_frm, int(video_length * fps))
-    sampled_frm = min(total_frames, num_frm)
-    indices = np.linspace(0, total_frames - 1, sampled_frm, dtype=int)
-
-    # Append the last frame index if not already included
-    if total_frames - 1 not in indices:
-        indices = np.append(indices, total_frames - 1)
-
+    stream = container.streams.video[0]
+    frame_rate = float(stream.average_rate) if stream.average_rate is not None else None
+    sampled_frm = _compute_sample_count(total_frames, num_frm, fps, frame_rate)
+    indices = _compute_uniform_indices(total_frames, sampled_frm, force_include_last_frame=force_include_last_frame)
     return [frames[i] for i in indices]
+
+
+def _frames_to_ndarray(frames, format: str) -> np.ndarray:
+    if not frames:
+        raise ValueError("Cannot decode frames from an empty video")
+
+    converted = [frame.to_ndarray(format=format) for frame in frames]
+    try:
+        output = np.stack(converted)
+    except ValueError as exc:
+        shapes = [frame.shape for frame in converted]
+        raise ValueError(f"Decoded video frames have inconsistent shapes: {shapes}") from exc
+    return np.ascontiguousarray(output)
 
 
 def read_video_torchcodec(
@@ -273,7 +333,7 @@ def read_video(
 
     Dispatches to the decode backend selected by *backend* (or the
     ``LMMS_VIDEO_DECODE_BACKEND`` env-var).  Supported backends:
-    ``pyav`` (default), ``torchcodec``, ``dali``.
+    ``pyav`` (default), ``torchcodec``, ``dali``, and legacy ``decord``.
 
     Args:
         video_path: Path to the video file.
@@ -305,13 +365,42 @@ def read_video(
             format=format,
             force_include_last_frame=force_include_last_frame,
         )
+    if selected_backend == "decord":
+        return read_video_decord(
+            resolved_path,
+            num_frm=num_frm,
+            fps=fps,
+            format=format,
+            force_include_last_frame=force_include_last_frame,
+        )
 
+    return read_video_pyav(
+        resolved_path,
+        num_frm=num_frm,
+        fps=fps,
+        format=format,
+        force_include_last_frame=force_include_last_frame,
+    )
+
+
+def read_video_pyav(
+    video_path: Union[str, tuple, list],
+    *,
+    num_frm: int = 8,
+    fps: Optional[float] = None,
+    format="rgb24",
+    force_include_last_frame=False,
+) -> np.ndarray:
+    """Decode with PyAV, falling back to a full packet scan when needed."""
+
+    resolved_path = _resolve_video_path(video_path)
+    av = _import_pyav()
     container = av.open(resolved_path)
-    container.streams.video[0].thread_type = "AUTO"
 
     try:
-        if "webm" not in resolved_path and "mkv" not in resolved_path:
-            # For mp4, we try loading with stream first
+        container.streams.video[0].thread_type = "AUTO"
+        packet_scan_required = resolved_path.lower().split("?", maxsplit=1)[0].endswith((".webm", ".mkv"))
+        if not packet_scan_required:
             try:
                 frames = load_video_stream(
                     container,
@@ -320,19 +409,24 @@ def read_video(
                     force_include_last_frame=force_include_last_frame,
                 )
             except Exception:
-                container.seek(0)
-                frames = record_video_length_packet(container)
+                # Reopen instead of seeking: a failed decode may leave the
+                # codec context in a state that is not reset by seek(0).
+                container.close()
+                container = av.open(resolved_path)
+                container.streams.video[0].thread_type = "AUTO"
+                frames = load_video_packet(
+                    container,
+                    num_frm,
+                    fps,
+                    force_include_last_frame=force_include_last_frame,
+                )
         else:
-            frames = record_video_length_packet(container)
-        first = frames[0].to_ndarray(format=format)
-        output = np.empty((len(frames),) + first.shape, dtype=first.dtype)
-        output[0] = first
-        for i, frame in enumerate(frames[1:], start=1):
-            output[i] = frame.to_ndarray(format=format)
-        return output
+            frames = load_video_packet(
+                container,
+                num_frm,
+                fps,
+                force_include_last_frame=force_include_last_frame,
+            )
+        return _frames_to_ndarray(frames, format)
     finally:
         container.close()  # Ensure container is closed to prevent resource leak
-
-
-# Backward-compat alias; will be removed in a future release.
-read_video_pyav = read_video

--- a/lmms_eval/models/simple/vllm.py
+++ b/lmms_eval/models/simple/vllm.py
@@ -5,6 +5,7 @@ import time
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Callable, List, Optional, Tuple, Union
 
+import numpy as np
 import torch.distributed as dist
 from accelerate import Accelerator, DistributedType
 from loguru import logger as eval_logger
@@ -59,8 +60,9 @@ class VLLM(lmms):
             Should be between 0.0 and 1.0. Default: 0.8
         batch_size (int): Number of requests to process in parallel per GPU.
             Default: 1
-        max_frame_num (int): Maximum number of frames to extract from videos.
-            Frames are sampled uniformly across the video duration. Default: 32
+        max_frame_num (int): Number of frames to extract from videos. Frames
+            are sampled uniformly; short clips repeat frames for compatibility
+            with the historical Decord path. Default: 32
         threads (int): Number of threads to use for parallel visual encoding.
             Default: 16
         trust_remote_code (bool, optional): Whether to trust remote code when loading
@@ -69,7 +71,8 @@ class VLLM(lmms):
             If None, uses the model's default template. Default: None
         video_decode_backend (str, optional): Video decoder used by the shared
             media loader. Defaults to PyAV and can also be set to ``torchcodec``
-            or ``dali``. ``LMMS_VIDEO_DECODE_BACKEND`` is used when omitted.
+            or ``dali``. Use ``decord`` for legacy reproduction runs.
+            ``LMMS_VIDEO_DECODE_BACKEND`` is used when omitted.
         **kwargs: Additional arguments passed to the VLLM LLM constructor.
             - NOTE: model specific arguments can be passed here without the need to add more arguments to this class (see example below)
             - String arguments that look like JSON dictionaries will be automatically parsed.
@@ -444,12 +447,18 @@ class VLLM(lmms):
 
     # Function to encode the video
     def encode_video(self, video_path):
+        # Decord historically returned max_frame_num entries by repeating
+        # indices for short clips. Decode each available frame once, then
+        # reproduce that adapter-level contract independently of the backend.
         frames = read_video(
             video_path,
             num_frm=self.max_frame_num,
             force_include_last_frame=True,
             backend=self.video_decode_backend,
         )
+        if 0 < len(frames) < self.max_frame_num:
+            repeat_indices = np.linspace(0, len(frames) - 1, self.max_frame_num, dtype=int)
+            frames = frames[repeat_indices]
 
         base64_frames = []
         for frame in frames:

--- a/lmms_eval/models/simple/vllm.py
+++ b/lmms_eval/models/simple/vllm.py
@@ -5,7 +5,6 @@ import time
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Callable, List, Optional, Tuple, Union
 
-import numpy as np
 import torch.distributed as dist
 from accelerate import Accelerator, DistributedType
 from loguru import logger as eval_logger
@@ -15,12 +14,9 @@ from lmms_eval.api.instance import Instance
 from lmms_eval.api.model import lmms
 from lmms_eval.api.registry import register_model
 from lmms_eval.imports import optional_import
+from lmms_eval.models.model_utils.load_video import read_video
 from lmms_eval.models.model_utils.media_encoder import encode_image_to_base64
 from lmms_eval.models.model_utils.progress import make_progress
-
-# decord has no wheels for some platforms (e.g. macOS); defer the import so the wrapper stays importable and only video-decoding paths require it.
-VideoReader, _HAS_DECORD = optional_import("decord", "VideoReader")
-cpu, _ = optional_import("decord", "cpu")
 
 NUM_SECONDS_TO_SLEEP = int(os.getenv("NUM_SECONDS_TO_SLEEP", "5"))
 WORKERS = int(os.getenv("WORKERS", "32"))
@@ -71,6 +67,9 @@ class VLLM(lmms):
             the model. Default: True
         chat_template (str, optional): Path to chat template file or template string.
             If None, uses the model's default template. Default: None
+        video_decode_backend (str, optional): Video decoder used by the shared
+            media loader. Defaults to PyAV and can also be set to ``torchcodec``
+            or ``dali``. ``LMMS_VIDEO_DECODE_BACKEND`` is used when omitted.
         **kwargs: Additional arguments passed to the VLLM LLM constructor.
             - NOTE: model specific arguments can be passed here without the need to add more arguments to this class (see example below)
             - String arguments that look like JSON dictionaries will be automatically parsed.
@@ -162,6 +161,7 @@ class VLLM(lmms):
         disable_log_stats: bool = False,
         image_first: bool = False,
         max_new_tokens: int = 1024,
+        video_decode_backend: Optional[str] = None,
         **kwargs,
     ) -> None:
         super().__init__()
@@ -176,6 +176,7 @@ class VLLM(lmms):
         self.tensor_parallel_size = int(tensor_parallel_size)
         self.image_first = image_first
         self.max_new_tokens = int(max_new_tokens)
+        self.video_decode_backend = video_decode_backend
         # Qwen 2/2.5-VL models enforce minimum image dimensions
         self._enforce_image_resize = self._is_qwen_vl_model(model)
 
@@ -443,16 +444,12 @@ class VLLM(lmms):
 
     # Function to encode the video
     def encode_video(self, video_path):
-        vr = VideoReader(video_path, ctx=cpu(0))
-        total_frame_num = len(vr)
-        uniform_sampled_frames = np.linspace(0, total_frame_num - 1, self.max_frame_num, dtype=int)
-
-        # Ensure the last frame is included
-        if total_frame_num - 1 not in uniform_sampled_frames:
-            uniform_sampled_frames = np.append(uniform_sampled_frames, total_frame_num - 1)
-
-        frame_idx = uniform_sampled_frames.tolist()
-        frames = vr.get_batch(frame_idx).asnumpy()
+        frames = read_video(
+            video_path,
+            num_frm=self.max_frame_num,
+            force_include_last_frame=True,
+            backend=self.video_decode_backend,
+        )
 
         base64_frames = []
         for frame in frames:

--- a/lmms_eval/protocol.py
+++ b/lmms_eval/protocol.py
@@ -8,9 +8,8 @@ from pydantic import BaseModel
 from lmms_eval.imports import optional_import
 from lmms_eval.models.model_utils.media_encoder import encode_image_to_base64
 
-# Optional video processing dependencies
-VideoReader, _has_decord = optional_import("decord", "VideoReader")
-cpu, _ = optional_import("decord", "cpu")
+# Optional video processing dependency. qwen-vl-utils selects and imports its
+# decoder lazily when a video is actually processed.
 fetch_video, _has_qwen_vl = optional_import("qwen_vl_utils", "fetch_video")
 
 

--- a/test/models/test_load_video.py
+++ b/test/models/test_load_video.py
@@ -1,0 +1,121 @@
+import importlib
+
+import numpy as np
+import pytest
+
+from lmms_eval.models.model_utils import load_video
+
+
+class _FakeDecordBatch:
+    def __init__(self, frames):
+        self._frames = frames
+
+    def asnumpy(self):
+        return self._frames
+
+
+class _FakeVideoReader:
+    last_indices = None
+
+    def __init__(self, path, ctx, num_threads):
+        self.path = path
+        self.ctx = ctx
+        self.num_threads = num_threads
+        self.frames = np.stack([np.full((2, 2, 3), value, dtype=np.uint8) for value in range(10)])
+
+    def __len__(self):
+        return len(self.frames)
+
+    def get_avg_fps(self):
+        return 10.0
+
+    def get_batch(self, indices):
+        type(self).last_indices = indices
+        return _FakeDecordBatch(self.frames[indices])
+
+
+class _FakeDecord:
+    VideoReader = _FakeVideoReader
+
+    @staticmethod
+    def cpu(device_id):
+        return ("cpu", device_id)
+
+
+def test_shared_decord_backend_is_lazy_and_uses_canonical_indices(monkeypatch):
+    real_import_module = importlib.import_module
+
+    def fake_import_module(name, *args, **kwargs):
+        if name == "decord":
+            return _FakeDecord
+        return real_import_module(name, *args, **kwargs)
+
+    monkeypatch.setattr(load_video.importlib, "import_module", fake_import_module)
+
+    frames = load_video.read_video("demo.mp4", num_frm=4, backend="decord", force_include_last_frame=True)
+
+    assert _FakeVideoReader.last_indices == [0, 3, 6, 9]
+    assert frames[:, 0, 0, 0].tolist() == [0, 3, 6, 9]
+
+
+def test_legacy_decord_helper_keeps_duplicate_short_video_indices(monkeypatch):
+    real_import_module = importlib.import_module
+
+    def fake_import_module(name, *args, **kwargs):
+        if name == "decord":
+            return _FakeDecord
+        return real_import_module(name, *args, **kwargs)
+
+    monkeypatch.setattr(load_video.importlib, "import_module", fake_import_module)
+    monkeypatch.setattr(
+        _FakeVideoReader,
+        "__init__",
+        lambda self, path, ctx, num_threads: setattr(
+            self,
+            "frames",
+            np.stack([np.full((2, 2, 3), value, dtype=np.uint8) for value in range(3)]),
+        ),
+    )
+
+    frames = load_video.load_video_decord("short.mp4", max_frames_num=5)
+
+    assert _FakeVideoReader.last_indices == [0, 0, 1, 1, 2]
+    assert frames[:, 0, 0, 0].tolist() == [0, 0, 1, 1, 2]
+
+
+def _write_matroska_video(path, frame_count):
+    av = pytest.importorskip("av")
+    container = av.open(str(path), mode="w")
+    stream = container.add_stream("ffv1", rate=10)
+    stream.width = 16
+    stream.height = 16
+    stream.pix_fmt = "yuv420p"
+
+    for index in range(frame_count):
+        array = np.full((16, 16, 3), index * 10, dtype=np.uint8)
+        frame = av.VideoFrame.from_ndarray(array, format="rgb24")
+        for packet in stream.encode(frame):
+            container.mux(packet)
+    for packet in stream.encode():
+        container.mux(packet)
+    container.close()
+
+
+def test_pyav_packet_fallback_samples_instead_of_returning_every_frame(tmp_path):
+    video_path = tmp_path / "unknown-frame-count.mkv"
+    _write_matroska_video(video_path, frame_count=12)
+
+    frames = load_video.read_video(video_path.as_posix(), num_frm=3, backend="pyav", force_include_last_frame=True)
+
+    assert frames.shape == (3, 16, 16, 3)
+    assert np.allclose(frames.mean(axis=(1, 2, 3)), [0, 50, 110], atol=2)
+
+
+def test_pyav_short_video_returns_each_source_frame_once(tmp_path):
+    video_path = tmp_path / "short.mkv"
+    _write_matroska_video(video_path, frame_count=4)
+
+    frames = load_video.read_video(video_path.as_posix(), num_frm=8, backend="pyav", force_include_last_frame=True)
+
+    assert frames.shape == (4, 16, 16, 3)
+    assert np.allclose(frames.mean(axis=(1, 2, 3)), [0, 10, 20, 30], atol=2)

--- a/test/models/test_vllm_video_encoder.py
+++ b/test/models/test_vllm_video_encoder.py
@@ -6,6 +6,10 @@ route video encoding through ``to_qwen3_vl_openai_messages`` only when
 ``is_qwen3_vl`` is set, on both request paths.
 """
 
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
 from types import SimpleNamespace
 
 import numpy as np
@@ -104,3 +108,46 @@ def test_simple_vllm_uses_shared_video_decoder(monkeypatch):
         "force_include_last_frame": True,
         "backend": "torchcodec",
     }
+
+
+def test_vllm_model_resolution_does_not_import_decord():
+    """Both the default chat route and force-simple route must stay Decord-free."""
+
+    repo_root = Path(__file__).resolve().parents[2]
+    script = textwrap.dedent(
+        """
+        import builtins
+        import importlib
+
+        real_import = builtins.__import__
+        real_import_module = importlib.import_module
+
+        def reject_decord(name, *args, **kwargs):
+            if name == "decord" or name.startswith("decord."):
+                raise RuntimeError(f"unexpected eager Decord import: {name}")
+            return real_import(name, *args, **kwargs)
+
+        def reject_decord_module(name, *args, **kwargs):
+            if name == "decord" or name.startswith("decord."):
+                raise RuntimeError(f"unexpected eager Decord import: {name}")
+            return real_import_module(name, *args, **kwargs)
+
+        builtins.__import__ = reject_decord
+        importlib.import_module = reject_decord_module
+
+        from lmms_eval import models
+
+        models.get_model("vllm")
+        models.get_model("vllm", force_simple=True)
+        """
+    )
+
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stdout + completed.stderr

--- a/test/models/test_vllm_video_encoder.py
+++ b/test/models/test_vllm_video_encoder.py
@@ -8,9 +8,11 @@ route video encoding through ``to_qwen3_vl_openai_messages`` only when
 
 from types import SimpleNamespace
 
+import numpy as np
 import pytest
 
 from lmms_eval.models.chat.vllm import VLLM
+from lmms_eval.models.simple import vllm as simple_vllm
 from lmms_eval.protocol import ChatMessages
 
 
@@ -76,3 +78,29 @@ def test_multi_round_path_routes_video_by_flag(encoder_calls):
     model = _video_model(False)
     model._to_openai_messages([{"role": "user", "content": [{"type": "text", "text": "hello"}]}])
     assert encoder_calls == ["qwen3vl", "openai"]
+
+
+def test_simple_vllm_uses_shared_video_decoder(monkeypatch):
+    model = simple_vllm.VLLM.__new__(simple_vllm.VLLM)
+    model.max_frame_num = 3
+    model.video_decode_backend = "torchcodec"
+    model.min_image_pixels = 1
+    model._enforce_image_resize = False
+    observed = {}
+
+    def fake_read_video(video_path, **kwargs):
+        observed.update({"video_path": video_path, **kwargs})
+        return np.stack([np.full((2, 2, 3), value, dtype=np.uint8) for value in range(3)])
+
+    monkeypatch.setattr(simple_vllm, "read_video", fake_read_video)
+    monkeypatch.setattr(simple_vllm, "encode_image_to_base64", lambda image, **kwargs: int(np.asarray(image)[0, 0, 0]))
+
+    encoded = model.encode_video("demo.mp4")
+
+    assert encoded == [0, 1, 2]
+    assert observed == {
+        "video_path": "demo.mp4",
+        "num_frm": 3,
+        "force_include_last_frame": True,
+        "backend": "torchcodec",
+    }

--- a/test/models/test_vllm_video_encoder.py
+++ b/test/models/test_vllm_video_encoder.py
@@ -110,6 +110,22 @@ def test_simple_vllm_uses_shared_video_decoder(monkeypatch):
     }
 
 
+def test_simple_vllm_repeats_short_video_frames_for_legacy_compatibility(monkeypatch):
+    model = simple_vllm.VLLM.__new__(simple_vllm.VLLM)
+    model.max_frame_num = 8
+    model.video_decode_backend = "pyav"
+    model.min_image_pixels = 1
+    model._enforce_image_resize = False
+
+    frames = np.stack([np.full((2, 2, 3), value, dtype=np.uint8) for value in range(4)])
+    monkeypatch.setattr(simple_vllm, "read_video", lambda *args, **kwargs: frames)
+    monkeypatch.setattr(simple_vllm, "encode_image_to_base64", lambda image, **kwargs: int(np.asarray(image)[0, 0, 0]))
+
+    encoded = model.encode_video("short.mp4")
+
+    assert encoded == [0, 0, 0, 1, 1, 2, 2, 3]
+
+
 def test_vllm_model_resolution_does_not_import_decord():
     """Both the default chat route and force-simple route must stay Decord-free."""
 


### PR DESCRIPTION
## Summary

- Prevent Decord from being imported when either the default chat vLLM route or the `--force_simple` vLLM route is merely resolved/imported, removing the native-library collision precondition reported in #1432 for image-only evaluations.
- Route simple-vLLM video decoding through the shared loader, defaulting to PyAV while retaining Decord as an explicit lazy legacy backend for reproducibility.
- Make PyAV fallback sampling correct for containers whose metadata reports `stream.frames == 0`, and preserve the historical vLLM short-video frame-count behavior at the adapter boundary.
- Add fresh-process import guards, real-container decoder tests, and short-video compatibility coverage.

Fixes #1432.

## Root Cause

The first revision removed Decord from `lmms_eval.models.simple.vllm`, but `--model vllm` resolves to the chat wrapper by default. That route imports `protocol.py`, which still eagerly imported two unused Decord symbols. As a result, the initial fix protected only `--force_simple`; the default route still mapped `libdecord.so`.

Decord 0.6.0 loads its native library globally and exports `__cxa_thread_atexit`. The reported teardown crash can therefore be triggered even by an image-only evaluation that never needs a video decoder.

## Implementation

### Import and backend isolation

- Remove the unused Decord imports from `protocol.py`.
- Lazily import PyAV, Decord, TorchCodec, or DALI only when the selected backend is actually used.
- Add `decord` to the shared decoder dispatcher as an explicit legacy backend.
- Keep `load_video_decord` and its duplicate-index behavior for existing adapters.

### Sampling correctness

- Use one uniform NumPy-linspace index policy across the random-access PyAV, TorchCodec, and Decord paths.
- When PyAV cannot trust the container frame count, decode packets to determine the real count and then sample the requested number of frames instead of returning the whole video.
- Reopen the PyAV container before packet fallback so a failed stream decode cannot leave a reused codec context in a partial state.
- Return unique source frames from the shared loader for short videos, then repeat them inside the simple-vLLM adapter to reproduce the historical Decord output-count contract without changing every shared-loader caller.

## Reproduction / Compatibility

Decord is **not removed**. Historical runs can pin it explicitly:

- Simple vLLM/shared loader: `--force_simple --model_args ...,video_decode_backend=decord`, or `LMMS_VIDEO_DECODE_BACKEND=decord`, with the `video-legacy` extra.
- Default chat vLLM: video decoding remains delegated to `qwen-vl-utils`; use its existing `FORCE_QWENVL_VIDEO_READER=decord` switch for historical chat-video reproduction.

Changing decoder libraries can alter seeking, demuxing, or color conversion for some codecs, so reproduction runs should pin both the backend and dependency versions rather than assume all decoders are bit-identical.

## Validation

### Targeted tests

```text
python -m pytest -q \
  test/models/test_load_video.py \
  test/models/test_vllm_video_encoder.py \
  test/models/test_vllm_sampling_contract.py \
  test/models/test_vllm_sampling_params.py \
  test/models/test_model_registry_v2.py

31 passed
```

### Fresh-process import matrix

Tested with Decord 0.6.0 installed:

| Revision | Default chat route | `force_simple=True` |
|---|---|---|
| Pre-PR `59385164` | Decord imported; `libdecord.so` mapped | imported; mapped |
| Current `1937e31b` | **not imported; not mapped** | **not imported; not mapped** |

A `dlsym`/`dladdr` probe resolved process-global `__cxa_thread_atexit` directly to Decord's `libdecord.so` after importing Decord. On the current head, neither vLLM model-resolution route loads that module or native library.

### Real video decoding

Generated 100-frame and 4-frame videos in MP4, Matroska, WebM, FLV, and WMV:

- All long videos returned the requested 8 frames from PyAV and Decord.
- All short videos returned 4 unique shared-loader frames and the historical 8-frame repeated vLLM sequence.
- Matroska, WebM, FLV, and WMV reported `stream.frames == 0`; PyAV still returned exactly 8/4 sampled frames instead of every decoded frame.
- MP4, Matroska, WebM, and FLV were pixel-identical between PyAV and Decord in this corpus.
- Long WMV exposed a Decord 0.6 random-access difference, while the explicit Decord path still matched the old vLLM adapter byte-for-byte. This confirms both the value of the safer PyAV default and the need to retain a pinnable Decord compatibility path.
- `fps` sampling, one-frame endpoint selection, environment backend selection, and short-frame repetition matched their contracts.

### Teardown and static checks

- 24 fresh processes completed cleanly: 12 alternating current chat/simple resolution processes asserting Decord was not mapped, plus 12 explicit Decord decode processes.
- Ruff check/format, `git diff --check`, and the remote lint workflow passed.

## Risk / Compatibility

- The simple-vLLM default video backend changes from Decord to PyAV. Explicit Decord selection preserves old adapter output when exact historical behavior is required.
- Default chat-vLLM video processing still follows qwen-vl-utils backend selection; this PR fixes its eager image-only import path rather than replacing that video pipeline.
- TorchCodec and DALI remain optional and depend on compatible external runtimes. They should not be assumed bit-identical to PyAV or Decord.
- The original issue used Intel XPU, glibc 2.39, and an XPU vLLM nightly. The import collision was reproduced and structurally removed on NVIDIA H800/glibc 2.31, but the original POPE command should still be rerun in the reporter's exact container for platform-identical teardown confirmation.
- Image-only vLLM evaluation behavior is otherwise unchanged.

## Out of Scope

- Removing Decord from unrelated model adapters.
- Replacing qwen-vl-utils' chat-video decoder pipeline.
- Claiming universal bit-exact equivalence across decoder libraries or codecs.

## Type of Change

- [x] Bug fix (non-breaking change)
- [ ] New feature
- [ ] New benchmark/task
- [ ] New model integration
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
