### PR TITLE
fix(cache): validate recovered responses and repair invalid entries

### DIFF
--- a/docs/advanced/caching.md
+++ b/docs/advanced/caching.md
@@ -101,7 +101,7 @@ To force re-evaluation: delete the `{model_hash}/` directory under your cache pa
 
 ### Crash recovery
 
-Write order: JSONL append + fsync -> SQLite upsert. On startup, any JSONL entries missing from SQLite are replayed. This survives crashes between the two writes.
+Write order: JSONL append + fsync -> SQLite upsert. On startup, valid JSONL entries missing from SQLite are replayed. Valid audit entries also replace invalid SQLite entries left by older versions. This survives crashes between the two writes.
 
 ### Poisoning prevention
 
@@ -109,7 +109,9 @@ Responses are validated before caching:
 
 - `None` -> rejected
 - Empty or whitespace-only strings -> rejected
-- Malformed loglikelihood tuples (not `[float, bool]`) -> rejected
+- Loglikelihood responses that are not a two-element list or tuple -> rejected; element types are not validated
+
+The same validity policy applies to audit recovery, local/shared cache reads, and shard merging. Invalid responses remain in the audit log with an empty cache key. Older keyed audit entries are validated before replay. Invalid SQLite payloads are treated as misses, and valid retries can replace them during replay or shard merging. Existing valid entries are preserved.
 
 ### Merge distributed shards
 

--- a/lmms_eval/caching/response_cache.py
+++ b/lmms_eval/caching/response_cache.py
@@ -344,14 +344,6 @@ def _serialize_response(response: Any) -> str:
     return json.dumps(response, ensure_ascii=False, default=str)
 
 
-def _deserialize_response(stored: str) -> Any:
-    """json.loads returns list for stored tuples — downstream tuple unpacking still works."""
-    try:
-        return json.loads(stored)
-    except (json.JSONDecodeError, TypeError):
-        return stored
-
-
 _SCHEMA_SQL = """\
 CREATE TABLE IF NOT EXISTS responses (
     cache_key     TEXT PRIMARY KEY,
@@ -613,16 +605,21 @@ class ResponseCache:
                         continue
                     try:
                         rec = json.loads(line)
+                        if not isinstance(rec, dict):
+                            continue
                         if not rec.get("deterministic", True) or not rec.get("cache_key"):
                             continue
-                        cur = self.db.execute("SELECT 1 FROM responses WHERE cache_key = ?", (rec["cache_key"],))
-                        if cur.fetchone() is None:
+                        if self._decode_valid_response(rec["response"], rec["request_type"]) is None:
+                            continue
+                        cur = self.db.execute("SELECT response, request_type FROM responses WHERE cache_key = ?", (rec["cache_key"],))
+                        existing = cur.fetchone()
+                        if existing is None or self._decode_valid_response(*existing) is None:
                             self.db.execute(
-                                "INSERT INTO responses (cache_key, request_type, task_name, doc_id, idx, gen_kwargs, response, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                                "INSERT OR REPLACE INTO responses (cache_key, request_type, task_name, doc_id, idx, gen_kwargs, response, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
                                 (rec["cache_key"], rec["request_type"], rec["task_name"], rec["doc_id"], rec.get("idx", 0), rec.get("gen_kwargs", "{}"), rec["response"], rec.get("created_at", time.time())),
                             )
                             replayed += 1
-                    except (json.JSONDecodeError, KeyError):
+                    except (json.JSONDecodeError, KeyError, TypeError):
                         continue
             if replayed > 0:
                 self.db.commit()
@@ -631,20 +628,24 @@ class ResponseCache:
             eval_logger.warning(f"ResponseCache: audit log replay failed: {e}")
 
     def _lookup(self, cache_key: str) -> Any:
-        """Look up a cache key: local DB first, then shared DB."""
+        """Read valid responses only, including from caches written by older versions."""
         # 1. Check local (writable) DB
-        cur = self.db.execute("SELECT response FROM responses WHERE cache_key = ?", (cache_key,))
+        cur = self.db.execute("SELECT response, request_type FROM responses WHERE cache_key = ?", (cache_key,))
         row = cur.fetchone()
         if row is not None:
-            return _deserialize_response(row[0])
+            response = self._decode_valid_response(*row)
+            if response is not None:
+                return response
         # 2. Fall back to shared (read-only) DB
         if self._shared_db is not None:
             try:
-                cur = self._shared_db.execute("SELECT response FROM responses WHERE cache_key = ?", (cache_key,))
+                cur = self._shared_db.execute("SELECT response, request_type FROM responses WHERE cache_key = ?", (cache_key,))
                 row = cur.fetchone()
                 if row is not None:
-                    self._hits_shared += 1
-                    return _deserialize_response(row[0])
+                    response = self._decode_valid_response(*row)
+                    if response is not None:
+                        self._hits_shared += 1
+                        return response
             except Exception:
                 pass  # shared DB failure is non-fatal
         return None
@@ -729,6 +730,15 @@ class ResponseCache:
             return False
         return True
 
+    @classmethod
+    def _decode_valid_response(cls, stored: str, request_type: str) -> Any:
+        """Apply the live-write validity policy to persisted JSON payloads."""
+        try:
+            response = json.loads(stored)
+        except (json.JSONDecodeError, TypeError):
+            return None
+        return response if cls._is_valid_response(response, request_type) else None
+
     def execute(self, lm: Any, reqtype: str, requests: List[Instance]) -> list:
         """Check cache -> run model on misses -> store results -> return merged list.
 
