### PR TITLE
fix(cache): rebuild live requests from cached contexts

### DIFF
--- a/docs/advanced/caching.md
+++ b/docs/advanced/caching.md
@@ -1,3 +1,14 @@
+## Request cache
+
+`--cache_requests true` reuses document IDs and few-shot contexts. On a cache hit, the task constructs fresh requests with its current callbacks, generation settings, and metadata. Cached data never replaces live request objects or binds callbacks to an earlier task.
+
+- Omit `--cache_requests` to disable both reads and writes.
+- Use `--cache_requests refresh` to rebuild contexts without reading old cache files.
+- Request cache files use bounded, hashed names that distinguish task classes and output types. Older Instance-based cache files are ignored and remain on disk.
+- Cache publication replaces the old file only after the new data is fully serialized and written. A failed write preserves the previous file.
+
+Request caching does not yet fingerprint every input to context construction. Use `refresh` when the dataset, prompt, few-shot seed, or context-building settings change. Request caches use pickle and must come from a trusted directory.
+
 ## Response Cache
 
 `lmms-eval` includes a unified response cache backed by SQLite + JSONL write-ahead log. When enabled, deterministic model responses are stored and reused across runs, skipping redundant inference.

--- a/lmms_eval/api/task.py
+++ b/lmms_eval/api/task.py
@@ -449,8 +449,14 @@ class Task(abc.ABC):
         else:
             assert False, f"Task dataset (path={self.DATASET_PATH}, name={self.DATASET_NAME}) must have valid or test docs!"
 
-        # used with caching
-        og_limit = limit
+        # Cached contexts contain this rank's documents, while limit is global.
+        rank_limit = None if limit is None else len(range(offset + rank, offset + limit, world_size))
+
+        def request_metadata(doc_id):
+            metadata = {"task": self.config["task"], "doc_id": doc_id, "repeats": self.config.repeats, "split": split}
+            if isinstance(self.config.metadata, dict):
+                metadata.update(self.config.metadata)
+            return metadata
 
         cache_key = f"requests-{self._config.task}-{self.config.num_fewshot}shot-rank{rank}-world_size{world_size}"
         if offset:
@@ -459,23 +465,28 @@ class Task(abc.ABC):
         cache_key += "-fewshot_as_multiturn" if fewshot_as_multiturn else ""
         cache_key += f"-system_prompt_hash{utils.hash_string(system_instruction)}" if system_instruction is not None else ""
         cache_key += f"-tokenizer{tokenizer_name}"
+        cache_key += f"-request_type{type(self).__module__}.{type(self).__qualname__}-{self.OUTPUT_TYPE}"
+        cache_key = f"requests-v2-{utils.hash_string(cache_key)}"
 
-        cached_instances = load_from_cache(file_name=cache_key)
+        cached_contexts = load_from_cache(file_name=cache_key) if cache_requests and not rewrite_requests_cache else None
 
-        if cache_requests and cached_instances and not rewrite_requests_cache:
-            cached_instances = cached_instances[:limit]
-
-            flattened_instances = [instance for instance_group in cached_instances for instance in instance_group]
-
-            self._instances = flattened_instances
-            return
+        if cached_contexts:
+            instances = []
+            for cached in cached_contexts[:rank_limit]:
+                doc_id = cached["doc_id"]
+                restored = self.construct_requests(doc_id=doc_id, ctx=cached["context"], metadata=request_metadata(doc_id))
+                instances.append(restored if isinstance(restored, list) else [restored])
+            self._instances = [instance for instance_group in instances for instance in instance_group]
+            if self._instances:
+                return
 
         eval_logger.info(f"Building contexts for {self.config.task} on rank {rank}...")
 
         instances = []
+        request_contexts = []
 
         # process all documents when caching is specified for simplicity
-        if cache_requests and (not cached_instances or rewrite_requests_cache) and limit is not None:
+        if cache_requests and not cached_contexts and limit is not None:
             limit = None
 
         doc_id_docs = utils.create_iterator(
@@ -520,20 +531,18 @@ class Task(abc.ABC):
             )
 
             # TODO: we should override self.config.repeats if doing greedy gen so users don't waste time+compute
-            per_task_metadata = {"task": self.config["task"], "doc_id": doc_id, "repeats": self.config.repeats, "split": split}
-            if self.config.metadata and type(self.config.metadata) is dict:  # TODO: temporary fix for metadata loading, ignore the list of dict type.
-                per_task_metadata.update(self.config.metadata)
-
-            inst = self.construct_requests(doc_id=doc_id, ctx=fewshot_ctx, metadata=per_task_metadata)
+            inst = self.construct_requests(doc_id=doc_id, ctx=fewshot_ctx, metadata=request_metadata(doc_id))
 
             if not isinstance(inst, list):
                 inst = [inst]
 
             instances.append(inst)
