### PR TITLE
fix(mathvision): call _fix_fracs unconditionally in _strip_string

### DIFF
--- a/lmms_eval/tasks/mathvision/eval_utils.py
+++ b/lmms_eval/tasks/mathvision/eval_utils.py
@@ -308,12 +308,15 @@ def _fix_sqrt(string):
     for split in splits[1:]:
         # If the split portion is non-empty and the first character isn't a '{',
         # then it means the argument of the sqrt is not enclosed in braces.
-        if len(split) > 0 and split[0] != "{":
+        # An optional root index ("\\sqrt[3]{8}") starts with '[' and is already
+        # well-formed: bracing its '[' corrupted it to '\\sqrt{[}3]{8}', invalid
+        # LaTeX that kills the latex2sympy equivalence path in is_equal.
+        if len(split) > 0 and split[0] not in "{[":
             a = split[0]
             # Add braces around the first character and append the rest of the split portion.
             new_substr = "\\sqrt{" + a + "}" + split[1:]
         else:
-            # If the split portion starts with a '{', then it's already correct.
+            # If the split portion starts with a '{' or a root index '[', it's already correct.
             new_substr = "\\sqrt" + split
         # Add the new substring to our result string.
         new_string += new_substr

--- a/lmms_eval/tasks/mathvision/eval_utils.py
+++ b/lmms_eval/tasks/mathvision/eval_utils.py
@@ -378,9 +378,12 @@ def _strip_string(string):
     # Remove all spaces
     string = string.replace(" ", "")
 
-    # Transform certain fraction notations to the desired format. Note: The function _fix_fracs is not provided.
-    if "sqrt" in string:
-        string = _fix_fracs(string)
+    # Transform certain fraction notations to the desired format.
+    # Unconditional, matching the canonical hendrycks math_equivalence:
+    # the "sqrt" guard here was a copy of the _fix_sqrt guard above and
+    # made \frac12-style shorthand unreachable for every sqrt-free
+    # answer, which latex2sympy then fails to parse inside is_equal.
+    string = _fix_fracs(string)
 
     # Convert 0.5 to its fraction representation
     if string == "0.5":

--- a/test/test_mathvision_eval_utils.py
+++ b/test/test_mathvision_eval_utils.py
@@ -26,3 +26,28 @@ def test_strip_string_leaves_indexed_roots_parseable():
     stripped = _strip_string("\\sqrt[3]{8}")
     # the stripped gold/answer must still parse, so is_equal's sympy fallback works
     assert str(latex2sympy(stripped)) == "8**(1/3)"
+
+
+def test_frac_shorthand_normalized_without_sqrt():
+    assert _strip_string("\\frac12") == "\\frac{1}{2}"
+    assert _strip_string("\\frac1{2}") == "\\frac{1}{2}"
+    assert _strip_string("\\frac34") == "\\frac{3}{4}"
+    assert _strip_string("1\\frac12") == "1\\frac{1}{2}"
+
+
+def test_frac_shorthand_parseable_without_sqrt():
+    from latex2sympy2 import latex2sympy
+
+    assert str(latex2sympy(_strip_string("\\frac12"))) == "1/2"
+
+
+def test_frac_braced_numeral_form_is_canonical_passthrough():
+    # \frac{1}2 is left as-is by the canonical _fix_fracs (hendrycks
+    # math_equivalence); this documents parity, not a fix.
+    assert _strip_string("\\frac{1}2") == "\\frac{1}2"
+
+
+def test_frac_still_normalized_with_sqrt_present():
+    # Control: normalization already worked when a sqrt was present;
+    # the fix removes the guard that made sqrt presence a precondition.
+    assert _strip_string("\\frac12 + \\sqrt2") == "\\frac{1}{2}+\\sqrt{2}"

--- a/test/test_mathvision_eval_utils.py
+++ b/test/test_mathvision_eval_utils.py
@@ -1,0 +1,28 @@
+import pytest
+
+pytest.importorskip("latex2sympy2")
+
+from lmms_eval.tasks.mathvision.eval_utils import _fix_sqrt, _strip_string  # noqa: E402
+
+
+def test_fix_sqrt_preserves_indexed_roots():
+    r"""\sqrt[<n>]{...} is already well-formed. Bracing its '[' corrupted it to
+    '\sqrt{[}3]{8}', which is invalid LaTeX and killed the latex2sympy
+    equivalence path in is_equal."""
+    assert _fix_sqrt("\\sqrt[3]{8}") == "\\sqrt[3]{8}"
+    assert _fix_sqrt("\\sqrt[3]{2}+1") == "\\sqrt[3]{2}+1"
+    assert _fix_sqrt("2\\sqrt[3]{2}") == "2\\sqrt[3]{2}"
+
+
+def test_fix_sqrt_keeps_existing_shorthand_behavior():
+    assert _fix_sqrt("\\sqrt{2}") == "\\sqrt{2}"
+    assert _fix_sqrt("\\sqrt2") == "\\sqrt{2}"
+    assert _fix_sqrt("\\sqrta") == "\\sqrt{a}"
+
+
+def test_strip_string_leaves_indexed_roots_parseable():
+    from latex2sympy2 import latex2sympy
+
+    stripped = _strip_string("\\sqrt[3]{8}")
+    # the stripped gold/answer must still parse, so is_equal's sympy fallback works
+    assert str(latex2sympy(stripped)) == "8**(1/3)"


### PR DESCRIPTION
Related: #1507

> Stacked on #1506 (shares its test file and the `_fix_sqrt` hunks; once #1506 merges, the diff of this PR is the frac-guard removal only).

## Summary
- `_strip_string` gated `_fix_fracs` behind `if "sqrt" in string:` — a copy-paste of the `_fix_sqrt` guard; fraction shorthand (`\frac12`, `\frac1{2}`) never normalized for any sqrt-free answer
- The unnormalized shorthand makes `latex2sympy` raise inside `is_equal`'s `except: return False`, silently scoring a correct answer as wrong
- Remove the guard: `_fix_fracs` is called unconditionally, as in the canonical hendrycks `math_equivalence`

## In scope
- `lmms_eval/tasks/mathvision/eval_utils.py`: guard removal (2 deleted lines) + comment
- `test/test_mathvision_eval_utils.py`: four frac tests (normalization without sqrt, end-to-end parseability, canonical passthrough for `\frac{1}2`, control with sqrt present)

## Out of scope
- The `\frac{1}2` form (braced numerator): canonical `_fix_fracs` leaves it as-is; kept as a parity test, not changed
- Any scoring logic in `is_equal` / `find_math_answer`

## Validation
- `PYTHONPATH=. python -m pytest test/test_mathvision_eval_utils.py -q` | sample size: `N=7` | key metrics: pre-fix 2 failed / 5 passed → post-fix `7 passed` | result: `pass`
- Pre-fix FAIL evidence: `test_frac_shorthand_normalized_without_sqrt` (`\frac12` survived `_strip_string`) and `test_frac_shorthand_parseable_without_sqrt` (`Exception: I expected something else here` from latex2sympy2.py:141)
- Control: `\frac12 + \sqrt2` normalized correctly both before and after (proves the guard was the only blocker)
- `uvx ruff@0.16.4 check` + `format --check` on both touched files | result: `pass`

## Risk / Compatibility
- Braced `\frac{a}{b}` strings pass through `_fix_fracs` unchanged → zero behavior delta for already-well-formed answers
- Strings containing `sqrt` behave identically to before (the function already ran there)
- Only unbraced shorthand changes: exactly the inputs that previously caused silent false negatives

## Type of Change
- [x] Bug fix (non-breaking change)