@@ -783,6 +793,7 @@ class ResponseCache:
                 cacheable = self._extract_cacheable(resp)
                 gen_kwargs = extract_gen_kwargs(req)
                 deterministic = is_deterministic(reqtype, gen_kwargs)
+                valid = self._is_valid_response(cacheable, reqtype)
                 ch = _extract_content_hash(req)
                 tf = self._task_fingerprints.get(req.task_name, "")
                 cache_key = (
@@ -807,13 +818,13 @@ class ResponseCache:
                     req.idx,
                     gen_kwargs,
                     cacheable,
-                    cache_key=cache_key,
+                    cache_key=cache_key if valid else "",
                     deterministic=deterministic,
                     task_fingerprint=tf,
                     content_hash=ch,
                     model_fingerprint_hash=self._model_fingerprint_hash,
                 )
-                if deterministic and self._is_valid_response(resp, reqtype):
+                if deterministic and valid:
                     self._store(cache_key, reqtype, req.task_name, req.doc_id, req.idx, gen_kwargs, cacheable)
                     if self._use_scratch:
                         self._entries_since_checkpoint += 1
@@ -1021,7 +1032,7 @@ class ResponseCache:
     def merge_shards(shard_paths: List[str], output_path: str) -> int:
         """Merge per-rank SQLite shards into a consolidated DB.
 
-        Uses INSERT OR IGNORE so existing entries in ``output_path`` are preserved.
+        Preserves valid existing entries and replaces invalid entries with valid retries.
         Creates ``output_path`` if it does not exist.
 
         Returns the number of entries inserted.
@@ -1037,9 +1048,14 @@ class ResponseCache:
             shard_db = sqlite3.connect(shard_path)
             rows = shard_db.execute("SELECT cache_key, request_type, task_name, doc_id, idx, gen_kwargs, response, created_at FROM responses").fetchall()
             for row in rows:
+                if ResponseCache._decode_valid_response(row[6], row[1]) is None:
+                    continue
+                existing = out_db.execute("SELECT response, request_type FROM responses WHERE cache_key = ?", (row[0],)).fetchone()
+                if existing is not None and ResponseCache._decode_valid_response(*existing) is not None:
+                    continue
                 try:
                     out_db.execute(
-                        "INSERT OR IGNORE INTO responses (cache_key, request_type, task_name, doc_id, idx, gen_kwargs, response, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                        "INSERT OR REPLACE INTO responses (cache_key, request_type, task_name, doc_id, idx, gen_kwargs, response, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
                         row,
                     )
                     total += 1

--- a/test/cache/test_response_cache.py
+++ b/test/cache/test_response_cache.py
@@ -323,6 +323,119 @@ class TestAuditLogObservability(_CacheTestBase):
 
 
 class TestCrashRecovery(_CacheTestBase):
+    def test_invalid_responses_stay_observable_but_are_not_recovered(self):
+        requests = [_gen_request(doc_id=i) for i in range(3)]
+        cache = self._open_cache()
+        try:
+            self.assertEqual(cache.execute(_mock_model([None, "", "  "]), "generate_until", requests), [None, "", "  "])
+            self.assertEqual(cache.get_stats()["total_cached_entries"], 0)
+        finally:
+            cache.close()
+
+        records = self._read_audit_lines()
+        self.assertEqual([json.loads(rec["response"]) for rec in records], [None, "", "  "])
+        self.assertTrue(all(rec["deterministic"] and not rec["cache_key"] for rec in records))
+        cache = self._open_cache()
+        try:
+            model = _mock_model(["retry0", "retry1", "retry2"])
+            self.assertEqual(cache.execute(model, "generate_until", requests), ["retry0", "retry1", "retry2"])
+            model.generate_until.assert_called_once()
+        finally:
+            cache.close()
+
+    def test_legacy_audit_skips_invalid_rows_and_recovers_later_valid_rows(self):
+        # Old writers assigned cache keys to invalid responses as well.
+        rows = [
+            ("generate_until", "null"),
+            ("generate_until", '""'),
+            ("generate_until", '"  "'),
+            ("loglikelihood", "[0.5]"),
+            ("generate_until", "truncated-json"),
+            ("generate_until", '"recovered"'),
+            ("loglikelihood", "[0.5, true]"),
+        ]
+        with open(self.audit_path, "w") as audit:
+            for request_type, response in rows:
+                audit.write(json.dumps({"cache_key": request_type, "deterministic": True, "request_type": request_type, "task_name": "t", "doc_id": 0, "response": response}) + "\n")
+        cache = self._open_cache()
+        try:
+            self.assertEqual(cache.get_stats()["total_cached_entries"], 2)
+            self.assertEqual(cache._lookup("generate_until"), "recovered")
+            self.assertEqual(cache._lookup("loglikelihood"), [0.5, True])
+        finally:
+            cache.close()
+
+    def test_existing_invalid_database_rows_are_misses(self):
+        for request_type, response in [("generate_until", ""), ("generate_until", "  "), ("generate_until", None), ("loglikelihood", [0.5])]:
+            with self.subTest(request_type=request_type, response=response):
+                cache = self._open_cache()
+                try:
+                    cache._store("legacy", request_type, "t", 0, 0, {}, response)
+                    self.assertIsNone(cache._lookup("legacy"))
+                    cache.db.execute("UPDATE responses SET response = ? WHERE cache_key = ?", ("truncated-json", "legacy"))
+                    cache.db.commit()
+                    self.assertIsNone(cache._lookup("legacy"))
+                finally:
+                    cache.close()
+
+    def test_invalid_local_row_falls_through_to_valid_shared_cache(self):
+        shared_path = os.path.join(self.tmpdir, "shared.db")
+        shared = ResponseCache(shared_path, os.path.join(self.tmpdir, "shared.jsonl"))
+        try:
+            shared._store("valid", "generate_until", "t", 0, 0, {}, "shared-answer")
+            shared._store("invalid", "generate_until", "t", 1, 0, {}, "")
+        finally:
+            shared.close()
+        cache = self._open_cache(shared_db_path=shared_path)
+        try:
+            cache._store("valid", "generate_until", "t", 0, 0, {}, "")
+            self.assertEqual(cache._lookup("valid"), "shared-answer")
+            self.assertIsNone(cache._lookup("invalid"))
+            self.assertEqual(cache.get_stats()["hits_shared"], 1)
+        finally:
+            cache.close()
+
+    def test_valid_audit_repairs_invalid_existing_database_row(self):
+        cache = self._open_cache()
+        try:
+            cache._store("retry", "generate_until", "t", 0, 0, {}, "")
+            cache._log_to_audit("generate_until", "t", 0, 0, {}, "recovered", cache_key="retry")
+        finally:
+            cache.close()
+        cache = self._open_cache()
+        try:
+            self.assertEqual(cache._lookup("retry"), "recovered")
+        finally:
+            cache.close()
+
+    def test_retry_repairs_shared_cache_after_merge(self):
+        request = _gen_request()
+        shared_path = os.path.join(self.tmpdir, "shared.db")
+        key = compute_cache_key("generate_until", "t", 0, extract_gen_kwargs(request), content_hash=_extract_content_hash(request))
+        shared = ResponseCache(shared_path, os.path.join(self.tmpdir, "shared.jsonl"))
+        try:
+            shared._store(key, "generate_until", "t", 0, 0, {}, "")
+            shared._store("preserve", "generate_until", "t", 1, 0, {}, "original")
+        finally:
+            shared.close()
+        cache = self._open_cache(shared_db_path=shared_path)
+        try:
+            self.assertEqual(cache.execute(_mock_model(["retry"]), "generate_until", [request]), ["retry"])
+            cache._store("preserve", "generate_until", "t", 1, 0, {}, "replacement")
+            cache._store("invalid", "generate_until", "t", 2, 0, {}, "")
+        finally:
+            cache.close()
+        self.assertEqual(ResponseCache.merge_shards([self.db_path], shared_path), 1)
+        fresh = ResponseCache(os.path.join(self.tmpdir, "fresh.db"), os.path.join(self.tmpdir, "fresh.jsonl"), shared_db_path=shared_path)
+        try:
+            model = _mock_model([])
+            self.assertEqual(fresh.execute(model, "generate_until", [request]), ["retry"])
+            model.generate_until.assert_not_called()
+            self.assertEqual(fresh._lookup("preserve"), "original")
+            self.assertIsNone(fresh._lookup("invalid"))
+        finally:
+            fresh.close()
+
     def test_jsonl_replay_after_simulated_crash(self):
         model = _mock_model(["crash_answer"])
         req = _gen_request(temperature=0)


### PR DESCRIPTION
We found that reopening the response cache could restore empty answers that the live write path had rejected. This applies the same response checks during recovery, reads, and shard merging, so failed responses cannot become cache hits and valid retries can repair old entries.

## Root cause

The audit log records every response before SQLite validation. Replay trusted the deterministic flag and cache key without validating the stored response. Database reads also trusted existing payloads, and shard merging preserved invalid destination entries.

## Fix

- Validate persisted JSON with the existing response validity policy during replay and local/shared reads.
- Keep invalid responses in the audit log without a reusable cache key. Continue validating legacy keyed records.
- Recover valid audit responses over invalid rows and merge valid retries over invalid shared entries. Preserve existing valid responses and skip invalid shard inputs.

## Minimal reproduction

The six added TestCrashRecovery methods run against the base response-cache module at e0bfc699 with nine assertion failures, including subtests. They exercise empty/null answers, malformed likelihood responses, invalid stored JSON, valid audit recovery, and shared-cache repair.

## Validation

- `uv run python -m pytest test/cache -q`: 61 passed, 4 subtests passed, using the existing local environment.
- The shared-cache regression verifies miss -> retry -> merge -> fresh-run hit without another model call.
- `uvx pre-commit run --all-files`: passed.

## Risk / Compatibility

Cache keys and the deterministic-request policy are unchanged. This uses the existing validity policy, including its two-element shape check for likelihood responses; it does not add element-type validation. Tests use mocked models and temporary SQLite/JSONL files.
