### PR TITLE
feat: add group-level postprocess hook for custom result aggregation

### DIFF
--- a/lmms_eval/api/group.py
+++ b/lmms_eval/api/group.py
@@ -26,6 +26,7 @@ class GroupConfig(dict):
     group_alias: Optional[str] = None
     task: Optional[Union[str, list]] = None
     aggregate_metric_list: Optional[Union[List[AggMetricConfig], AggMetricConfig, dict]] = None
+    postprocess_results: Optional[Union[Callable, str]] = None
     metadata: Optional[dict] = None  # by default, not used in the code. allows for users to pass arbitrary info to tasks
 
     def __getitem__(self, item):

--- a/lmms_eval/evaluator.py
+++ b/lmms_eval/evaluator.py
@@ -980,6 +980,9 @@ def evaluate(
     cli_args=None,
     response_cache: Optional[ResponseCache] = None,
     process_docs_parallel: int = 4,
+    output_dir: Optional[str] = None,
+    model_output_dir: Optional[str] = None,
+    sample_files: Optional[dict] = None,
 ):
     """Instantiate and evaluate a model on a list of tasks.
 
@@ -1519,7 +1522,24 @@ def evaluate(
 
         ### Calculate group metrics ###
         if bool(results):
-            results, versions, show_group_table, *_ = consolidate_group_results(results, versions, task_dict)
+            # Resolve output dirs for group hooks if cli_args carries them
+            _output_dir = output_dir
+            _model_output_dir = model_output_dir
+            _sample_files = sample_files
+            if _output_dir is None and cli_args is not None:
+                _output_dir = getattr(cli_args, "output_path", None)
+            if _sample_files is None and cli_args is not None:
+                _sample_files = getattr(cli_args, "sample_files", None)
+            results, versions, show_group_table, *_ = consolidate_group_results(
+                results,
+                versions,
+                task_dict,
+                samples=samples,
+                configs=configs,
+                output_dir=_output_dir,
+                model_output_dir=_model_output_dir,
+                sample_files=_sample_files,
+            )
 
         results_agg, group_agg = prepare_print_tasks(task_dict, results)
         subtask_list = get_subtask_list(task_dict)

--- a/lmms_eval/evaluator_utils.py
+++ b/lmms_eval/evaluator_utils.py
@@ -459,6 +459,122 @@ def consolidate_results(
     return results, samples, configs, versions, num_fewshot, higher_is_better
 
 
+def _resolve_group_postprocess_callable(raw):
+    """Resolve group postprocess_results value to a callable.
+
+    Supports a callable directly (from YAML !function) or a string import path
+    such as "lmms_eval.tasks.sitebench.utils.sitebench_merge_results".
+    """
+    if raw is None:
+        return None
+    if callable(raw):
+        return raw
+    if isinstance(raw, str):
+        import importlib
+
+        try:
+            module_name, func_name = raw.rsplit(".", 1)
+            mod = importlib.import_module(module_name)
+            fn = getattr(mod, func_name)
+            if callable(fn):
+                return fn
+            eval_logger.warning(f"Group postprocess_results '{raw}' resolved to non-callable {fn}")
+            return None
+        except Exception as e:
+            eval_logger.warning(f"Failed to resolve group postprocess_results '{raw}': {e}")
+            return None
+    eval_logger.warning(f"Unsupported postprocess_results type {type(raw)}: {raw}")
+    return None
+
+
+def _invoke_group_postprocess(
+    hook,
+    *,
+    group_name,
+    subtask_names,
+    results,
+    samples=None,
+    configs=None,
+    versions=None,
+    output_dir=None,
+    model_output_dir=None,
+    sample_files=None,
+    group_config=None,
+    group_metadata=None,
+):
+    """Invoke group postprocess hook with flexible signature support.
+
+    The hook may declare any subset of the available context. We inspect its
+    signature and only pass arguments it accepts (plus **kwargs passthrough).
+    """
+    if hook is None:
+        return None
+    # Build full context
+    context = {
+        "group_name": group_name,
+        "group": group_name,
+        "subtask_names": subtask_names,
+        "subtasks": subtask_names,
+        "task_names": subtask_names,
+        "results": results,
+        "samples": samples,
+        "configs": configs,
+        "versions": versions,
+        "output_dir": output_dir,
+        "output_path": output_dir,
+        "model_output_dir": model_output_dir,
+        "model_result_dir": model_output_dir,
+        "sample_files": sample_files,
+        "sample_paths": sample_files,
+        "group_config": group_config,
+        "config": group_config,
+        "group_metadata": group_metadata,
+        "metadata": group_metadata,
+    }
+    # Also include mapping for sample JSONL paths alias
+    try:
+        sig = inspect.signature(hook)
+    except (ValueError, TypeError):
+        # fallback: try calling with minimal args
+        try:
+            return hook(group_name, subtask_names, results)
+        except Exception as e:
+            eval_logger.warning(f"Group postprocess hook '{group_name}' failed with fallback call: {e}")
+            return None
+
+    # Check if hook accepts **kwargs
+    has_var_kw = any(p.kind == inspect.Parameter.VAR_KEYWORD for p in sig.parameters.values())
+    # Filter context to params that hook accepts if it doesn't have **kwargs
+    if has_var_kw:
+        filtered = context
+    else:
+        filtered = {k: v for k, v in context.items() if k in sig.parameters}
+
+    # Special handling: if hook expects exactly 3 positional args (group_name, subtasks, results)
+    # and filtered lost some required params, try to call with positional
+    try:
+        # Try keyword call first
+        return hook(**filtered)
+    except TypeError as e:
+        # Try positional fallback: (group_name, subtask_names, results) + kwargs
+        eval_logger.debug(f"Group postprocess hook '{group_name}' keyword call failed ({e}), trying positional fallback")
+        try:
+            # Determine if hook wants positional args
+            params = list(sig.parameters.values())
+            # If first 3 params are positional-like, try
+            if len(params) >= 3:
+                # Try calling with first 3 as positional and rest as kwargs
+                kwargs_rest = {k: v for k, v in filtered.items() if k not in [p.name for p in params[:3]]}
+                return hook(group_name, subtask_names, results, **kwargs_rest)
+            return hook(group_name, subtask_names, results)
+        except Exception as e2:
+            eval_logger.warning(f"Group postprocess hook '{group_name}' failed: {e2}")
+            return None
+    except Exception as e:
+        eval_logger.warning(f"Group postprocess hook '{group_name}' failed: {e}")
+        return None
+
+
 def consolidate_group_results(
     results,
     versions,
@@ -466,6 +582,11 @@ def consolidate_group_results(
     task_root=None,
     show_group_table=False,
     task_aggregation_list=None,
+    samples=None,
+    configs=None,
+    output_dir=None,
+    model_output_dir=None,
+    sample_files=None,
 ) -> Tuple[dict, dict, bool, Union[None, dict]]:
     """
     (Recursively) calculates groups' aggregated metrics and updates the results and versions dictionaries with this info.
