### PR TITLE
style: fix Qwen3-VL lint failure

### DIFF
--- a/lmms_eval/models/simple/qwen3_vl.py
+++ b/lmms_eval/models/simple/qwen3_vl.py
@@ -83,7 +83,7 @@ class Qwen3_VL(lmms):
         batch_size: Optional[Union[int, str]] = 1,
         use_cache=True,
         attn_implementation: Optional[str] = None,
-        min_pixels: int = 64 * 32 * 32, 
+        min_pixels: int = 64 * 32 * 32,
         max_pixels: int = 16384 * 32 * 32,
         total_pixels: Optional[int] = None,
         max_num_frames: int = 32,


### PR DESCRIPTION
## Summary
- Remove trailing whitespace from the Qwen3-VL `min_pixels` parameter.
- Restore a clean Ruff formatting result on `main`.

## In scope
- Formatting-only change in `lmms_eval/models/simple/qwen3_vl.py`.

## Out of scope
- No runtime behavior, model configuration, or CI workflow changes.

## Validation
- `ruff check .` | sample size: `N=1006 files` | key metrics: `0 lint errors` | result: `pass`
- `ruff format --check .` | sample size: `N=1006 files` | key metrics: `1006 files already formatted` | result: `pass`
- `git diff --check` | sample size: `N=1 changed file` | key metrics: `0 whitespace errors` | result: `pass`

## Risk / Compatibility
- Formatting-only; no functional or compatibility impact.

## Type of Change
- [x] Bug fix (non-breaking change)
- [ ] New feature
- [ ] New benchmark/task
- [ ] New model integration
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring (no functional changes)