### PR TITLE
fix(llava): handle transformers compat for apply_chunking_to_forward import

### DIFF
--- a/lmms_eval/models/model_utils/llava_transformers_compat.py
+++ b/lmms_eval/models/model_utils/llava_transformers_compat.py
@@ -1,0 +1,61 @@
+"""Compatibility shim for LLaVA + transformers version mismatch.
+
+External LLaVA-NeXT code historically imported
+
+    from transformers.modeling_utils import apply_chunking_to_forward
+
+whereas transformers >= 4.47 moved those helpers to
+
+    transformers.pytorch_utils.
+
+Newer LLaVA patches swap the import, but older installs still
+reference the old location, and some forks mistakenly import
+``PreTrainedModel`` from ``pytorch_utils``.  This module mirrors the
+helpers to both locations so that either import path succeeds
+regardless of the installed transformers version, without pinning
+the dependency.
+"""
+
+from __future__ import annotations
+
+
+def ensure_transformers_compat() -> None:
+    try:
+        import transformers.modeling_utils as modeling_utils
+    except Exception:
+        modeling_utils = None  # type: ignore[assignment]
+    try:
+        import transformers.pytorch_utils as pytorch_utils
+    except Exception:
+        pytorch_utils = None  # type: ignore[assignment]
+
+    if modeling_utils is None and pytorch_utils is None:
+        return
+
+    names = [
+        "apply_chunking_to_forward",
+        "find_pruneable_heads_and_indices",
+        "prune_linear_layer",
+    ]
+    for name in names:
+        mu_has = hasattr(modeling_utils, name) if modeling_utils is not None else False
+        pu_has = hasattr(pytorch_utils, name) if pytorch_utils is not None else False
+        if pu_has and not mu_has:
+            try:
+                setattr(modeling_utils, name, getattr(pytorch_utils, name))
+            except Exception:
+                pass
+        if mu_has and not pu_has:
+            try:
+                setattr(pytorch_utils, name, getattr(modeling_utils, name))
+            except Exception:
+                pass
+
+    # Some patched LLaVA forks incorrectly import PreTrainedModel from
+    # pytorch_utils; ensure that path also resolves.
+    if modeling_utils is not None and pytorch_utils is not None:
+        if hasattr(modeling_utils, "PreTrainedModel") and not hasattr(pytorch_utils, "PreTrainedModel"):
+            try:
+                setattr(pytorch_utils, "PreTrainedModel", getattr(modeling_utils, "PreTrainedModel"))
+            except Exception:
+                pass

--- a/lmms_eval/models/simple/llava.py
+++ b/lmms_eval/models/simple/llava.py
@@ -18,6 +18,13 @@ from lmms_eval.api.instance import Instance  # noqa: E402
 from lmms_eval.api.model import lmms  # noqa: E402
 from lmms_eval.api.registry import register_model  # noqa: E402
 
+try:
+    from lmms_eval.models.model_utils.llava_transformers_compat import ensure_transformers_compat  # noqa: E402
+
+    ensure_transformers_compat()
+except Exception:
+    pass
+
 warnings.filterwarnings("ignore")
 
 from loguru import logger as eval_logger  # noqa: E402

--- a/lmms_eval/models/simple/llava_onevision.py
+++ b/lmms_eval/models/simple/llava_onevision.py
@@ -19,7 +19,10 @@ from lmms_eval import utils
 from lmms_eval.api.instance import Instance
 from lmms_eval.api.model import lmms
 from lmms_eval.api.registry import register_model
+from lmms_eval.models.model_utils.llava_transformers_compat import ensure_transformers_compat
 from lmms_eval.models.model_utils.load_video import read_video
+
+ensure_transformers_compat()
 
 # Suppress warnings
 warnings.filterwarnings("ignore")

--- a/lmms_eval/models/simple/llava_onevision_moviechat.py
+++ b/lmms_eval/models/simple/llava_onevision_moviechat.py
@@ -24,6 +24,9 @@ from lmms_eval import utils
 from lmms_eval.api.instance import Instance
 from lmms_eval.api.model import lmms
 from lmms_eval.api.registry import register_model
+from lmms_eval.models.model_utils.llava_transformers_compat import ensure_transformers_compat
+
+ensure_transformers_compat()
 
 # Suppress warnings
 warnings.filterwarnings("ignore")

--- a/lmms_eval/models/simple/llava_vid.py
+++ b/lmms_eval/models/simple/llava_vid.py
@@ -10,6 +10,14 @@ import torch
 from accelerate import Accelerator, DistributedType, InitProcessGroupKwargs
 from accelerate.state import AcceleratorState
 from decord import VideoReader, cpu
+
+try:
+    from lmms_eval.models.model_utils.llava_transformers_compat import ensure_transformers_compat
+
+    ensure_transformers_compat()
+except Exception:
+    pass
+
 from llava.constants import (
     DEFAULT_IM_END_TOKEN,
     DEFAULT_IM_START_TOKEN,

--- a/lmms_eval/models/simple/slime.py
+++ b/lmms_eval/models/simple/slime.py
@@ -18,6 +18,13 @@ from lmms_eval.api.instance import Instance  # noqa: E402
 from lmms_eval.api.model import lmms  # noqa: E402
 from lmms_eval.api.registry import register_model  # noqa: E402
 
+try:
+    from lmms_eval.models.model_utils.llava_transformers_compat import ensure_transformers_compat  # noqa: E402
+
+    ensure_transformers_compat()
+except Exception:
+    pass
+
 warnings.filterwarnings("ignore")
 
 from loguru import logger as eval_logger  # noqa: E402

--- a/lmms_eval/models/simple/vila.py
+++ b/lmms_eval/models/simple/vila.py
@@ -16,6 +16,13 @@ from lmms_eval.api.registry import register_model
 from lmms_eval.imports import require_package
 from lmms_eval.models.model_utils.load_video import read_video
 
+try:
+    from lmms_eval.models.model_utils.llava_transformers_compat import ensure_transformers_compat
+
+    ensure_transformers_compat()
+except Exception:
+    pass
+
 eval_logger = logging.getLogger("lmms-eval")
 
 require_package("llava", feature="VILA model")


### PR DESCRIPTION
## Summary
- Fix `llava_onevision` (and sibling llava models) failing to import on transformers>=4.47 where `apply_chunking_to_forward` moved from `modeling_utils` to `pytorch_utils`
- Add `lmms_eval/models/model_utils/llava_transformers_compat.py` that mirrors `apply_chunking_to_forward`, `find_pruneable_heads_and_indices`, `prune_linear_layer` bidirectionally and shims `PreTrainedModel` for mistaken imports
- Call the shim before any `from llava.* import` in `llava_onevision`, `llava`, `llava_vid`, `vila`, `slime`, `llava_onevision_moviechat`

## In scope
- New compat module + 6 one-line ensures in llava-family model wrappers

## Out of scope
- No change to model logic, training, or evaluation; no dependency pin
- Does not vendor or patch external LLaVA code itself

## Validation
- `python /tmp/test_compat.py` with mocked new/old transformers layout | N=2 scenarios | result: pass
- `ruff check` on patched files | result: pass
- `python -m py_compile` on patched files | result: pass

## Risk / Compatibility
- No breaking change; shim is no-op when both locations already have helpers
- Isolated to llava-family imports; does not affect `llava_hf` path

## Type of Change
- [x] Bug fix (non-breaking change)

Fixes #860