+            if cache_requests:
+                request_contexts.append({"doc_id": doc_id, "context": fewshot_ctx})
 
         # now flatten, this is to allow slicing to work with pickles
 
-        sliced_instances = instances[:og_limit]
+        sliced_instances = instances[:rank_limit]
 
         flattened_instances = [instance for instance_group in sliced_instances for instance in instance_group]
 
@@ -566,17 +575,8 @@ class Task(abc.ABC):
             else:
                 raise ValueError("task.build_requests() did not find any docs!")
 
-        if cache_requests and (not cached_instances or rewrite_requests_cache):
-            save_to_cache(file_name=cache_key, obj=instances)
-
-        # FIXME: Bo - We need to check if the doc_to_visual if it's exists and restore it. If we use cache, the doc_to_visual will be None since it's not serializable
-        for instance in self._instances:
-            if instance.arguments[2] is None:
-                arguments = (instance.arguments[0], instance.arguments[1], self.doc_to_visual, *instance.arguments[3:])
-            else:
-                arguments = instance.arguments
-
-            instance.arguments = arguments
+        if cache_requests and not cached_contexts:
+            save_to_cache(file_name=cache_key, obj=request_contexts)
 
     @abc.abstractmethod
     def construct_requests(self, doc_id, ctx, **kwargs):

--- a/lmms_eval/caching/cache.py
+++ b/lmms_eval/caching/cache.py
@@ -1,10 +1,9 @@
 import hashlib
 import os
-import pickle
+import tempfile
 
 import dill
 
-from lmms_eval.loggers.utils import _handle_non_serializable, is_serializable
 from lmms_eval.utils import eval_logger
 
 MODULE_DIR = os.path.dirname(os.path.realpath(__file__))
@@ -36,29 +35,23 @@ def load_from_cache(file_name):
 
 
 def save_to_cache(file_name, obj):
-    if not os.path.exists(PATH):
-        os.mkdir(PATH)
+    os.makedirs(PATH, exist_ok=True)
 
     file_path = f"{PATH}/{file_name}{FILE_SUFFIX}"
 
-    serializable_obj = []
-
-    for item in obj:
-        serializable_item = []
-        for subitem in item:
-            if hasattr(subitem, "arguments"):  # we need to handle the arguments specially since doc_to_visual is callable method and not serializable
-                serializable_arguments = tuple(arg if not callable(arg) else None for arg in subitem.arguments)
-                subitem.arguments = serializable_arguments
-            serializable_item.append(subitem)
-        serializable_obj.append(serializable_item)
-
     eval_logger.debug(f"Saving {file_path} to cache...")
+    payload = dill.dumps(obj)
+    temporary_path = None
     try:
-        with open(file_path, "wb") as file:
-            file.write(dill.dumps(serializable_obj))
-    except (pickle.PickleError, dill.PicklingError, TypeError, AttributeError):
-        with open(file_path, "wb") as file:
-            file.write(dill.dumps([[subitem if is_serializable(subitem) else _handle_non_serializable(subitem) for subitem in item] for item in obj]))
+        with tempfile.NamedTemporaryFile(dir=PATH, delete=False) as file:
+            temporary_path = file.name
+            file.write(payload)
+            file.flush()
+            os.fsync(file.fileno())
+        os.replace(temporary_path, file_path)
+    finally:
+        if temporary_path is not None and os.path.exists(temporary_path):
+            os.unlink(temporary_path)
 
 
 # NOTE the "key" param is to allow for flexibility

--- a/test/eval/test_request_construction_contract.py
+++ b/test/eval/test_request_construction_contract.py
@@ -1,10 +1,12 @@
 """Production request-construction contracts without dataset initialization."""
 
 from types import SimpleNamespace
+from unittest.mock import Mock
 
 import pytest
 
-from lmms_eval.api.task import ConfigurableMessagesTask, ConfigurableTask
+from lmms_eval.api.task import ConfigurableMessagesTask, ConfigurableTask, TaskConfig
+from lmms_eval.caching import cache as request_cache
 
 
 def _doc_to_text(doc, lmms_eval_specific_kwargs=None):
@@ -119,3 +121,146 @@ def test_messages_task_agentic_constructs_chat_multi_step_layout():
     assert request.args[4] == 17
     assert request.args[5] == "request-contract"
     assert request.args[6] == "validation"
