### PR TITLE
fix(video_llava): pass num_frm to read_video by keyword

### DIFF
--- a/lmms_eval/models/simple/video_llava.py
+++ b/lmms_eval/models/simple/video_llava.py
@@ -179,7 +179,7 @@ class VideoLLaVA(lmms):
             visuals = [doc_to_visual(self.task_dict[task][split][doc_id])]
             visuals = self.flatten(visuals)
             assert len(visuals) == 1
-            clip = read_video(visuals[0], self.num_frames)
+            clip = read_video(visuals[0], num_frm=self.num_frames)
 
             inputs = self._processor(text=self.prompt.format(contexts), videos=clip, return_tensors="pt")
             pixel_values_videos = inputs["pixel_values_videos"]


### PR DESCRIPTION
## What

`VideoLLaVA.generate_until` cannot run. `read_video`'s frame-count parameter is
keyword-only:

```python
# lmms_eval/models/model_utils/load_video.py
def read_video(video_path, *, num_frm=8, fps=None, format="rgb24",
               force_include_last_frame=False, backend=None) -> np.ndarray:
```

but `video_llava.py` passes it positionally:

```python
clip = read_video(visuals[0], self.num_frames)
# TypeError: read_video() takes 1 positional argument but 2 were given
```

This is on the only response path of the model, so every request fails before
the processor is reached.

## Why this is a call-site slip and not intended

Twelve of the fourteen `read_video(...)` call sites in
`lmms_eval/models/simple/` already pass the count by keyword — including
`llama_vid.py:217`, which uses the identical attribute name:

```
auroracap.py:432/436   read_video(visuals[0], num_frm=self.max_frames_num)
gemma3.py:258          read_video(visual,     num_frm=self.max_num_frames)
llama_vid.py:217       read_video(visual,     num_frm=self.num_frames)      <- same field
llava_onevision.py     read_video(visual[0],  num_frm=self.max_frames_num)  (x3)
longva.py:412          read_video(visual[0],  num_frm=self.max_frames_num)
oryx.py:357            read_video(visual,     num_frm=self.max_frames_num)
qwen2_5_omni.py:218    read_video(visual,     num_frm=self.max_num_frames, fps=self.fps)
video_chatgpt.py:116   read_video(visual,     num_frm=self.num_frm)
vila.py:305            read_video(visual,     num_frm=num_video_frames)
```

`video_llava.py:182` and `llava_vid.py:464` are the only two that don't.

## Scope

This PR changes **only** `video_llava.py:182`.

`llava_vid.py:464` is broken too, but differently and more deeply — its `pyav`
branch passes three positionals plus an unsupported `force_sample=` keyword,
*and* unpacks the result into `video, frame_time, video_time` while
`read_video` returns a single `ndarray`. Making that branch work means
deciding what `frame_time` / `video_time` should be for the pyav path, which is
a design call for a maintainer, so I left it alone rather than guessing. Happy
to follow up if you tell me the intended shape.

## Verification

No model weights or video files needed: I parsed `read_video`'s real signature
out of `load_video.py` with `ast`, and replayed every `read_video(...)` call
site through `inspect.Signature.bind`, before and after the change, with
`llama_vid.py` as the control:

```
read_video signature: (video_path, *, num_frm=8, fps=None, format=..., force_include_last_frame=..., backend=None)

== BEFORE ==
  FAIL  video_llava:182        read_video(<pos>, <pos>)   -> TypeError: too many positional arguments
  OK    llama_vid (sibling):217 read_video(<pos>, num_frm=...)

== AFTER ==
  OK    video_llava:182        read_video(<pos>, num_frm=...)
  OK    llama_vid (sibling):217 read_video(<pos>, num_frm=...)

== llava_vid (NOT touched by this PR) ==
  FAIL  llava_vid:464 read_video(<pos>, <pos>, <pos>, force_sample=...) -> TypeError: too many positional arguments
```

`ruff` at the version pinned in `.pre-commit-config.yaml` (`v0.16.4`), from the
repo root:

```
ruff check lmms_eval/models/simple/video_llava.py    # All checks passed!
ruff format --check ...                              # 1 file already formatted
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
