### PR TITLE
docs: update localized README hero images

### DIFF
--- a/docs/i18n/README_ar.md
+++ b/docs/i18n/README_ar.md
@@ -1,5 +1,5 @@
-<p align="center" width="70%">
-<img src="https://i.postimg.cc/KvkLzbF9/WX20241212-014400-2x.png">
+<p align="center">
+  <img src="../images/lmms-eval-hero.avif" alt="LMMs-Eval" width="70%">
 </p>
 
 <div dir="rtl">

--- a/docs/i18n/README_de.md
+++ b/docs/i18n/README_de.md
@@ -1,5 +1,5 @@
-<p align="center" width="70%">
-<img src="https://i.postimg.cc/KvkLzbF9/WX20241212-014400-2x.png">
+<p align="center">
+  <img src="../images/lmms-eval-hero.avif" alt="LMMs-Eval" width="70%">
 </p>
 
 # Evaluierungssuite für Große Multimodale Modelle

--- a/docs/i18n/README_es.md
+++ b/docs/i18n/README_es.md
@@ -1,5 +1,5 @@
-<p align="center" width="70%">
-<img src="https://i.postimg.cc/KvkLzbF9/WX20241212-014400-2x.png">
+<p align="center">
+  <img src="../images/lmms-eval-hero.avif" alt="LMMs-Eval" width="70%">
 </p>
 
 # Suite de Evaluación de Modelos Multimodales de Gran Escala

--- a/docs/i18n/README_fr.md
+++ b/docs/i18n/README_fr.md
@@ -1,5 +1,5 @@
-<p align="center" width="70%">
-<img src="https://i.postimg.cc/KvkLzbF9/WX20241212-014400-2x.png">
+<p align="center">
+  <img src="../images/lmms-eval-hero.avif" alt="LMMs-Eval" width="70%">
 </p>
 
 # Suite d'Évaluation des Grands Modèles Multimodaux

--- a/docs/i18n/README_hi.md
+++ b/docs/i18n/README_hi.md
@@ -1,5 +1,5 @@
-<p align="center" width="70%">
-<img src="https://i.postimg.cc/KvkLzbF9/WX20241212-014400-2x.png">
+<p align="center">
+  <img src="../images/lmms-eval-hero.avif" alt="LMMs-Eval" width="70%">
 </p>
 
 # बड़े मल्टीमॉडल मॉडल मूल्यांकन सूट

--- a/docs/i18n/README_id.md
+++ b/docs/i18n/README_id.md
@@ -1,5 +1,5 @@
-<p align="center" width="70%">
-<img src="https://i.postimg.cc/KvkLzbF9/WX20241212-014400-2x.png">
+<p align="center">
+  <img src="../images/lmms-eval-hero.avif" alt="LMMs-Eval" width="70%">
 </p>
 
 # Suite Evaluasi Model Multimodal Besar

--- a/docs/i18n/README_it.md
+++ b/docs/i18n/README_it.md
@@ -1,5 +1,5 @@
-<p align="center" width="70%">
-<img src="https://i.postimg.cc/KvkLzbF9/WX20241212-014400-2x.png">
+<p align="center">
+  <img src="../images/lmms-eval-hero.avif" alt="LMMs-Eval" width="70%">
 </p>
 
 # Suite di Valutazione per Grandi Modelli Multimodali

--- a/docs/i18n/README_ja.md
+++ b/docs/i18n/README_ja.md
@@ -1,5 +1,5 @@
-<p align="center" width="70%">
-<img src="https://i.postimg.cc/KvkLzbF9/WX20241212-014400-2x.png">
+<p align="center">
+  <img src="../images/lmms-eval-hero.avif" alt="LMMs-Eval" width="70%">
 </p>
 
 # 大規模マルチモーダルモデル評価スイート

--- a/docs/i18n/README_ko.md
+++ b/docs/i18n/README_ko.md
@@ -1,5 +1,5 @@
-<p align="center" width="70%">
-<img src="https://i.postimg.cc/KvkLzbF9/WX20241212-014400-2x.png">
+<p align="center">
+  <img src="../images/lmms-eval-hero.avif" alt="LMMs-Eval" width="70%">
 </p>
 
 # 대규모 멀티모달 모델 평가 스위트