+
+
+def _cached_task(task_class=ConfigurableTask, output_type="generate_until"):
+    task = object.__new__(task_class)
+    task.OUTPUT_TYPE = output_type
+    task._config = TaskConfig(
+        task="cache-contract",
+        output_type=output_type,
+        test_split="test",
+        num_fewshot=0,
+        doc_to_text=_doc_to_text,
+        doc_to_visual=lambda doc: [doc["media"]],
+        doc_to_target=lambda doc: doc["answer"],
+        doc_to_messages=lambda doc: [{"role": "user", "content": [{"type": "text", "text": doc["question"]}]}],
+        generation_kwargs={"temperature": 0},
+    )
+    task.lmms_eval_specific_kwargs = None
+    task.model_specific_target_kwargs = None
+    task.dataset = {"test": [{"question": f"question{i}", "answer": "yes", "media": f"media{i}"} for i in range(6)]}
+    task.dataset_no_image = task.dataset
+    task.fewshot_context = Mock(side_effect=lambda doc, *args: doc["question"])
+    return task
+
+
+@pytest.mark.parametrize(
+    "task_class,output_type",
+    [
+        (ConfigurableTask, "generate_until"),
+        (ConfigurableTask, "loglikelihood"),
+        (ConfigurableTask, "generate_until_multi_round"),
+        (ConfigurableTask, "generate_until_agentic"),
+        (ConfigurableMessagesTask, "generate_until"),
+        (ConfigurableMessagesTask, "generate_until_multi_round"),
+        (ConfigurableMessagesTask, "generate_until_agentic"),
+    ],
+)
+def test_request_cache_cold_and_warm_preserve_live_callbacks(tmp_path, monkeypatch, task_class, output_type):
+    monkeypatch.setattr(request_cache, "PATH", str(tmp_path))
+    cold = _cached_task(task_class, output_type)
+    cold.build_all_requests(cache_requests=True, limit=2)
+    expected = _cached_task(task_class, output_type)
+    expected.build_all_requests(cache_requests=False, limit=2)
+    warm = _cached_task(task_class, output_type)
+    warm.build_all_requests(cache_requests=True, limit=2)
+    warm.fewshot_context.assert_not_called()
+
+    for task in (cold, warm):
+        assert [request.doc_id for request in task.instances] == [0, 1]
+        for actual, reference in zip(task.instances, expected.instances):
+            doc = task.dataset["test"][actual.doc_id]
+            assert len(actual.args) == len(reference.args)
+            for arg, ref in zip(actual.args, reference.args):
+                if callable(ref):
+                    assert callable(arg)
+                    assert arg(doc) == ref(doc)
+                    if hasattr(arg, "__self__"):
+                        assert arg.__self__ is task
+                else:
+                    assert arg == ref
+
+
+@pytest.mark.parametrize("enabled,refresh", [(False, False), (False, True), (True, True)])
+def test_disabled_or_refresh_request_cache_never_reads(monkeypatch, tmp_path, enabled, refresh):
+    monkeypatch.setattr(request_cache, "PATH", str(tmp_path))
+    load = Mock(side_effect=AssertionError("must not deserialize a cache"))
+    monkeypatch.setattr("lmms_eval.api.task.load_from_cache", load)
+    task = _cached_task()
+    task.build_all_requests(cache_requests=enabled, rewrite_requests_cache=refresh, limit=2)
+    load.assert_not_called()
+    assert [request.doc_id for request in task.instances] == [0, 1]
+    assert bool(list(tmp_path.iterdir())) is enabled
+
+
+@pytest.mark.parametrize("rank", [0, 1, 2])
+def test_request_cache_preserves_global_limit_and_offset(tmp_path, monkeypatch, rank):
+    monkeypatch.setattr(request_cache, "PATH", str(tmp_path))
+    for enabled in (False, True, True):
+        task = _cached_task()
+        task.build_all_requests(cache_requests=enabled, limit=4, offset=1, rank=rank, world_size=3)
+        assert [request.doc_id for request in task.instances] == list(range(1 + rank, 5, 3))
+
+
+def test_request_cache_separates_simple_and_chat_tasks(tmp_path, monkeypatch):
+    monkeypatch.setattr(request_cache, "PATH", str(tmp_path))
+    simple = _cached_task()
+    simple.build_all_requests(cache_requests=True, limit=1)
+    chat = _cached_task(ConfigurableMessagesTask)
+    chat.build_all_requests(cache_requests=True, limit=1)
+    assert chat.fewshot_context.called
+    assert len(list(tmp_path.iterdir())) == 2
+
+
+def test_request_cache_bounds_filename_with_system_instruction(tmp_path, monkeypatch):
+    monkeypatch.setattr(request_cache, "PATH", str(tmp_path))
+    for _ in range(2):
+        task = _cached_task(ConfigurableMessagesTask)
+        task.build_all_requests(cache_requests=True, limit=1, system_instruction="Be precise", tokenizer_name="organization/" + "model" * 60)
+        assert len(task.instances) == 1
+    task.fewshot_context.assert_not_called()
+    assert len(next(tmp_path.iterdir()).name.encode()) <= 255
+
+
+def test_request_cache_save_preserves_contexts_and_previous_file(tmp_path, monkeypatch):
+    monkeypatch.setattr(request_cache, "PATH", str(tmp_path / "nested" / "cache"))
+    contexts = [{"doc_id": 0, "context": "original"}]
+    request_cache.save_to_cache("test", contexts)
+    assert request_cache.load_from_cache("test") == contexts
+    path = next((tmp_path / "nested" / "cache").iterdir())
+    before = path.read_bytes()
+    monkeypatch.setattr(request_cache.os, "replace", Mock(side_effect=OSError("publication failed")))
+    with pytest.raises(OSError, match="publication failed"):
+        request_cache.save_to_cache("test", [{"doc_id": 0, "context": "replacement"}])
+    assert path.read_bytes() == before
+    assert list(path.parent.iterdir()) == [path]
+
+
+def test_request_cache_rebuilds_current_metadata(tmp_path, monkeypatch):
+    monkeypatch.setattr(request_cache, "PATH", str(tmp_path))
+    cold = _cached_task()
+    cold.config.metadata = {"sample_frames": 8, "old_key": True, "repeats": 3}
+    cold.build_all_requests(cache_requests=True, limit=1)
+    for metadata in (cold.config.metadata, {"sample_frames": 32, "repeats": 2}):
+        warm = _cached_task()
+        warm.config.metadata = metadata
+        warm.build_all_requests(cache_requests=True, limit=1)
+        reference = _cached_task()
+        reference.config.metadata = metadata
+        reference.build_all_requests(limit=1)
+        assert warm.instances[0].metadata == reference.instances[0].metadata
+        assert warm.instances[0].repeats == metadata["repeats"]
+
+
+def test_request_cache_preserves_context_before_custom_construction(tmp_path, monkeypatch):
+    class PrefixTask(ConfigurableTask):
+        def construct_requests(self, doc_id, ctx, **kwargs):
+            return super().construct_requests(doc_id, f"prefix {ctx}", **kwargs)
+
+    monkeypatch.setattr(request_cache, "PATH", str(tmp_path))
+    for _ in range(2):
+        task = _cached_task(PrefixTask)
+        task.build_all_requests(cache_requests=True, limit=1)
+        assert task.instances[0].args[0] == "prefix question0"
+    task.fewshot_context.assert_not_called()


