### PR TITLE
feat: add EgoLifeQA benchmark

### DIFF
--- a/lmms_eval/tasks/egolifeqa/README.md
+++ b/lmms_eval/tasks/egolifeqa/README.md
@@ -1,0 +1,29 @@
+# EgoLifeQA
+
+EgoLifeQA is a long-context, life-oriented video QA benchmark from the EgoLife project (CVPR 2025).
+
+- Paper: https://arxiv.org/abs/2503.03803
+- Project: https://egolife-ai.github.io/
+- Dataset: https://huggingface.co/datasets/lmms-lab/EgoLife (EgoLifeQA/EgoLifeQA_A1_JAKE.json, 500 4-way multiple-choice questions)
+- Videos: 300 hours of egocentric video under `A1_JAKE/DAY*/` in the same HF repo (30s clips, ~32k files)
+
+## Task
+
+- Modality: Video
+- Output type: `multiple_choice` (loglikelihood-based, 4 options A-D)
+- Question types: EntityLog, etc. covering recall, health, recommendations over long temporal context.
+
+## Usage
+
+```bash
+python -m lmms_eval --model qwen2_5_vl --model_args pretrained=Qwen/Qwen2.5-VL-7B-Instruct --tasks egolifeqa --batch_size 1
+```
+
+Videos are resolved via `lmms_eval/tasks/_task_utils/media_resolver.py`:
+- Set `EGOLIFEQA_VIDEO_DIR=/path/to/egolife/videos` to use a local copy, or leave unset to use `~/.cache/huggingface/egolifeqa`.
+- The `data_files` entry uses `hf://datasets/lmms-lab/EgoLife` so `datasets` will stream/download the QA JSON directly from the Hub without a separate manual step.
+
+## Notes
+
+- Currently one participant (A1_JAKE) is released; the task will automatically pick up additional `EgoLifeQA_*.json` files when they appear by updating `data_files` to a glob.
+- For long-context evaluation, `doc_to_visual` returns the single 30s clip nearest to `query_time`; retrieval-augmented methods (EgoRAG) can override this by feeding additional context via the model's retrieval path.

--- a/lmms_eval/tasks/egolifeqa/_default_template_yaml
+++ b/lmms_eval/tasks/egolifeqa/_default_template_yaml
@@ -1,0 +1,24 @@
+dataset_path: json
+dataset_kwargs:
+  data_files:
+    test: hf://datasets/lmms-lab/EgoLife/EgoLifeQA/EgoLifeQA_A1_JAKE.json
+  cache_dir: egolifeqa
+test_split: test
+output_type: multiple_choice
+doc_to_visual: !function utils.egolifeqa_doc_to_visual
+doc_to_text: !function utils.egolifeqa_doc_to_text
+doc_to_choice: !function utils.egolifeqa_doc_to_choice
+doc_to_target: !function utils.egolifeqa_doc_to_target
+metric_list:
+  - metric: acc
+    aggregation: mean
+    higher_is_better: true
+lmms_eval_specific_kwargs:
+  default:
+    pre_prompt: ""
+    post_prompt: "\nAnswer with the option's letter from the given choices directly."
+  qwen3_vl:
+    pre_prompt: "Question: "
+    post_prompt: "\nAnswer with the option letter only."
+metadata:
+  version: 0.1

--- a/lmms_eval/tasks/egolifeqa/egolifeqa.yaml
+++ b/lmms_eval/tasks/egolifeqa/egolifeqa.yaml
@@ -1,0 +1,2 @@
+include: _default_template_yaml
+task: egolifeqa

