### PR TITLE
feat: add HERBench benchmark (CVPR 2026, multi-evidence video QA)

### DIFF
--- a/docs/advanced/current_tasks.md
+++ b/docs/advanced/current_tasks.md
@@ -286,6 +286,10 @@ python -m lmms_eval --tasks list_with_num
 - [EgoPlan](https://github.com/ChenYi99/EgoPlan) (egoplan)
 - [EgoTempo](https://github.com/google-research-datasets/egotempo) (egotempo)
 - [EgoThink](https://github.com/AdaCheng/EgoThink) (egothink)
+- [HERBench](https://huggingface.co/datasets/DanBenAmi/HERBench) (herbench)
+  - Full set, 27,631 questions / 335 videos (herbench_full)
+  - Lite subset, 2,000 questions / 68 videos (herbench_lite)
+  - Refined lite subset, 1,971 questions / 68 videos (herbench_lite_v2)
 - [IntPhys2](https://arxiv.org/abs/2506.09849) (intphys2)
   - intphys2_debug
 - [MLVU](https://github.com/JUNJIE99/MLVU) (mlvu)

--- a/lmms_eval/tasks/herbench/README.md
+++ b/lmms_eval/tasks/herbench/README.md
@@ -1,0 +1,72 @@
+# HERBench
+
+HERBench: A Benchmark for Multi-Evidence Integration in Video Question Answering (CVPR 2026).
+
+- Paper: https://arxiv.org/abs/2512.14870
+- Project page: https://herbench.github.io/
+- Dataset: https://huggingface.co/datasets/DanBenAmi/HERBench
+- Code: https://github.com/DanBenAmi/HERBench
+
+HERBench evaluates how vision-language models integrate multiple pieces of evidence in
+long videos. Every question is a five-way multiple-choice question that requires
+aggregating at least **3 distinct, temporally separated visual cues** (mean Minimum
+Required Frame-Set ~5.5), covering 12 compositional task types over 335 videos
+(avg. ~6.6 minutes).
+
+## Tasks
+
+| Task | HF config | Questions | Videos | Video download |
+|---|---|---|---|---|
+| `herbench_full` | `full` | ~27.6k | 335 | ~161 GB |
+| `herbench_lite` | `lite` | 2,000 | 68 | ~35 GB |
+| `herbench_lite_v2` | `lite_v2` (refined) | 1,971 | 68 | ~35 GB |
+
+`herbench_lite_v2` is the recommended smaller split: 9 of the 12 tasks were regenerated
+with additional manual refinement.
+
+## Usage
+
+```bash
+python -m lmms_eval \
+    --model qwen2_5_vl \
+    --model_args pretrained=Qwen/Qwen2.5-VL-7B-Instruct,max_num_frames=16 \
+    --tasks herbench_lite_v2 \
+    --batch_size 1 \
+    --log_samples \
+    --output_path ./logs/
+```
+
+On the first run the videos are downloaded from HuggingFace and extracted to
+`$HF_HOME/herbench/videos/`. The download is variant-aware: the lite tasks fetch only
+the 4 archive chunks (~35 GB) that contain the 68 lite videos, while `herbench_full`
+fetches all 17 chunks (~161 GB). Downloads resume if interrupted; extraction streams
+directly from the split chunks (no intermediate concatenated tar), and needs roughly
+the same amount of free disk again for the extracted videos.
+
+If you already have the extracted videos elsewhere, point the tasks at them with:
+
+```bash
+export HERBENCH_VIDEO_DIR=/path/to/HERBench   # the dir containing the videos/ folder
+```
+
+## Metrics
+
+- `herbench_overall_accuracy`: micro-averaged accuracy (%) over all questions
+  (random baseline: 20%).
+- `herbench_<task_type>_accuracy`: per-task-type accuracy (%) for each of the 12
+  compositional task types.
+
+Answers are extracted with the official HERBench letter-extraction protocol
+(with the shared lmms-eval MCQ extractor as fallback) and scored by exact match
+against the ground-truth letter.
+
+## Citation
+
+```bibtex
+@article{herbench2025,
+  title={HERBench: A Benchmark for Multi-Evidence Integration in Video Question Answering},
+  author={Ben-Ami, Dan and Serussi, Gabriele and Cohen, Kobi and Baskin, Chaim},
+  journal={arXiv preprint arXiv:2512.14870},
+  year={2025}
+}
+```

--- a/lmms_eval/tasks/herbench/_default_template_yaml
+++ b/lmms_eval/tasks/herbench/_default_template_yaml
@@ -1,0 +1,61 @@
+dataset_path: DanBenAmi/HERBench
+test_split: test
+output_type: generate_until
+cluster_key: video_id
+doc_to_text: !function utils.herbench_doc_to_text
+doc_to_target: answer
+process_results: !function utils.herbench_process_results
+generation_kwargs:
+  max_new_tokens: 16
+  temperature: 0
+  top_p: 1.0
+  num_beams: 1
+  do_sample: false
+metric_list:
+  - metric: herbench_overall_accuracy
+    aggregation: !function utils.herbench_aggregate_overall
+    higher_is_better: true
+  - metric: herbench_temporal_shot_ordering_accuracy
+    aggregation: !function utils.herbench_aggregate_temporal_shot_ordering
+    higher_is_better: true
+  - metric: herbench_multi_person_duration_reasoning_accuracy
+    aggregation: !function utils.herbench_aggregate_multi_person_duration_reasoning
+    higher_is_better: true
+  - metric: herbench_action_sequence_integrity_identification_accuracy
+    aggregation: !function utils.herbench_aggregate_action_sequence_integrity_identification
+    higher_is_better: true
+  - metric: herbench_appearance_grounded_behavior_interactions_accuracy
+    aggregation: !function utils.herbench_aggregate_appearance_grounded_behavior_interactions
+    higher_is_better: true
+  - metric: herbench_appearance_grounded_attribute_recognition_accuracy
+    aggregation: !function utils.herbench_aggregate_appearance_grounded_attribute_recognition
+    higher_is_better: true
+  - metric: herbench_appearance_grounded_localization_trajectory_accuracy
+    aggregation: !function utils.herbench_aggregate_appearance_grounded_localization_trajectory
+    higher_is_better: true
+  - metric: herbench_false_action_memory_accuracy
+    aggregation: !function utils.herbench_aggregate_false_action_memory
+    higher_is_better: true
+  - metric: herbench_scene_verification_arrangement_accuracy
+    aggregation: !function utils.herbench_aggregate_scene_verification_arrangement
+    higher_is_better: true
+  - metric: herbench_false_object_memory_accuracy
+    aggregation: !function utils.herbench_aggregate_false_object_memory
+    higher_is_better: true
+  - metric: herbench_multi_entities_grounding_localization_accuracy
+    aggregation: !function utils.herbench_aggregate_multi_entities_grounding_localization
+    higher_is_better: true
+  - metric: herbench_action_counting_accuracy
+    aggregation: !function utils.herbench_aggregate_action_counting
+    higher_is_better: true
+  - metric: herbench_region_localized_people_counting_accuracy
+    aggregation: !function utils.herbench_aggregate_region_localized_people_counting
+    higher_is_better: true
+lmms_eval_specific_kwargs:
+  default:
+    pre_prompt: ""
+    # post_prompt is intentionally not set: the official HERBench answer
+    # instruction is appended automatically (see utils.herbench_doc_to_text).
+    # Set post_prompt here (or per model) to override it.
+metadata:
+  version: 1.0

--- a/lmms_eval/tasks/herbench/herbench_full.yaml
+++ b/lmms_eval/tasks/herbench/herbench_full.yaml
@@ -1,0 +1,5 @@
+task: herbench_full
+dataset_name: full
+include: _default_template_yaml
+doc_to_visual: !function utils.herbench_full_doc_to_visual
+doc_to_messages: !function utils.herbench_full_doc_to_messages

--- a/lmms_eval/tasks/herbench/herbench_lite.yaml
+++ b/lmms_eval/tasks/herbench/herbench_lite.yaml
@@ -1,0 +1,5 @@
+task: herbench_lite
+dataset_name: lite
+include: _default_template_yaml
+doc_to_visual: !function utils.herbench_lite_doc_to_visual
+doc_to_messages: !function utils.herbench_lite_doc_to_messages

--- a/lmms_eval/tasks/herbench/herbench_lite_v2.yaml
+++ b/lmms_eval/tasks/herbench/herbench_lite_v2.yaml
@@ -1,0 +1,5 @@
+task: herbench_lite_v2
+dataset_name: lite_v2
+include: _default_template_yaml
+doc_to_visual: !function utils.herbench_lite_doc_to_visual
+doc_to_messages: !function utils.herbench_lite_doc_to_messages

--- a/lmms_eval/tasks/herbench/utils.py
+++ b/lmms_eval/tasks/herbench/utils.py
@@ -1,0 +1,380 @@
+"""HERBench: A Benchmark for Multi-Evidence Integration in Video Question Answering.
+
+Paper: https://arxiv.org/abs/2512.14870
+Data:  https://huggingface.co/datasets/DanBenAmi/HERBench
+
+Five-way multiple-choice questions over long videos; each question requires
+aggregating at least 3 distinct, temporally separated visual cues. Three
+configs: 'full' (27k+ questions / 335 videos / ~161 GB of videos), 'lite'
+(68 videos / ~35 GB) and 'lite_v2' (refined lite, same 68 videos).
+
+Videos ship as 17 split archive chunks (videos/videos.tar.part.00 .. .16).
+Chunks 00-03 form one complete tar with the 68 lite videos; chunks 04-16 form
+a second complete tar with the remaining videos of the full set. The download
+below is therefore variant-aware (lite tasks only fetch ~35 GB) and the
+extraction streams straight from the chunks (no 170 GB intermediate tar).
+"""
+
+import os
+import re
+import tarfile
+from pathlib import Path
+
+from loguru import logger as eval_logger
+
+REPO_ID = "DanBenAmi/HERBench"
+CACHE_DIR_NAME = "herbench"
+CHOICE_LETTERS = ("A", "B", "C", "D", "E")
+
+# chunks 00-03 hold the 68 HERBench-Lite videos; the remaining chunks hold the rest
+# (for the full set, the chunk list is discovered from the Hub at download time)
+LITE_PART_IDS = tuple(range(0, 4))
+
+TASK_TYPES = {
+    "Temporal Shot Ordering": "temporal_shot_ordering",
+    "Multi-Person Duration Reasoning": "multi_person_duration_reasoning",
+    "Action Sequence Integrity Identification": "action_sequence_integrity_identification",
+    "Appearance-Grounded Behavior & Interactions": "appearance_grounded_behavior_interactions",
+    "Appearance-Grounded Attribute Recognition": "appearance_grounded_attribute_recognition",
+    "Appearance-Grounded Localization & Trajectory": "appearance_grounded_localization_trajectory",
+    "False Action Memory": "false_action_memory",
+    "Scene Verification & Arrangement": "scene_verification_arrangement",
+    "False Object Memory": "false_object_memory",
+    "Multi-Entities Grounding and Localization": "multi_entities_grounding_localization",
+    "Action Counting": "action_counting",
+    "Region Localized People Counting": "region_localized_people_counting",
+}
+
+
+def _cache_root() -> str:
+    hf_home = os.path.expanduser(os.getenv("HF_HOME", "~/.cache/huggingface"))
+    return os.path.join(hf_home, CACHE_DIR_NAME)
+
+
+def _extract_tar_parts(part_files, videos_root):
+    """Stream-extract the split tar chunks without concatenating them on disk.
+
+    ignore_zeros lets tarfile read through the end-of-archive markers between
+    the two complete tar archives that make up the chunk sequence.
+    """
+
+    class _ChainedReader:
+        def __init__(self, paths):
+            self.paths = list(paths)
+            self.idx = 0
+            self.consumed = 0
+            self.fp = open(self.paths[0], "rb") if self.paths else None
+
+        def read(self, size=-1):
+            if size is None or size < 0:
+                raise ValueError("unbounded read not supported")
+            chunks = []
+            remaining = size
+            while remaining > 0 and self.fp is not None:
+                chunk = self.fp.read(remaining)
+                if chunk:
+                    chunks.append(chunk)
+                    remaining -= len(chunk)
+                    self.consumed += len(chunk)
+                else:
+                    self.fp.close()
+                    self.idx += 1
+                    self.fp = open(self.paths[self.idx], "rb") if self.idx < len(self.paths) else None
+            return b"".join(chunks)
+
+        def close(self):
+            if self.fp is not None:
+                self.fp.close()
+                self.fp = None
+
+    os.makedirs(videos_root, exist_ok=True)
+    reader = _ChainedReader(part_files)
+    extracted = skipped = 0
+    try:
+        with tarfile.open(fileobj=reader, mode="r|", ignore_zeros=True) as tar:
+            for member in tar:
+                if not member.isfile():
+                    continue
+                name = member.name.lstrip("./")
+                if name.startswith("/") or ".." in name.split("/"):
+                    eval_logger.warning(f"Skipping suspicious tar member: {member.name}")
+                    continue
+                target = os.path.join(videos_root, name)
+                if os.path.exists(target) and os.path.getsize(target) == member.size:
+                    skipped += 1
+                    continue
+                member.name = name
+                tar.extract(member, path=videos_root)
+                extracted += 1
+    finally:
+        reader.close()
+    # a corrupt chunk can make the stream end early without an exception; verify
+    # the whole chunk sequence was consumed before treating extraction as done
+    total_bytes = sum(os.path.getsize(p) for p in part_files)
+    if reader.consumed < total_bytes:
+        raise RuntimeError(
+            f"HERBench video extraction stopped after {reader.consumed} of {total_bytes} bytes - "
+            f"an archive chunk is likely corrupted. Delete the affected videos.tar.part.* files "
+            f"from the HuggingFace cache (run `huggingface-cli scan-cache` to locate it) and re-run."
+        )
+    eval_logger.info(f"HERBench video extraction done: {extracted} extracted, {skipped} already present.")
+
+
+def _needed_video_paths(variant: str):
+    """Video paths the annotations reference (lite and lite_v2 share videos)."""
+    from datasets import load_dataset
+
+    config = "full" if variant == "full" else "lite"
+    return sorted(set(load_dataset(REPO_ID, config, split="test")["video_path"]))
+
+
+def _ensure_videos(variant: str) -> str:
+    """Download (if needed) and extract the HERBench videos for a variant.
+
+    variant: 'lite' (chunks 00-03, ~35 GB) or 'full' (all chunks, ~161 GB).
+    Returns the directory that doc['video_path'] entries are relative to.
+    """
+    root = _cache_root()
+    marker = Path(root) / f".videos_{variant}_extracted"
+    if marker.exists():
+        return root
+
+    from filelock import FileLock
+    from huggingface_hub import HfApi, hf_hub_download
+
+    os.makedirs(root, exist_ok=True)
+    with FileLock(os.path.join(root, ".videos.lock")):
+        if marker.exists():
+            return root
+
+        needed = _needed_video_paths(variant)
+        if all(os.path.exists(os.path.join(root, p)) for p in needed):
+            marker.touch()
+            return root
+
+        repo_files = HfApi().list_repo_files(REPO_ID, repo_type="dataset")
+        if variant == "full":
+            # take every chunk on the Hub, so chunks appended later are picked up
+            part_names = sorted(f for f in repo_files if f.startswith("videos/videos.tar.part."))
+        else:
+            part_names = [f"videos/videos.tar.part.{i:02d}" for i in LITE_PART_IDS]
+        eval_logger.info(f"Downloading HERBench videos ({variant}: {len(part_names)} archive chunks, ~{'161' if variant == 'full' else '35'} GB) from {REPO_ID}. This only happens once; downloads resume if interrupted.")
+        part_files = [hf_hub_download(REPO_ID, name, repo_type="dataset") for name in part_names]
+        _extract_tar_parts(part_files, os.path.join(root, "videos"))
+
+        # Also fetch any loose video files shipped next to the archives
+        # (e.g. hotfixes for videos missing from the tar chunks).
+        loose = [f for f in repo_files if f.startswith("videos/") and f.lower().endswith(".mp4")]
+        for repo_path in loose:
+            cached = hf_hub_download(REPO_ID, repo_path, repo_type="dataset")
+            _symlink_over(cached, os.path.join(root, repo_path))
+
+        # the marker permanently short-circuits this function, so only stamp it
+        # once every referenced video is actually on disk
+        missing = [p for p in needed if not os.path.exists(os.path.join(root, p))]
+        if missing:
+            raise RuntimeError(
+                f"{len(missing)} HERBench videos are missing after extraction, e.g. {missing[:3]}. "
+                "If the downloaded archive chunks are corrupted, delete them from the HuggingFace "
+                "cache and re-run; otherwise please report this at "
+                "https://github.com/DanBenAmi/HERBench/issues."
+            )
+        marker.touch()
+    return root
+
+
+def _symlink_over(src, dst):
+    """Symlink src at dst, replacing an existing or dangling link; race-safe."""
+    os.makedirs(os.path.dirname(dst), exist_ok=True)
+    if os.path.lexists(dst):
+        if os.path.exists(dst):
+            return  # a valid file/link is already there
+        os.unlink(dst)  # dangling link left by a cleaned HF cache
+    try:
+        os.symlink(src, dst)
+    except FileExistsError:
+        pass  # another rank won the race
+
+
+def _doc_to_visual(doc: dict, variant: str) -> list[str]:
+    # a user-provided video directory takes precedence over (and avoids) the auto-download
+    for env_var in ("HERBENCH_VIDEO_DIR", "HERBENCH_ROOT"):
+        override = os.getenv(env_var)
+        if override:
+            candidate = os.path.join(os.path.expanduser(override), doc["video_path"])
+            if os.path.exists(candidate):
+                return [candidate]
+            eval_logger.warning(f"{env_var} is set but {candidate} does not exist; falling back to the auto-downloaded videos.")
+
+    root = _ensure_videos(variant)
+    video_path = os.path.join(root, doc["video_path"])
+    if not os.path.exists(video_path):
+        # self-heal: the video may exist as a loose file on the Hub
+        # (e.g. a hotfix for a video missing from the tar chunks)
+        try:
+            from huggingface_hub import hf_hub_download
+
+            cached = hf_hub_download(REPO_ID, doc["video_path"], repo_type="dataset")
+            _symlink_over(cached, video_path)
+        except Exception as e:
+            eval_logger.debug(f"No loose copy of {doc['video_path']} on the Hub: {e}")
+        if not os.path.exists(video_path):
+            raise FileNotFoundError(
+                f"HERBench video not found: {video_path}. Delete '{_cache_root()}' (including the hidden "
+                f".videos_{variant}_extracted marker) to force re-extraction, or set HERBENCH_VIDEO_DIR "
+                "to a directory containing the extracted videos/ folder."
+            )
+    return [video_path]
+
+
+def herbench_full_doc_to_visual(doc: dict) -> list[str]:
+    return _doc_to_visual(doc, "full")
+
+
+def herbench_lite_doc_to_visual(doc: dict) -> list[str]:
+    return _doc_to_visual(doc, "lite")
+
+
+def _present_letters(doc: dict) -> list[str]:
+    # a handful of questions have 4 options instead of 5
+    return [CHOICE_LETTERS[i] for i in range(len(doc["choices"]))]
+
+
+def herbench_doc_to_text(doc: dict, lmms_eval_specific_kwargs: dict | None = None) -> str:
+    kwargs = lmms_eval_specific_kwargs or {}
+    pre_prompt = kwargs.get("pre_prompt", "")
+    # choices already carry 'A. ' style letter prefixes in the dataset
+    options = "\n".join(str(choice) for choice in doc["choices"])
+    post_prompt = kwargs.get("post_prompt")
+    if post_prompt is None:
+        # official HERBench answer instruction (dynamic letter list)
+        letters = _present_letters(doc)
+        letter_str = ", ".join(letters[:-1]) + f", or {letters[-1]}"
+        post_prompt = f"\n\nPlease respond with only the correct answer letter ({letter_str}) without any explanations or additional text."
+    return f"{pre_prompt}{doc['question']}\n\n{options}{post_prompt}"
+
+
+def _doc_to_messages(doc: dict, variant: str, lmms_eval_specific_kwargs: dict | None = None) -> list[dict]:
+    """Structured chat messages for chat models (video first, then the prompt)."""
+    content = [{"type": "video", "url": path} for path in _doc_to_visual(doc, variant)]
+    content.append({"type": "text", "text": herbench_doc_to_text(doc, lmms_eval_specific_kwargs)})
+    return [{"role": "user", "content": content}]
+
+
+def herbench_full_doc_to_messages(doc: dict, lmms_eval_specific_kwargs: dict | None = None) -> list[dict]:
+    return _doc_to_messages(doc, "full", lmms_eval_specific_kwargs)
+
+
+def herbench_lite_doc_to_messages(doc: dict, lmms_eval_specific_kwargs: dict | None = None) -> list[dict]:
+    return _doc_to_messages(doc, "lite", lmms_eval_specific_kwargs)
+
+
+def extract_herbench_answer(response: str, letters) -> str:
+    """Extract the answer letter from a model response.
+
+    Port of the official HERBench answer extraction
+    (evaluation/model_wrappers/base_vlm.py::extract_answer_choice), with the
+    shared lmms-eval MCQ extractor as a fallback for exotic answer formats.
+    """
+    s = str(response).strip()
+    if not s:
+        return ""
+    answer_prefixes = [
+        "The best answer is",
+        "The correct answer is",
+        "The answer is",
+        "The best option is",
+        "The correct option is",
+        "Best answer:",
+        "Best option:",
+        "Final answer:",
+        "Answer:",
+        "Option:",
+    ]
+    for answer_prefix in answer_prefixes:
+        s = s.replace(answer_prefix, "").replace(answer_prefix.lower(), "").strip()
+    letter_set = "".join(letters)
+
+    patterns = [
+        rf"^([{letter_set}])[\s\.\,\)\:]",  # letter at start followed by a delimiter
+        rf"^\(([{letter_set}])\)",  # letter in parentheses at start
+        rf"^([{letter_set}])$",  # just the letter alone
+        rf"[Aa]nswer:\s*\(?([{letter_set}])\b",  # "Answer: A"
+        rf"[Cc]hoice:\s*\(?([{letter_set}])\b",  # "Choice: A"
+        rf"\b([{letter_set}])\b[\.\,]",  # standalone letter followed by punctuation
+    ]
+    for pattern in patterns:
+        match = re.search(pattern, s)
+        if match:
+            return match.group(1).upper()
+
+    # standalone letter surrounded by non-letters (avoids the 'B' in 'Based', etc.)
+    upper = s.upper()
+    for match in re.finditer(rf"([{letter_set}])", upper):
+        start, end = match.start(1), match.end(1)
+        before_ok = start == 0 or not upper[start - 1].isalpha()
+        after_ok = end == len(upper) or not upper[end].isalpha()
+        if before_ok and after_ok:
+            return match.group(1)
+
+    from lmms_eval.tasks._task_utils.mcq_extract import extract_mcq_answer
+
+    return extract_mcq_answer(s, choices=list(letters))
+
+
+def herbench_process_results(doc, results):
+    prediction = results[0] if results else ""
+    letters = _present_letters(doc)
+    pred_answer = extract_herbench_answer(str(prediction), letters)
+    answer = str(doc["answer"]).strip().upper()
+    record = {
+        "question_id": doc["question_id"],
+        "video_id": doc["video_id"],
+        "task_type": doc["task_type"],
+        "source_dataset": doc.get("source_dataset", ""),
+        "pred_answer": pred_answer,
+        "answer": answer,
+        "score": float(pred_answer == answer),
+    }
+    metrics = {"herbench_overall_accuracy": record}
+    slug = TASK_TYPES.get(doc["task_type"])
+    if slug is not None:
+        metrics[f"herbench_{slug}_accuracy"] = record
+    else:
+        eval_logger.warning(f"Unknown HERBench task type: {doc['task_type']}")
+    return metrics
+
+
+def _aggregate_accuracy(results, task_type=None):
+    selected = [r for r in results if task_type is None or r["task_type"] == task_type]
+    if not selected:
+        return 0.0
+    correct = sum(r["score"] for r in selected)
+    accuracy = 100.0 * correct / len(selected)
+    eval_logger.info(f"HERBench {task_type or 'overall'} accuracy: {accuracy:.2f}% ({int(correct)}/{len(selected)})")
+    return accuracy
+
+
+def herbench_aggregate_overall(results):
+    return _aggregate_accuracy(results)
+
+
+def _make_task_aggregator(task_type):
+    def aggregate(results):
+        return _aggregate_accuracy(results, task_type=task_type)
+
+    return aggregate
+
+
+herbench_aggregate_temporal_shot_ordering = _make_task_aggregator("Temporal Shot Ordering")
+herbench_aggregate_multi_person_duration_reasoning = _make_task_aggregator("Multi-Person Duration Reasoning")
+herbench_aggregate_action_sequence_integrity_identification = _make_task_aggregator("Action Sequence Integrity Identification")
+herbench_aggregate_appearance_grounded_behavior_interactions = _make_task_aggregator("Appearance-Grounded Behavior & Interactions")
+herbench_aggregate_appearance_grounded_attribute_recognition = _make_task_aggregator("Appearance-Grounded Attribute Recognition")
+herbench_aggregate_appearance_grounded_localization_trajectory = _make_task_aggregator("Appearance-Grounded Localization & Trajectory")
+herbench_aggregate_false_action_memory = _make_task_aggregator("False Action Memory")
+herbench_aggregate_scene_verification_arrangement = _make_task_aggregator("Scene Verification & Arrangement")
+herbench_aggregate_false_object_memory = _make_task_aggregator("False Object Memory")
+herbench_aggregate_multi_entities_grounding_localization = _make_task_aggregator("Multi-Entities Grounding and Localization")
+herbench_aggregate_action_counting = _make_task_aggregator("Action Counting")
+herbench_aggregate_region_localized_people_counting = _make_task_aggregator("Region Localized People Counting")


### PR DESCRIPTION
## Summary
- Adds **HERBench** ([paper](https://arxiv.org/abs/2512.14870) · [project page](https://herbench.github.io/) · [dataset](https://huggingface.co/datasets/DanBenAmi/HERBench)), a CVPR 2026 benchmark for multi-evidence integration in video QA: five-way MCQs over long videos (avg ~6.6 min) where every question needs ≥3 temporally separated visual cues; SOTA models reach 31–42% (random = 20%).
- Three tasks: `herbench_full` (27,631 q / 335 videos / ~161 GB), `herbench_lite` (2,000 q / 68 videos / ~35 GB), `herbench_lite_v2` (1,971 q, refined, same videos) — with variant-aware download so lite users fetch only ~35 GB.
- The Hub archives are two complete tars split into 17 chunks; the generic `video: true` path would concatenate them and silently extract only the first archive, so the task streams extraction with `ignore_zeros`, verifies every referenced video before stamping its cache marker, and self-heals per video from loose Hub files.

## In scope
- `lmms_eval/tasks/herbench/` (3 task yamls + `_default_template_yaml` + `utils.py` + `README.md`): download/extraction, `doc_to_visual` / `doc_to_text` / `doc_to_messages` / `doc_to_target`, official HERBench letter extraction (shared `mcq_extract` fallback), `herbench_overall_accuracy` + one metric per task type (12), `cluster_key: video_id`.
- `docs/advanced/current_tasks.md`: HERBench entry.

## Out of scope
- No changes to the core framework, models, or other tasks.
- The benchmark's MRFS metric and frame-selection research code (they stay in the official HERBench repo).

## Validation
- `python -m lmms_eval --model qwen2_5_vl --model_args pretrained=Qwen/Qwen2.5-VL-3B-Instruct,max_num_frames=16 --tasks herbench_lite_v2 --batch_size 1 --limit 32` (1× B200) | sample size: `N=32` | key metrics: `herbench_overall_accuracy = 40.6%` (published SOTA band: 31–42%, random 20%), clustered stderr computed via `cluster_key` | result: **pass**
- `python -m lmms_eval --model qwen2_5_vl --model_args pretrained=Qwen/Qwen2.5-VL-3B-Instruct,max_num_frames=4 --tasks herbench_lite_v2 --batch_size 1 --limit 8` (CPU) | sample size: `N=8` | key metrics: pipeline end-to-end (download → 35 GB extraction of all 68 videos → generation → letter parsing → metrics table) | result: **pass**
- Harness-level test over `N=400` docs per task with simulated model outputs: every `process_results` record and all 13 aggregations verified; oracle answers score exactly 100%; 4-option question and literal-"None" options covered | result: **pass**
- Streaming extraction unit-tested on a synthetic two-tar split fixture (byte-identical output, GNU LongLink names, truncation detection, skip-existing re-run) and on the real 161 GB full set (334 videos; the one video absent from the Hub archives fails with a clear per-question error) | result: **pass**
- `uv run pre-commit run` (ruff check + format) clean on all added files.

## Risk / Compatibility
- Additive only (new task directory + one docs line); no behavior change for existing tasks or models.
- Known upstream data issue: `videos/PersonPath22/uid_vid_00109.mp4` is currently missing from the Hub archives (65 `herbench_full` questions); the dataset authors are uploading it as a loose file, which this task picks up automatically — `herbench_lite`/`herbench_lite_v2` are unaffected.

## Type of Change
- [x] New benchmark/task
- [x] Documentation update
