### PR TITLE
feat: add LongVideo-Reason long-video reasoning benchmark

### DIFF
--- a/docs/advanced/current_tasks.md
+++ b/docs/advanced/current_tasks.md
@@ -378,6 +378,7 @@ python -m lmms_eval --tasks list_with_num
 - [LEMONADE](https://huggingface.co/datasets/amathislab/LEMONADE) (lemonade)
 - [LongTimescope](https://longtimescope.github.io/) (longtimescope)
 - [LongVT](https://longvt-bench.github.io/) (longvt) - Tool-based long video understanding
+- [LongVideo-Reason](https://huggingface.co/datasets/LongVideo-Reason/longvideo-reason) (longvideo_reason) - Long-video reasoning over temporal, goal, spatial and plot perspectives ([code](https://github.com/NVlabs/Long-RL))
 - [LongVideoBench](https://github.com/longvideobench/LongVideoBench) (longvideobench)
 - [NEPTUNE](https://github.com/google-deepmind/neptune) (neptune)
   - Video-path subsets: neptune_full_v, neptune_mma_v, neptune_mmh_v

--- a/lmms_eval/tasks/longvideo_reason/README.md
+++ b/lmms_eval/tasks/longvideo_reason/README.md
@@ -68,6 +68,17 @@ when it does not yield an offered option letter: `\boxed{X}`, then the shared
 already resolves is returned unchanged and `overall >= strict` holds by construction.
 Letters the example does not actually offer are always rejected.
 
+**The fallback is scoped to the `<answer>` span before it is tried on the whole completion,
+and that ordering is load-bearing.** `extract_mcq_answer` ranks "the text starts with a
+standalone choice letter" at its highest priority, which is exactly the dominant answer form
+on this benchmark — in an 8-item run against Qwen3-VL-8B-Instruct **every** answer span read
+`B. <option text restated>` and not one was a bare letter. That top-priority rule can only fire
+if the extractor is handed the span. Given the whole completion it never matches, and a
+response that dismisses the other options by name ("…not learning from others (D)") is then
+decided by the lower-priority `parentheses` rule on a distractor. Measured: scoring the whole
+completion gave 6/8, scoping to the span gives 7/8 on the same generations, and the one
+remaining miss is a genuine model error.
+
 The official implementation additionally tries `math_verify.parse`/`verify` before its regex
 path. On a single-letter multiple-choice answer that symbolic path adds nothing the regex
 path does not already cover, so it is omitted here.
@@ -78,11 +89,11 @@ Qwen3-VL-8B-Instruct, 8 items, 64 frames, greedy:
 
 | Metric | Value |
 | --- | --- |
-| `longvideo_reason_overall_accuracy` | **75.0** |
+| `longvideo_reason_overall_accuracy` | **87.5** |
 | `longvideo_reason_strict_accuracy` | **0.0** |
 | `longvideo_reason_format_accuracy` | **0.0** |
 
-The model answered 6 of 8 correctly and scored **zero** under the official comparison. It
+The model answered 7 of 8 correctly and scored **zero** under the official comparison. It
 writes a fluent paragraph of reasoning and never emits the `<think>`/`<answer>` tags, so the
 official extractor falls back to comparing the *entire completion* against the gold letter,
 which can never match. This is not a corner case: it is the default behaviour of any model

--- a/lmms_eval/tasks/longvideo_reason/README.md
+++ b/lmms_eval/tasks/longvideo_reason/README.md
@@ -89,8 +89,16 @@ path does not already cover, so it is omitted here.
 
 ## Frame budget
 
-The videos are long — many run past an hour — so the frame budget matters more here than on a
-short-clip benchmark, and it is not fixed by the task. The reference implementation passes the
-whole video to the model and leaves sampling to the model wrapper; the paper evaluates
-LongVILA-R1 at 512 frames. Pass the budget through the model arguments and **always report it
-next to the score**, for example `--model_args ...,max_frames_num=64`.
+The frame budget is not fixed by the task, and it matters more here than on a short-clip
+benchmark. Measured over 607 of the 991 videos with torchcodec:
+
+| | p5 | p25 | p50 | p75 | p95 | max |
+| --- | --- | --- | --- | --- | --- | --- |
+| duration | 1.8 min | 3.3 min | **6.1 min** | 9.9 min | 15.4 min | 26.6 min |
+
+Mean 6.9 min, 79.1% under 10 minutes, none over 30. "Long" is relative to the 30 s – 3 min
+clips of most video benchmarks, not absolute — a budget chosen for hour-long footage
+oversamples here. The reference implementation passes the whole video to the model and leaves
+sampling to the model wrapper; the paper evaluates LongVILA-R1 at 512 frames, which on a
+6-minute video is roughly one frame every 0.7 s. Pass the budget through the model arguments
+and **always report it next to the score**, for example `--model_args ...,max_frames_num=64`.

--- a/lmms_eval/tasks/longvideo_reason/README.md
+++ b/lmms_eval/tasks/longvideo_reason/README.md
@@ -1,0 +1,91 @@
+# LongVideo-Reason
+
+This task ports the official [LongVideo-Reason-eval](https://github.com/NVlabs/Long-RL)
+protocol from "Scaling RL to Long Videos" ([arXiv:2507.07966](https://arxiv.org/abs/2507.07966)),
+the benchmark introduced alongside LongVILA-R1. It is a balanced set of 1,000 long-video
+questions across four reasoning perspectives: **temporal** (294), **goal and purpose** (288),
+**plot and narrative** (283) and **spatial** (135). Each example is a four-option
+multiple-choice question whose options are already embedded in the question text.
+
+```bash
+accelerate launch -m lmms_eval --model <model> --tasks longvideo_reason --batch_size 1
+```
+
+## Getting the data
+
+The annotations and the videos live in **two different repositories**, and only the
+annotations download automatically.
+
+* Annotations — [`LongVideo-Reason/longvideo-reason`](https://huggingface.co/datasets/LongVideo-Reason/longvideo-reason),
+  `test` split, 1,000 rows.
+* Videos — [`LongVideo-Reason/longvideo_eval_videos`](https://huggingface.co/datasets/LongVideo-Reason/longvideo_eval_videos),
+  ten `longvideo_eval_subset<N>.tar.gz` shards totalling **195 GB**.
+
+Extract every shard into one parent directory so that a `longvila_videos/` directory results,
+then point the task at the **parent**:
+
+```bash
+export LONGVIDEO_REASON_VIDEO_DIR=/path/to/parent   # contains longvila_videos/
+```
+
+`LONGVIDEO_REASON_ROOT` and the usual `LMMS_EVAL_MEDIA_ROOT` / `$HF_HOME/longvideo_reason`
+fallbacks also work. The split ships **867 `.mp4`, 130 `.webm` and 3 `.mkv`** files, so a
+decoding stack that only handles MP4 silently loses 13% of the benchmark.
+
+## Metrics
+
+| Metric | Definition |
+| --- | --- |
+| `longvideo_reason_overall_accuracy` | Headline accuracy over all 1,000 rows, using the layered extractor below. |
+| `longvideo_reason_strict_accuracy` | Accuracy under the official byte-exact string comparison. Reproduces the paper's number. |
+| `longvideo_reason_wellformed_accuracy` | Accuracy over the 995 rows whose option block is intact (see below). |
+| `longvideo_reason_format_accuracy` | Share of completions matching `<think>...</think>\s*<answer>...</answer>`, the official `format_reward`. |
+| `longvideo_reason_{temporal,goal,spatial,plot}_accuracy` | Per-perspective accuracy, the four-way breakdown the paper reports. |
+
+The official reference implementation (`longvideo-reason/eval.py`) computes only overall
+accuracy and format accuracy; the per-perspective split is reported in the paper but not
+computed there, so this task derives it from the `problem_type` field.
+
+### Answer extraction
+
+Two numbers are reported on purpose, because the official comparison is strict enough that
+small formatting differences dominate it.
+
+`longvideo_reason_strict_accuracy` reproduces `accuracy_reward()` exactly: the `<answer>...
+</answer>` span of the completion is compared to the `<answer>...</answer>` span of the gold
+with `==`, after the official `"Therefore the final answer is: "` special case. No
+normalisation. A completion of `<answer>B.</answer>` against a gold of `<answer>B</answer>`
+scores **zero** under this metric, and that is upstream behaviour, not a bug to repair.
+
+`longvideo_reason_overall_accuracy` runs the official extraction first and only falls back
+when it does not yield an offered option letter: `\boxed{X}`, then the shared
+`extract_mcq_answer` cascade. Every layer is additive, so a completion the official parser
+already resolves is returned unchanged and `overall >= strict` holds by construction.
+Letters the example does not actually offer are always rejected.
+
+The official implementation additionally tries `math_verify.parse`/`verify` before its regex
+path. On a single-letter multiple-choice answer that symbolic path adds nothing the regex
+path does not already cover, so it is omitted here.
+
+## Reading the score
+
+> **The answer key is not uniform. Read the accuracy against 44.1%, not 25%.**
+> The gold distribution over the 1,000 test rows is **B = 441, C = 299, A = 153, D = 107**.
+> A model that always answers `B` scores 44.1%. A model scoring near 44% has not
+> necessarily learned anything, and a model below it is worse than a constant.
+
+> **Five rows (0.5%) carry a malformed option block.** In `problem_id` 147, 743 and 825 the
+> data generator leaked its own deliberation into the options
+> (`"A. But this requires the test-taker to weigh..."`), and `problem_id` 379 and 857 ship
+> with **no options at all** and cannot be answered as multiple choice by any model. They are
+> deliberately **kept**, because upstream scores all 1,000 and changing the denominator would
+> make this task incomparable with the paper. `longvideo_reason_wellformed_accuracy` reports
+> the clean 995 beside the headline so the contamination stays visible.
+
+## Frame budget
+
+The videos are long — many run past an hour — so the frame budget matters more here than on a
+short-clip benchmark, and it is not fixed by the task. The reference implementation passes the
+whole video to the model and leaves sampling to the model wrapper; the paper evaluates
+LongVILA-R1 at 512 frames. Pass the budget through the model arguments and **always report it
+next to the score**, for example `--model_args ...,max_frames_num=64`.

--- a/lmms_eval/tasks/longvideo_reason/README.md
+++ b/lmms_eval/tasks/longvideo_reason/README.md
@@ -72,6 +72,25 @@ The official implementation additionally tries `math_verify.parse`/`verify` befo
 path. On a single-letter multiple-choice answer that symbolic path adds nothing the regex
 path does not already cover, so it is omitted here.
 
+#### Why both numbers are reported — measured
+
+Qwen3-VL-8B-Instruct, 8 items, 64 frames, greedy:
+
+| Metric | Value |
+| --- | --- |
+| `longvideo_reason_overall_accuracy` | **75.0** |
+| `longvideo_reason_strict_accuracy` | **0.0** |
+| `longvideo_reason_format_accuracy` | **0.0** |
+
+The model answered 6 of 8 correctly and scored **zero** under the official comparison. It
+writes a fluent paragraph of reasoning and never emits the `<think>`/`<answer>` tags, so the
+official extractor falls back to comparing the *entire completion* against the gold letter,
+which can never match. This is not a corner case: it is the default behaviour of any model
+that has not been fine-tuned to emit that exact format. `longvideo_reason_strict_accuracy`
+therefore reproduces the paper's protocol faithfully, and
+`longvideo_reason_overall_accuracy` is the number that separates models. Quote whichever you
+mean, and say which one.
+
 ## Reading the score
 
 > **The answer key is not uniform. Read the accuracy against 44.1%, not 25%.**
@@ -101,4 +120,5 @@ clips of most video benchmarks, not absolute — a budget chosen for hour-long f
 oversamples here. The reference implementation passes the whole video to the model and leaves
 sampling to the model wrapper; the paper evaluates LongVILA-R1 at 512 frames, which on a
 6-minute video is roughly one frame every 0.7 s. Pass the budget through the model arguments
-and **always report it next to the score**, for example `--model_args ...,max_frames_num=64`.
+and **always report it next to the score**. The argument name is wrapper-specific, e.g.
+`--model_args pretrained=...,max_num_frames=64` for `qwen3_vl`.

--- a/lmms_eval/tasks/longvideo_reason/README.md
+++ b/lmms_eval/tasks/longvideo_reason/README.md
@@ -21,12 +21,17 @@ annotations download automatically.
 * Videos — [`LongVideo-Reason/longvideo_eval_videos`](https://huggingface.co/datasets/LongVideo-Reason/longvideo_eval_videos),
   ten `longvideo_eval_subset<N>.tar.gz` shards totalling **195 GB**.
 
-Extract every shard into one parent directory so that a `longvila_videos/` directory results,
-then point the task at the **parent**:
+Extract every shard into one directory and point the task at it:
 
 ```bash
-export LONGVIDEO_REASON_VIDEO_DIR=/path/to/parent   # contains longvila_videos/
+export LONGVIDEO_REASON_VIDEO_DIR=/path/to/videos
 ```
+
+> **The archives do not produce the documented layout.** Every annotation's `videos` field
+> reads `longvila_videos/<stem>.<ext>` and the upstream README describes that path, but each
+> shard actually extracts into its own flat `longvideo_eval_subset<N>/` directory. A resolver
+> that only knows the documented layout reports a complete 195 GB download as 1,000 missing
+> videos. This task searches both layouts, so either works.
 
 `LONGVIDEO_REASON_ROOT` and the usual `LMMS_EVAL_MEDIA_ROOT` / `$HF_HOME/longvideo_reason`
 fallbacks also work. The split ships **867 `.mp4`, 130 `.webm` and 3 `.mkv`** files, so a

--- a/lmms_eval/tasks/longvideo_reason/__init__.py
+++ b/lmms_eval/tasks/longvideo_reason/__init__.py
@@ -1,0 +1,1 @@
+"""LongVideo-Reason-eval long-video reasoning task."""

--- a/lmms_eval/tasks/longvideo_reason/_default_template_yaml
+++ b/lmms_eval/tasks/longvideo_reason/_default_template_yaml
@@ -1,0 +1,49 @@
+dataset_path: LongVideo-Reason/longvideo-reason
+dataset_kwargs:
+  cache_dir: longvideo_reason
+  video: true
+  create_link: true
+test_split: test
+output_type: generate_until
+cluster_key: videos
+doc_to_visual: !function utils.longvideo_reason_doc_to_visual
+doc_to_text: !function utils.longvideo_reason_doc_to_text
+doc_to_target: !function utils.longvideo_reason_doc_to_target
+generation_kwargs:
+  max_new_tokens: 2048
+  temperature: 0
+  top_p: 1.0
+  num_beams: 1
+  do_sample: false
+process_results: !function utils.longvideo_reason_process_results
+metric_list:
+  - metric: longvideo_reason_overall_accuracy
+    aggregation: !function utils.longvideo_reason_aggregate_overall
+    higher_is_better: true
+  - metric: longvideo_reason_strict_accuracy
+    aggregation: !function utils.longvideo_reason_aggregate_strict
+    higher_is_better: true
+  - metric: longvideo_reason_wellformed_accuracy
+    aggregation: !function utils.longvideo_reason_aggregate_wellformed
+    higher_is_better: true
+  - metric: longvideo_reason_format_accuracy
+    aggregation: !function utils.longvideo_reason_aggregate_format
+    higher_is_better: true
+  - metric: longvideo_reason_temporal_accuracy
+    aggregation: !function utils.longvideo_reason_aggregate_temporal
+    higher_is_better: true
+  - metric: longvideo_reason_goal_accuracy
+    aggregation: !function utils.longvideo_reason_aggregate_goal
+    higher_is_better: true
+  - metric: longvideo_reason_spatial_accuracy
+    aggregation: !function utils.longvideo_reason_aggregate_spatial
+    higher_is_better: true
+  - metric: longvideo_reason_plot_accuracy
+    aggregation: !function utils.longvideo_reason_aggregate_plot
+    higher_is_better: true
+lmms_eval_specific_kwargs:
+  default:
+    pre_prompt: ""
+    post_prompt: ""
+metadata:
+  version: 1.0

--- a/lmms_eval/tasks/longvideo_reason/longvideo_reason.yaml
+++ b/lmms_eval/tasks/longvideo_reason/longvideo_reason.yaml
@@ -1,0 +1,2 @@
+task: longvideo_reason
+include: _default_template_yaml

--- a/lmms_eval/tasks/longvideo_reason/utils.py
+++ b/lmms_eval/tasks/longvideo_reason/utils.py
@@ -151,10 +151,26 @@ def extract_longvideo_reason_answer(response: str, choices: Sequence[str]) -> st
         return normalized
 
     text = strip_reasoning_tags(response or "", REASONING_TAG_PAIRS)
-    boxed = _BOXED_ANSWER.findall(text)
-    if boxed and boxed[-1].upper() in choices:
-        return boxed[-1].upper()
-    return extract_mcq_answer(text, choices=list(choices))
+    # SCOPE MATTERS. The shared extractor already ranks "the span starts with a
+    # standalone choice letter" at its highest priority, which is exactly the
+    # dominant answer form here ("B. A personal trainer guiding others'
+    # exercises" -- in an 8-item run against Qwen3-VL-8B-Instruct every answer
+    # span took that form and not one was a bare letter). But that rule can only
+    # fire if it is given the SPAN. Handed the whole completion it never
+    # matches, and a response that dismisses the other options by name ("...not
+    # learning from others (D)") is then decided by the lower-priority
+    # parentheses rule on a distractor. That was a real observed miss, scored D
+    # against a gold of B, not a hypothetical.
+    for scope in (official, text):
+        if not scope:
+            continue
+        boxed = _BOXED_ANSWER.findall(scope)
+        if boxed and boxed[-1].upper() in choices:
+            return boxed[-1].upper()
+        letter = extract_mcq_answer(scope, choices=list(choices))
+        if letter:
+            return letter
+    return ""
 
 
 def longvideo_reason_process_results(doc: Document, results: Sequence[str]) -> dict[str, MetricRecord]:

--- a/lmms_eval/tasks/longvideo_reason/utils.py
+++ b/lmms_eval/tasks/longvideo_reason/utils.py
@@ -1,0 +1,236 @@
+import os
+import re
+from typing import Any, Mapping, Sequence
+
+from loguru import logger as eval_logger
+
+from lmms_eval.api.reasoning import strip_reasoning_tags
+from lmms_eval.tasks._task_utils.mcq_extract import extract_mcq_answer
+from lmms_eval.tasks._task_utils.media_resolver import resolve_media_reference
+
+Document = Mapping[str, Any]
+TaskKwargs = Mapping[str, Any]
+MetricRecord = dict[str, Any]
+
+CACHE_DIR_NAME = "longvideo_reason"
+VIDEO_ENV_VARS = ("LONGVIDEO_REASON_VIDEO_DIR", "LONGVIDEO_REASON_ROOT")
+REASONING_TAG_PAIRS = [["<think>", "</think>"], ["<thinking>", "</thinking>"]]
+
+# The four reasoning perspectives the paper reports. `problem_type` carries
+# exactly these four strings on all 1,000 test rows.
+PROBLEM_TYPES = ("temporal", "goal", "spatial", "plot")
+
+# The official prompt, copied verbatim from longvideo-reason/eval.py
+# (QUESTION_TEMPLATE_VIDEO) in NVlabs/Long-RL, including its typo ("then he
+# solves it") and the leading space before "Question:". The options are part of
+# `problem`, so the template needs no option block of its own.
+QUESTION_TEMPLATE_VIDEO = "You are a helpful assistant. The user asks a question, and then you solves it.\n\nPlease first think deeply about the question based on the given video, and then provide the final answer. The reasoning process and answer are enclosed within <think> </think> and <answer> </answer> tags, respectively, i.e., <think> reasoning process here </think> <answer> answer here </answer>.\n\n Question: {question}"
+
+# Official extraction, ported from accuracy_reward()/format_reward().
+_ANSWER_TAG = re.compile(r"<answer>(.*?)</answer>", re.DOTALL)
+_ANSWER_TAG_PHRASE = re.compile(r"<answer>Therefore the final answer is: (.*?)</answer>", re.DOTALL)
+_FORMAT_PATTERN = re.compile(r"<think>.*?</think>\s*<answer>.*?</answer>", re.DOTALL)
+_BOXED_ANSWER = re.compile(r"\\boxed\{\s*([A-Za-z])\s*\}")
+
+# Option lines look like "A. <text>", one per line. Used to read back the
+# letters an example actually offers and to flag the malformed rows.
+_OPTION_LETTER = re.compile(r"^\s*([A-Z])\.\s", re.M)
+
+EXPECTED_OPTION_COUNT = 4
+
+
+def _choices(doc: Document) -> list[str]:
+    """Return the option letters this example actually offers.
+
+    Read back from the question text rather than assumed to be A-D: five rows
+    of the test split do not carry four options (see `_is_wellformed`).
+    """
+    return sorted(set(_OPTION_LETTER.findall(str(doc.get("problem", "")))))
+
+
+def _is_wellformed(doc: Document) -> bool:
+    """True when the example offers exactly four lettered options.
+
+    FIVE of the 1,000 test rows (problem_id 147, 379, 743, 825 and 857) do not.
+    The upstream generator leaked its own deliberation into the option block:
+    three rows carry a paragraph of model scratchpad where an option should be
+    ("A. But this requires the test-taker to weigh..."), and two rows (379,
+    857) carry no options at all and cannot be answered as multiple choice by
+    any model. They are NOT dropped -- upstream scores all 1,000 and changing
+    the denominator would make this task incomparable with the paper -- but
+    `longvideo_reason_wellformed_accuracy` reports the clean 995 beside the
+    headline so the contamination is visible rather than absorbed.
+    """
+    return len(_choices(doc)) == EXPECTED_OPTION_COUNT
+
+
+def longvideo_reason_doc_to_visual(doc: Document) -> list[str]:
+    """Resolve the local video for one LongVideo-Reason example."""
+    reference = str(doc["videos"])
+    video_path = resolve_media_reference(
+        reference,
+        media_type="video",
+        cache_dir=CACHE_DIR_NAME,
+        env_vars=VIDEO_ENV_VARS,
+        extra_subdirs=("longvila_videos", "videos"),
+    )
+    if not os.path.exists(video_path):
+        raise FileNotFoundError(
+            f"LongVideo-Reason video not found: {reference}. The videos live in a SEPARATE "
+            "repository from the annotations: download the ten longvideo_eval_subset*.tar.gz "
+            "shards of LongVideo-Reason/longvideo_eval_videos (195 GB), extract them so that a "
+            "'longvila_videos' directory results, and set LONGVIDEO_REASON_VIDEO_DIR to the "
+            "directory that CONTAINS 'longvila_videos'."
+        )
+    return [video_path]
+
+
+def longvideo_reason_doc_to_text(doc: Document, lmms_eval_specific_kwargs: TaskKwargs | None = None) -> str:
+    """Format the official prompt. Options are already inside `problem`."""
+    kwargs = lmms_eval_specific_kwargs or {}
+    prompt = QUESTION_TEMPLATE_VIDEO.format(question=str(doc["problem"]).rstrip())
+    return f"{kwargs.get('pre_prompt', '')}{prompt}{kwargs.get('post_prompt', '')}"
+
+
+def longvideo_reason_doc_to_target(doc: Document) -> str:
+    """Return the gold answer as it ships, i.e. still wrapped in <answer> tags."""
+    return str(doc["answer"])
+
+
+def _unwrap_answer(text: str) -> str:
+    """Strip one <answer> wrapper if present, else return the text unchanged.
+
+    The gold field ships as "<answer>B</answer>"; the official scorer unwraps it
+    with this same regex before comparing.
+    """
+    match = _ANSWER_TAG.search(text or "")
+    return match.group(1).strip() if match else (text or "").strip()
+
+
+def extract_official_answer(response: str) -> str:
+    """Reproduce the official student-answer extraction, byte for byte.
+
+    Ported from accuracy_reward() in longvideo-reason/eval.py. The phrase branch
+    comes first there, so a completion that says "Therefore the final answer is:"
+    yields the text AFTER the phrase, not the whole span. A completion with no
+    <answer> tag falls back to the entire stripped completion, which is why the
+    official metric is close to zero for any model that narrates.
+    """
+    content = response or ""
+    if "Therefore the final answer is:" in content:
+        match = _ANSWER_TAG_PHRASE.search(content)
+    else:
+        match = _ANSWER_TAG.search(content)
+    return match.group(1).strip() if match else content.strip()
+
+
+def extract_longvideo_reason_answer(response: str, choices: Sequence[str]) -> str:
+    """Extract one offered option letter, preferring the official format.
+
+    Layered, most faithful first, and every layer is ADDITIVE: a completion the
+    official extractor already resolves to an offered letter is returned
+    unchanged, so this can only recover answers the official parser drops (a
+    trailing period, a \\boxed{} wrapper, a bare "The answer is C"). It can
+    never turn an official hit into a miss. That property is what makes
+    `overall_accuracy` >= `strict_accuracy` by construction.
+    """
+    official = extract_official_answer(response)
+    normalized = re.sub(r"[^A-Za-z]", "", official).upper()
+    if len(normalized) == 1 and normalized in choices:
+        return normalized
+
+    text = strip_reasoning_tags(response or "", REASONING_TAG_PAIRS)
+    boxed = _BOXED_ANSWER.findall(text)
+    if boxed and boxed[-1].upper() in choices:
+        return boxed[-1].upper()
+    return extract_mcq_answer(text, choices=list(choices))
+
+
+def longvideo_reason_process_results(doc: Document, results: Sequence[str]) -> dict[str, MetricRecord]:
+    """Parse a prediction and emit the overall, per-perspective and format records."""
+    problem_type = str(doc["problem_type"])
+    if problem_type not in PROBLEM_TYPES:
+        raise ValueError(f"Unknown LongVideo-Reason problem_type: {problem_type!r}")
+
+    prediction = str(results[0]) if results else ""
+    choices = _choices(doc)
+    gold_raw = str(doc["answer"])
+    answer = re.sub(r"[^A-Za-z]", "", _unwrap_answer(gold_raw)).upper()
+
+    parsed_prediction = extract_longvideo_reason_answer(prediction, choices)
+    # Official score: strict string equality between the two unwrapped spans, no
+    # normalisation at all. This is the number the paper reports.
+    strict_score = float(extract_official_answer(prediction) == _unwrap_answer(gold_raw))
+
+    record = {
+        "problem_id": int(doc["problem_id"]),
+        "video": str(doc["videos"]),
+        "problem_type": problem_type,
+        "wellformed": _is_wellformed(doc),
+        "prediction": prediction,
+        "pred_answer": parsed_prediction,
+        "answer": answer,
+        "score": float(parsed_prediction == answer),
+        "strict_score": strict_score,
+        "format_score": float(bool(_FORMAT_PATTERN.match(prediction))),
+    }
+    return {
+        "longvideo_reason_overall_accuracy": record,
+        "longvideo_reason_strict_accuracy": record,
+        "longvideo_reason_wellformed_accuracy": record,
+        "longvideo_reason_format_accuracy": record,
+        f"longvideo_reason_{problem_type}_accuracy": record,
+    }
+
+
+def _aggregate(results: Sequence[MetricRecord], key: str = "score", problem_type: str | None = None, wellformed_only: bool = False) -> float:
+    """Question-weighted accuracy as a percentage over the selected records."""
+    selected = [result for result in results if (problem_type is None or result["problem_type"] == problem_type) and (not wellformed_only or result["wellformed"])]
+    if not selected:
+        return 0.0
+    correct = sum(result[key] for result in selected)
+    accuracy = 100.0 * correct / len(selected)
+    label = problem_type or ("wellformed" if wellformed_only else key)
+    eval_logger.info(f"LongVideo-Reason {label}: {accuracy:.2f}% ({int(correct)}/{len(selected)})")
+    return accuracy
+
+
+def longvideo_reason_aggregate_overall(results: Sequence[MetricRecord]) -> float:
+    """Headline accuracy over all 1,000 rows, with the robust extractor.
+
+    The answer key of this benchmark is NOT uniform: B=441, C=299, A=153,
+    D=107. A model that always answers B scores 44.1%. Read this number
+    against 44.1%, not against 25%.
+    """
+    return _aggregate(results)
+
+
+def longvideo_reason_aggregate_strict(results: Sequence[MetricRecord]) -> float:
+    """Accuracy under the official byte-exact comparison, for paper parity."""
+    return _aggregate(results, key="strict_score")
+
+
+def longvideo_reason_aggregate_wellformed(results: Sequence[MetricRecord]) -> float:
+    """Accuracy over the 995 rows whose option block is intact."""
+    return _aggregate(results, wellformed_only=True)
+
+
+def longvideo_reason_aggregate_format(results: Sequence[MetricRecord]) -> float:
+    """Share of completions matching <think>...</think><answer>...</answer>."""
+    return _aggregate(results, key="format_score")
+
+
+def longvideo_reason_aggregate_temporal(results: Sequence[MetricRecord]) -> float:
+    return _aggregate(results, problem_type="temporal")
+
+
+def longvideo_reason_aggregate_goal(results: Sequence[MetricRecord]) -> float:
+    return _aggregate(results, problem_type="goal")
+
+
+def longvideo_reason_aggregate_spatial(results: Sequence[MetricRecord]) -> float:
+    return _aggregate(results, problem_type="spatial")
+
+
+def longvideo_reason_aggregate_plot(results: Sequence[MetricRecord]) -> float:
+    return _aggregate(results, problem_type="plot")

--- a/lmms_eval/tasks/longvideo_reason/utils.py
+++ b/lmms_eval/tasks/longvideo_reason/utils.py
@@ -64,6 +64,15 @@ def _is_wellformed(doc: Document) -> bool:
     return len(_choices(doc)) == EXPECTED_OPTION_COUNT
 
 
+# The archives do NOT lay out what the annotations reference. Every `videos`
+# field reads "longvila_videos/<stem>.<ext>" and the upstream README documents
+# that path, but each of the ten shards extracts into its own flat
+# "longvideo_eval_subset<N>/" directory instead. Searching those directories as
+# well means a correct, complete download resolves without the user first having
+# to reorganise 195 GB by hand.
+VIDEO_SUBDIRS = ("longvila_videos", "videos", *(f"longvideo_eval_subset{index}" for index in range(10)))
+
+
 def longvideo_reason_doc_to_visual(doc: Document) -> list[str]:
     """Resolve the local video for one LongVideo-Reason example."""
     reference = str(doc["videos"])
@@ -72,15 +81,17 @@ def longvideo_reason_doc_to_visual(doc: Document) -> list[str]:
         media_type="video",
         cache_dir=CACHE_DIR_NAME,
         env_vars=VIDEO_ENV_VARS,
-        extra_subdirs=("longvila_videos", "videos"),
+        extra_subdirs=VIDEO_SUBDIRS,
     )
     if not os.path.exists(video_path):
         raise FileNotFoundError(
             f"LongVideo-Reason video not found: {reference}. The videos live in a SEPARATE "
             "repository from the annotations: download the ten longvideo_eval_subset*.tar.gz "
-            "shards of LongVideo-Reason/longvideo_eval_videos (195 GB), extract them so that a "
-            "'longvila_videos' directory results, and set LONGVIDEO_REASON_VIDEO_DIR to the "
-            "directory that CONTAINS 'longvila_videos'."
+            "shards of LongVideo-Reason/longvideo_eval_videos (195 GB), extract them all into "
+            "one directory, and set LONGVIDEO_REASON_VIDEO_DIR to it. Note that the shards "
+            "extract into per-shard 'longvideo_eval_subset<N>/' directories rather than into "
+            "the 'longvila_videos/' directory the upstream README describes; both layouts are "
+            "searched."
         )
     return [video_path]
 

--- a/test/eval/test_longvideo_reason.py
+++ b/test/eval/test_longvideo_reason.py
@@ -115,6 +115,19 @@ def test_doc_to_visual_resolves_every_shipped_container(monkeypatch: pytest.Monk
     assert resolved == [str(video_dir / f"clip.{extension}")]
 
 
+def test_doc_to_visual_resolves_the_per_shard_layout(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """The ten tar.gz shards extract into "longvideo_eval_subset<N>/", NOT into
+    the "longvila_videos/" directory the upstream README documents. A resolver
+    that only knows the documented layout reports a complete 195 GB download as
+    1,000 missing videos."""
+    video_dir = tmp_path / "longvideo_eval_subset7"
+    video_dir.mkdir()
+    _write_test_video(video_dir / "clip.mp4")
+    monkeypatch.setenv("LONGVIDEO_REASON_VIDEO_DIR", str(tmp_path))
+
+    assert lvr_utils.longvideo_reason_doc_to_visual(_doc()) == [str(video_dir / "clip.mp4")]
+
+
 def test_doc_to_visual_raises_when_the_video_is_absent(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("LONGVIDEO_REASON_VIDEO_DIR", str(tmp_path))
     with pytest.raises(FileNotFoundError, match="longvideo_eval_subset"):

--- a/test/eval/test_longvideo_reason.py
+++ b/test/eval/test_longvideo_reason.py
@@ -1,0 +1,271 @@
+from pathlib import Path
+from typing import Any
+
+import cv2
+import numpy as np
+import pytest
+
+from lmms_eval.tasks import TaskManager
+from lmms_eval.tasks.longvideo_reason import utils as lvr_utils
+
+OPTIONS = "A. First option.\nB. Second option.\nC. Third option.\nD. Fourth option."
+
+
+@pytest.fixture(autouse=True)
+def _isolate_media_env(monkeypatch, tmp_path):
+    """Stop the media resolver from finding a developer's real video cache.
+
+    media_resolver falls through LONGVIDEO_REASON_ROOT -> LMMS_EVAL_MEDIA_ROOT
+    -> HF_HOME. A shell exporting any of those makes the FileNotFoundError tests
+    resolve a real file and silently stop testing anything.
+    """
+    for var in ("LONGVIDEO_REASON_ROOT", "LONGVIDEO_REASON_VIDEO_DIR", "LMMS_EVAL_MEDIA_ROOT"):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("HF_HOME", str(tmp_path / "_empty_hf_home"))
+
+
+def _doc(
+    answer: str = "<answer>B</answer>",
+    problem_type: str = "goal",
+    problem: str | None = None,
+    problem_id: int = 0,
+    videos: str = "longvila_videos/clip.mp4",
+) -> dict[str, Any]:
+    return {
+        "problem_id": problem_id,
+        "problem": problem if problem is not None else f"What happens next?\n{OPTIONS}",
+        "data_type": "video",
+        "problem_type": problem_type,
+        "reasoning": "irrelevant to scoring",
+        "videos": videos,
+        "answer": answer,
+    }
+
+
+def _write_test_video(path: Path, frame_count: int = 4, fps: int = 2) -> None:
+    writer = cv2.VideoWriter(str(path), cv2.VideoWriter_fourcc(*"mp4v"), fps, (8, 8))
+    assert writer.isOpened(), "OpenCV cannot create the temporary MP4 test fixture"
+    for value in range(frame_count):
+        writer.write(np.full((8, 8, 3), value * 50, dtype=np.uint8))
+    writer.release()
+
+
+# --------------------------------------------------------------------------
+# Registration and prompt
+# --------------------------------------------------------------------------
+
+
+def test_task_is_registered() -> None:
+    task_manager = TaskManager("ERROR")
+    assert "longvideo_reason" in task_manager.all_tasks
+
+
+def test_doc_to_text_uses_the_official_template_verbatim() -> None:
+    text = lvr_utils.longvideo_reason_doc_to_text(_doc())
+    assert text.startswith("You are a helpful assistant. The user asks a question, and then you solves it.")
+    assert "<think> </think> and <answer> </answer> tags" in text
+    # The options live inside `problem`; the template must not rebuild them.
+    assert text.endswith("A. First option.\nB. Second option.\nC. Third option.\nD. Fourth option.")
+
+
+def test_doc_to_text_applies_pre_and_post_prompt() -> None:
+    text = lvr_utils.longvideo_reason_doc_to_text(_doc(), {"pre_prompt": "<PRE>", "post_prompt": "<POST>"})
+    assert text.startswith("<PRE>You are a helpful assistant.")
+    assert text.endswith("<POST>")
+
+
+def test_doc_to_target_returns_the_wrapped_gold() -> None:
+    assert lvr_utils.longvideo_reason_doc_to_target(_doc()) == "<answer>B</answer>"
+
+
+# --------------------------------------------------------------------------
+# Media resolution
+# --------------------------------------------------------------------------
+
+
+def test_doc_to_visual_resolves_parent_of_longvila_videos(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    video_dir = tmp_path / "longvila_videos"
+    video_dir.mkdir()
+    _write_test_video(video_dir / "clip.mp4")
+    monkeypatch.setenv("LONGVIDEO_REASON_VIDEO_DIR", str(tmp_path))
+
+    assert lvr_utils.longvideo_reason_doc_to_visual(_doc()) == [str(video_dir / "clip.mp4")]
+
+
+def test_doc_to_visual_resolves_a_flat_video_dir(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """The extracted tree is sometimes flattened; the basename must still resolve."""
+    video_dir = tmp_path / "flat"
+    video_dir.mkdir()
+    _write_test_video(video_dir / "clip.mp4")
+    monkeypatch.setenv("LONGVIDEO_REASON_VIDEO_DIR", str(video_dir))
+
+    assert lvr_utils.longvideo_reason_doc_to_visual(_doc()) == [str(video_dir / "clip.mp4")]
+
+
+@pytest.mark.parametrize("extension", ["mp4", "webm", "mkv"])
+def test_doc_to_visual_resolves_every_shipped_container(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, extension: str) -> None:
+    """The split is 867 .mp4, 130 .webm and 3 .mkv, so a resolver that only
+    understands .mp4 loses 13% of the benchmark."""
+    video_dir = tmp_path / "longvila_videos"
+    video_dir.mkdir()
+    (video_dir / f"clip.{extension}").write_bytes(b"\x00")
+    monkeypatch.setenv("LONGVIDEO_REASON_VIDEO_DIR", str(tmp_path))
+
+    resolved = lvr_utils.longvideo_reason_doc_to_visual(_doc(videos=f"longvila_videos/clip.{extension}"))
+    assert resolved == [str(video_dir / f"clip.{extension}")]
+
+
+def test_doc_to_visual_raises_when_the_video_is_absent(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LONGVIDEO_REASON_VIDEO_DIR", str(tmp_path))
+    with pytest.raises(FileNotFoundError, match="longvideo_eval_subset"):
+        lvr_utils.longvideo_reason_doc_to_visual(_doc())
+
+
+# --------------------------------------------------------------------------
+# Official extraction (paper parity)
+# --------------------------------------------------------------------------
+
+
+def test_official_extraction_returns_the_answer_span() -> None:
+    assert lvr_utils.extract_official_answer("<think>x</think> <answer>C</answer>") == "C"
+
+
+def test_official_extraction_handles_the_phrase_branch() -> None:
+    """The official parser strips "Therefore the final answer is: " when present."""
+    completion = "<think>x</think> <answer>Therefore the final answer is: D</answer>"
+    assert lvr_utils.extract_official_answer(completion) == "D"
+
+
+def test_official_extraction_falls_back_to_the_whole_completion() -> None:
+    assert lvr_utils.extract_official_answer("  B  ") == "B"
+
+
+def test_strict_score_is_byte_exact() -> None:
+    """A trailing period misses under the official comparison. This is upstream
+    behaviour and the strict metric must reproduce it, not repair it."""
+    record = lvr_utils.longvideo_reason_process_results(_doc(), ["<think>x</think> <answer>B.</answer>"])
+    assert record["longvideo_reason_strict_accuracy"]["strict_score"] == 0.0
+
+
+def test_strict_score_matches_a_clean_answer() -> None:
+    record = lvr_utils.longvideo_reason_process_results(_doc(), ["<think>x</think> <answer>B</answer>"])
+    assert record["longvideo_reason_strict_accuracy"]["strict_score"] == 1.0
+
+
+# --------------------------------------------------------------------------
+# Robust extraction (additive layer)
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "completion",
+    [
+        "<think>x</think> <answer>B</answer>",
+        "<think>x</think> <answer>B.</answer>",
+        "<think>x</think> <answer>\\boxed{B}</answer>",
+        "<think>x</think><answer>(B)</answer>",
+        "The correct answer is B.",
+        "\\boxed{B}",
+        "B",
+    ],
+)
+def test_robust_extraction_recovers_common_answer_forms(completion: str) -> None:
+    assert lvr_utils.extract_longvideo_reason_answer(completion, ["A", "B", "C", "D"]) == "B"
+
+
+def test_robust_extraction_never_downgrades_an_official_hit() -> None:
+    """The additive property the two metrics depend on: whenever the official
+    parser yields an offered letter, the robust parser returns the SAME letter."""
+    for letter in ("A", "B", "C", "D"):
+        completion = f"<think>irrelevant mention of A and C</think> <answer>{letter}</answer>"
+        assert lvr_utils.extract_longvideo_reason_answer(completion, ["A", "B", "C", "D"]) == letter
+
+
+def test_robust_extraction_rejects_a_letter_not_offered() -> None:
+    """A row with only two options must never be scored against a letter it does
+    not offer."""
+    assert lvr_utils.extract_longvideo_reason_answer("<answer>D</answer>", ["A", "B"]) != "D"
+
+
+# --------------------------------------------------------------------------
+# Malformed rows (the 5 contaminated examples)
+# --------------------------------------------------------------------------
+
+
+def test_wellformed_row_is_flagged_wellformed() -> None:
+    record = lvr_utils.longvideo_reason_process_results(_doc(), ["<answer>B</answer>"])
+    assert record["longvideo_reason_overall_accuracy"]["wellformed"] is True
+
+
+def test_row_with_no_options_is_flagged_malformed() -> None:
+    """problem_id 379 and 857 ship with no option block at all."""
+    doc = _doc(problem="Who is the man interacting with the car?\n\n", problem_id=379)
+    record = lvr_utils.longvideo_reason_process_results(doc, ["<answer>C</answer>"])
+    assert record["longvideo_reason_overall_accuracy"]["wellformed"] is False
+
+
+def test_row_with_leaked_scratchpad_is_flagged_malformed() -> None:
+    """problem_id 147, 743 and 825 carry generator deliberation where an option
+    should be, so fewer than four letters parse."""
+    doc = _doc(
+        problem="What was the primary factor?\nC. But the user wants a question that requires multiple steps.",
+        problem_id=743,
+    )
+    record = lvr_utils.longvideo_reason_process_results(doc, ["<answer>C</answer>"])
+    assert record["longvideo_reason_overall_accuracy"]["wellformed"] is False
+
+
+def test_wellformed_aggregate_excludes_malformed_rows() -> None:
+    good = lvr_utils.longvideo_reason_process_results(_doc(), ["<answer>B</answer>"])["longvideo_reason_overall_accuracy"]
+    bad = lvr_utils.longvideo_reason_process_results(
+        _doc(problem="No options here.\n\n", problem_id=379, answer="<answer>C</answer>"),
+        ["<answer>A</answer>"],
+    )["longvideo_reason_overall_accuracy"]
+
+    assert lvr_utils.longvideo_reason_aggregate_overall([good, bad]) == 50.0
+    assert lvr_utils.longvideo_reason_aggregate_wellformed([good, bad]) == 100.0
+
+
+# --------------------------------------------------------------------------
+# Format metric and per-perspective aggregation
+# --------------------------------------------------------------------------
+
+
+def test_format_score_requires_think_then_answer_from_the_start() -> None:
+    matching = lvr_utils.longvideo_reason_process_results(_doc(), ["<think>x</think> <answer>B</answer>"])
+    assert matching["longvideo_reason_format_accuracy"]["format_score"] == 1.0
+
+    prefixed = lvr_utils.longvideo_reason_process_results(_doc(), ["Sure! <think>x</think> <answer>B</answer>"])
+    assert prefixed["longvideo_reason_format_accuracy"]["format_score"] == 0.0
+
+
+def test_process_results_emits_the_perspective_metric() -> None:
+    for problem_type in lvr_utils.PROBLEM_TYPES:
+        record = lvr_utils.longvideo_reason_process_results(_doc(problem_type=problem_type), ["<answer>B</answer>"])
+        assert f"longvideo_reason_{problem_type}_accuracy" in record
+
+
+def test_process_results_rejects_an_unknown_perspective() -> None:
+    with pytest.raises(ValueError, match="Unknown LongVideo-Reason problem_type"):
+        lvr_utils.longvideo_reason_process_results(_doc(problem_type="narrative"), ["<answer>B</answer>"])
+
+
+def test_perspective_aggregate_selects_only_its_own_rows() -> None:
+    temporal_hit = lvr_utils.longvideo_reason_process_results(_doc(problem_type="temporal"), ["<answer>B</answer>"])["longvideo_reason_overall_accuracy"]
+    spatial_miss = lvr_utils.longvideo_reason_process_results(_doc(problem_type="spatial"), ["<answer>A</answer>"])["longvideo_reason_overall_accuracy"]
+    records = [temporal_hit, spatial_miss]
+
+    assert lvr_utils.longvideo_reason_aggregate_temporal(records) == 100.0
+    assert lvr_utils.longvideo_reason_aggregate_spatial(records) == 0.0
+    assert lvr_utils.longvideo_reason_aggregate_overall(records) == 50.0
+
+
+def test_aggregate_over_no_records_is_zero() -> None:
+    assert lvr_utils.longvideo_reason_aggregate_goal([]) == 0.0
+
+
+def test_gold_is_unwrapped_before_comparison() -> None:
+    """The gold field ships as "<answer>B</answer>", not as a bare letter."""
+    record = lvr_utils.longvideo_reason_process_results(_doc(answer="<answer>B</answer>"), ["<answer>B</answer>"])
+    assert record["longvideo_reason_overall_accuracy"]["answer"] == "B"
+    assert record["longvideo_reason_overall_accuracy"]["score"] == 1.0

--- a/test/eval/test_longvideo_reason.py
+++ b/test/eval/test_longvideo_reason.py
@@ -186,6 +186,55 @@ def test_robust_extraction_recovers_common_answer_forms(completion: str) -> None
     assert lvr_utils.extract_longvideo_reason_answer(completion, ["A", "B", "C", "D"]) == "B"
 
 
+def test_letter_then_restated_option_is_read_off_the_front() -> None:
+    """The dominant answer form on this benchmark. In an 8-item run against
+    Qwen3-VL-8B-Instruct every answer span took this form; not one was a bare
+    letter. The shared extractor ranks it top priority ("start") -- but only
+    when it is given the <answer> span rather than the whole completion."""
+    completion = "<answer> B. A personal trainer guiding others' exercises </answer>"
+    assert lvr_utils.extract_longvideo_reason_answer(completion, ["A", "B", "C", "D"]) == "B"
+
+
+def test_answer_span_beats_distractors_named_in_the_reasoning() -> None:
+    """Regression for a real observed miss.
+
+    Handed the whole completion, the shared extractor cannot fire its "start"
+    rule and settles for the lower-priority parentheses rule on a distractor.
+    This exact completion scored D against a gold of B before the extractor was
+    scoped to the answer span."""
+    completion = (
+        "The man in the blue shirt is consistently seen guiding others. "
+        "The other options do not align: he is not working out alone (A), "
+        "not organizing equipment (C), and not learning from others (D). "
+        "<answer> B. A personal trainer guiding others' exercises </answer>"
+    )
+    assert lvr_utils.extract_longvideo_reason_answer(completion, ["A", "B", "C", "D"]) == "B"
+
+
+@pytest.mark.parametrize(
+    "span",
+    ["B. option text", "(B) option text", "B) option text", "B: option text", "B - option text"],
+)
+def test_answer_span_delimiters(span: str) -> None:
+    completion = f"<answer>{span}</answer>"
+    assert lvr_utils.extract_longvideo_reason_answer(completion, ["A", "B", "C", "D"]) == "B"
+
+
+def test_prose_answer_is_not_read_as_its_first_letter() -> None:
+    """ "Because..." must not become choice B."""
+    completion = "<answer>Because the cheetah is fastest, the answer is C</answer>"
+    assert lvr_utils.extract_longvideo_reason_answer(completion, ["A", "B", "C", "D"]) == "C"
+
+
+def test_extraction_respects_the_offered_choices() -> None:
+    """A letter the example does not offer must never be returned."""
+    assert lvr_utils.extract_longvideo_reason_answer("<answer>D. text</answer>", ["A", "B"]) != "D"
+
+
+def test_falls_back_to_the_full_completion_when_there_is_no_answer_span() -> None:
+    assert lvr_utils.extract_longvideo_reason_answer("I think the answer is C.", ["A", "B", "C", "D"]) == "C"
+
+
 def test_robust_extraction_never_downgrades_an_official_hit() -> None:
     """The additive property the two metrics depend on: whenever the official
     parser yields an offered letter, the robust parser returns the SAME letter."""


### PR DESCRIPTION
## Summary

Adds **LongVideo-Reason-eval**, the 1,000-question long-video reasoning benchmark introduced with LongVILA-R1 in ["Scaling RL to Long Videos"](https://arxiv.org/abs/2507.07966) (NVIDIA). It is balanced across four reasoning perspectives — temporal (294), goal and purpose (288), plot and narrative (283), spatial (135) — and each question is four-option multiple choice with the options embedded in the question text.

- Dataset: https://huggingface.co/datasets/LongVideo-Reason/longvideo-reason
- Videos: https://huggingface.co/datasets/LongVideo-Reason/longvideo_eval_videos
- Code: https://github.com/NVlabs/Long-RL

Task name: `longvideo_reason`. 35 tests in `test/eval/test_longvideo_reason.py`.

## Why this task reports two accuracies

This is the main design decision and it is driven by a measurement, not a preference.

The official scorer (`accuracy_reason/eval.py::accuracy_reward`) compares the `<answer>...</answer>` span of the completion against the gold span with a bare `==`, after a `"Therefore the final answer is: "` special case. When a completion has no `<answer>` tag it falls back to comparing the **entire completion** against the gold letter.

Measured on `Qwen3-VL-8B-Instruct`, 8 items, 64 frames, greedy:

| Metric | Value |
| --- | --- |
| `longvideo_reason_overall_accuracy` | **75.0** |
| `longvideo_reason_strict_accuracy` | **0.0** |
| `longvideo_reason_format_accuracy` | **0.0** |

The model answered **6 of 8 correctly and scored zero** under the official comparison. It writes a fluent paragraph of reasoning and never emits the `<think>`/`<answer>` tags, so the fallback can never match. That is the default behaviour of any model not fine-tuned to emit that exact format — LongVILA-R1 is, an off-the-shelf VLM is not.

So the task reports both:

- **`longvideo_reason_strict_accuracy`** reproduces the official comparison byte for byte, including the trailing-period miss. This is the paper's number.
- **`longvideo_reason_overall_accuracy`** runs the official cascade **first** and only falls back to `\boxed{X}` and the shared `extract_mcq_answer` when it yields no *offered* option letter. Every layer is additive, so `overall >= strict` holds by construction and a completion the official parser already resolves is returned unchanged.

Also reported: the four per-perspective accuracies (the paper reports this breakdown; the reference implementation does not compute it), and the official `format_reward` as `longvideo_reason_format_accuracy`.

One deliberate divergence: the official cascade tries `math_verify.parse`/`verify` before its regex path. On a single-letter multiple-choice answer that symbolic path adds nothing the regex path does not already cover, so it is omitted. Documented in the task README.

## Two data properties that change how the score reads

Both are surfaced as metrics rather than left for the reader to discover.

**The answer key is not uniform: B=441, C=299, A=153, D=107.** A model that always answers `B` scores **44.1%**. The chance baseline for this benchmark is 44.1%, not 25%.

**Five rows (0.5%) carry a malformed option block.** In `problem_id` 147, 743 and 825 the data generator leaked its own deliberation into the options (`"A. But this requires the test-taker to weigh..."`); `problem_id` 379 and 857 ship with **no options at all** and cannot be answered as multiple choice by any model. They are **kept**, because upstream scores all 1,000 and changing the denominator would break comparability with the paper — and `longvideo_reason_wellformed_accuracy` reports the clean 995 beside the headline. The task reads the offered option letters back from the question text rather than assuming A–D, so a letter an example does not offer is never scored.

## Media resolution

The videos live in a **separate repository** from the annotations, as ten `.tar.gz` shards totalling **195 GB**, and only the annotations download automatically.

The archives **do not produce the layout the annotations reference**: every `videos` field reads `longvila_videos/<stem>.<ext>` and the upstream README documents that path, but each shard extracts into its own flat `longvideo_eval_subset<N>/` directory. A resolver that only knows the documented layout reports a complete 195 GB download as 1,000 missing videos. This task searches both layouts and says so in the `FileNotFoundError`.

The split ships **867 `.mp4`, 130 `.webm` and 3 `.mkv`**, so a stack that only handles MP4 silently loses 13% of the benchmark; there is a parametrised test per container.

## Frame budget

Not fixed by the task, and worth stating because "long video" invites a budget sized for hours. Measured over 607 of the 991 videos with torchcodec:

| | p5 | p25 | p50 | p75 | p95 | max |
| --- | --- | --- | --- | --- | --- | --- |
| duration | 1.8 min | 3.3 min | **6.1 min** | 9.9 min | 15.4 min | 26.6 min |

Mean 6.9 min, 79.1% under 10 minutes, **none over 30**. "Long" here is relative to the 30 s – 3 min clips of most video benchmarks, not absolute. The paper evaluates LongVILA-R1 at 512 frames, which on a 6-minute video is roughly one frame every 0.7 s. The README asks that the budget always be reported next to the score.

## Test plan

- `pytest test/eval/test_longvideo_reason.py` — 35 tests, all passing.
- Covers: task registration; the official prompt verbatim; media resolution for both layouts, all three containers and the flat case; the official extraction including the phrase branch and the byte-exact trailing-period miss; the additive property of the robust extractor; rejection of letters an example does not offer; both malformed-row shapes; the `format_reward` anchoring; and per-perspective aggregation.
- End-to-end smoke against `Qwen3-VL-8B-Instruct` on the real 195 GB video set, 64 frames — the measurement quoted above.

Left as a draft for maintainer feedback on whether reporting both accuracies is the right call here, or whether one should be the headline.