@@ -491,7 +612,10 @@ def consolidate_group_results(
     for group_or_task, group_or_task_info in task_dict.items():
         # Convert to string
         if isinstance(group_or_task, ConfigurableGroup):
-            group_config = group_or_task.config
+            try:
+                group_config = group_or_task._config.to_dict(keep_callable=True)
+            except Exception:
+                group_config = group_or_task.config
             group_or_task = group_or_task.group_name
         else:
             group_config = None
@@ -512,61 +636,130 @@ def consolidate_group_results(
                 group_or_task,
                 show_group_table,
                 task_aggregation_list,
+                samples=samples,
+                configs=configs,
+                output_dir=output_dir,
+                model_output_dir=model_output_dir,
+                sample_files=sample_files,
             )
             if task_root:
                 task_aggregation_list.setdefault(task_root, []).extend(task_aggregation_list.get(group_or_task, []))
 
-            if (group_config is None) or (group_config["aggregate_metric_list"] is None):
-                results[group_or_task][" "] = " "
-                continue
+            # Ensure group entry exists
+            if group_or_task not in results:
+                results[group_or_task] = {}
+            # Track whether this group should appear in group table
+            has_agg_list = bool(group_config and group_config.get("aggregate_metric_list"))
+            has_hook = bool(group_config and group_config.get("postprocess_results"))
 
-            if "aggregate_metric_list" in group_config:
+            if not has_agg_list and not has_hook:
+                if " " not in results[group_or_task]:
+                    results[group_or_task][" "] = " "
+            else:
+                # Remove placeholder if present
+                if " " in results[group_or_task] and (has_agg_list or has_hook):
+                    # keep placeholder removal? placeholder indicates no aggregation; but hook will provide metrics
+                    # we remove it when we have real metrics
+                    pass
+
+            if has_agg_list:
                 agg_metric_list = group_config["aggregate_metric_list"]
+                show_group_table = show_group_table | bool(agg_metric_list)
+                task_list = _task_aggregation_list.get(group_or_task, [])
+                if task_list:
+                    metric_list = list({key for task in task_list for key in results[task].keys() if "_stderr" not in key and key not in ["task", "alias", "samples"]})
+                    for metric in metric_list:
+                        stderr = "_stderr,".join(metric.split(","))
 
-            show_group_table = show_group_table | bool(group_config["aggregate_metric_list"])
+                        # gather metrics, sizes, and stderrs from subtasks
+                        metrics = [results[task][metric] for task in task_list if metric in results[task]]  # TODO: copy?
+                        stderrs = [results[task][stderr] for task in task_list if stderr in results[task]]
+                        sizes = [results[task]["samples"] for task in task_list if metric in results[task]]
 
-            task_list = _task_aggregation_list[group_or_task]
+                        for metric_config in agg_metric_list:
+                            for filter_name in metric_config["filter_list"]:
+                                if metric_config["metric"] not in metric:
+                                    continue
 
-            metric_list = list({key for task in task_list for key in results[task].keys() if "_stderr" not in key and key not in ["task", "alias", "samples"]})
-            for metric in metric_list:
-                stderr = "_stderr,".join(metric.split(","))
+                                # compute group's pooled metric and stderr
+                                if metric_config["aggregation"] == "mean":
+                                    aggregate_fn = aggregate_subtask_metrics
+                                elif callable(metric_config["aggregation"]):
+                                    aggregate_fn = metric_config["aggregation"]
+                                else:
+                                    raise ValueError(f"Currently, only 'mean' is supported for automatically aggregating scores across groups' subtasks. Got '{metric_config['aggregation']}' for group '{group_or_task}'")
 
-                # gather metrics, sizes, and stderrs from subtasks
-                metrics = [results[task][metric] for task in task_list if metric in results[task]]  # TODO: copy?
-                stderrs = [results[task][stderr] for task in task_list if stderr in results[task]]
-                sizes = [results[task]["samples"] for task in task_list if metric in results[task]]
+                                results[group_or_task][metric] = aggregate_fn(
+                                    metrics,
+                                    sizes,
+                                    metric_config["weight_by_size"],
+                                )
+                                if "N/A" in stderrs:
+                                    results[group_or_task][stderr] = "N/A"
+                                else:
+                                    results[group_or_task][stderr] = pooled_sample_stderr(stderrs, sizes)
 
-                for metric_config in agg_metric_list:
-                    for filter_name in metric_config["filter_list"]:
-                        # if metric != ",".join([metric_config["metric"], filter_name]):
-                        #     continue
-                        if metric_config["metric"] not in metric:
-                            continue
+                    # compute samples and clean placeholder
+                    if task_list:
+                        try:
+                            sizes_all = [results[task].get("samples", 0) for task in task_list if "samples" in results[task]]
+                            if sizes_all:
+                                results[group_or_task]["samples"] = sum(sizes_all)
+                        except Exception:
+                            pass
+                    if " " in results[group_or_task]:
+                        results[group_or_task].pop(" ", None)
 
-                        # compute group's pooled metric and stderr
-                        if metric_config["aggregation"] == "mean":
-                            aggregate_fn = aggregate_subtask_metrics
-                        elif callable(metric_config["aggregation"]):
-                            aggregate_fn = metric_config["aggregation"]
-                        else:
-                            raise ValueError(f"Currently, only 'mean' is supported for automatically aggregating scores across groups' subtasks. Got '{metric_config['aggregation']}' for group '{group_or_task}'")
+                group_metadata_tmp = group_config.get("metadata", None) if group_config else None
+                if group_metadata_tmp is not None:
+                    versions[group_or_task] = group_metadata_tmp.get("version", None)
 
-                        results[group_or_task][metric] = aggregate_fn(
-                            metrics,
-                            sizes,
-                            metric_config["weight_by_size"],
-                        )
-                        # TODO: calculate groups' metrics using arbitrary agg fns
-                        if "N/A" in stderrs:
-                            results[group_or_task][stderr] = "N/A"
-                        else:
-                            # NOTE: this assumes we are using the mean to aggregate. There are warnings about this elsewhere
-                            results[group_or_task][stderr] = pooled_sample_stderr(stderrs, sizes)
-
-                results[group_or_task]["samples"] = sum(sizes)
-                group_metadata = group_config.get("metadata", None)
-                if group_metadata is not None:
-                    versions[group_or_task] = group_metadata.get("version", None)
+            # Group-level postprocess_results hook (runs after aggregate_metric_list)
+            if has_hook:
+                raw_hook = group_config.get("postprocess_results")
+                hook_fn = _resolve_group_postprocess_callable(raw_hook)
+                if hook_fn is not None:
+                    task_list = _task_aggregation_list.get(group_or_task, [])
+                    # Ensure group entry has at least alias
+                    if "alias" not in results[group_or_task]:
+                        results[group_or_task]["alias"] = group_or_task
+                    hook_result = _invoke_group_postprocess(
+                        hook_fn,
+                        group_name=group_or_task,
+                        subtask_names=list(task_list),
+                        results=results,
+                        samples=samples,
+                        configs=configs,
+                        versions=versions,
+                        output_dir=output_dir,
+                        model_output_dir=model_output_dir,
+                        sample_files=sample_files,
+                        group_config=group_config,
+                        group_metadata=group_config.get("metadata") if group_config else None,
+                    )
+                    if isinstance(hook_result, dict) and hook_result:
+                        for k, v in hook_result.items():
+                            results[group_or_task][k] = v
+                        if " " in results[group_or_task]:
+                            results[group_or_task].pop(" ", None)
+                        show_group_table = True
+                    elif hook_result is not None and not isinstance(hook_result, dict):
+                        eval_logger.warning(f"Group postprocess hook '{group_or_task}' returned non-dict {type(hook_result)}, ignoring")
+                # ensure versions metadata handled even when only hook
+                if not has_agg_list:
+                    group_metadata_tmp = group_config.get("metadata", None) if group_config else None
+                    if group_metadata_tmp is not None and group_or_task not in versions:
+                        versions[group_or_task] = group_metadata_tmp.get("version", None)
+                    # ensure samples aggregated if not already
+                    if "samples" not in results[group_or_task]:
+                        task_list = _task_aggregation_list.get(group_or_task, [])
+                        if task_list:
+                            try:
+                                sizes_all = [results[task].get("samples", 0) for task in task_list if "samples" in results[task]]
+                                if sizes_all:
+                                    results[group_or_task]["samples"] = sum(sizes_all)
+                            except Exception:
+                                pass
     # print(results)
     return results, versions, show_group_table, task_aggregation_list
 

--- a/lmms_eval/tasks/sitebench/utils.py
+++ b/lmms_eval/tasks/sitebench/utils.py
@@ -562,7 +562,6 @@ def sitebench_merge_results(
     if samples is None:
         samples = kwargs.get("samples")
     sample_files = kwargs.get("sample_files") or kwargs.get("sample_paths") or kwargs.get("samples_files")
-    output_dir = kwargs.get("output_dir") or kwargs.get("output_path") or kwargs.get("model_output_dir") or kwargs.get("model_result_dir")
 
     # If samples is empty but sample_files are available, try to load JSONL files
     metric_stats_list = []

--- a/lmms_eval/tasks/sitebench/utils.py
+++ b/lmms_eval/tasks/sitebench/utils.py
@@ -437,3 +437,226 @@ def aggregate_spatial_relationship_reasoning_acc(results):
 
 def aggregate_spatial_relationship_reasoning_caa(results):
     return _aggregate_category_caa(results, "spatial relationship reasoning")
+
+
+def _sitebench_empty_stats():
+    return {"caa_num": 0.0, "caa_den": 0.0, "acc_num": 0.0, "acc_den": 0.0}
+
+
+def _sitebench_stats_from_samples(samples_list):
+    """Compute metric_stats from in-memory logged samples (list of dicts)."""
+    from collections import defaultdict
+
+    metric_stats = defaultdict(_sitebench_empty_stats)
+    category_stats = defaultdict(_sitebench_empty_stats)
+    for item in samples_list:
+        if not isinstance(item, dict):
+            continue
+        acc = item.get("accuracy", {})
+        caa = item.get("chance_adjusted_acc", {})
+        if not isinstance(acc, dict):
+            acc = {}
+        if not isinstance(caa, dict):
+            caa = {}
+        acc_total = acc.get("total", 0.0)
+        caa_total = caa.get("total", 0.0)
+        for key, value in acc.items():
+            if key == "total":
+                continue
+            try:
+                metric_stats[key]["acc_num"] += float(value)
+                metric_stats[key]["acc_den"] += float(acc_total)
+            except Exception:
+                continue
+        for key, value in caa.items():
+            if key == "total":
+                continue
+            try:
+                metric_stats[key]["caa_num"] += float(value)
+                metric_stats[key]["caa_den"] += float(caa_total)
+            except Exception:
+                continue
+        doc = item.get("doc")
+        if isinstance(doc, dict):
+            category = doc.get("category")
+            if category:
+                try:
+                    category_stats[category]["acc_num"] += float(acc.get("overall", 0.0))
+                    category_stats[category]["acc_den"] += float(acc_total)
+                    category_stats[category]["caa_num"] += float(caa.get("overall", 0.0))
+                    category_stats[category]["caa_den"] += float(caa_total)
+                except Exception:
+                    continue
+    overall = metric_stats.get("overall")
+    return dict(metric_stats), dict(category_stats), overall
+
+
+def _sitebench_merge_stats(stats1, stats2):
+    from collections import defaultdict
+
+    merged = defaultdict(_sitebench_empty_stats)
+    for key, val in (stats1 or {}).items():
+        merged[key]["acc_num"] += val.get("acc_num", 0.0)
+        merged[key]["acc_den"] += val.get("acc_den", 0.0)
+        merged[key]["caa_num"] += val.get("caa_num", 0.0)
+        merged[key]["caa_den"] += val.get("caa_den", 0.0)
+    for key, val in (stats2 or {}).items():
+        merged[key]["acc_num"] += val.get("acc_num", 0.0)
+        merged[key]["acc_den"] += val.get("acc_den", 0.0)
+        merged[key]["caa_num"] += val.get("caa_num", 0.0)
+        merged[key]["caa_den"] += val.get("caa_den", 0.0)
+    return dict(merged)
+
+
+def sitebench_merge_results(
+    group_name=None,
+    subtask_names=None,
+    results=None,
+    samples=None,
+    **kwargs,
+):
+    """Group-level postprocess hook for SiteBench.
+
+    This is the hook referenced in the group YAML as:
+
+        postprocess_results: !function utils.sitebench_merge_results
+
+    It merges per-sample sufficient statistics from subtasks
+    (site_bench_image + site_bench_video) to reproduce the official
+    SiteBench combined score, which cannot be expressed as a simple mean
+    of scalar task metrics.
+
+    The hook is designed for the ``consolidate_group_results`` contract:
+    - receives ``group_name``, subtask list, aggregated ``results``, and
+      ``samples`` dict (task -> logged samples) when ``--log_samples`` is
+      enabled;
+    - optionally receives ``sample_files``/``sample_paths`` mapping task ->
+      JSONL path and ``output_dir``/``model_output_dir`` when results are
+      written to disk;
+    - returns a dict of group-level metrics to be merged into
+      ``results[group_name]``.
+
+    Args:
+        group_name: Name of the group (e.g. "sitebench").
+        subtask_names: List of subtask names in the group.
+        results: Full results dict (unused except for introspection).
+        samples: Dict mapping subtask name -> list of logged samples.
+        **kwargs: Additional context (subtasks, task_names, sample_files,
+            sample_paths, output_dir, model_output_dir, group_config, etc.)
+
+    Returns:
+        Dict of metric key -> value (metric keys should include ",none"
+        filter suffix to match lmms-eval conventions).
+    """
+    # Normalize subtask list (support multiple kwarg aliases)
+    if subtask_names is None:
+        subtask_names = kwargs.get("subtasks") or kwargs.get("task_names") or kwargs.get("subtask_names")
+    if subtask_names is None and isinstance(results, dict) and group_name:
+        # fallback: try to infer from group_config
+        gc = kwargs.get("group_config") or kwargs.get("config")
+        if isinstance(gc, dict) and gc.get("task"):
+            subtask_names = gc.get("task")
+    if subtask_names is None:
+        subtask_names = []
+    # samples may be passed via alias
+    if samples is None:
+        samples = kwargs.get("samples")
+    sample_files = kwargs.get("sample_files") or kwargs.get("sample_paths") or kwargs.get("samples_files")
+    output_dir = kwargs.get("output_dir") or kwargs.get("output_path") or kwargs.get("model_output_dir") or kwargs.get("model_result_dir")
+
+    # If samples is empty but sample_files are available, try to load JSONL files
+    metric_stats_list = []
+    category_stats_list = []
+
+    # Try file-based path first if we have file paths and samples are empty/insufficient
+    use_file = False
+    if sample_files and isinstance(sample_files, dict):
+        # check if any file exists
+        try:
+            import os
+
+            existing = {k: v for k, v in sample_files.items() if isinstance(v, str) and os.path.exists(v)}
+            if existing and (not samples or all(not samples.get(t) for t in subtask_names)):
+                # attempt to use file-based stats
+                try:
+                    from lmms_eval.tasks.sitebench.merge_results import compute_stats_from_jsonl
+
+                    for task in subtask_names:
+                        path = existing.get(task)
+                        if path:
+                            stats = compute_stats_from_jsonl(path)
+                            metric_stats_list.append(stats.get("metric_stats", {}))
+                            category_stats_list.append(stats.get("category_stats", {}))
+                    use_file = True
+                except Exception:
+                    use_file = False
+        except Exception:
+            pass
+
+    if not use_file:
+        if not isinstance(samples, dict) or not subtask_names:
+            return {}
+        for task in subtask_names:
+            task_samples = samples.get(task, [])
+            if not task_samples:
+                continue
+            m_stats, c_stats, _ = _sitebench_stats_from_samples(task_samples)
+            if m_stats:
+                metric_stats_list.append(m_stats)
+                category_stats_list.append(c_stats)
+
+    if not metric_stats_list:
+        return {}
+
+    # Merge across subtasks
+    merged_metric = metric_stats_list[0]
+    for ms in metric_stats_list[1:]:
+        merged_metric = _sitebench_merge_stats(merged_metric, ms)
+    merged_category = {}
+    if category_stats_list:
+        merged_category = category_stats_list[0]
+        for cs in category_stats_list[1:]:
+            merged_category = _sitebench_merge_stats(merged_category, cs)
+
+    # Compute group metrics
+    out = {}
+    if "overall" in merged_metric:
+        overall = merged_metric["overall"]
+        acc_den = overall.get("acc_den", 0.0)
+        caa_den = overall.get("caa_den", 0.0)
+        if acc_den > 0:
+            acc = overall.get("acc_num", 0.0) / acc_den * 100
+            out["accuracy,none"] = round(acc, 5)
+        if caa_den > 0:
+            caa = overall.get("caa_num", 0.0) / caa_den * 100
+            out["chance_adjusted_acc,none"] = round(caa, 5)
+        # Also expose explicit sitebench keys for clarity
+        if "accuracy,none" in out:
+            out["sitebench_accuracy,none"] = out["accuracy,none"]
+        if "chance_adjusted_acc,none" in out:
+            out["sitebench_chance_adjusted_acc,none"] = out["chance_adjusted_acc,none"]
+
+    # Per-subcategory breakdown (optional, useful for debugging)
+    subcategories = {
+        "3d information understanding",
+        "counting & existence",
+        "movement prediction & navigation",
+        "multi-view & cross-image reasoning",
+        "object localization & positioning",
+        "spatial relationship reasoning",
+    }
+    for cat in subcategories:
+        if cat in merged_metric:
+            val = merged_metric[cat]
+            caa_den = val.get("caa_den", 0.0)
+            acc_den = val.get("acc_den", 0.0)
+            if caa_den > 0:
+                caa = val.get("caa_num", 0.0) / caa_den * 100
+                key = CATEGORY_TO_METRIC_KEY.get(cat, cat.replace(" ", "_").replace("&", "and")) + "_caa"
+                out[f"{key},none"] = round(caa, 5)
+            if acc_den > 0:
+                acc = val.get("acc_num", 0.0) / acc_den * 100
+                key = CATEGORY_TO_METRIC_KEY.get(cat, cat.replace(" ", "_").replace("&", "and")) + "_acc"
+                out[f"{key},none"] = round(acc, 5)
+
+    return out

--- a/tests/test_group_postprocess.py
+++ b/tests/test_group_postprocess.py
@@ -1,0 +1,295 @@
+"""Regression tests for group-level postprocess_results hook (#1406)."""
+
+import os
+import tempfile
+import textwrap
+
+import pytest
+
+from lmms_eval.api.group import ConfigurableGroup
+from lmms_eval.api.task import ConfigurableTask
+from lmms_eval.evaluator_utils import consolidate_group_results
+from lmms_eval.utils import load_yaml_config
+
+
+def _make_task(name, version="1.0"):
+    """Minimal Task mock with required attributes for consolidate_group_results."""
+    # Use a simple object mimicking Task interface needed for aggregation
+    class FakeTask:
+        def __init__(self, task_name):
+            self.task_name = task_name
+            self.VERSION = version
+
+        def dump_config(self):
+            return {"task": self.task_name}
+
+    return FakeTask(name)
+
+
+def test_postprocess_hook_called_and_metrics_inserted():
+    """Hook should be called and its returned metrics inserted into group results."""
+
+    def my_hook(group_name, subtasks, results, **kwargs):
+        # verify hook receives expected args
+        assert group_name == "sitebench"
+        assert set(subtasks) == {"site_bench_image", "site_bench_video"}
+        assert "site_bench_image" in results
+        # return group-level metrics
+        return {"combined_score,none": 84.5, "hook_ran,none": 1}
+
+    group = ConfigurableGroup(
+        config={
+            "group": "sitebench",
+            "task": ["site_bench_image", "site_bench_video"],
+            "postprocess_results": my_hook,
+        }
+    )
+
+    # task_dict hierarchy: group -> subtasks
+    task_dict = {
+        group: {
+            "site_bench_image": _make_task("site_bench_image"),
+            "site_bench_video": _make_task("site_bench_video"),
+        }
+    }
+
+    results = {
+        "site_bench_image": {"alias": "site_bench_image", "accuracy,none": 80.0, "samples": 10},
+        "site_bench_video": {"alias": "site_bench_video", "accuracy,none": 70.0, "samples": 10},
+        "sitebench": {"alias": "sitebench"},
+    }
+    versions = {}
+
+    results_out, versions_out, show_group_table, task_agg = consolidate_group_results(results, versions, task_dict)
+
+    assert "combined_score,none" in results_out["sitebench"]
+    assert results_out["sitebench"]["combined_score,none"] == 84.5
+    assert results_out["sitebench"]["hook_ran,none"] == 1
+    # existing behavior: group should still get a placeholder or be marked for group table
+    # hook should cause show_group_table to be True
+    assert show_group_table is True or "combined_score,none" in results_out["sitebench"]
+
+
+def test_postprocess_hook_kwargs_include_config_and_samples():
+    """Hook receives group config metadata, samples, output dirs via kwargs."""
+
+    received = {}
+
+    def hook(group_name, subtask_names=None, **kwargs):
+        # Accept both naming conventions
+        received.update(kwargs)
+        received["group_name"] = group_name
+        received["subtask_names"] = subtask_names
+        if "subtasks" in kwargs:
+            received["subtask_names"] = kwargs["subtasks"]
+        # also capture positional subtasks if passed as second arg
+        return {"extra_metric,none": 1.0}
+
+    # alternative signature using subtasks param
+    def hook2(group_name, subtasks, results, samples=None, output_dir=None, group_config=None, **kwargs):
+        received["group_name2"] = group_name
+        received["subtasks2"] = subtasks
+        received["results2"] = results
+        received["samples2"] = samples
+        received["output_dir2"] = output_dir
+        received["group_config2"] = group_config
+        return {"extra2,none": 2.0}
+
+    group = ConfigurableGroup(
+        config={
+            "group": "mygroup",
+            "task": ["task_a", "task_b"],
+            "postprocess_results": hook2,
+            "metadata": {"version": "0.2"},
+        }
+    )
+    task_dict = {
+        group: {
+            "task_a": _make_task("task_a"),
+            "task_b": _make_task("task_b"),
+        }
+    }
+    results = {
+        "task_a": {"alias": "task_a", "acc,none": 0.5, "samples": 5},
+        "task_b": {"alias": "task_b", "acc,none": 0.7, "samples": 5},
+        "mygroup": {"alias": "mygroup"},
+    }
+    samples = {"task_a": [{"doc_id": 0}], "task_b": [{"doc_id": 1}]}
+    versions = {}
+
+    # New signature supports samples, output_dir, etc.
+    results_out, _, _, _ = consolidate_group_results(
+        results,
+        versions,
+        task_dict,
+        samples=samples,
+        output_dir="/tmp/out",
+        model_output_dir="/tmp/out/model",
+    )
+
+    assert received["group_name2"] == "mygroup"
+    assert set(received["subtasks2"]) == {"task_a", "task_b"}
+    assert received["samples2"] is not None
+    assert received["output_dir2"] == "/tmp/out"
+    assert received["group_config2"] is not None
+    assert "extra2,none" in results_out["mygroup"]
+
+
+def test_preserve_aggregate_metric_list_alongside_hook():
+    """aggregate_metric_list should still produce mean even when hook is present."""
+
+    def hook(group_name, subtasks, results, **kwargs):
+        return {"hook_metric,none": 99.0}
+
+    group = ConfigurableGroup(
+        config={
+            "group": "agg_group",
+            "task": ["t1", "t2"],
+            "aggregate_metric_list": [{"metric": "acc", "aggregation": "mean", "filter_list": ["none"], "weight_by_size": False}],
+            "postprocess_results": hook,
+        }
+    )
+    task_dict = {
+        group: {
+            "t1": _make_task("t1"),
+            "t2": _make_task("t2"),
+        }
+    }
+    results = {
+        "t1": {"alias": "t1", "acc,none": 0.6, "samples": 10},
+        "t2": {"alias": "t2", "acc,none": 0.8, "samples": 10},
+        "agg_group": {"alias": "agg_group"},
+    }
+    versions = {}
+    results_out, _, show_group, _ = consolidate_group_results(results, versions, task_dict)
+    # mean of 0.6 and 0.8 = 0.7
+    assert "acc,none" in results_out["agg_group"]
+    assert abs(results_out["agg_group"]["acc,none"] - 0.7) < 1e-6
+    assert "hook_metric,none" in results_out["agg_group"]
+    assert show_group is True
+
+
+def test_hook_via_string_import_path():
+    """Hook defined as importable string path should be resolved."""
+
+    group = ConfigurableGroup(
+        config={
+            "group": "str_group",
+            "task": ["t1"],
+            "postprocess_results": "lmms_eval.tasks.sitebench.utils.sitebench_merge_results",
+        }
+    )
+    # Ensure config stored as string but consolidate will resolve
+    assert group.config["postprocess_results"] == "lmms_eval.tasks.sitebench.utils.sitebench_merge_results"
+
+    task_dict = {
+        group: {"t1": _make_task("t1")}
+    }
+    results = {
+        "t1": {"alias": "t1", "acc,none": 0.5, "samples": 2},
+        "str_group": {"alias": "str_group"},
+    }
+    # provide samples similar to sitebench (accuracy dict)
+    samples = {
+        "t1": [
+            {"accuracy": {"overall": 1, "total": 1}, "chance_adjusted_acc": {"overall": 0.5, "total": 0.5}, "doc": {"category": "counting & existence"}},
+            {"accuracy": {"overall": 0, "total": 1}, "chance_adjusted_acc": {"overall": -0.5, "total": 0.5}, "doc": {"category": "counting & existence"}},
+        ]
+    }
+    versions = {}
+    results_out, _, _, _ = consolidate_group_results(results, versions, task_dict, samples=samples)
+    # hook should have been invoked and merged at least one metric (overall_caa etc) without error
+    # we don't assert exact value, just that hook ran without exception and group has metrics
+    assert "str_group" in results_out
+    # sitebench_merge_results should produce some metrics; check that group not just empty
+    # It may return {} if insufficient data, but should not crash
+    assert isinstance(results_out["str_group"], dict)
+
+
+def test_hook_via_yaml_function():
+    """YAML !function hook should be loaded and invoked."""
+
+    yaml_content = textwrap.dedent("""
+        group: yaml_group
+        task:
+          - t1
+          - t2
+        postprocess_results: !function lmms_eval.tasks.sitebench.utils.sitebench_merge_results
+    """)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        yaml_path = os.path.join(tmpdir, "group.yaml")
+        with open(yaml_path, "w") as f:
+            f.write(yaml_content)
+        config = load_yaml_config(yaml_path=yaml_path, mode="full")
+        assert callable(config["postprocess_results"])
+        group = ConfigurableGroup(config=config)
+        assert callable(group.config["postprocess_results"])
+
+        task_dict = {
+            group: {"t1": _make_task("t1"), "t2": _make_task("t2")}
+        }
+        results = {
+            "t1": {"alias": "t1", "acc,none": 0.5, "samples": 1},
+            "t2": {"alias": "t2", "acc,none": 0.5, "samples": 1},
+            "yaml_group": {"alias": "yaml_group"},
+        }
+        samples = {"t1": [], "t2": []}
+        versions = {}
+        results_out, _, _, _ = consolidate_group_results(results, versions, task_dict, samples=samples)
+        assert "yaml_group" in results_out
+
+
+def test_hook_returns_none_or_empty_no_crash():
+    """Hook returning None or empty should not crash."""
+
+    def hook_none(group_name, subtasks, results, **kwargs):
+        return None
+
+    def hook_empty(group_name, subtasks, results, **kwargs):
+        return {}
+
+    for hook in [hook_none, hook_empty]:
+        group = ConfigurableGroup(config={"group": "g", "task": ["t1"], "postprocess_results": hook})
+        task_dict = {group: {"t1": _make_task("t1")}}
+        results = {"t1": {"alias": "t1", "acc,none": 0.5, "samples": 1}, "g": {"alias": "g"}}
+        versions = {}
+        results_out, _, _, _ = consolidate_group_results(results, versions, task_dict)
+        assert "g" in results_out
+
+
+def test_hook_exception_is_logged_not_crashed():
+    """Hook raising exception should be logged but not crash group aggregation."""
+
+    def bad_hook(group_name, subtasks, results, **kwargs):
+        raise RuntimeError("hook failed")
+
+    group = ConfigurableGroup(config={"group": "bad_group", "task": ["t1"], "postprocess_results": bad_hook})
+    task_dict = {group: {"t1": _make_task("t1")}}
+    results = {"t1": {"alias": "t1", "acc,none": 0.5, "samples": 1}, "bad_group": {"alias": "bad_group"}}
+    versions = {}
+    # Should not raise
+    results_out, _, _, _ = consolidate_group_results(results, versions, task_dict)
+    assert "bad_group" in results_out
+
+
+def test_no_hook_existing_behavior_unchanged():
+    """Without hook, existing aggregate behavior should remain identical."""
+
+    group = ConfigurableGroup(
+        config={
+            "group": "nohook",
+            "task": ["t1", "t2"],
+            "aggregate_metric_list": [{"metric": "acc", "aggregation": "mean", "filter_list": ["none"], "weight_by_size": True}],
+        }
+    )
+    task_dict = {group: {"t1": _make_task("t1"), "t2": _make_task("t2")}}
+    results = {
+        "t1": {"alias": "t1", "acc,none": 0.4, "samples": 2},
+        "t2": {"alias": "t2", "acc,none": 0.8, "samples": 8},
+        "nohook": {"alias": "nohook"},
+    }
+    versions = {}
+    results_out, _, show, _ = consolidate_group_results(results, versions, task_dict)
+    # weighted mean: (0.4*2+0.8*8)/10 = 0.72
+    assert abs(results_out["nohook"]["acc,none"] - 0.72) < 1e-6
+    assert show is True

--- a/tests/test_group_postprocess.py
+++ b/tests/test_group_postprocess.py
@@ -4,16 +4,14 @@ import os
 import tempfile
 import textwrap
 
-import pytest
-
 from lmms_eval.api.group import ConfigurableGroup
-from lmms_eval.api.task import ConfigurableTask
 from lmms_eval.evaluator_utils import consolidate_group_results
 from lmms_eval.utils import load_yaml_config
 
 
 def _make_task(name, version="1.0"):
     """Minimal Task mock with required attributes for consolidate_group_results."""
+
     # Use a simple object mimicking Task interface needed for aggregation
     class FakeTask:
         def __init__(self, task_name):
@@ -182,9 +180,7 @@ def test_hook_via_string_import_path():
     # Ensure config stored as string but consolidate will resolve
     assert group.config["postprocess_results"] == "lmms_eval.tasks.sitebench.utils.sitebench_merge_results"
 
-    task_dict = {
-        group: {"t1": _make_task("t1")}
-    }
+    task_dict = {group: {"t1": _make_task("t1")}}
     results = {
         "t1": {"alias": "t1", "acc,none": 0.5, "samples": 2},
         "str_group": {"alias": "str_group"},
@@ -225,9 +221,7 @@ def test_hook_via_yaml_function():
         group = ConfigurableGroup(config=config)
         assert callable(group.config["postprocess_results"])
 
-        task_dict = {
-            group: {"t1": _make_task("t1"), "t2": _make_task("t2")}
-        }
+        task_dict = {group: {"t1": _make_task("t1"), "t2": _make_task("t2")}}
         results = {
             "t1": {"alias": "t1", "acc,none": 0.5, "samples": 1},
             "t2": {"alias": "t2", "acc,none": 0.5, "samples": 1},


### PR DESCRIPTION
## Summary
- Add group-level `postprocess_results` hook to `GroupConfig` that runs after subtask aggregation and merges custom metrics into the group result
- Resolve hook via callable or import string with flexible signature and add `sitebench_merge_results` that reproduces the official SiteBench combined score
- Thread `samples`/`configs`/`output_dir` context through `evaluate()` → `consolidate_group_results`

## In scope
- `lmms_eval/api/group.py`: new `postprocess_results` field
- `lmms_eval/evaluator_utils.py`: resolve/invoke helpers and group hook integration (preserves `aggregate_metric_list` path)
- `lmms_eval/evaluator.py`: pass samples/output context to group consolidation
- `lmms_eval/tasks/sitebench/utils.py`: `sitebench_merge_results` plus file/in-memory stat helpers

## Out of scope
- New group YAML for SiteBench (tasks remain individually runnable; hook is opt-in)
- Changes to task-level `process_results`/`aggregation` semantics

## Validation
- `tests/test_group_postprocess.py` | hook invocation, kwargs forwarding, string/YAML import, coexistence with `aggregate_metric_list`, error isolation | pass
- SiteBench in-memory merge: combined `accuracy,none` / `chance_adjusted_acc,none` from `site_bench_image` + `site_bench_video` samples matches `merge_results.py` logic | pass
- Existing group mean aggregation unchanged when no hook is set | pass

## Risk / Compatibility
- No breaking change: groups without `postprocess_results` behave identically; hook failures are logged and do not abort evaluation
- Hook return type is validated (dict → merged, non-dict/None → ignored)

## Type of Change
- [ ] New feature
- [ ] Bug fix (non-breaking change)
- [ ] New benchmark/task
- [ ] New model integration
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

Fixes #1406