### PR TITLE
fix: make opencv optional on linux ppc64le to allow uv sync

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
     "einops",
     "ftfy",
     "openai",
-    "opencv-python-headless",
+    "opencv-python-headless; sys_platform != 'linux' or platform_machine != 'ppc64le'",
     "av<16.0.0",
     "hf_transfer",
     "nltk",


### PR DESCRIPTION
## Summary
- `uv sync` fails on IBM Power 10 (linux ppc64le, RHEL 9.6) because `opencv-python-headless==4.13.0.92` has no wheel for `manylinux_2_34_ppc64le`
- Make `opencv-python-headless` conditional (`sys_platform != 'linux' or platform_machine != 'ppc64le'`) so `uv` skips it only on that platform
- Preserves default behavior on x86_64/aarch64/macos/windows

## In scope
- `pyproject.toml`: add environment marker to `opencv-python-headless` dependency

## Out of scope
- No change to runtime import logic (`cv2` is already optional in `lmms_eval/models/chat/llava_onevision2.py` and task utils)
- No new optional-dependency group

## Validation
- `python -m pytest test/test_ppc64le_opencv_marker.py -v` | sample size: `N=4` | result: `pass` (marker exists, evaluates `False` on `linux/ppc64le` and `True` on `linux/x86_64`, `linux/aarch64`, `darwin/arm64`, `win32/AMD64`)
- `packaging.Requirement` parse check | result: `pass`
- `ruff check` | result: `pass`
- `git diff --check` | result: `pass`

## Risk / Compatibility
- No breaking change: non-ppc64le installs unchanged; ppc64le installs now succeed (opencv features requiring `cv2` will need alternative/config)
- Marker follows PEP 508 and matches `uv` hint in the error message

## Type of Change
- [x] Bug fix (non-breaking change)
- [ ] New feature
- [ ] New benchmark/task
- [ ] New model integration
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

Closes #1283