### PR TITLE
docs: fix hero image rendering on PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="docs/images/lmms-eval-hero.avif" alt="LMMs-Eval" width="70%">
+  <img src="https://raw.githubusercontent.com/EvolvingLMMs-Lab/lmms-eval/main/docs/images/lmms-eval-hero.avif" alt="LMMs-Eval" width="70%">
 </p>
 
 # LMMs-Eval: Probing Intelligence in the Real World


### PR DESCRIPTION
## Summary

- Replace the root README hero's repository-relative path with an absolute, repository-owned Raw GitHub URL.
- Keep the optimized AVIF asset introduced in #1478 while making it available to PyPI's long-description renderer.

## Context

This is a follow-up to #1478 and #1484. The relative `docs/images/lmms-eval-hero.avif` path renders on GitHub, but PyPI proxies it to a `pypi-camo` URL that returns 404. The localized READMEs updated in #1484 remain relative because GitHub renders those files in repository context.

## Validation

- `git diff --check`
- Raw asset request: `HTTP 200`, `content-type: image/avif`, 33,366 bytes
- PyPI-compatible `readme-renderer[md]`: pass
- Diff scope: one line in `README.md`

## Type of Change

- [x] Bug fix (non-breaking change)
- [ ] New feature
- [ ] New benchmark/task
- [ ] New model integration
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring (no functional changes)