### PR TITLE
fix: report aggregate MVBench accuracy

### DIFF
--- a/lmms_eval/tasks/mvbench/mvbench.yaml
+++ b/lmms_eval/tasks/mvbench/mvbench.yaml
@@ -21,4 +21,9 @@ task:
   - mvbench_moving_attribute
   - mvbench_egocentric_navigation
 
+aggregate_metric_list:
+  - metric: mvbench_accuracy
+    aggregation: mean
+    weight_by_size: true
+
 # ['action_sequence', 'moving_count', 'action_prediction', 'episodic_reasoning', 'action_antonym', 'action_count', 'scene_transition', 'object_shuffle', 'object_existence', 'fine_grained_pose', 'unexpected_action', 'moving_direction', 'state_change', 'object_interaction', 'character_order', 'action_localization', 'counterfactual_inference', 'fine_grained_action', 'moving_attribute', 'egocentric_navigation']


### PR DESCRIPTION
## Summary
- Add a group-level `mvbench_accuracy` result so evaluating `--tasks mvbench` reports one overall score; MVBench continues to use its existing deterministic multiple-choice grading and requires no external LLM judge.
- Weight subtask accuracies by sample count, matching MVBench's official `correct / total` calculation.
- Closes #925.

## In scope
- Configure aggregate reporting across the 20 existing MVBench subtasks.

## Out of scope
- No changes to the dataset, prompts, per-sample answer parsing, individual subtask metrics, or model implementations.
- This PR does not report the smoke-test score as a full 4,000-sample benchmark result.

## Validation
- `.venv/bin/accelerate launch --multi_gpu --num_processes=8 ... -m lmms_eval eval --model qwen2_5_vl ... --tasks mvbench --limit 8` | sample size: `N=160` (8 samples x 20 subtasks) | key metrics: `108/160 = 67.5`; reported group score `67.5` | result: `pass`
- Independent JSONL recomputation | sample size: `N=160` | key metrics: 20 sample files with 8 unique evaluated samples each; recomputed and reported scores both `67.5` | result: `pass`
- `.venv/bin/ruff check lmms_eval/tasks/mvbench`, targeted pre-commit, and `git diff --check` | sample size: `N/A` | key metrics: no lint or whitespace errors | result: `pass`

<details>
<summary>Full lmms-eval output table (Qwen2.5-VL-7B-Instruct, 8 GPUs, limit 8 per subtask)</summary>

```text
qwen2_5_vl (pretrained=/mnt/umm/shared_model/Qwen2.5-VL-7B-Instruct,max_num_frames=8,attn_implementation=sdpa), gen_kwargs: (), limit: 8.0, offset: 0, num_fewshot: None, batch_size: 1

branch: main
commit: v0.6-208-gb6b01c84

|               Tasks               |Filter|n-shot|     Metric     |   |Value|   |Stderr|Stderr_CLT|
|-----------------------------------|------|-----:|----------------|---|----:|---|------|----------|
|mvbench                            |none  |      |mvbench_accuracy|↑  | 67.5|±  |N/A   |N/A       |
| - mvbench_action_antonym          |none  |     0|mvbench_accuracy|↑  | 87.5|±  |N/A   |0.1250    |
| - mvbench_action_count            |none  |     0|mvbench_accuracy|↑  | 37.5|±  |N/A   |0.1830    |
| - mvbench_action_localization     |none  |     0|mvbench_accuracy|↑  | 37.5|±  |N/A   |0.1830    |
| - mvbench_action_prediction       |none  |     0|mvbench_accuracy|↑  | 37.5|±  |N/A   |0.1830    |
| - mvbench_action_sequence         |none  |     0|mvbench_accuracy|↑  | 62.5|±  |N/A   |0.1830    |
| - mvbench_character_order         |none  |     0|mvbench_accuracy|↑  |100.0|±  |N/A   |0.0000    |
| - mvbench_counterfactual_inference|none  |     0|mvbench_accuracy|↑  | 75.0|±  |N/A   |0.1637    |
| - mvbench_egocentric_navigation   |none  |     0|mvbench_accuracy|↑  | 75.0|±  |N/A   |0.1637    |
| - mvbench_episodic_reasoning      |none  |     0|mvbench_accuracy|↑  | 62.5|±  |N/A   |0.1830    |
| - mvbench_fine_grained_action     |none  |     0|mvbench_accuracy|↑  | 62.5|±  |N/A   |0.1830    |
| - mvbench_fine_grained_pose       |none  |     0|mvbench_accuracy|↑  | 75.0|±  |N/A   |0.1637    |
| - mvbench_moving_attribute        |none  |     0|mvbench_accuracy|↑  | 87.5|±  |N/A   |0.1250    |
| - mvbench_moving_count            |none  |     0|mvbench_accuracy|↑  | 50.0|±  |N/A   |0.1890    |
| - mvbench_moving_direction        |none  |     0|mvbench_accuracy|↑  | 62.5|±  |N/A   |0.1830    |
| - mvbench_object_existence        |none  |     0|mvbench_accuracy|↑  | 87.5|±  |N/A   |0.1250    |
| - mvbench_object_interaction      |none  |     0|mvbench_accuracy|↑  | 87.5|±  |N/A   |0.1250    |
| - mvbench_object_shuffle          |none  |     0|mvbench_accuracy|↑  | 50.0|±  |N/A   |0.1890    |
| - mvbench_scene_transition        |none  |     0|mvbench_accuracy|↑  | 87.5|±  |N/A   |0.1250    |
| - mvbench_state_change            |none  |     0|mvbench_accuracy|↑  | 50.0|±  |N/A   |0.1890    |
| - mvbench_unexpected_action       |none  |     0|mvbench_accuracy|↑  | 75.0|±  |N/A   |0.1637    |

|Groups |Filter|n-shot|     Metric     |   |Value|   |Stderr|
|-------|------|------|----------------|---|----:|---|------|
|mvbench|none  |      |mvbench_accuracy|↑  | 67.5|±  |N/A   |
```

</details>

## Risk / Compatibility
- Non-breaking task-group configuration change; existing per-subtask results remain unchanged.
- The new overall score is sample-count weighted, so it remains a micro-average if subtask sample counts differ.

## Type of Change
- [x] Bug fix (non-breaking change)
- [ ] New feature
- [ ] New benchmark/task
- [ ] New model integration
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