--- a/lmms_eval/tasks/egolifeqa/utils.py
+++ b/lmms_eval/tasks/egolifeqa/utils.py
@@ -1,0 +1,234 @@
+import glob
+import os
+import re
+from pathlib import Path
+
+from loguru import logger as eval_logger
+
+from lmms_eval.tasks._task_utils.media_resolver import resolve_media_reference
+
+_HF_REPO = "lmms-lab/EgoLife"
+_PARTICIPANT = "A1_JAKE"
+_VIDEO_EXTENSIONS = ("mp4", "MP4", "mkv", "webm", "mov")
+
+
+def _parse_time_str(time_str: str) -> int | None:
+    s = str(time_str).strip()
+    if not s.isdigit():
+        return None
+    try:
+        if len(s) == 8:
+            h = int(s[0:2])
+            m = int(s[2:4])
+            sec = int(s[4:6])
+            frac = int(s[6:8])
+            return h * 3600 + m * 60 + sec + frac / 100
+        if len(s) == 6:
+            h = int(s[0:2])
+            m = int(s[2:4])
+            sec = int(s[4:6])
+            return h * 3600 + m * 60 + sec
+        return int(s)
+    except ValueError:
+        return None
+
+
+def _time_to_seconds(time_obj) -> int | None:
+    if isinstance(time_obj, dict):
+        t = time_obj.get("time", "")
+        return _parse_time_str(t)
+    return _parse_time_str(time_obj)
+
+
+def _candidate_video_dirs(participant: str = _PARTICIPANT) -> list[Path]:
+    paths: list[Path] = []
+    explicit = os.getenv("EGOLIFEQA_VIDEO_DIR", "").strip()
+    if explicit:
+        paths.append(Path(os.path.expanduser(explicit)))
+    explicit_cache = os.getenv("EGOLIFEQA_CACHE_DIR", "").strip()
+    if explicit_cache:
+        paths.append(Path(os.path.expanduser(explicit_cache)))
+    hf_home = Path(os.path.expanduser(os.getenv("HF_HOME", "~/.cache/huggingface")))
+    paths.append(hf_home / "egolifeqa")
+    paths.append(hf_home / "egolife")
+    # hf hub snapshot location for lmms-lab/EgoLife
+    hub_base = hf_home / "hub" / "datasets--lmms-lab--EgoLife"
+    if hub_base.exists():
+        for snap in (hub_base / "snapshots").glob("*"):
+            paths.append(snap / participant)
+            paths.append(snap)
+    return paths
+
+
+def _find_nearest_video(participant: str, day: str, query_time: str) -> str | None:
+    target_sec = _parse_time_str(query_time)
+    if target_sec is None:
+        return None
+    day = str(day).strip()
+    search_dirs = _candidate_video_dirs(participant)
+    # Also try resolving via media_resolver for direct filename guess
+    # Guess filename: DAYx_PARTICIPANT_HHMMSS00.mp4 floored to 30s
+    for root in search_dirs:
+        # Pattern: DAY*/DAY*_PARTICIPANT*.mp4 sorted
+        pattern = str(root / participant / day / f"{day}_{participant}_*.mp4")
+        candidates = glob.glob(pattern)
+        if not candidates:
+            pattern2 = str(root / day / f"{day}_{participant}_*.mp4")
+            candidates = glob.glob(pattern2)
+        if not candidates:
+            pattern3 = str(root / f"{day}_{participant}_*.mp4")
+            candidates = glob.glob(pattern3)
+        if candidates:
+            best = None
+            best_dist = float("inf")
+            for cand in candidates:
+                m = re.search(r"_(\d{8})(?:\.mp4)?$", cand)
+                if not m:
+                    m = re.search(r"_(\d{6})(?:\.mp4)?$", cand)
+                if m:
+                    sec = _parse_time_str(m.group(1))
+                    if sec is not None:
+                        dist = abs(sec - target_sec)
+                        if dist < best_dist:
+                            best_dist = dist
+                            best = cand
+            if best:
+                return best
+    # Fallback: try media_resolver direct reference without existence check
+    guess = f"{day}_{participant}_{str(query_time)[:6]}0000"
+    resolved = resolve_media_reference(guess, media_type="video", cache_dir="egolifeqa", env_vars=("EGOLIFEQA_VIDEO_DIR", "EGOLIFEQA_CACHE_DIR"))
+    if isinstance(resolved, str) and os.path.exists(resolved):
+        return resolved
+    return None
+
+
+def egolifeqa_doc_to_visual(doc):
+    participant = str(doc.get("participant", _PARTICIPANT)).strip() or _PARTICIPANT
+    query_time = doc.get("query_time", {})
+    day = ""
+    time_str = ""
+    if isinstance(query_time, dict):
+        day = query_time.get("date", "")
+        time_str = query_time.get("time", "")
+    else:
+        day = str(doc.get("day", "DAY1"))
+        time_str = str(query_time)
+    if not day:
+        day = "DAY1"
+    if not time_str:
+        time_str = "11000000"
+
+    # Try direct video field if present
+    for key in ("video", "video_path", "video_file", "clip_path"):
+        val = doc.get(key)
+        if val:
+            resolved = resolve_media_reference(str(val), media_type="video", cache_dir="egolifeqa", env_vars=("EGOLIFEQA_VIDEO_DIR", "EGOLIFEQA_CACHE_DIR"))
+            if isinstance(resolved, str) and os.path.exists(resolved):
+                return [resolved]
+            if isinstance(resolved, str):
+                return [resolved]
+
+    found = _find_nearest_video(participant, day, time_str)
+    if found:
+        return [found]
+
+    # Try constructing HF hub path
+    vid_name = f"{day}_{participant}_{str(time_str)[:8]}.mp4"
+    # Attempt hf_hub_download style path (will be downloaded lazily by model if needed)
+    # Return a path that media_resolver would resolve
+    fallback = resolve_media_reference(vid_name, media_type="video", cache_dir="egolifeqa", env_vars=("EGOLIFEQA_VIDEO_DIR", "EGOLIFEQA_CACHE_DIR"))
+    if isinstance(fallback, str):
+        if os.path.exists(fallback):
+            return [fallback]
+        # If not exists, warn and return fallback path anyway (model may handle missing gracefully)
+        eval_logger.warning(f"EgoLifeQA: video not found for {participant}/{day}/{time_str}, fallback {fallback}")
+        return [fallback]
+    eval_logger.warning(f"EgoLifeQA: no video found for {participant}/{day}/{time_str}")
+    return []
+
+
+def egolifeqa_doc_to_text(doc, lmms_eval_specific_kwargs=None):
+    if lmms_eval_specific_kwargs is None:
+        lmms_eval_specific_kwargs = {}
+    pre_prompt = lmms_eval_specific_kwargs.get("pre_prompt", "")
+    post_prompt = lmms_eval_specific_kwargs.get("post_prompt", "")
+
+    question = str(doc.get("question", "")).strip()
+    options = []
+    # Support both choice_a/b/c/d and options list
+    if "choice_a" in doc:
+        for key in ("choice_a", "choice_b", "choice_c", "choice_d", "choice_e"):
+            if key in doc and doc[key]:
+                letter = chr(ord("A") + len(options))
+                options.append(f"{letter}. {doc[key]}")
+    elif "options" in doc:
+        opts = doc["options"]
+        if isinstance(opts, list):
+            for i, opt in enumerate(opts):
+                options.append(f"{chr(ord('A')+i)}. {opt}")
+        elif isinstance(opts, dict):
+            for letter in sorted(opts.keys()):
+                options.append(f"{letter}. {opts[letter]}")
+    elif "option" in doc:
+        opts = doc["option"]
+        if isinstance(opts, list):
+            for op in opts:
+                options.append(str(op))
+        elif isinstance(opts, dict):
+            for letter in sorted(opts.keys()):
+                options.append(f"{letter}. {opts[letter]}")
+
+    prompt = question
+    if options:
+        prompt = f"{question}\n" + "\n".join(options)
+
+    return f"{pre_prompt}{prompt}{post_prompt}"
+
+
+def egolifeqa_doc_to_choice(doc):
+    choices = []
+    if "choice_a" in doc:
+        for key in ("choice_a", "choice_b", "choice_c", "choice_d", "choice_e"):
+            if key in doc and doc[key] is not None:
+                choices.append(str(doc[key]).strip())
+        # filter empty
+        choices = [c for c in choices if c]
+        return choices
+    if "options" in doc:
+        opts = doc["options"]
+        if isinstance(opts, list):
+            return [str(o).strip() for o in opts]
+        if isinstance(opts, dict):
+            return [str(opts[k]).strip() for k in sorted(opts.keys())]
+    if "option" in doc:
+        opts = doc["option"]
+        if isinstance(opts, list):
+            # handle "A. xxx" format
+            return [str(op).split(".", 1)[-1].strip() if "." in str(op) else str(op).strip() for op in opts]
+        if isinstance(opts, dict):
+            return [str(opts[k]).strip() for k in sorted(opts.keys())]
+    # fallback: try choice_*
+    for key in ("choice_a", "choice_b", "choice_c", "choice_d"):
+        if doc.get(key):
+            choices.append(str(doc[key]).strip())
+    return choices
+
+
+def egolifeqa_doc_to_target(doc):
+    answer = str(doc.get("answer", "")).strip()
+    # Normalize to upper letter
+    if len(answer) == 1 and answer.upper() in "ABCDE":
+        choices = egolifeqa_doc_to_choice(doc)
+        idx = ord(answer.upper()) - ord("A")
+        if 0 <= idx < len(choices):
+            return choices[idx]
+        return answer.upper()
+    # If answer is full text, return as is if in choices
+    choices = egolifeqa_doc_to_choice(doc)
+    if answer in choices:
+        return answer
+    # Try case-insensitive match
+    for c in choices:
+        if c.lower() == answer.lower():
+            return c
+    return answer