### PR DESCRIPTION
We found that request caching could erase live callbacks on its first write and return requests without callbacks on later runs. This caches the original document IDs and few-shot contexts, then builds fresh requests through the current task on every cache hit.

## Root cause

Request serialization modified live Instance arguments. Cache hits returned the serialized objects before callback restoration, and the restoration code only handled the simple visual callback position. Disabled caching also performed a pickle read, and limited distributed runs sliced cached rank records using a global sample count.

## Fix

- Cache document IDs and original construction contexts. Use the existing request factory with current task metadata and generation settings for both cold and warm runs.
- Bypass reads when caching is disabled or refresh is requested, and apply the global limit consistently to each rank.
- Use bounded, versioned cache filenames that distinguish task class and output type. Serialize before atomically replacing the cache file, without a lossy fallback.

## Minimal reproduction

The 18 new request-cache cases produce 15 failures and three passes against the base task/cache modules at 4eb7d01b. They cover callback execution, disabled/refresh reads, rank selection, metadata updates, custom context transformations, long filenames, and failed publication.

## Validation

- Request construction, sample limits, evaluator, and cache suites: 96 passed.
- The full nine-file Hermetic CPU Contracts command: 213 passed locally with offline settings.
- `uvx pre-commit run --all-files`: passed. Independent correctness, silent-failure, and evaluation reviews found no remaining issues.

## Risk / Compatibility

Existing request-cache files are ignored by the v2 filename namespace and remain on disk. The first enabled run rebuilds its contexts. Changes to datasets, prompts, few-shot seeds, or other context-building settings still require explicit refresh; this does not introduce a complete context fingerprint. Cache serialization failures now propagate instead of writing partially reconstructed objects. No response-cache behavior changes or model inference are included.
