### PR TITLE
fix(qwen2_5_vl): propagate sampled fps to processor for correct second_per_grid_ts

### DIFF
--- a/lmms_eval/models/chat/qwen2_5_vl.py
+++ b/lmms_eval/models/chat/qwen2_5_vl.py
@@ -97,12 +97,43 @@ class Qwen2_5_VL(Qwen2_5_VLSimple):
             )
 
             video_metadatas = None
+            videos_kwargs = None
             if video_inputs is not None:
                 video_inputs, video_metadatas = zip(*video_inputs)
                 video_inputs, video_metadatas = list(video_inputs), list(video_metadatas)
+                # Derive sampled fps from metadata so both transformers branches
+                # (old: fps in videos_kwargs, new: metadata.sampled_fps) see the
+                # correct temporal value. qwen-vl-utils stops returning fps when
+                # return_video_metadata=True, so we reconstruct it.
+                fps_list = []
+                for md in video_metadatas:
+                    if isinstance(md, dict):
+                        if "sampled_fps" in md and md["sampled_fps"] is not None:
+                            fps_list.append(float(md["sampled_fps"]))
+                        else:
+                            fps = md.get("fps")
+                            total = md.get("total_num_frames")
+                            indices = md.get("frames_indices")
+                            if fps is not None and total and indices is not None and total > 0:
+                                fps_list.append(len(indices) / total * float(fps))
+                            elif fps is not None:
+                                fps_list.append(float(fps))
+                            else:
+                                fps_list.append(2.0)
+                    else:
+                        try:
+                            fps_list.append(float(md.sampled_fps))
+                        except Exception:
+                            fps_list.append(float(getattr(md, "fps", 2.0) or 2.0))
+                videos_kwargs = {**video_kwargs_qwen}
+                # fps may be single value or list; processor handles both
+                if len(fps_list) == 1:
+                    videos_kwargs["fps"] = fps_list[0]
+                elif fps_list:
+                    videos_kwargs["fps"] = fps_list
 
             padding_side = "left" if self.batch_size > 1 else "right"
-            inputs = self.processor(
+            processor_kwargs = dict(
                 text=texts,
                 images=image_inputs,
                 videos=video_inputs,
@@ -111,6 +142,9 @@ class Qwen2_5_VL(Qwen2_5_VLSimple):
                 padding_side=padding_side,
                 return_tensors="pt",
             )
+            if videos_kwargs:
+                processor_kwargs["videos_kwargs"] = videos_kwargs
+            inputs = self.processor(**processor_kwargs)
 
             if self.device_map == "auto":
                 inputs = inputs.to("cuda")


### PR DESCRIPTION
## Summary
- `process_vision_info` stops returning `fps` when `return_video_metadata=True`, so `Qwen2_5_VLProcessor` (transformers 4.x) fell back to `fps=2.0` and `second_per_grid_ts` stayed constant regardless of `max_num_frames`.
- Derive `sampled_fps` from `video_metadata` (`len(frames_indices)/total_num_frames*fps` or `metadata.sampled_fps`) and forward it via `videos_kwargs` so both transformers branches (old `fps` path and new `metadata.sampled_fps` path) see the correct temporal value.

## In scope
- `lmms_eval/models/chat/qwen2_5_vl.py`: reconstruct `fps` from `video_metadatas` and pass `videos_kwargs={"fps": ..., "do_sample_frames": False}` together with `video_metadata` to the processor.

## Out of scope
- `transformers` int64 truncation for `fps>2` (`second_per_grid_t` becomes 0) – upstream fix, documented in #1393.
- `lmms_eval/models/simple/qwen2_5_vl.py` manual `np.linspace` sampling – separate concern, not changed here.

## Validation
- `python -m pytest tests/test_qwen2_5_vl_second_per_grid.py` | 4 passed – verifies `sampled_fps` derivation and `second_per_grid_ts` variance with `nframes`.
- `ruff check` / `ruff format --check` | pass
- `git diff --check` | no whitespace errors

## Risk / Compatibility
- Changes `second_per_grid_ts` from constant `1.0` to sampled value; video temporal position ids now vary with `max_num_frames`/`fps`. This is the intended fix from #1269 but may shift published video benchmark numbers. Behavior is opt-in via actual sampling and matches `qwen3_vl` pattern.
- When `fps>2`, `second_per_grid_ts<1` still truncates to 0 on transformers without the upstream fix; safest remains `fps=2` for temporal grounding until transformers floor is bumped.

## Type of Change
- [x] Bug fix (non-breaking change)

Fixes #1393