--- a/lmms_eval/tasks/egolifeqa/utils.py
+++ b/lmms_eval/tasks/egolifeqa/utils.py
@@ -165,7 +165,7 @@ def egolifeqa_doc_to_text(doc, lmms_eval_specific_kwargs=None):
         opts = doc["options"]
         if isinstance(opts, list):
             for i, opt in enumerate(opts):
-                options.append(f"{chr(ord('A')+i)}. {opt}")
+                options.append(f"{chr(ord('A') + i)}. {opt}")
         elif isinstance(opts, dict):
             for letter in sorted(opts.keys()):
                 options.append(f"{letter}. {opts[letter]}")


### PR DESCRIPTION
## Summary
- Add EgoLifeQA long-context life-oriented video QA benchmark (CVPR 2025)
- Implements `lmms_eval/tasks/egolifeqa` with `multiple_choice` loglikelihood evaluation
- Resolves 30s egocentric clips nearest to `query_time` via `media_resolver`

## In scope
- `lmms_eval/tasks/egolifeqa/_default_template_yaml` — dataset config (`hf://datasets/lmms-lab/EgoLife`, `multiple_choice`)
- `lmms_eval/tasks/egolifeqa/egolifeqa.yaml` — task include wrapper
- `lmms_eval/tasks/egolifeqa/utils.py` — `doc_to_visual/text/choice/target` with flexible answer/option handling and video lookup
- `lmms_eval/tasks/egolifeqa/README.md` — usage and dataset notes

## Out of scope
- No changes to models, evaluator, or other tasks
- No update to `docs/advanced/current_tasks.md` (can be added in follow-up)
- No grouping/alias changes

## Validation
- `python -m py_compile lmms_eval/tasks/egolifeqa/utils.py` | sample size: `N=1` | key metrics: `compile` | result: `pass`
- `uv run ruff check lmms_eval/tasks/egolifeqa/utils.py` | sample size: `N=1` | key metrics: `lint` | result: `pass`
- `python /tmp/test_egolifeqa_proof.py` | sample size: `N=5` | key metrics: `doc_to_choice/target/text/visual + yaml` | result: `pass`

## Risk / Compatibility
- No breaking changes; new task only, opt-in via `--tasks egolifeqa`
- Dataset requires network fetch from `hf://datasets/lmms-lab/EgoLife`; videos resolved lazily via `EGOLIFEQA_VIDEO_DIR` or HF cache

## Type of Change
- [x] New benchmark/task

Fixes #1214