### PR TITLE
chore: update PyPI homepage URL

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -212,7 +212,7 @@ lmms-eval-mcp = "lmms_eval.mcp:main"
 lmms-eval-ui = "lmms_eval.tui.cli:main"
 
 [project.urls]
-Homepage = "https://lmms-lab.github.io"
+Homepage = "https://www.lmms-lab.com/"
 Repository = "https://github.com/EvolvingLMMs-Lab/lmms-eval"
 
 [dependency-groups]


### PR DESCRIPTION
## Summary
- Update the package Homepage URL to `https://www.lmms-lab.com/`.
- Ensure future PyPI releases show the current LMMs-Lab site under Project links.

## In scope
- Change `[project.urls].Homepage` in `pyproject.toml`.

## Out of scope
- Existing historical blog and release links under `lmms-lab.github.io`.
- Republishing or modifying the already released `0.7.3` package.

## Validation
- `uv run --no-project --python 3.11 python -c ...` | sample size: `N=1` metadata file | key metrics: parsed Homepage matches the new URL | result: pass
- `curl --fail --location https://www.lmms-lab.com/` | sample size: `N=1` URL | key metrics: HTTP 200 | result: pass
- `git diff --check` | sample size: `N=1` changed file | key metrics: no whitespace errors | result: pass

## Risk / Compatibility
- Metadata-only change; the updated Homepage appears on PyPI with the next release.

## Type of Change
- [ ] Bug fix (non-breaking change)
- [ ] New feature
- [ ] New benchmark/task
- [ ] New model integration
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring (no functional changes)