### PR TITLE
fix(mdpbench): pass line_type when match_gt2pred_no_split calls get_gt_pred_lines

### DIFF
--- a/lmms_eval/tasks/mdpbench/match.py
+++ b/lmms_eval/tasks/mdpbench/match.py
@@ -302,7 +302,7 @@ def match_gt2pred_simple(gt_items, pred_items, line_type, img_name):
 
 def match_gt2pred_no_split(gt_items, pred_items, line_type, img_name):
     # directly concatenate gt and pred by position
-    gt_lines, norm_gt_lines, gt_cat_list, pred_lines, norm_pred_lines = get_gt_pred_lines(gt_items, pred_items)
+    gt_lines, norm_gt_lines, gt_cat_list, pred_lines, norm_pred_lines, gt_items, pred_items = get_gt_pred_lines(gt_items, pred_items, line_type)
     gt_line_with_position = []
     for gt_line, norm_gt_line, gt_item in zip(gt_lines, norm_gt_lines, gt_items):
         gt_position = gt_item["order"] if gt_item.get("order") else gt_item.get("position", [""])[0]


### PR DESCRIPTION
## Summary
- `match_gt2pred_no_split` calls `get_gt_pred_lines(gt_items, pred_items)`, but that helper takes three required positional parameters — the call raises `TypeError` on the function's very first statement.
- The same file's sibling matcher `match_gt2pred_simple` (identical `(gt_items, pred_items, line_type, img_name)` signature) already calls it correctly on line 188; this PR makes the `no_split` variant match it.
- The unpack is also the wrong arity: `get_gt_pred_lines` has a single `return` of **7** values, so the existing 5-tuple target would raise `ValueError` even once the `TypeError` was gone.

## In scope
- `lmms_eval/tasks/mdpbench/match.py`: one call site inside `match_gt2pred_no_split`, changed to the exact form already used by `match_gt2pred_simple`.

## Out of scope
- No change to `get_gt_pred_lines` itself, to `match_gt2pred_simple` / `match_gt2pred_quick`, or to any matching semantics.
- The rebound `gt_items` / `pred_items` are pass-throughs (the helper never reassigns its inputs), so this is behaviour-preserving relative to the sibling — it only makes the function callable.

## Validation
The two call sites are in the same file and take the same arguments, so `match_gt2pred_simple` is a natural control group. I exec'd `match.py` with the third-party imports stubbed and ran both matchers on the same synthetic `line_type="text"` input, before and after the change:

```
[UPSTREAM] no_split        -> TypeError: get_gt_pred_lines() missing 1 required positional argument: 'line_type'
[UPSTREAM] simple(control) -> reaches the matching logic (past argument binding)
[PATCHED ] no_split        -> OK  gt='alpha\n\ngamma' pred='alpha\n\ngamma'
[PATCHED ] simple(control) -> reaches the matching logic (past argument binding)
```

The control behaves identically in both builds; only `no_split` changes, from a hard `TypeError` to the expected position-ordered merge (the empty middle element is filtered by `get_gt_pred_lines`, as intended).

- `ruff check` / `ruff format --check` (v0.16.4, per `.pre-commit-config.yaml`) | result: `pass`

## Risk / Compatibility
- `match_gt2pred_no_split` currently has no callers in-tree, so nothing regresses; it is the third of three sibling matchers and fails immediately for anyone who wires it up.
- Note this file is adapted from the MDPBench reference implementation, so you may want the same one-liner upstream.

## Type of Change
- [x] Bug fix (non-breaking change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
