### PR TITLE
style: fix lint for video generation backends

### DIFF
--- a/lmms_eval/models/chat/sglang_diffusion.py
+++ b/lmms_eval/models/chat/sglang_diffusion.py
@@ -140,7 +140,7 @@ def _load_diff_generator():
     try:
         from sglang.multimodal_gen import DiffGenerator
     except (ImportError, AttributeError) as exc:
-        raise ImportError("SGLang Diffusion is required for Wan generation. Install the validated build with " "`uv pip install --prerelease=allow 'sglang[diffusion]==0.5.10.post1'`.") from exc
+        raise ImportError("SGLang Diffusion is required for Wan generation. Install the validated build with `uv pip install --prerelease=allow 'sglang[diffusion]==0.5.10.post1'`.") from exc
     return DiffGenerator
 
 
@@ -218,7 +218,7 @@ class SGLangDiffusion(lmms):
 
         accelerator = Accelerator()
         if accelerator.num_processes > 1:
-            raise RuntimeError("SGLang Diffusion manages its own GPU workers. Launch lmms-eval as one process " "and set num_gpus in --model_args instead of using accelerate launch.")
+            raise RuntimeError("SGLang Diffusion manages its own GPU workers. Launch lmms-eval as one process and set num_gpus in --model_args instead of using accelerate launch.")
         self.accelerator = accelerator
         self._rank = accelerator.process_index
         self._world_size = accelerator.num_processes

--- a/lmms_eval/models/chat/vllm_omni.py
+++ b/lmms_eval/models/chat/vllm_omni.py
@@ -519,7 +519,7 @@ class VLLMOmni(lmms):
                 )
             except Exception as e:
                 warnings.warn(
-                    f"Failed to load AutoProcessor for {processor_name or model}: {type(e).__name__}: {e}. " "Falling back to plain-text prompts.",
+                    f"Failed to load AutoProcessor for {processor_name or model}: {type(e).__name__}: {e}. Falling back to plain-text prompts.",
                     stacklevel=2,
                 )
         if self.chat_template is not None and self.processor is not None:

--- a/lmms_eval/models/chat/vllm_omni_api.py
+++ b/lmms_eval/models/chat/vllm_omni_api.py
@@ -112,7 +112,7 @@ class VLLMOmniAPI(lmms):
         if model is not None:
             model_version = model
         if kwargs:
-            eval_logger.warning(f"Unknown model_args ignored: {list(kwargs.keys())}. " "Check the supported parameters for the 'vllm_omni_api' backend.")
+            eval_logger.warning(f"Unknown model_args ignored: {list(kwargs.keys())}. Check the supported parameters for the 'vllm_omni_api' backend.")
 
         self.model_version = model_version or None
         configured_base_urls = base_urls or os.getenv("VLLM_OMNI_API_BASES")
@@ -374,7 +374,7 @@ class VLLMOmniAPI(lmms):
                 return self._pack_result(os.path.abspath(output_path), metadata), idx
             except Exception as exc:  # noqa: BLE001
                 last_error = str(exc)
-                eval_logger.info(f"vllm_omni_api attempt {attempt + 1}/{self.max_retries} failed " f"for {output_path}: {last_error[:300]}")
+                eval_logger.info(f"vllm_omni_api attempt {attempt + 1}/{self.max_retries} failed for {output_path}: {last_error[:300]}")
                 if attempt < self.max_retries - 1:
                     await asyncio.sleep(self.retry_backoff_s)
 


### PR DESCRIPTION
## Summary
- Apply the Ruff formatting generated by the failing `main` lint run after #1314.
- Normalize five adjacent string literal concatenations across the SGLang Diffusion and vLLM-Omni backends.
- Restore a clean lint result on `main`.

## In scope
- Formatting-only updates in `sglang_diffusion.py`, `vllm_omni.py`, and `vllm_omni_api.py`.

## Out of scope
- No runtime behavior, backend configuration, or CI workflow changes.

## Validation
- `ruff check .` | sample size: `N=1010 files` | key metrics: `0 lint errors` | result: `pass`
- `ruff format --check .` | sample size: `N=1010 files` | key metrics: `1010 files already formatted` | result: `pass`
- `python -m py_compile <3 changed files>` | sample size: `N=3 files` | key metrics: `0 syntax errors` | result: `pass`

## Risk / Compatibility
- Formatting-only; the concatenated string values and runtime behavior are unchanged.

## Type of Change
- [x] Bug fix (non-breaking change)
- [ ] New feature
- [ ] New benchmark/task
- [ ] New model integration
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring (no functional changes)