--- a/docs/i18n/README_nl.md
+++ b/docs/i18n/README_nl.md
@@ -1,5 +1,5 @@
-<p align="center" width="70%">
-<img src="https://i.postimg.cc/KvkLzbF9/WX20241212-014400-2x.png">
+<p align="center">
+  <img src="../images/lmms-eval-hero.avif" alt="LMMs-Eval" width="70%">
 </p>
 
 # Evaluatiesuite voor Grote Multimodale Modellen

--- a/docs/i18n/README_pl.md
+++ b/docs/i18n/README_pl.md
@@ -1,5 +1,5 @@
-<p align="center" width="70%">
-<img src="https://i.postimg.cc/KvkLzbF9/WX20241212-014400-2x.png">
+<p align="center">
+  <img src="../images/lmms-eval-hero.avif" alt="LMMs-Eval" width="70%">
 </p>
 
 # Pakiet Ewaluacyjny dla Dużych Modeli Multimodalnych

--- a/docs/i18n/README_pt-BR.md
+++ b/docs/i18n/README_pt-BR.md
@@ -1,5 +1,5 @@
-<p align="center" width="70%">
-<img src="https://i.postimg.cc/KvkLzbF9/WX20241212-014400-2x.png">
+<p align="center">
+  <img src="../images/lmms-eval-hero.avif" alt="LMMs-Eval" width="70%">
 </p>
 
 # Suite de Avaliação de Grandes Modelos Multimodais

--- a/docs/i18n/README_ru.md
+++ b/docs/i18n/README_ru.md
@@ -1,5 +1,5 @@
-<p align="center" width="70%">
-<img src="https://i.postimg.cc/KvkLzbF9/WX20241212-014400-2x.png">
+<p align="center">
+  <img src="../images/lmms-eval-hero.avif" alt="LMMs-Eval" width="70%">
 </p>
 
 # Набор Инструментов для Оценки Больших Мультимодальных Моделей

--- a/docs/i18n/README_tr.md
+++ b/docs/i18n/README_tr.md
@@ -1,5 +1,5 @@
-<p align="center" width="70%">
-<img src="https://i.postimg.cc/KvkLzbF9/WX20241212-014400-2x.png">
+<p align="center">
+  <img src="../images/lmms-eval-hero.avif" alt="LMMs-Eval" width="70%">
 </p>
 
 # Büyük Çok Modlu Modeller için Değerlendirme Paketi

--- a/docs/i18n/README_vi.md
+++ b/docs/i18n/README_vi.md
@@ -1,5 +1,5 @@
-<p align="center" width="70%">
-<img src="https://i.postimg.cc/KvkLzbF9/WX20241212-014400-2x.png">
+<p align="center">
+  <img src="../images/lmms-eval-hero.avif" alt="LMMs-Eval" width="70%">
 </p>
 
 # Bộ Công Cụ Đánh Giá Mô Hình Đa Phương Thức Lớn

--- a/docs/i18n/README_zh-CN.md
+++ b/docs/i18n/README_zh-CN.md
@@ -1,5 +1,5 @@
-<p align="center" width="70%">
-<img src="https://i.postimg.cc/KvkLzbF9/WX20241212-014400-2x.png">
+<p align="center">
+  <img src="../images/lmms-eval-hero.avif" alt="LMMs-Eval" width="70%">
 </p>
 
 # 大型多模态模型评估套件

--- a/docs/i18n/README_zh-TW.md
+++ b/docs/i18n/README_zh-TW.md
@@ -1,5 +1,5 @@
-<p align="center" width="70%">
-<img src="https://i.postimg.cc/KvkLzbF9/WX20241212-014400-2x.png">
+<p align="center">
+  <img src="../images/lmms-eval-hero.avif" alt="LMMs-Eval" width="70%">
 </p>
 
 # 大型多模態模型評估套件


### PR DESCRIPTION
## Summary

- Update all 17 localized READMEs to use the repository-hosted AVIF hero added in #1478.
- Match the root README markup, including centered layout, descriptive alt text, and 70% display width.
- Remove all remaining references to the old externally hosted hero PNG.

## Scope

- Documentation only; translated prose and other documentation images are unchanged.

## Validation

- `git diff --check`
- Verified 17/17 localized READMEs reference `../images/lmms-eval-hero.avif`.
- Verified the relative image path resolves to `docs/images/lmms-eval-hero.avif`.
- Verified zero references remain to `WX20241212-014400-2x.png`.

## Type of Change

- [ ] Bug fix (non-breaking change)
- [ ] New feature
- [ ] New benchmark/task
- [ ] New model integration
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring (no functional changes)