### PR TITLE
docs: add Papers with Code badges for LLaVA-OneVision

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 [![GitHub contributors](https://img.shields.io/github/contributors/EvolvingLMMs-Lab/lmms-eval)](https://github.com/EvolvingLMMs-Lab/lmms-eval/graphs/contributors)
 [![issue resolution](https://img.shields.io/github/issues-closed-raw/EvolvingLMMs-Lab/lmms-eval)](https://github.com/EvolvingLMMs-Lab/lmms-eval/issues)
 [![open issues](https://img.shields.io/github/issues-raw/EvolvingLMMs-Lab/lmms-eval)](https://github.com/EvolvingLMMs-Lab/lmms-eval/issues)
+[![Papers with Code: #2 on NLVR2](https://paperswithcode.co/api/v1/papers/2408.03326/leaderboard-badge.svg?eval=7144&live=1)](https://paperswithcode.co/api/v1/papers/2408.03326/leaderboard-badge-link?eval=7144)
+[![Papers with Code: #3 on CLIP-CC-Bench](https://paperswithcode.co/api/v1/papers/2408.03326/leaderboard-badge.svg?eval=28575&live=1)](https://paperswithcode.co/api/v1/papers/2408.03326/leaderboard-badge-link?eval=28575)
 
 > We are building the unified evaluation toolkit for frontier models and probing the abilities in real world, shape what we build next.
 


### PR DESCRIPTION
## Summary
- Add Papers with Code live leaderboard badges for LLaVA-OneVision (NLVR2 and CLIP-CC-Bench) to README as suggested in #1483.
- Fixes #1483.

## In scope
- Add two PwC badges (`eval=7144` NLVR2, `eval=28575` CLIP-CC-Bench) alongside existing shields in `README.md`.

## Out of scope
- No model, task or evaluation code changes.
- No verification or correction of individual scores (maintainers can edit via PwC page as noted in #1483).

## Validation
- `git diff --check` | sample size: `N=1` file | key metrics: no whitespace errors | result: `pass`
- `git diff --stat` | sample size: `N=1` file | key metrics: `README.md | 2 ++` | result: `pass`
- Manual README preview: badges render as live PwC SVGs and link to `paperswithcode.co/paper/2408.03326`

## Risk / Compatibility
- Documentation-only change, no runtime or API impact.
- External badge SVGs are live from Papers with Code; no local asset change.

## Type of Change
- [ ] Bug fix (non-breaking change)
- [ ] New feature
- [ ] New benchmark/task
- [ ] New model integration
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring (no functional changes)