### PR TITLE
fix(mathvision): preserve optional root indices in _fix_sqrt

### DIFF
--- a/lmms_eval/tasks/mathvision/eval_utils.py
+++ b/lmms_eval/tasks/mathvision/eval_utils.py
@@ -308,12 +308,15 @@ def _fix_sqrt(string):
     for split in splits[1:]:
         # If the split portion is non-empty and the first character isn't a '{',
         # then it means the argument of the sqrt is not enclosed in braces.
-        if len(split) > 0 and split[0] != "{":
+        # An optional root index ("\\sqrt[3]{8}") starts with '[' and is already
+        # well-formed: bracing its '[' corrupted it to '\\sqrt{[}3]{8}', invalid
+        # LaTeX that kills the latex2sympy equivalence path in is_equal.
+        if len(split) > 0 and split[0] not in "{[":
             a = split[0]
             # Add braces around the first character and append the rest of the split portion.
             new_substr = "\\sqrt{" + a + "}" + split[1:]
         else:
-            # If the split portion starts with a '{', then it's already correct.
+            # If the split portion starts with a '{' or a root index '[', it's already correct.
             new_substr = "\\sqrt" + split
         # Add the new substring to our result string.
         new_string += new_substr

--- a/test/test_mathvision_eval_utils.py
+++ b/test/test_mathvision_eval_utils.py
@@ -1,0 +1,28 @@
+import pytest
+
+pytest.importorskip("latex2sympy2")
+
+from lmms_eval.tasks.mathvision.eval_utils import _fix_sqrt, _strip_string  # noqa: E402
+
+
+def test_fix_sqrt_preserves_indexed_roots():
+    r"""\sqrt[<n>]{...} is already well-formed. Bracing its '[' corrupted it to
+    '\sqrt{[}3]{8}', which is invalid LaTeX and killed the latex2sympy
+    equivalence path in is_equal."""
+    assert _fix_sqrt("\\sqrt[3]{8}") == "\\sqrt[3]{8}"
+    assert _fix_sqrt("\\sqrt[3]{2}+1") == "\\sqrt[3]{2}+1"
+    assert _fix_sqrt("2\\sqrt[3]{2}") == "2\\sqrt[3]{2}"
+
+
+def test_fix_sqrt_keeps_existing_shorthand_behavior():
+    assert _fix_sqrt("\\sqrt{2}") == "\\sqrt{2}"
+    assert _fix_sqrt("\\sqrt2") == "\\sqrt{2}"
+    assert _fix_sqrt("\\sqrta") == "\\sqrt{a}"
+
+
+def test_strip_string_leaves_indexed_roots_parseable():
+    from latex2sympy2 import latex2sympy
+
+    stripped = _strip_string("\\sqrt[3]{8}")
+    # the stripped gold/answer must still parse, so is_equal's sympy fallback works
+    assert str(latex2sympy(stripped)) == "8**(1/3)"


### PR DESCRIPTION
Related: #1505

## Summary
- `_fix_sqrt` braced the first character after every `\sqrt` it rewrites; for indexed roots (`\sqrt[3]{8}`) that character is the `[` of the root index, producing invalid LaTeX (`\sqrt{[}3]{8}`)
- The corrupted form makes `latex2sympy` raise inside `is_equal`'s `except: return False` fallback, converting indexed-root comparisons into silent false negatives
- Skip rewriting when the segment already starts with `[`; braceless shorthands (`\sqrt2`, `\sqrta`) keep the existing behavior

## In scope
- `lmms_eval/tasks/mathvision/eval_utils.py`: the guard in `_fix_sqrt` now accepts `{` **or** `[` as "already well-formed" (1-line condition change + comment)
- `test/test_mathvision_eval_utils.py`: regression tests for indexed roots, existing shorthand behavior, and end-to-end `_strip_string` parseability

## Out of scope
- Other task directories (`_fix_sqrt` exists only in mathvision)
- Any change to scoring logic in `is_equal` / `find_math_answer`

## Validation
- `PYTHONPATH=. python -m pytest test/test_mathvision_eval_utils.py -q` | sample size: `N=3` | key metrics: pre-fix 2 failed / 1 passed → post-fix `3 passed` | result: `pass`
- Pre-fix FAIL evidence: `test_fix_sqrt_preserves_indexed_roots` (corruption `\sqrt{[}3]{8}`) and `test_strip_string_leaves_indexed_roots_parseable` (`Exception: I expected something else here` at latex2sympy2.py:141)
- `uvx ruff@0.16.4 check` + `format --check` on both touched files | result: `pass`

## Risk / Compatibility
- No behavior change for `\sqrt{...}` / `\sqrt2` / `\sqrta` inputs; only previously-corrupted indexed-root inputs stop being corrupted
- Verification env: full `lmms-eval` deps installed (Python 3.11), `latex2sympy2` importable

## Type of Change
- [x] Bug fix (non-breaking change)