### PR TITLE
fix(mathvision): unwrap \\text{...}/\\mbox{...} instead of leaving braces behind

### DIFF
--- a/lmms_eval/tasks/mathvision/eval_utils.py
+++ b/lmms_eval/tasks/mathvision/eval_utils.py
@@ -417,7 +417,16 @@ def find_math_answer(s: str) -> str:
     # Clean the string from various LaTeX formatting.
     ans = ans.replace(" ", "").replace("\\,", "").replace("∞", "\\infty")
     ans = ans.replace("+\infty", "\infty").replace("\\\\", "\\").replace("\n", "")
-    ans = ans.replace("\\text", "").replace("\\mbox", "").replace("bmatrix", "pmatrix")
+    # Unwrap \text{...}/\mbox{...} content instead of deleting only the
+    # command name: leftover braces corrupt the answer (\text{Sunday} ->
+    # "{sunday}", which latex2sympy cannot post-process, so is_equal
+    # scores False against the bare gold "Sunday"). Only brace-balanced
+    # spans are unwrapped; anything with nested braces falls back to the
+    # legacy bare replace, because "{\frac{1}{2}}" parses and must keep
+    # doing so.
+    ans = re.sub(r"\\(?:text|mbox)\{([^{}]*)\}", r"\1", ans)
+    ans = ans.replace("\\text", "").replace("\\mbox", "")
+    ans = ans.replace("bmatrix", "pmatrix")
     ans = ans.replace("\\left", "").replace("\\right", "").replace("^{\\circ}", "")
     ans = ans.replace("^\\circ", "").replace("{m}^3", "").replace("m^3", "")
     ans = ans.replace("{units}", "").replace("units", "").replace("{km}", "").replace("km", "")

--- a/lmms_eval/tasks/mathvision/eval_utils.py
+++ b/lmms_eval/tasks/mathvision/eval_utils.py
@@ -308,12 +308,15 @@ def _fix_sqrt(string):
     for split in splits[1:]:
         # If the split portion is non-empty and the first character isn't a '{',
         # then it means the argument of the sqrt is not enclosed in braces.
-        if len(split) > 0 and split[0] != "{":
+        # An optional root index ("\\sqrt[3]{8}") starts with '[' and is already
+        # well-formed: bracing its '[' corrupted it to '\\sqrt{[}3]{8}', invalid
+        # LaTeX that kills the latex2sympy equivalence path in is_equal.
+        if len(split) > 0 and split[0] not in "{[":
             a = split[0]
             # Add braces around the first character and append the rest of the split portion.
             new_substr = "\\sqrt{" + a + "}" + split[1:]
         else:
-            # If the split portion starts with a '{', then it's already correct.
+            # If the split portion starts with a '{' or a root index '[', it's already correct.
             new_substr = "\\sqrt" + split
         # Add the new substring to our result string.
         new_string += new_substr

--- a/lmms_eval/tasks/mathvision/eval_utils.py
+++ b/lmms_eval/tasks/mathvision/eval_utils.py
@@ -378,9 +378,12 @@ def _strip_string(string):
     # Remove all spaces
     string = string.replace(" ", "")
 
-    # Transform certain fraction notations to the desired format. Note: The function _fix_fracs is not provided.
-    if "sqrt" in string:
-        string = _fix_fracs(string)
+    # Transform certain fraction notations to the desired format.
+    # Unconditional, matching the canonical hendrycks math_equivalence:
+    # the "sqrt" guard here was a copy of the _fix_sqrt guard above and
+    # made \frac12-style shorthand unreachable for every sqrt-free
+    # answer, which latex2sympy then fails to parse inside is_equal.
+    string = _fix_fracs(string)
 
     # Convert 0.5 to its fraction representation
     if string == "0.5":

--- a/test/test_mathvision_eval_utils.py
+++ b/test/test_mathvision_eval_utils.py
@@ -26,3 +26,28 @@ def test_strip_string_leaves_indexed_roots_parseable():
     stripped = _strip_string("\\sqrt[3]{8}")
     # the stripped gold/answer must still parse, so is_equal's sympy fallback works
     assert str(latex2sympy(stripped)) == "8**(1/3)"
+
+
+def test_frac_shorthand_normalized_without_sqrt():
+    assert _strip_string("\\frac12") == "\\frac{1}{2}"
+    assert _strip_string("\\frac1{2}") == "\\frac{1}{2}"
+    assert _strip_string("\\frac34") == "\\frac{3}{4}"
+    assert _strip_string("1\\frac12") == "1\\frac{1}{2}"
+
+
+def test_frac_shorthand_parseable_without_sqrt():
+    from latex2sympy2 import latex2sympy
+
+    assert str(latex2sympy(_strip_string("\\frac12"))) == "1/2"
+
+
+def test_frac_braced_numeral_form_is_canonical_passthrough():
+    # \frac{1}2 is left as-is by the canonical _fix_fracs (hendrycks
+    # math_equivalence); this documents parity, not a fix.
+    assert _strip_string("\\frac{1}2") == "\\frac{1}2"
+
+
+def test_frac_still_normalized_with_sqrt_present():
+    # Control: normalization already worked when a sqrt was present;
+    # the fix removes the guard that made sqrt presence a precondition.
+    assert _strip_string("\\frac12 + \\sqrt2") == "\\frac{1}{2}+\\sqrt{2}"

--- a/test/test_mathvision_eval_utils.py
+++ b/test/test_mathvision_eval_utils.py
@@ -2,7 +2,12 @@ import pytest
 
 pytest.importorskip("latex2sympy2")
 
-from lmms_eval.tasks.mathvision.eval_utils import _fix_sqrt, _strip_string  # noqa: E402
+from lmms_eval.tasks.mathvision.eval_utils import (  # noqa: E402
+    _fix_sqrt,
+    _strip_string,
+    find_math_answer,
+    is_equal,
+)
 
 
 def test_fix_sqrt_preserves_indexed_roots():
@@ -51,3 +56,23 @@ def test_frac_still_normalized_with_sqrt_present():
     # Control: normalization already worked when a sqrt was present;
     # the fix removes the guard that made sqrt presence a precondition.
     assert _strip_string("\\frac12 + \\sqrt2") == "\\frac{1}{2}+\\sqrt{2}"
+
+
+def test_boxed_text_answer_is_unwrapped_not_braced():
+    assert find_math_answer("\\boxed{\\text{Sunday}}") == "sunday"
+    assert is_equal(find_math_answer("\\boxed{\\text{Sunday}}"), "Sunday") is True
+
+
+def test_mbox_answer_is_unwrapped():
+    assert find_math_answer("\\boxed{\\mbox{8}}") == "8"
+
+
+def test_nested_text_falls_back_to_bare_replace():
+    # Only brace-balanced spans are unwrapped. Nested \text must keep the
+    # legacy bare-replace result, because "{\frac{1}{2}}" parses in
+    # latex2sympy and must keep doing so.
+    assert find_math_answer("\\boxed{\\text{\\frac{1}{2}}}") == "{\\frac{1}{2}}"
+
+
+def test_plain_boxed_answer_untouched():
+    assert find_math_answer("\\boxed{3}") == "3"

--- a/test/test_mathvision_eval_utils.py
+++ b/test/test_mathvision_eval_utils.py
@@ -1,0 +1,28 @@
+import pytest
+
+pytest.importorskip("latex2sympy2")
+
+from lmms_eval.tasks.mathvision.eval_utils import _fix_sqrt, _strip_string  # noqa: E402
+
+
+def test_fix_sqrt_preserves_indexed_roots():
+    r"""\sqrt[<n>]{...} is already well-formed. Bracing its '[' corrupted it to
+    '\sqrt{[}3]{8}', which is invalid LaTeX and killed the latex2sympy
+    equivalence path in is_equal."""
+    assert _fix_sqrt("\\sqrt[3]{8}") == "\\sqrt[3]{8}"
+    assert _fix_sqrt("\\sqrt[3]{2}+1") == "\\sqrt[3]{2}+1"
+    assert _fix_sqrt("2\\sqrt[3]{2}") == "2\\sqrt[3]{2}"
+
+
+def test_fix_sqrt_keeps_existing_shorthand_behavior():
+    assert _fix_sqrt("\\sqrt{2}") == "\\sqrt{2}"
+    assert _fix_sqrt("\\sqrt2") == "\\sqrt{2}"
+    assert _fix_sqrt("\\sqrta") == "\\sqrt{a}"
+
+
+def test_strip_string_leaves_indexed_roots_parseable():
+    from latex2sympy2 import latex2sympy
+
+    stripped = _strip_string("\\sqrt[3]{8}")
+    # the stripped gold/answer must still parse, so is_equal's sympy fallback works
+    assert str(latex2sympy(stripped)) == "8**(1/3)"


### PR DESCRIPTION
Related: #1509

> Stacked on #1506 → #1508 (shares their test file; each earlier PR is green and merges independently — once they merge, this diff shrinks to the unwrap change).

## Summary
- `find_math_answer` deleted the `\text` command name but kept its braces: `\boxed{\text{Sunday}}` → `{sunday}`, which `latex2sympy` cannot post-process, so `is_equal` scored False against the bare gold `Sunday`
- Every braced text answer (dates, names, unit-bearing values) was a silent false negative
- Unwrap brace-balanced `\text{...}`/`\mbox{...}` spans; nested spans fall back to the legacy bare replace (`{\frac{1}{2}}` parses and must keep doing so)

## In scope
- `lmms_eval/tasks/mathvision/eval_utils.py`: one line becomes a regex unwrap + legacy fallback + comment
- `test/test_mathvision_eval_utils.py`: four tests (text answer unwrap + end-to-end is_equal, mbox unwrap, nested fallback parity, plain-boxed control)

## Out of scope
- The greedy boxed-extraction regex (`oxed{(.*)}`)
- Other task directories (pattern is unique to mathvision)
- `\textbf{A}` handling (unchanged legacy behavior, outcome identical)

## Validation
- `PYTHONPATH=. python -m pytest test/test_mathvision_eval_utils.py -q` | sample size: `N=11` | key metrics: pre-fix 2 failed / 9 passed → post-fix `11 passed` | result: `pass`
- Pre-fix FAIL evidence: `test_boxed_text_answer_is_unwrapped_not_braced` (`{sunday}` vs expected `sunday`; `is_equal` False) and `test_mbox_answer_is_unwrapped` (`{8}` vs expected `8`)
- Parity controls pass before AND after: nested `\text{\frac{1}{2}}` keeps the legacy `{\frac{1}{2}}` result (parses), plain `\boxed{3}` untouched
- `uvx ruff@0.16.4 check` + `format --check` | result: `pass`

## Risk / Compatibility
- Non-nested `\text{...}`/`\mbox{...}`: braces removed — strictly closer to gold for text answers; numeric forms like `{8}` compared equal either way
- Nested forms: byte-identical to before (fallback path)
- No change to `is_equal` / extraction regex / other tasks

## Type of Change
- [x] Bug fix (non-breaking change)